### PR TITLE
feat: remove redundant JSON schema text from classification prompt

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
@@ -52,4 +52,11 @@ public class PaperbaseAIOptions
     /// 超出时从低优先级候选末尾依次丢弃并记录警告。
     /// </summary>
     public int MaxRelationInferencePromptCharacters { get; set; } = 30000;
+
+    /// <summary>
+    /// 启用时向 LLM 传递 <c>ChatOptions.ResponseFormat = Json</c>，
+    /// 由 SDK 注入类型 schema 约束，同时从 prompt 中移除手写的 JSON schema 文本。
+    /// 关闭时回退到旧的 prompt 内联 schema（适用于不支持 JSON mode 的 Provider）。
+    /// </summary>
+    public bool UseStrictJsonMode { get; set; } = true;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentClassificationWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentClassificationWorkflow.cs
@@ -74,6 +74,12 @@ public class DocumentClassificationWorkflow : ITransientDependency
 
                 ## Document Text (first {{_options.MaxTextLengthPerExtraction}} characters)
                 {{PromptBoundary.WrapDocument(truncatedText)}}
+                """;
+
+        if (!_options.UseStrictJsonMode)
+        {
+            userMessage += """
+
 
                 ## Response Format (JSON only, no explanation)
                 {
@@ -85,12 +91,13 @@ public class DocumentClassificationWorkflow : ITransientDependency
                   ]
                 }
                 """;
+        }
 
         var response = await _agent.RunAsync<ClassificationResponse>(
             userMessage,
             session: null,
             serializerOptions: null,
-            options: null,
+            options: BuildRunOptions(_options.UseStrictJsonMode),
             cancellationToken);
 
         var parsed = response.Result;
@@ -134,6 +141,12 @@ public class DocumentClassificationWorkflow : ITransientDependency
 
         return outcome;
     }
+
+    // internal so Application.Tests can assert ResponseFormat without a real LLM.
+    internal static ChatClientAgentRunOptions? BuildRunOptions(bool useStrictJsonMode)
+        => useStrictJsonMode
+            ? new ChatClientAgentRunOptions(new ChatOptions { ResponseFormat = ChatResponseFormat.Json })
+            : null;
 
     // internal so Application.Tests can directly verify the regression-critical
     // out-of-range coercion logic (the surrounding 4-line branch in RunAsync is

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentClassificationJsonModeTests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentClassificationJsonModeTests.cs
@@ -1,0 +1,25 @@
+using Dignite.Paperbase.Documents.AI.Workflows;
+using Microsoft.Extensions.AI;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+public class DocumentClassificationJsonModeTests
+{
+    [Fact]
+    public void BuildRunOptions_StrictMode_Sets_Json_ResponseFormat()
+    {
+        var opts = DocumentClassificationWorkflow.BuildRunOptions(useStrictJsonMode: true);
+
+        opts.ShouldNotBeNull();
+        opts.ChatOptions.ShouldNotBeNull();
+        opts.ChatOptions.ResponseFormat.ShouldBe(ChatResponseFormat.Json);
+    }
+
+    [Fact]
+    public void BuildRunOptions_FallbackMode_Returns_Null()
+    {
+        DocumentClassificationWorkflow.BuildRunOptions(useStrictJsonMode: false).ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PaperbaseAIOptions.UseStrictJsonMode` (default `true`): passes `ChatOptions.ResponseFormat = ChatResponseFormat.Json` through `ChatClientAgentRunOptions` so `Microsoft.Extensions.AI` injects the POCO schema automatically — adding a field to `ClassificationResponse` no longer requires updating the prompt.
- Remove the hand-written `## Response Format` JSON block from the user message when strict mode is on.
- When `UseStrictJsonMode = false`, the inline schema block is preserved as a fallback for providers that do not support JSON mode (e.g. self-hosted Ollama without `--json-mode`).
- Add `DocumentClassificationJsonModeTests` with two unit tests that verify `BuildRunOptions` returns the correct `ChatClientAgentRunOptions` in each mode, without hitting a real LLM.

closes #10

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~DocumentClassification"` — 34 tests pass (2 new JSON-mode tests included)
- [ ] Verify Azure OpenAI path: provider honours `ResponseFormat = Json`; classification still deserializes correctly
- [ ] Verify Ollama fallback: set `UseStrictJsonMode = false` in host config; inline schema restored; Ollama responds as before