### PR TITLE
feat: mean-pool source chunk vectors for relation inference candidate retrieval

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
@@ -36,4 +36,9 @@ public class PaperbaseAIOptions
     /// 关系推断最低置信度阈值；低于此值的推断项将被硬性过滤，即使 LLM 在 prompt 中已被要求排除。
     /// </summary>
     public double RelationInferenceMinConfidence { get; set; } = 0.5;
+
+    /// <summary>
+    /// 关系推断候选文档召回上限（Top-K 文档数），与 QaTopKChunks 解耦，允许独立调优。
+    /// </summary>
+    public int RelationInferenceCandidateTopK { get; set; } = 20;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentRelationInferenceBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentRelationInferenceBackgroundJob.cs
@@ -59,15 +59,15 @@ public class DocumentRelationInferenceBackgroundJob
                 return;
             }
 
-            var firstVector = sourceChunks.First().EmbeddingVector.ToArray();
+            var pooled = MeanPool(sourceChunks.Select(c => c.EmbeddingVector.ToArray()).ToList());
             var candidateChunks = await _chunkRepository.SearchByVectorAsync(
-                firstVector, topK: _aiOptions.QaTopKChunks * 3);
+                pooled, topK: _aiOptions.RelationInferenceCandidateTopK * 3);
 
             var candidateDocIds = candidateChunks
                 .Select(c => c.DocumentId)
                 .Where(id => id != document.Id)
                 .Distinct()
-                .Take(_aiOptions.QaTopKChunks)
+                .Take(_aiOptions.RelationInferenceCandidateTopK)
                 .ToList();
 
             if (candidateDocIds.Count == 0)
@@ -133,6 +133,18 @@ public class DocumentRelationInferenceBackgroundJob
             await _pipelineRunManager.FailAsync(document, run, ex.Message);
             await _documentRepository.UpdateAsync(document);
         }
+    }
+
+    private static float[] MeanPool(IReadOnlyList<float[]> vectors)
+    {
+        var dim = vectors[0].Length;
+        var result = new float[dim];
+        foreach (var v in vectors)
+            for (var i = 0; i < dim; i++)
+                result[i] += v[i];
+        for (var i = 0; i < dim; i++)
+            result[i] /= vectors.Count;
+        return result;
     }
 }
 

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentRelationInferenceJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentRelationInferenceJob_Tests.cs
@@ -228,6 +228,41 @@ public class DocumentRelationInferenceJob_Tests : PaperbaseApplicationTestBase<D
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task MeanPooled_Vector_Is_Used_For_Candidate_Retrieval()
+    {
+        var doc = CreateDocument(extractedText: "契約内容...");
+        _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(doc);
+
+        var vec1 = new float[PaperbaseDbProperties.EmbeddingVectorDimension];
+        var vec2 = new float[PaperbaseDbProperties.EmbeddingVectorDimension];
+        vec1[0] = 2.0f;
+        vec2[0] = 4.0f;
+
+        _chunkRepository
+            .GetListByDocumentIdAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentChunk>
+            {
+                new(Guid.NewGuid(), null, doc.Id, 0, "chunk1", new Vector(vec1)),
+                new(Guid.NewGuid(), null, doc.Id, 1, "chunk2", new Vector(vec2))
+            });
+
+        _chunkRepository
+            .SearchByVectorAsync(
+                Arg.Any<float[]>(), Arg.Any<int>(),
+                Arg.Any<Guid?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentChunk>());
+
+        await _job.ExecuteAsync(new DocumentRelationInferenceJobArgs { DocumentId = doc.Id });
+
+        await _chunkRepository.Received(1).SearchByVectorAsync(
+            Arg.Is<float[]>(v => Math.Abs(v[0] - 3.0f) < 1e-5f),
+            Arg.Any<int>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private static Document CreateDocument(string? extractedText = null)
     {
         var doc = new Document(


### PR DESCRIPTION
## Summary

- Replace `sourceChunks.First().EmbeddingVector` with element-wise mean of **all** source chunk vectors, so late-section content (appendix lists, termination clauses) is represented in candidate retrieval instead of only the opening chunk.
- Add `PaperbaseAIOptions.RelationInferenceCandidateTopK = 20` to decouple candidate topK from `QaTopKChunks`, allowing independent tuning of each retrieval path.
- Add `MeanPooled_Vector_Is_Used_For_Candidate_Retrieval` test that asserts the pooled vector (element 0 = mean of two chunks) is what reaches `SearchByVectorAsync`.

Closes #7