### PR TITLE
refactor: move ChatClientAgent construction to RunAsync for per-call prompt freshness

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentClassificationWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentClassificationWorkflow.cs
@@ -17,7 +17,8 @@ namespace Dignite.Paperbase.Documents.AI.Workflows;
 /// </summary>
 public class DocumentClassificationWorkflow : ITransientDependency
 {
-    private readonly ChatClientAgent _agent;
+    private readonly IChatClient _chatClient;
+    private readonly IPromptProvider _promptProvider;
     private readonly PaperbaseAIOptions _options;
 
     public ILogger<DocumentClassificationWorkflow> Logger { get; set; }
@@ -28,10 +29,9 @@ public class DocumentClassificationWorkflow : ITransientDependency
         IOptions<PaperbaseAIOptions> options,
         IPromptProvider promptProvider)
     {
+        _chatClient = chatClient;
+        _promptProvider = promptProvider;
         _options = options.Value;
-        var template = promptProvider.GetClassificationPrompt(_options.DefaultLanguage);
-        var instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule;
-        _agent = new ChatClientAgent(chatClient, instructions: instructions);
     }
 
     public virtual async Task<DocumentClassificationOutcome> RunAsync(
@@ -93,7 +93,12 @@ public class DocumentClassificationWorkflow : ITransientDependency
                 """;
         }
 
-        var response = await _agent.RunAsync<ClassificationResponse>(
+        var template = _promptProvider.GetClassificationPrompt(_options.DefaultLanguage);
+        var agent = new ChatClientAgent(
+            _chatClient,
+            instructions: template.SystemInstructions + " " + PromptBoundary.BoundaryRule);
+
+        var response = await agent.RunAsync<ClassificationResponse>(
             userMessage,
             session: null,
             serializerOptions: null,

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentQaWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentQaWorkflow.cs
@@ -18,7 +18,8 @@ namespace Dignite.Paperbase.Documents.AI.Workflows;
 /// </summary>
 public class DocumentQaWorkflow : ITransientDependency
 {
-    private readonly ChatClientAgent _agent;
+    private readonly IChatClient _chatClient;
+    private readonly IPromptProvider _promptProvider;
     private readonly PaperbaseAIOptions _options;
 
     public ILogger<DocumentQaWorkflow> Logger { get; set; }
@@ -29,10 +30,9 @@ public class DocumentQaWorkflow : ITransientDependency
         IOptions<PaperbaseAIOptions> options,
         IPromptProvider promptProvider)
     {
+        _chatClient = chatClient;
+        _promptProvider = promptProvider;
         _options = options.Value;
-        var template = promptProvider.GetQaPrompt(_options.DefaultLanguage);
-        var instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule;
-        _agent = new ChatClientAgent(chatClient, instructions: instructions);
     }
 
     public virtual Task<DocumentQaOutcome> RunRagAsync(
@@ -79,7 +79,12 @@ public class DocumentQaWorkflow : ITransientDependency
         IReadOnlyList<QaChunk> chunks,
         CancellationToken cancellationToken)
     {
-        var run = await _agent.RunAsync(userMessage, session: null, options: null, cancellationToken);
+        var template = _promptProvider.GetQaPrompt(_options.DefaultLanguage);
+        var agent = new ChatClientAgent(
+            _chatClient,
+            instructions: template.SystemInstructions + " " + PromptBoundary.BoundaryRule);
+
+        var run = await agent.RunAsync(userMessage, session: null, options: null, cancellationToken);
 
         var outcome = new DocumentQaOutcome
         {

--- a/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentRelationInferenceWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/AI/Workflows/DocumentRelationInferenceWorkflow.cs
@@ -17,7 +17,8 @@ namespace Dignite.Paperbase.Documents.AI.Workflows;
 /// </summary>
 public class DocumentRelationInferenceWorkflow : ITransientDependency
 {
-    private readonly ChatClientAgent _agent;
+    private readonly IChatClient _chatClient;
+    private readonly IPromptProvider _promptProvider;
     private readonly PaperbaseAIOptions _options;
 
     public ILogger<DocumentRelationInferenceWorkflow> Logger { get; set; }
@@ -28,11 +29,9 @@ public class DocumentRelationInferenceWorkflow : ITransientDependency
         IOptions<PaperbaseAIOptions> options,
         IPromptProvider promptProvider)
     {
+        _chatClient = chatClient;
+        _promptProvider = promptProvider;
         _options = options.Value;
-        var template = promptProvider.GetRelationInferencePrompt(
-            _options.DefaultLanguage, _options.RelationInferenceMinConfidence);
-        var instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule;
-        _agent = new ChatClientAgent(chatClient, instructions: instructions);
     }
 
     public virtual async Task<IReadOnlyList<InferredDocumentRelation>> RunAsync(
@@ -46,7 +45,13 @@ public class DocumentRelationInferenceWorkflow : ITransientDependency
 
         var userMessage = BuildUserMessage(sourceText, candidates);
 
-        var response = await _agent.RunAsync<List<RelationItem>>(
+        var template = _promptProvider.GetRelationInferencePrompt(
+            _options.DefaultLanguage, _options.RelationInferenceMinConfidence);
+        var agent = new ChatClientAgent(
+            _chatClient,
+            instructions: template.SystemInstructions + " " + PromptBoundary.BoundaryRule);
+
+        var response = await agent.RunAsync<List<RelationItem>>(
             userMessage,
             session: null,
             serializerOptions: null,

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentWorkflowPromptLifetime_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentWorkflowPromptLifetime_Tests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Documents;
+using Dignite.Paperbase.Documents.AI;
+using Dignite.Paperbase.Documents.AI.Workflows;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// 验证三个 Workflow 在每次 RunAsync 调用时都重新从 IPromptProvider 取得提示词，
+/// 而非在构造函数中固定 — 保证 IPromptProvider 的动态变更（语言切换、租户定制）
+/// 在下一次调用时立即生效，无需重启宿主。
+/// </summary>
+public class DocumentWorkflowPromptLifetime_Tests
+{
+    // ── Classification ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ClassificationWorkflow_GetClassificationPrompt_CalledOnEachRunAsync()
+    {
+        var inner = BuildChatClientReturning(
+            """{"typeCode":null,"confidence":0,"reason":"none","candidates":[]}""");
+
+        var promptProvider = Substitute.For<IPromptProvider>();
+        promptProvider.GetClassificationPrompt(Arg.Any<string>())
+            .Returns(new PromptTemplate("Prompt-A"), new PromptTemplate("Prompt-B"));
+
+        var workflow = new DocumentClassificationWorkflow(
+            inner, Options.Create(new PaperbaseAIOptions()), promptProvider);
+
+        var types = new List<DocumentTypeDefinition>
+            { new DocumentTypeDefinition("contract.general", "合同") };
+
+        await workflow.RunAsync(types, "text one");
+        await workflow.RunAsync(types, "text two");
+
+        // Prompt is fetched from provider on every call, not once at construction.
+        promptProvider.Received(2).GetClassificationPrompt(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ClassificationWorkflow_SystemInstructions_ReflectFreshPromptOnEachCall()
+    {
+        var capturedSystemMessages = new List<string>();
+        var inner = BuildChatClientCapturing(
+            capturedSystemMessages,
+            """{"typeCode":null,"confidence":0,"reason":"none","candidates":[]}""");
+
+        var promptProvider = Substitute.For<IPromptProvider>();
+        promptProvider.GetClassificationPrompt(Arg.Any<string>())
+            .Returns(new PromptTemplate("Prompt-A"), new PromptTemplate("Prompt-B"));
+
+        var workflow = new DocumentClassificationWorkflow(
+            inner, Options.Create(new PaperbaseAIOptions()), promptProvider);
+
+        var types = new List<DocumentTypeDefinition>
+            { new DocumentTypeDefinition("contract.general", "合同") };
+
+        await workflow.RunAsync(types, "text");
+        await workflow.RunAsync(types, "text");
+
+        capturedSystemMessages.Count.ShouldBe(2);
+        capturedSystemMessages[0].ShouldContain("Prompt-A");
+        capturedSystemMessages[1].ShouldContain("Prompt-B");
+    }
+
+    // ── RelationInference ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RelationInferenceWorkflow_GetRelationInferencePrompt_CalledOnEachRunAsync()
+    {
+        var inner = BuildChatClientReturning("[]");
+
+        var promptProvider = Substitute.For<IPromptProvider>();
+        promptProvider.GetRelationInferencePrompt(Arg.Any<string>(), Arg.Any<double>())
+            .Returns(new PromptTemplate("Prompt-A"), new PromptTemplate("Prompt-B"));
+
+        var workflow = new DocumentRelationInferenceWorkflow(
+            inner, Options.Create(new PaperbaseAIOptions()), promptProvider);
+
+        var candidates = new List<RelationCandidate>
+            { new RelationCandidate { DocumentId = Guid.NewGuid(), Summary = "s" } };
+
+        await workflow.RunAsync(Guid.NewGuid(), "source text", candidates);
+        await workflow.RunAsync(Guid.NewGuid(), "source text", candidates);
+
+        promptProvider.Received(2).GetRelationInferencePrompt(Arg.Any<string>(), Arg.Any<double>());
+    }
+
+    [Fact]
+    public async Task RelationInferenceWorkflow_SystemInstructions_ReflectFreshPromptOnEachCall()
+    {
+        var capturedSystemMessages = new List<string>();
+        var inner = BuildChatClientCapturing(capturedSystemMessages, "[]");
+
+        var promptProvider = Substitute.For<IPromptProvider>();
+        promptProvider.GetRelationInferencePrompt(Arg.Any<string>(), Arg.Any<double>())
+            .Returns(new PromptTemplate("Prompt-A"), new PromptTemplate("Prompt-B"));
+
+        var workflow = new DocumentRelationInferenceWorkflow(
+            inner, Options.Create(new PaperbaseAIOptions()), promptProvider);
+
+        var candidates = new List<RelationCandidate>
+            { new RelationCandidate { DocumentId = Guid.NewGuid(), Summary = "s" } };
+
+        await workflow.RunAsync(Guid.NewGuid(), "source text", candidates);
+        await workflow.RunAsync(Guid.NewGuid(), "source text", candidates);
+
+        capturedSystemMessages.Count.ShouldBe(2);
+        capturedSystemMessages[0].ShouldContain("Prompt-A");
+        capturedSystemMessages[1].ShouldContain("Prompt-B");
+    }
+
+    // ── QA ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QaWorkflow_GetQaPrompt_CalledOnEachRunAsync()
+    {
+        var inner = BuildChatClientReturning("Answer.");
+
+        var promptProvider = Substitute.For<IPromptProvider>();
+        promptProvider.GetQaPrompt(Arg.Any<string>())
+            .Returns(new PromptTemplate("Prompt-A"), new PromptTemplate("Prompt-B"));
+
+        var workflow = new DocumentQaWorkflow(
+            inner, Options.Create(new PaperbaseAIOptions()), promptProvider);
+
+        await workflow.RunFullTextAsync("question", "doc text");
+        await workflow.RunFullTextAsync("question", "doc text");
+
+        promptProvider.Received(2).GetQaPrompt(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task QaWorkflow_SystemInstructions_ReflectFreshPromptOnEachCall()
+    {
+        var capturedSystemMessages = new List<string>();
+        var inner = BuildChatClientCapturing(capturedSystemMessages, "Answer.");
+
+        var promptProvider = Substitute.For<IPromptProvider>();
+        promptProvider.GetQaPrompt(Arg.Any<string>())
+            .Returns(new PromptTemplate("Prompt-A"), new PromptTemplate("Prompt-B"));
+
+        var workflow = new DocumentQaWorkflow(
+            inner, Options.Create(new PaperbaseAIOptions()), promptProvider);
+
+        await workflow.RunFullTextAsync("question", "doc text");
+        await workflow.RunFullTextAsync("question", "doc text");
+
+        capturedSystemMessages.Count.ShouldBe(2);
+        capturedSystemMessages[0].ShouldContain("Prompt-A");
+        capturedSystemMessages[1].ShouldContain("Prompt-B");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static IChatClient BuildChatClientReturning(string responseText)
+    {
+        var inner = Substitute.For<IChatClient>();
+        inner.GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                new ChatResponse([new ChatMessage(ChatRole.Assistant, responseText)])));
+        return inner;
+    }
+
+    private static IChatClient BuildChatClientCapturing(
+        List<string> capturedSystemMessages,
+        string responseText)
+    {
+        var inner = Substitute.For<IChatClient>();
+        inner.GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var msgs = call.Arg<IEnumerable<ChatMessage>>().ToList();
+                var opts = call.Arg<ChatOptions?>();
+
+                // ChatClientAgent passes system instructions via ChatOptions.Instructions
+                // (Microsoft.Extensions.AI ≥ 10.5) rather than as a ChatRole.System message.
+                // Collect both sources so the assertion stays correct across versions.
+                var allText = string.Join(" ",
+                    msgs.Select(m => m.Text ?? "").Append(opts?.Instructions ?? ""));
+
+                capturedSystemMessages.Add(allText);
+                return Task.FromResult(
+                    new ChatResponse([new ChatMessage(ChatRole.Assistant, responseText)]));
+            });
+        return inner;
+    }
+}


### PR DESCRIPTION
## Summary

- Move `ChatClientAgent` construction from the constructor into each `RunAsync` / `InvokeAsync` call in three workflows: `DocumentClassificationWorkflow`, `DocumentRelationInferenceWorkflow`, and `DocumentQaWorkflow`
- Retain `IChatClient` and `IPromptProvider` as fields; fetch the prompt template on each invocation and construct a new `ChatClientAgent`
- This ensures that prompt changes returned by `IPromptProvider` — due to language, tenant, or hot-reload — take effect immediately on the next `RunAsync` call without restarting the host (satisfies the "Done when" condition in Issue #11)

## Changes

| File | Change |
|------|--------|
| `DocumentClassificationWorkflow.cs` | Remove `_agent` field → replace with `_chatClient` / `_promptProvider`; construct `new ChatClientAgent` on each `RunAsync` |
| `DocumentRelationInferenceWorkflow.cs` | Same; construct inside `RunAsync` |
| `DocumentQaWorkflow.cs` | Same; construct inside `InvokeAsync` |
| `DocumentWorkflowPromptLifetime_Tests.cs` | New tests (6 cases) |

## Tests

2 tests per workflow, 6 new tests total:
1. **CalledOnEachRunAsync** — verifies `GetXPrompt()` is called on every `RunAsync` via `Received(2)`
2. **SystemInstructions_ReflectFreshPromptOnEachCall** — verifies that when the mock returns "Prompt-A" on the first call and "Prompt-B" on the second, different instructions reach `IChatClient` via `ChatOptions.Instructions` (Microsoft.Extensions.AI ≥ 10.5)

All 85 existing tests continue to pass (total 91/91 pass).

closes #11