### PR TITLE
feat: introduce IPromptProvider to externalize workflow system prompts (#4)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/DefaultPromptProvider.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/DefaultPromptProvider.cs
@@ -1,0 +1,40 @@
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Documents.AI;
+
+/// <summary>
+/// 内置 <see cref="IPromptProvider"/> 实现。
+/// 按 <paramref name="language"/> 参数将语言指令嵌入系统提示词；
+/// 返回的 <see cref="PromptTemplate.SystemInstructions"/> 不含 PromptBoundary 规则，
+/// 由各 Workflow 在使用前追加。
+/// </summary>
+public class DefaultPromptProvider : IPromptProvider, ITransientDependency
+{
+    public virtual PromptTemplate GetClassificationPrompt(string language) => new(
+        "You are a document classification expert. " +
+        "Analyze the document text and determine the best matching document type from the provided list. " +
+        "If you are not confident, set confidence low and typeCode to null. " +
+        $"Respond in: {language}."
+    );
+
+    public virtual PromptTemplate GetRelationInferencePrompt(string language, double minConfidence) => new(
+        "You are a document relation analyst. Given a source document and several candidate documents, " +
+        "identify candidates that have a substantive relationship with the source, and write one sentence " +
+        "that clearly states the relationship. " +
+        "Example phrasings: 'This contract supplements the payment terms in section 3 of the main contract.'; " +
+        "'This supersedes the 2024-03 version, making the original void.'; " +
+        "'This is an attachment list of the main contract.'; " +
+        "'This addresses the same project as the main contract.'. " +
+        "Return a JSON array; each item contains: targetDocumentId (string), description (one sentence, " +
+        "max 200 characters), confidence (0.0-1.0). " +
+        $"Include only items with confidence >= {minConfidence:F1}; return [] if none. " +
+        $"Write all descriptions in: {language}."
+    );
+
+    public virtual PromptTemplate GetQaPrompt(string language) => new(
+        "You are a helpful assistant that answers questions based on the provided document content. " +
+        "Answer in the same language as the question. " +
+        "If citing a source, reference it by [chunk N]. " +
+        "If the answer is not in the provided content, say so clearly rather than guessing."
+    );
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/IPromptProvider.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/IPromptProvider.cs
@@ -1,0 +1,15 @@
+namespace Dignite.Paperbase.Documents.AI;
+
+/// <summary>
+/// 为各 MAF Workflow 提供系统提示词。
+/// 实现侧可按语言、租户或业务场景返回不同模板；
+/// 测试侧注入替代实现以隔离 LLM 调用。
+/// </summary>
+public interface IPromptProvider
+{
+    PromptTemplate GetClassificationPrompt(string language);
+
+    PromptTemplate GetRelationInferencePrompt(string language, double minConfidence);
+
+    PromptTemplate GetQaPrompt(string language);
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/PromptTemplate.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/PromptTemplate.cs
@@ -1,0 +1,9 @@
+namespace Dignite.Paperbase.Documents.AI;
+
+/// <summary>
+/// Workflow 系统提示词模板，由 <see cref="IPromptProvider"/> 返回。
+/// </summary>
+/// <param name="SystemInstructions">
+/// 系统指令主体文本，不含 PromptBoundary 规则（由 Workflow 在使用侧追加）。
+/// </param>
+public record PromptTemplate(string SystemInstructions);

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentClassificationWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentClassificationWorkflow.cs
@@ -17,12 +17,6 @@ namespace Dignite.Paperbase.Documents.AI.Workflows;
 /// </summary>
 public class DocumentClassificationWorkflow : ITransientDependency
 {
-    private const string SystemInstructions =
-        "You are a document classification expert. " +
-        "Analyze the document text and determine the best matching document type from the provided list. " +
-        "If you are not confident, set confidence low and typeCode to null. " +
-        PromptBoundary.BoundaryRule;
-
     private readonly ChatClientAgent _agent;
     private readonly PaperbaseAIOptions _options;
 
@@ -31,10 +25,13 @@ public class DocumentClassificationWorkflow : ITransientDependency
 
     public DocumentClassificationWorkflow(
         IChatClient chatClient,
-        IOptions<PaperbaseAIOptions> options)
+        IOptions<PaperbaseAIOptions> options,
+        IPromptProvider promptProvider)
     {
         _options = options.Value;
-        _agent = new ChatClientAgent(chatClient, instructions: SystemInstructions);
+        var template = promptProvider.GetClassificationPrompt(_options.DefaultLanguage);
+        var instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule;
+        _agent = new ChatClientAgent(chatClient, instructions: instructions);
     }
 
     public virtual async Task<DocumentClassificationOutcome> RunAsync(
@@ -87,8 +84,6 @@ public class DocumentClassificationWorkflow : ITransientDependency
                     {"typeCode": "TypeCode", "confidence": <number>}
                   ]
                 }
-
-                Respond in: {{_options.DefaultLanguage}}
                 """;
 
         var response = await _agent.RunAsync<ClassificationResponse>(

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentQaWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentQaWorkflow.cs
@@ -17,13 +17,6 @@ namespace Dignite.Paperbase.Documents.AI.Workflows;
 /// </summary>
 public class DocumentQaWorkflow : ITransientDependency
 {
-    private const string SystemInstructions =
-        "You are a helpful assistant that answers questions based on the provided document content. " +
-        "Answer in the same language as the question. " +
-        "If citing a source, reference it by [chunk N]. " +
-        "If the answer is not in the provided content, say so clearly rather than guessing. " +
-        PromptBoundary.BoundaryRule;
-
     private readonly ChatClientAgent _agent;
     private readonly PaperbaseAIOptions _options;
 
@@ -32,10 +25,13 @@ public class DocumentQaWorkflow : ITransientDependency
 
     public DocumentQaWorkflow(
         IChatClient chatClient,
-        IOptions<PaperbaseAIOptions> options)
+        IOptions<PaperbaseAIOptions> options,
+        IPromptProvider promptProvider)
     {
         _options = options.Value;
-        _agent = new ChatClientAgent(chatClient, instructions: SystemInstructions);
+        var template = promptProvider.GetQaPrompt(_options.DefaultLanguage);
+        var instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule;
+        _agent = new ChatClientAgent(chatClient, instructions: instructions);
     }
 
     public virtual Task<DocumentQaOutcome> RunRagAsync(

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentRelationInferenceWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentRelationInferenceWorkflow.cs
@@ -25,24 +25,15 @@ public class DocumentRelationInferenceWorkflow : ITransientDependency
 
     public DocumentRelationInferenceWorkflow(
         IChatClient chatClient,
-        IOptions<PaperbaseAIOptions> options)
+        IOptions<PaperbaseAIOptions> options,
+        IPromptProvider promptProvider)
     {
         _options = options.Value;
-        _agent = new ChatClientAgent(chatClient, instructions: BuildSystemInstructions(_options.RelationInferenceMinConfidence));
+        var template = promptProvider.GetRelationInferencePrompt(
+            _options.DefaultLanguage, _options.RelationInferenceMinConfidence);
+        var instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule;
+        _agent = new ChatClientAgent(chatClient, instructions: instructions);
     }
-
-    private static string BuildSystemInstructions(double minConfidence) =>
-        "You are a document relation analyst. Given a source document and several candidate documents, " +
-        "identify candidates that have a substantive relationship with the source, and write one sentence " +
-        "that clearly states the relationship. " +
-        "Example phrasings: 'This contract supplements the payment terms in section 3 of the main contract.'; " +
-        "'This supersedes the 2024-03 version, making the original void.'; " +
-        "'This is an attachment list of the main contract.'; " +
-        "'This addresses the same project as the main contract.'. " +
-        "Return a JSON array; each item contains: targetDocumentId (string), description (one sentence, " +
-        "max 200 characters), confidence (0.0-1.0). " +
-        $"Include only items with confidence >= {minConfidence:F1}; return [] if none. " +
-        PromptBoundary.BoundaryRule;
 
     public virtual async Task<IReadOnlyList<InferredDocumentRelation>> RunAsync(
         Guid sourceDocumentId,
@@ -136,9 +127,6 @@ public class DocumentRelationInferenceWorkflow : ITransientDependency
             sb.AppendLine($"- id: {candidate.DocumentId}, type: {candidate.DocumentTypeCode ?? "unknown"}");
             sb.AppendLine($"  excerpt: {PromptBoundary.WrapCandidate(i, candidate.Summary)}");
         }
-
-        sb.AppendLine();
-        sb.AppendLine($"Respond with each description in: {_options.DefaultLanguage}");
 
         return sb.ToString();
     }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentClassificationBackgroundJob_Tests.cs
@@ -32,7 +32,8 @@ public class DocumentClassificationJobTestModule : AbpModule
 
         var workflow = Substitute.ForPartsOf<DocumentClassificationWorkflow>(
             Substitute.For<IChatClient>(),
-            Options.Create(new PaperbaseAIOptions()));
+            Options.Create(new PaperbaseAIOptions()),
+            new DefaultPromptProvider());
         context.Services.AddSingleton(workflow);
 
         // 注册一个合同类型，阈值 0.75，含关键词"契約書"供关键词分类器使用

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentQaAppService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentQaAppService_Tests.cs
@@ -37,7 +37,8 @@ public class DocumentQaAppServiceTestModule : AbpModule
         // 用 Substitute 替换默认 Workflow，便于断言调用与返回
         var qaWorkflow = Substitute.ForPartsOf<DocumentQaWorkflow>(
             Substitute.For<IChatClient>(),
-            Microsoft.Extensions.Options.Options.Create(new PaperbaseAIOptions { QaTopKChunks = 5 }));
+            Microsoft.Extensions.Options.Options.Create(new PaperbaseAIOptions { QaTopKChunks = 5 }),
+            new DefaultPromptProvider());
         context.Services.AddSingleton(qaWorkflow);
 
         context.Services.Configure<PaperbaseAIOptions>(opt =>

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentRelationInferenceJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentRelationInferenceJob_Tests.cs
@@ -28,7 +28,8 @@ public class DocumentRelationInferenceJobTestModule : AbpModule
 
         var workflow = Substitute.ForPartsOf<DocumentRelationInferenceWorkflow>(
             Substitute.For<IChatClient>(),
-            Options.Create(new PaperbaseAIOptions { QaTopKChunks = 5 }));
+            Options.Create(new PaperbaseAIOptions { QaTopKChunks = 5 }),
+            new DefaultPromptProvider());
         context.Services.AddSingleton(workflow);
 
         context.Services.Configure<PaperbaseAIOptions>(opt =>


### PR DESCRIPTION
## Summary

- Add `IPromptProvider` interface with `GetClassificationPrompt`, `GetRelationInferencePrompt`, `GetQaPrompt` — synchronous, language-aware
- Add `PromptTemplate` record (`string SystemInstructions`)
- Add `DefaultPromptProvider : IPromptProvider, ITransientDependency` — embeds `DefaultLanguage` and `RelationInferenceMinConfidence` into the template at call time
- All three workflows (`Classification`, `RelationInference`, `Qa`) inject `IPromptProvider`; `const SystemInstructions` removed from all three
- `PromptBoundary.BoundaryRule` is always appended by the workflow after the provider's text, so custom providers don't need to know about it
- Redundant `"Respond in: {language}"` lines removed from user messages (language is now in system prompt via provider)
- Three test modules updated: pass `new DefaultPromptProvider()` as the third arg to `Substitute.ForPartsOf<>`

## Done when

- ✅ All three workflows' `const SystemInstructions` removed
- ✅ Switching `PaperbaseAIOptions.DefaultLanguage` changes actual system prompt content (`DefaultPromptProvider` embeds the value)
- ✅ Tests can override `IPromptProvider` to inject custom prompts without patching source

## Test plan

- [x] `dotnet build core/Dignite.Paperbase.slnx` — 0 warnings, 0 errors
- [x] `dotnet test Application.Tests` — 71/71 passing

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)