### PR TITLE
fix: typed exception catches replace string-matching IsAiProviderError (#3)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentClassificationBackgroundJob.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Abstractions.Documents;
 using Dignite.Paperbase.Application.Documents.Classification;
@@ -68,12 +70,29 @@ public class DocumentClassificationBackgroundJob
                 outcome = await _workflow.RunAsync(
                     candidates, document.ExtractedText ?? string.Empty);
             }
-            catch (Exception ex) when (IsAiProviderError(ex))
+            catch (Exception ex) when (IsTransientProviderError(ex))
             {
+                // 网络/超时类故障：LLM 暂时不可用，关键词兜底是合理替代——
+                // 关键词命中即按兜底结果完成分类，未命中走 LowConfidence → PendingReview。
                 Logger.LogWarning(ex,
-                    "AI classification workflow failed for document {DocumentId}, falling back to keyword classifier.",
+                    "AI classification provider unavailable for document {DocumentId}; falling back to keyword classifier.",
                     document.Id);
                 outcome = _keywordClassifier.Classify(candidates, document.ExtractedText ?? string.Empty);
+            }
+            catch (Exception ex) when (IsSchemaDeserializationError(ex))
+            {
+                // Schema 漂移：LLM 输出无法反序列化。这类问题不能用关键词兜底"修复"——
+                // 关键词命中只反映文本表面特征，不能替代被破坏的 LLM 语义判定。
+                // 直接走 PendingReview，由人工确认。
+                Logger.LogWarning(ex,
+                    "AI classification response failed JSON deserialization for document {DocumentId}; routing to PendingReview.",
+                    document.Id);
+                outcome = new DocumentClassificationOutcome
+                {
+                    TypeCode = null,
+                    ConfidenceScore = 0,
+                    Reason = "AI response could not be parsed (schema drift)."
+                };
             }
 
             await ApplyClassificationResultAsync(document, run, outcome);
@@ -85,6 +104,25 @@ public class DocumentClassificationBackgroundJob
             await _documentRepository.UpdateAsync(document);
         }
     }
+
+    /// <summary>
+    /// 网络/超时类瞬时故障：HTTP 通信失败、超时、操作取消。这类 LLM 不可用
+    /// 的情形下，关键词兜底是合理替代，因为产品语义上"分类未必基于深层语义
+    /// 理解"——关键词命中可信度足以推动流水线。
+    /// </summary>
+    private static bool IsTransientProviderError(Exception ex)
+        => ex is HttpRequestException
+            || ex is TimeoutException
+            || ex is OperationCanceledException
+            || ex.GetBaseException() is HttpRequestException
+            || ex.GetBaseException() is TimeoutException;
+
+    /// <summary>
+    /// LLM 输出 JSON 反序列化失败（包括 SDK 包装的内层异常）。这类问题
+    /// 必须走 PendingReview——schema 被破坏时关键词兜底无法替代语义判定。
+    /// </summary>
+    private static bool IsSchemaDeserializationError(Exception ex)
+        => ex is JsonException || ex.GetBaseException() is JsonException;
 
     private async Task ApplyClassificationResultAsync(
         Document document,
@@ -122,13 +160,6 @@ public class DocumentClassificationBackgroundJob
             document, run, outcome.Reason, candidates);
     }
 
-    private static bool IsAiProviderError(Exception ex)
-    {
-        return ex is TimeoutException
-            || ex is OperationCanceledException
-            || ex.GetType().Name.Contains("HttpRequestException", StringComparison.OrdinalIgnoreCase)
-            || (ex.Message.Contains("timeout", StringComparison.OrdinalIgnoreCase));
-    }
 }
 
 public class DocumentClassificationJobArgs

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentClassificationBackgroundJob_Tests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Abstractions.Documents;
@@ -263,6 +265,98 @@ public class DocumentClassificationBackgroundJob_Tests
         var run = doc.GetLatestRun(PaperbasePipelines.Classification);
         run.ShouldNotBeNull();
         run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+        doc.ReviewStatus.ShouldBe(DocumentReviewStatus.PendingReview);
+
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Any<DocumentClassifiedEto>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task HttpRequestException_FallsBack_To_Keyword_Classifier()
+    {
+        // HTTP 通信故障是 transient provider error，关键词兜底是合理替代。
+        // 旧实现用 ex.GetType().Name.Contains("HttpRequestException") 字符串匹配，
+        // 现在改为 typed catch (HttpRequestException) — 这个测试锁定新路径。
+        var doc = CreateDocument("業務委託契約書。甲：A社。乙：B社。");
+        SetupDocumentRepository(doc);
+
+        _workflow
+            .RunAsync(
+                Arg.Any<IReadOnlyList<DocumentTypeDefinition>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns<DocumentClassificationOutcome>(_ => throw new HttpRequestException("503 service unavailable"));
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        // 关键词兜底命中 contract.general
+        var run = doc.GetLatestRun(PaperbasePipelines.Classification);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentClassifiedEto>(e => e.DocumentTypeCode == "contract.general"),
+            Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task JsonException_Routes_To_PendingReview_Even_When_Keyword_Would_Match()
+    {
+        // 关键回归测试：schema 漂移类异常（JsonException）必须直接走 PendingReview，
+        // 不能用关键词兜底替代——关键词命中只反映文本表面，无法弥补 LLM 语义判定失效。
+        // 文本故意包含已注册关键词 "契約書"，如果错误地走了关键词兜底路径，文档会被
+        // 高置信度分类成 contract.general，测试断言失败。正确实现下，文档落入
+        // PendingReview，TypeCode 为 null。
+        var doc = CreateDocument("業務委託契約書。甲：A社。乙：B社。");
+        SetupDocumentRepository(doc);
+
+        _workflow
+            .RunAsync(
+                Arg.Any<IReadOnlyList<DocumentTypeDefinition>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns<DocumentClassificationOutcome>(_ => throw new JsonException("schema mismatch: missing required field"));
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        var run = doc.GetLatestRun(PaperbasePipelines.Classification);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+
+        // 没有走关键词兜底——TypeCode 为 null，ReviewStatus 为 PendingReview
+        doc.DocumentTypeCode.ShouldBeNull();
+        doc.ClassificationConfidence.ShouldBe(0);
+        doc.ReviewStatus.ShouldBe(DocumentReviewStatus.PendingReview);
+
+        // 不发布事件，不入队 Embedding
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Any<DocumentClassifiedEto>(), Arg.Any<bool>());
+        await _backgroundJobManager.DidNotReceive().EnqueueAsync(
+            Arg.Any<DocumentEmbeddingJobArgs>(),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task Wrapped_JsonException_Also_Routes_To_PendingReview()
+    {
+        // SDK 把 JsonException 包在外层异常里也算 schema drift。
+        var doc = CreateDocument("業務委託契約書。");
+        SetupDocumentRepository(doc);
+
+        var inner = new JsonException("invalid token");
+        var outer = new InvalidOperationException("LLM response could not be parsed", inner);
+
+        _workflow
+            .RunAsync(
+                Arg.Any<IReadOnlyList<DocumentTypeDefinition>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns<DocumentClassificationOutcome>(_ => throw outer);
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        doc.DocumentTypeCode.ShouldBeNull();
         doc.ReviewStatus.ShouldBe(DocumentReviewStatus.PendingReview);
 
         await _eventBus.DidNotReceive().PublishAsync(


### PR DESCRIPTION
## Summary

Replaces the brittle `IsAiProviderError` string-matching predicate in `DocumentClassificationBackgroundJob` with two typed-classification helpers, each routing to a semantically correct fallback path.

## Problem

The original implementation used `ex.GetType().Name.Contains("HttpRequestException")` and `ex.Message.Contains("timeout")` to decide whether to fall back to the keyword classifier. Consequences:

- 429 rate limits, 4xx validation errors, and `JsonException` from schema deserialization never entered the fallback path — they propagated up and the run was marked **Failed**
- `HttpRequestException` happened to match by type-name `Contains` but was brittle to subclassing or wrapping
- Keyword classifier was used as the universal fallback, even for **schema drift** where keyword matching cannot recover the broken LLM semantic

## Fix

Two typed predicates with clear semantic boundaries:

1. **`IsTransientProviderError`** → keyword fallback
   `HttpRequestException` / `TimeoutException` / `OperationCanceledException` (incl. `GetBaseException()` to handle SDK-wrapped inner exceptions). When the LLM is temporarily unreachable, keyword matching is a reasonable substitute.

2. **`IsSchemaDeserializationError`** → PendingReview-direct
   `JsonException` (incl. wrapped). Keyword matching reflects only surface text features and cannot replace a broken LLM semantic judgement; the document must go to human review.

Other unhandled exceptions still hit the outer catch and route to `FailAsync`, preserving existing safety.

## Tests

3 new regression tests in `DocumentClassificationBackgroundJob_Tests`:

- `HttpRequestException_FallsBack_To_Keyword_Classifier` — locks in typed catch semantics
- `JsonException_Routes_To_PendingReview_Even_When_Keyword_Would_Match` — uses text containing the registered "契約書" keyword to **prove** the keyword path is bypassed for schema drift
- `Wrapped_JsonException_Also_Routes_To_PendingReview` — covers the `GetBaseException()` path

All 70 Application tests pass.

## Test plan

- [x] `dotnet build core/Dignite.Paperbase.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Application.Tests` — 70/70 passing
- [x] Existing `AiProviderTimeout_*` tests still pass (existing keyword-fallback semantics preserved)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)