### PR TITLE
feat: wire UseDistributedCache on IChatClient to reduce token cost

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/PaperbaseAIOptions.cs
@@ -59,4 +59,11 @@ public class PaperbaseAIOptions
     /// 关闭时回退到旧的 prompt 内联 schema（适用于不支持 JSON mode 的 Provider）。
     /// </summary>
     public bool UseStrictJsonMode { get; set; } = true;
+
+    /// <summary>
+    /// 启用 <c>UseDistributedCache()</c> 中间件，对相同输入的 LLM 请求直接返回缓存响应，
+    /// 省去重复 token 消耗。使用宿主中已注册的 <c>IDistributedCache</c>（默认内存缓存）。
+    /// 开发/测试环境若需每次强制请求 LLM，可在 appsettings 中将此项设为 false。
+    /// </summary>
+    public bool PromptCachingEnabled { get; set; } = true;
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/PromptCaching_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/PromptCaching_Tests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// 验证 UseDistributedCache 中间件的缓存行为：
+/// 相同输入第二次命中缓存时，底层 IChatClient 不被调用。
+/// </summary>
+public class PromptCaching_Tests
+{
+    [Fact]
+    public async Task UseDistributedCache_ServesSecondIdenticalCallFromCache()
+    {
+        var callCount = 0;
+        var inner = Substitute.For<IChatClient>();
+        inner.GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")]));
+            });
+
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        services.AddLogging();
+        services.AddChatClient(_ => inner).UseDistributedCache();
+
+        await using var sp = services.BuildServiceProvider();
+        var client = sp.GetRequiredService<IChatClient>();
+
+        var messages = new List<ChatMessage> { new(ChatRole.User, "classify this document text") };
+
+        await client.GetResponseAsync(messages);   // cache miss → calls inner
+        await client.GetResponseAsync(messages);   // cache hit  → skips inner
+
+        callCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task UseDistributedCache_DifferentInputsBothCallInner()
+    {
+        var callCount = 0;
+        var inner = Substitute.For<IChatClient>();
+        inner.GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")]));
+            });
+
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        services.AddLogging();
+        services.AddChatClient(_ => inner).UseDistributedCache();
+
+        await using var sp = services.BuildServiceProvider();
+        var client = sp.GetRequiredService<IChatClient>();
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "document A text")]);
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "document B text")]);
+
+        callCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task WithoutDistributedCache_EachCallGoesToInner()
+    {
+        var callCount = 0;
+        var inner = Substitute.For<IChatClient>();
+        inner.GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")]));
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddChatClient(_ => inner);   // no UseDistributedCache
+
+        await using var sp = services.BuildServiceProvider();
+        var client = sp.GetRequiredService<IChatClient>();
+
+        var messages = new List<ChatMessage> { new(ChatRole.User, "classify this document text") };
+
+        await client.GetResponseAsync(messages);
+        await client.GetResponseAsync(messages);
+
+        callCount.ShouldBe(2);
+    }
+}

--- a/host/src/PaperbaseHostModule.cs
+++ b/host/src/PaperbaseHostModule.cs
@@ -399,12 +399,16 @@ public class PaperbaseHostModule : AbpModule
             new System.ClientModel.ApiKeyCredential(configuration["PaperbaseAI:ApiKey"]!),
             new OpenAIClientOptions { Endpoint = new Uri(configuration["PaperbaseAI:Endpoint"]!) });
 
-        context.Services
+        var chatBuilder = context.Services
             .AddChatClient(_ => openAIClient
                 .GetChatClient(configuration["PaperbaseAI:ChatModelId"]!)
                 .AsIChatClient())
-            .UseFunctionInvocation()
-            .UseLogging();
+            .UseFunctionInvocation();
+
+        if (configuration.GetValue("PaperbaseAI:PromptCachingEnabled", defaultValue: true))
+            chatBuilder = chatBuilder.UseDistributedCache();
+
+        chatBuilder.UseLogging();
 
         context.Services
             .AddEmbeddingGenerator(_ => openAIClient


### PR DESCRIPTION
## Summary

- `PaperbaseAIOptions.PromptCachingEnabled` (default `true`) — toggle for the caching middleware; configurable per environment via `appsettings.json` key `PaperbaseAI:PromptCachingEnabled`
- `PaperbaseHostModule.ConfigureAI` inserts `UseDistributedCache()` between `UseFunctionInvocation` and `UseLogging` when the option is enabled; uses `IDistributedCache` already registered by `AbpCachingModule` (in-memory by default, Redis in production)
- Three unit tests: same-input cache hit skips inner call (callCount == 1), different inputs both hit inner (callCount == 2), no-cache baseline (callCount == 2)

## Implementation notes

**Middleware order** (`UseLogging` outermost):
```
UseLogging → UseDistributedCache → UseFunctionInvocation → [Azure OpenAI]
```
Cache hits are still logged (for hit-rate visibility), and the entire tool-call sequence is bypassed on a hit.

**Provider behavior**:
- Azure OpenAI / Ollama: `UseDistributedCache` is client-side response caching keyed by the full message list hash. A cache hit returns the stored `ChatResponse` without any network call — `cache_read_tokens` on the provider side will be 0, but the API is never called at all (equivalent cost saving).
- To disable per environment: `appsettings.json` → `"PaperbaseAI": { "PromptCachingEnabled": false }`

## Test plan

- [x] `UseDistributedCache_ServesSecondIdenticalCallFromCache` — hit on second identical call
- [x] `UseDistributedCache_DifferentInputsBothCallInner` — distinct inputs both reach inner
- [x] `WithoutDistributedCache_EachCallGoesToInner` — baseline without middleware
- [x] Full suite: 85/85 pass

Closes #6