### PR TITLE
feat: move relation inference confidence threshold to PaperbaseAIOptions (#5)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
@@ -31,4 +31,9 @@ public class PaperbaseAIOptions
     /// AI 交互默认语言（影响系统提示词语言）。
     /// </summary>
     public string DefaultLanguage { get; set; } = "ja";
+
+    /// <summary>
+    /// 关系推断最低置信度阈值；低于此值的推断项将被硬性过滤，即使 LLM 在 prompt 中已被要求排除。
+    /// </summary>
+    public double RelationInferenceMinConfidence { get; set; } = 0.5;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentRelationInferenceWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentRelationInferenceWorkflow.cs
@@ -17,18 +17,6 @@ namespace Dignite.Paperbase.Documents.AI.Workflows;
 /// </summary>
 public class DocumentRelationInferenceWorkflow : ITransientDependency
 {
-    private const string SystemInstructions =
-        "You are a document relation analyst. Given a source document and several candidate documents, " +
-        "identify candidates that have a substantive relationship with the source, and write one sentence " +
-        "that clearly states the relationship. " +
-        "Example phrasings: 'This contract supplements the payment terms in section 3 of the main contract.'; " +
-        "'This supersedes the 2024-03 version, making the original void.'; " +
-        "'This is an attachment list of the main contract.'; " +
-        "'This addresses the same project as the main contract.'. " +
-        "Return a JSON array; each item contains: targetDocumentId (string), description (one sentence, " +
-        "max 200 characters), confidence (0.0-1.0). Include only items with confidence >= 0.5; return [] if none. " +
-        PromptBoundary.BoundaryRule;
-
     private readonly ChatClientAgent _agent;
     private readonly PaperbaseAIOptions _options;
 
@@ -40,8 +28,21 @@ public class DocumentRelationInferenceWorkflow : ITransientDependency
         IOptions<PaperbaseAIOptions> options)
     {
         _options = options.Value;
-        _agent = new ChatClientAgent(chatClient, instructions: SystemInstructions);
+        _agent = new ChatClientAgent(chatClient, instructions: BuildSystemInstructions(_options.RelationInferenceMinConfidence));
     }
+
+    private static string BuildSystemInstructions(double minConfidence) =>
+        "You are a document relation analyst. Given a source document and several candidate documents, " +
+        "identify candidates that have a substantive relationship with the source, and write one sentence " +
+        "that clearly states the relationship. " +
+        "Example phrasings: 'This contract supplements the payment terms in section 3 of the main contract.'; " +
+        "'This supersedes the 2024-03 version, making the original void.'; " +
+        "'This is an attachment list of the main contract.'; " +
+        "'This addresses the same project as the main contract.'. " +
+        "Return a JSON array; each item contains: targetDocumentId (string), description (one sentence, " +
+        "max 200 characters), confidence (0.0-1.0). " +
+        $"Include only items with confidence >= {minConfidence:F1}; return [] if none. " +
+        PromptBoundary.BoundaryRule;
 
     public virtual async Task<IReadOnlyList<InferredDocumentRelation>> RunAsync(
         Guid sourceDocumentId,

--- a/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentRelationInferenceBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentRelationInferenceBackgroundJob.cs
@@ -106,7 +106,11 @@ public class DocumentRelationInferenceBackgroundJob
             var inferred = await _workflow.RunAsync(
                 document.Id, document.ExtractedText ?? string.Empty, candidates);
 
-            foreach (var rel in inferred)
+            var filtered = inferred
+                .Where(r => r.Confidence >= _aiOptions.RelationInferenceMinConfidence)
+                .ToList();
+
+            foreach (var rel in filtered)
             {
                 await _relationRepository.InsertAsync(new DocumentRelation(
                     _guidGenerator.Create(),

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentRelationInferenceJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentRelationInferenceJob_Tests.cs
@@ -170,6 +170,64 @@ public class DocumentRelationInferenceJob_Tests : PaperbaseApplicationTestBase<D
         latestRun.Status.ShouldBe(PipelineRunStatus.Succeeded);
     }
 
+    [Fact]
+    public async Task LowConfidence_Relations_Are_Filtered_Before_Persisting()
+    {
+        var sourceDoc = CreateDocument(extractedText: "業務委託契約書。甲：A社。乙：B社。");
+        var highConfidenceId = Guid.NewGuid();
+        var lowConfidenceId = Guid.NewGuid();
+
+        _documentRepository.GetAsync(sourceDoc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(sourceDoc);
+        _documentRepository.FindAsync(highConfidenceId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDocument(extractedText: "発注書。金額900,000円。"));
+        _documentRepository.FindAsync(lowConfidenceId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDocument(extractedText: "メモ。特に関係なし。"));
+
+        var sourceChunk = new DocumentChunk(Guid.NewGuid(), null, sourceDoc.Id, 0, "業務委託契約書。",
+            new Vector(new float[PaperbaseDbProperties.EmbeddingVectorDimension]));
+        var highChunk = new DocumentChunk(Guid.NewGuid(), null, highConfidenceId, 0, "発注書。",
+            new Vector(new float[PaperbaseDbProperties.EmbeddingVectorDimension]));
+        var lowChunk = new DocumentChunk(Guid.NewGuid(), null, lowConfidenceId, 0, "メモ。",
+            new Vector(new float[PaperbaseDbProperties.EmbeddingVectorDimension]));
+
+        _chunkRepository
+            .GetListByDocumentIdAsync(sourceDoc.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentChunk> { sourceChunk });
+
+        _chunkRepository
+            .SearchByVectorAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(),
+                Arg.Any<Guid?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentChunk> { highChunk, lowChunk });
+
+        // Workflow returns two results: one above threshold (0.9), one below (0.3)
+        _workflow
+            .RunAsync(Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<RelationCandidate>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<InferredDocumentRelation>
+            {
+                new() { TargetDocumentId = highConfidenceId, Description = "本文書は発注書の委託元契約です", Confidence = 0.9 },
+                new() { TargetDocumentId = lowConfidenceId, Description = "弱い関係性", Confidence = 0.3 }
+            });
+
+        await _job.ExecuteAsync(new DocumentRelationInferenceJobArgs { DocumentId = sourceDoc.Id });
+
+        // Only the high-confidence relation reaches the aggregate
+        await _relationRepository.Received(1).InsertAsync(
+            Arg.Is<DocumentRelation>(r =>
+                r.TargetDocumentId == highConfidenceId &&
+                r.Source == RelationSource.AiSuggested),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+
+        // The 0.3-confidence relation must never reach the aggregate, even if LLM ignores the prompt rule
+        await _relationRepository.DidNotReceive().InsertAsync(
+            Arg.Is<DocumentRelation>(r => r.TargetDocumentId == lowConfidenceId),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private static Document CreateDocument(string? extractedText = null)
     {
         var doc = new Document(


### PR DESCRIPTION
## Summary

- Add `PaperbaseAIOptions.RelationInferenceMinConfidence = 0.5` — threshold is now configurable via `appsettings.json`
- Substitute the value into the system prompt at construction time via `BuildSystemInstructions(double minConfidence)`, removing the hardcoded `0.5` from prompt text
- Hard-filter workflow output in `DocumentRelationInferenceBackgroundJob` so relations below threshold never reach the `DocumentRelation` aggregate, even if the LLM ignores the prompt rule

## Problem

The previous `confidence >= 0.5` guard was encoded only inside the system-prompt string — a single line of natural language that the LLM could silently violate. The BackgroundJob did no server-side re-filtering, so a hallucinated low-confidence relation would be persisted unconditionally.

## Fix

Three-part defence:

1. **Configurable option** — `PaperbaseAIOptions.RelationInferenceMinConfidence` (default `0.5`) lets operators tune the threshold without touching code or prompts.
2. **Dynamic prompt** — `BuildSystemInstructions` replaces the static `const string` and formats the threshold from options, keeping LLM guidance and server-side value in sync.
3. **Server-side hard filter** — `filtered = inferred.Where(r => r.Confidence >= _aiOptions.RelationInferenceMinConfidence)` runs before any `InsertAsync`, making the guarantee unconditional.

## Test plan

- [x] `dotnet build core/Dignite.Paperbase.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Application.Tests` — 71/71 passing
- [x] Regression test `LowConfidence_Relations_Are_Filtered_Before_Persisting`: workflow returns `[{confidence: 0.9}, {confidence: 0.3}]`; asserts only the 0.9 item reaches `InsertAsync` and the 0.3 item is never persisted

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)