### PR TITLE
feat: externalize relation candidate summary length and add prompt budget guard

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
@@ -41,4 +41,15 @@ public class PaperbaseAIOptions
     /// 关系推断候选文档召回上限（Top-K 文档数），与 QaTopKChunks 解耦，允许独立调优。
     /// </summary>
     public int RelationInferenceCandidateTopK { get; set; } = 20;
+
+    /// <summary>
+    /// 每个候选文档摘要的最大字符数，超出时截断。
+    /// </summary>
+    public int MaxRelationCandidateSummaryLength { get; set; } = 500;
+
+    /// <summary>
+    /// 关系推断 Prompt 总字符预算（源文档摘要 + 所有候选摘要之和），
+    /// 超出时从低优先级候选末尾依次丢弃并记录警告。
+    /// </summary>
+    public int MaxRelationInferencePromptCharacters { get; set; } = 30000;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentRelationInferenceBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/BackgroundJobs/DocumentRelationInferenceBackgroundJob.cs
@@ -83,8 +83,9 @@ public class DocumentRelationInferenceBackgroundJob
                 var candidate = await _documentRepository.FindAsync(candidateId);
                 if (candidate?.ExtractedText != null)
                 {
-                    var summary = candidate.ExtractedText.Length > 500
-                        ? candidate.ExtractedText[..500]
+                    var maxLen = _aiOptions.MaxRelationCandidateSummaryLength;
+                    var summary = candidate.ExtractedText.Length > maxLen
+                        ? candidate.ExtractedText[..maxLen]
                         : candidate.ExtractedText;
 
                     candidates.Add(new RelationCandidate
@@ -103,8 +104,33 @@ public class DocumentRelationInferenceBackgroundJob
                 return;
             }
 
+            var sourceText = document.ExtractedText ?? string.Empty;
+            var budget = _aiOptions.MaxRelationInferencePromptCharacters;
+            var usedChars = sourceText.Length + candidates.Sum(c => c.Summary.Length);
+            if (usedChars > budget)
+            {
+                var beforeDrop = candidates.Count;
+                while (candidates.Count > 0 && usedChars > budget)
+                {
+                    var last = candidates[^1];
+                    usedChars -= last.Summary.Length;
+                    candidates.RemoveAt(candidates.Count - 1);
+                }
+                Logger.LogWarning(
+                    "RelationInference prompt budget exceeded for document {DocumentId}: " +
+                    "{Before} candidates → {After} after drop (budget {Budget} chars).",
+                    document.Id, beforeDrop, candidates.Count, budget);
+            }
+
+            if (candidates.Count == 0)
+            {
+                await _pipelineRunManager.CompleteAsync(document, run);
+                await _documentRepository.UpdateAsync(document);
+                return;
+            }
+
             var inferred = await _workflow.RunAsync(
-                document.Id, document.ExtractedText ?? string.Empty, candidates);
+                document.Id, sourceText, candidates);
 
             var filtered = inferred
                 .Where(r => r.Confidence >= _aiOptions.RelationInferenceMinConfidence)


### PR DESCRIPTION
## Summary

- `PaperbaseAIOptions.MaxRelationCandidateSummaryLength` (default 500) replaces the hardcoded `500` truncation constant at `DocumentRelationInferenceBackgroundJob.cs:86-88`
- `PaperbaseAIOptions.MaxRelationInferencePromptCharacters` (default 30_000) adds a total-budget guard: after all summaries are built, the job computes `sourceText.Length + Σ summary.Length` and drops tail candidates (lowest similarity priority) until within budget
- A structured `LogWarning` fires whenever candidates are dropped, including before/after counts and the budget limit

## Test plan

- [ ] Both options are overridable in `appsettings.json` via the `PaperbaseAI` section
- [ ] Setting `MaxRelationInferencePromptCharacters` very low (e.g. 100) causes all-but-first candidates to be dropped and the warning appears in logs
- [ ] Setting `RelationInferenceCandidateTopK` to 50 no longer risks context-window overflows at the default 30 000-char budget
- [ ] Build passes: 0 errors, 0 warnings

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)