### PR TITLE
refactor(rag): Slice B — denormalize DocumentChunk (DocumentTypeCode/Title/PageNumber)

### DIFF
--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs
@@ -92,6 +92,13 @@ public static class PaperbaseDbContextModelCreatingExtensions
                 .IsRequired()
                 .HasMaxLength(DocumentChunkConsts.MaxChunkTextLength);
 
+            // 反范式化字段（来自 Document 聚合）。让 provider 检索路径不再 JOIN Documents 表，
+            // 为 Slice C 切独立 PgvectorRagDbContext 做物理前置——跨 DbContext / 跨 DBMS 不能 JOIN。
+            b.Property(x => x.DocumentTypeCode)
+                .HasMaxLength(DocumentConsts.MaxDocumentTypeCodeLength);
+            b.Property(x => x.Title)
+                .HasMaxLength(DocumentChunkConsts.MaxTitleLength);
+
             if (isNpgsql)
             {
                 // EmbeddingVector CLR 类型是 float[]；pgvector 列类型保持 vector(N)。
@@ -121,6 +128,10 @@ public static class PaperbaseDbContextModelCreatingExtensions
 
             // (DocumentId, ChunkIndex) 唯一；DocumentId 单列查询命中此索引前缀
             b.HasIndex(x => new { x.DocumentId, x.ChunkIndex }).IsUnique();
+
+            // (TenantId, DocumentTypeCode) 复合索引：跨文档按文档类型 QA 的主路径
+            // （PgvectorDocumentVectorStore 在 vector / keyword 检索前先按这两个字段过滤）。
+            b.HasIndex(x => new { x.TenantId, x.DocumentTypeCode });
         });
     }
 }

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.Domain.Shared/Documents/DocumentChunkConsts.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.Domain.Shared/Documents/DocumentChunkConsts.cs
@@ -6,4 +6,9 @@ public static class DocumentChunkConsts
     /// 单个 chunk 文本最大长度。按主流 embedding 模型 token 上限保守取值。
     /// </summary>
     public static int MaxChunkTextLength { get; set; } = 8000;
+
+    /// <summary>
+    /// 反范式化的章节/页面 Title 最大长度，用于 source citation 展示。
+    /// </summary>
+    public static int MaxTitleLength { get; set; } = 256;
 }

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.Domain/Documents/DocumentChunk.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.Domain/Documents/DocumentChunk.cs
@@ -10,6 +10,18 @@ namespace Dignite.Paperbase.Rag.Pgvector.Documents;
 /// 向量维度由 <see cref="PaperbaseDbProperties.EmbeddingVectorDimension"/> 全局统一；
 /// Document 删除时由 EF 级联清理，亦可通过 <see cref="IDocumentChunkRepository.DeleteByDocumentIdAsync"/> 主动清理。
 /// ChunkIndex 在文档内唯一，不应跨文档比较。
+///
+/// <para>
+/// 反范式化字段（<see cref="DocumentTypeCode"/> / <see cref="Title"/> / <see cref="PageNumber"/>）从
+/// Document 聚合冗余复制到 chunk 行上，让 provider 检索路径不再需要 JOIN Documents 表——这是为
+/// Slice C 切独立 <c>PgvectorRagDbContext</c>（甚至跨 DBMS）做的物理前置。
+/// </para>
+///
+/// <para>
+/// <b>一致性约束：</b><see cref="DocumentTypeCode"/> 在 Document 分类阶段确定，目前认为之后基本不变；
+/// 一旦未来允许 Document 重新分类，必须发领域事件让 chunks 同步更新此字段——否则反范式数据会陈旧。
+/// 本 Slice 不引入该事件，仅在此声明约束（参见 #39）。
+/// </para>
 /// </summary>
 public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
 {
@@ -23,6 +35,23 @@ public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
 
     public virtual float[] EmbeddingVector { get; private set; } = default!;
 
+    /// <summary>
+    /// 反范式化的文档类型码（来自 Document 分类）。allow null 与 Document.DocumentTypeCode 语义一致：
+    /// 文档尚未成功分类时该字段为 null。
+    /// </summary>
+    public virtual string? DocumentTypeCode { get; private set; }
+
+    /// <summary>
+    /// 反范式化的章节/页面 Title，用于 source citation。当前 embedding pipeline 暂未生成 chunk-level title，
+    /// 因此实际写入仍为 null；保留字段是为了未来扩展（如 PDF outline 抽取）不再加 schema 改动。
+    /// </summary>
+    public virtual string? Title { get; private set; }
+
+    /// <summary>
+    /// 反范式化的 1-based 页码，用于 source citation。语义同 <see cref="Title"/>：占位字段，目前为 null。
+    /// </summary>
+    public virtual int? PageNumber { get; private set; }
+
     protected DocumentChunk() { }
 
     public DocumentChunk(
@@ -31,7 +60,10 @@ public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         Guid documentId,
         int chunkIndex,
         string chunkText,
-        float[] embeddingVector)
+        float[] embeddingVector,
+        string? documentTypeCode = null,
+        string? title = null,
+        int? pageNumber = null)
         : base(id)
     {
         TenantId = tenantId;
@@ -42,6 +74,9 @@ public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
             nameof(chunkText),
             DocumentChunkConsts.MaxChunkTextLength);
         EmbeddingVector = ValidateVector(embeddingVector);
+        DocumentTypeCode = documentTypeCode;
+        Title = ValidateTitle(title);
+        PageNumber = pageNumber;
     }
 
     public virtual void UpdateEmbedding(float[] embeddingVector)
@@ -54,7 +89,10 @@ public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         Guid documentId,
         int chunkIndex,
         string chunkText,
-        float[] embeddingVector)
+        float[] embeddingVector,
+        string? documentTypeCode = null,
+        string? title = null,
+        int? pageNumber = null)
     {
         ValidateTenantUnchanged(tenantId);
         ValidateDocumentUnchanged(documentId);
@@ -64,6 +102,9 @@ public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
             nameof(chunkText),
             DocumentChunkConsts.MaxChunkTextLength);
         EmbeddingVector = ValidateVector(embeddingVector);
+        DocumentTypeCode = documentTypeCode;
+        Title = ValidateTitle(title);
+        PageNumber = pageNumber;
     }
 
     protected virtual Guid ValidateDocumentId(Guid documentId)
@@ -104,6 +145,17 @@ public class DocumentChunk : CreationAuditedAggregateRoot<Guid>, IMultiTenant
                 .WithData("ChunkIndex", chunkIndex);
         }
         return chunkIndex;
+    }
+
+    protected virtual string? ValidateTitle(string? title)
+    {
+        if (title is null)
+            return null;
+        // 防御性截断：Title 是来源 citation，不是核心索引字段——超长时优先保留 chunk 写入成功，
+        // 而非让 embedding pipeline 因 schema 边界失败。EF 列宽度的同名常量做硬上限校验。
+        return title.Length > DocumentChunkConsts.MaxTitleLength
+            ? title[..DocumentChunkConsts.MaxTitleLength]
+            : title;
     }
 
     protected virtual float[] ValidateVector(float[] embeddingVector)

--- a/core/src/Dignite.Paperbase.Rag.Pgvector/PgvectorDocumentVectorStore.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector/PgvectorDocumentVectorStore.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dignite.Paperbase.Documents;
 using Dignite.Paperbase.EntityFrameworkCore;
 using Dignite.Paperbase.Rag.Pgvector.Documents;
 using Microsoft.EntityFrameworkCore;
@@ -97,7 +96,10 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
                         record.DocumentId,
                         record.ChunkIndex,
                         record.Text,
-                        record.Vector.ToArray());
+                        record.Vector.ToArray(),
+                        record.DocumentTypeCode,
+                        record.Title,
+                        record.PageNumber);
                 }
                 else
                 {
@@ -107,7 +109,10 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
                         record.DocumentId,
                         record.ChunkIndex,
                         record.Text,
-                        record.Vector.ToArray()));
+                        record.Vector.ToArray(),
+                        record.DocumentTypeCode,
+                        record.Title,
+                        record.PageNumber));
                 }
             }
         }
@@ -202,10 +207,9 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         }
         else if (!string.IsNullOrEmpty(request.DocumentTypeCode))
         {
-            var matchingDocIds = dbContext.Set<Document>()
-                .Where(d => d.DocumentTypeCode == request.DocumentTypeCode)
-                .Select(d => d.Id);
-            query = query.Where(c => matchingDocIds.Contains(c.DocumentId));
+            // 反范式化（Slice B）后直接用 chunk 行上的 DocumentTypeCode 过滤，
+            // 不再 JOIN PaperbaseDocuments；这是 Slice C 切独立 PgvectorRagDbContext 的前置。
+            query = query.Where(c => c.DocumentTypeCode == request.DocumentTypeCode);
         }
 
         var pgVector = new Vector(request.QueryVector.ToArray());
@@ -214,17 +218,11 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         // EF.Property<Vector>() accesses the column as Vector so pgvector's
         // CosineDistance SQL translation works correctly.
         var rows = await query
-            .Join(
-                dbContext.Set<Document>().AsNoTracking(),
-                c => c.DocumentId,
-                d => d.Id,
-                (c, d) => new { Chunk = c, Document = d })
-            .OrderBy(c => EF.Property<Vector>(c.Chunk, nameof(DocumentChunk.EmbeddingVector))!.CosineDistance(pgVector))
+            .OrderBy(c => EF.Property<Vector>(c, nameof(DocumentChunk.EmbeddingVector))!.CosineDistance(pgVector))
             .Select(c => new
             {
-                c.Chunk,
-                c.Document.DocumentTypeCode,
-                Distance = EF.Property<Vector>(c.Chunk, nameof(DocumentChunk.EmbeddingVector))!.CosineDistance(pgVector)
+                Chunk = c,
+                Distance = EF.Property<Vector>(c, nameof(DocumentChunk.EmbeddingVector))!.CosineDistance(pgVector)
             })
             .Take(topK)
             .ToListAsync(cancellationToken);
@@ -234,14 +232,14 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
             {
                 RecordId = r.Chunk.Id,
                 DocumentId = r.Chunk.DocumentId,
-                DocumentTypeCode = r.DocumentTypeCode,
+                DocumentTypeCode = r.Chunk.DocumentTypeCode,
                 ChunkIndex = r.Chunk.ChunkIndex,
                 Text = r.Chunk.ChunkText,
                 // Keep legacy cosine similarity semantics while enforcing the
                 // provider contract: Score must stay in [0, 1].
                 Score = Math.Clamp(1.0 - r.Distance, 0.0, 1.0),
-                Title = null,
-                PageNumber = null
+                Title = r.Chunk.Title,
+                PageNumber = r.Chunk.PageNumber
             })
             .ToList();
     }
@@ -271,7 +269,6 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
 
         var dbContext = await _dbContextProvider.GetDbContextAsync();
         var chunkTable = GetDelimitedTableName(dbContext, typeof(DocumentChunk));
-        var documentTable = GetDelimitedTableName(dbContext, typeof(Document));
 
         // Build the SQL with positional parameters. Filter precedence matches
         // SearchVectorAsync: DocumentId wins over DocumentTypeCode, both optional.
@@ -279,6 +276,9 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         // hidden from the EF model (managed entirely by the GENERATED ALWAYS
         // constraint in PostgreSQL); LINQ translation has no shadow property
         // for it.
+        //
+        // Slice B: keyword 路径同步去 JOIN PaperbaseDocuments——直接读 chunk 行上的反范式
+        // DocumentTypeCode / Title / PageNumber，为 Slice C 切独立 PgvectorRagDbContext 做物理前置。
         var parameters = new List<object>
         {
             request.QueryText,
@@ -293,7 +293,7 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         }
         else if (!string.IsNullOrEmpty(request.DocumentTypeCode))
         {
-            optionalFilter = $@"AND d.""DocumentTypeCode"" = {{{parameters.Count}}}";
+            optionalFilter = $@"AND c.""DocumentTypeCode"" = {{{parameters.Count}}}";
             parameters.Add(request.DocumentTypeCode);
         }
 
@@ -304,14 +304,15 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         // (TenantId = null) and explicit-tenant case share the same clause.
         var sql = $@"
             SELECT
-                c.""Id""           AS ""Id"",
-                c.""DocumentId""   AS ""DocumentId"",
-                d.""DocumentTypeCode"" AS ""DocumentTypeCode"",
-                c.""ChunkIndex""   AS ""ChunkIndex"",
-                c.""ChunkText""    AS ""ChunkText"",
+                c.""Id""               AS ""Id"",
+                c.""DocumentId""       AS ""DocumentId"",
+                c.""DocumentTypeCode"" AS ""DocumentTypeCode"",
+                c.""ChunkIndex""       AS ""ChunkIndex"",
+                c.""ChunkText""        AS ""ChunkText"",
+                c.""Title""            AS ""Title"",
+                c.""PageNumber""       AS ""PageNumber"",
                 ts_rank_cd(c.""SearchVector"", plainto_tsquery('simple', {{0}})) AS ""Rank""
             FROM {chunkTable} c
-            INNER JOIN {documentTable} d ON d.""Id"" = c.""DocumentId""
             WHERE c.""SearchVector"" @@ plainto_tsquery('simple', {{0}})
               AND c.""TenantId"" IS NOT DISTINCT FROM CAST({{1}} AS uuid)
               {optionalFilter}
@@ -331,8 +332,8 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
                 ChunkIndex = r.ChunkIndex,
                 Text = r.ChunkText,
                 Score = r.Rank,
-                Title = null,
-                PageNumber = null
+                Title = r.Title,
+                PageNumber = r.PageNumber
             })
             .ToList());
     }
@@ -421,6 +422,8 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         public string? DocumentTypeCode { get; set; }
         public int ChunkIndex { get; set; }
         public string ChunkText { get; set; } = default!;
+        public string? Title { get; set; }
+        public int? PageNumber { get; set; }
         public double Rank { get; set; }
     }
 }

--- a/core/test/Dignite.Paperbase.Domain.Tests/Documents/DocumentChunkTests.cs
+++ b/core/test/Dignite.Paperbase.Domain.Tests/Documents/DocumentChunkTests.cs
@@ -47,6 +47,71 @@ public class DocumentChunkTests
         chunk.EmbeddingVector[0].ShouldBe(0.3f);
     }
 
+    [Fact]
+    public void Constructor_Should_Persist_Denormalized_Fields()
+    {
+        var chunk = new DocumentChunk(
+            Guid.NewGuid(),
+            tenantId: null,
+            documentId: Guid.NewGuid(),
+            chunkIndex: 0,
+            chunkText: "section text",
+            embeddingVector: MakeVector(0.1f),
+            documentTypeCode: "Contract.Service",
+            title: "Section 3.1 — Indemnification",
+            pageNumber: 7);
+
+        chunk.DocumentTypeCode.ShouldBe("Contract.Service");
+        chunk.Title.ShouldBe("Section 3.1 — Indemnification");
+        chunk.PageNumber.ShouldBe(7);
+    }
+
+    [Fact]
+    public void Constructor_Should_Default_Denormalized_Fields_To_Null()
+    {
+        var chunk = CreateChunk(tenantId: null, documentId: Guid.NewGuid());
+
+        chunk.DocumentTypeCode.ShouldBeNull();
+        chunk.Title.ShouldBeNull();
+        chunk.PageNumber.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Constructor_Should_Truncate_Title_Exceeding_MaxLength()
+    {
+        var oversizedTitle = new string('A', DocumentChunkConsts.MaxTitleLength + 50);
+
+        var chunk = new DocumentChunk(
+            Guid.NewGuid(),
+            tenantId: null,
+            documentId: Guid.NewGuid(),
+            chunkIndex: 0,
+            chunkText: "text",
+            embeddingVector: MakeVector(0.1f),
+            title: oversizedTitle);
+
+        chunk.Title.ShouldNotBeNull();
+        chunk.Title!.Length.ShouldBe(DocumentChunkConsts.MaxTitleLength);
+    }
+
+    [Fact]
+    public void UpdateRecord_Should_Refresh_Denormalized_Fields()
+    {
+        var tenantId = Guid.NewGuid();
+        var documentId = Guid.NewGuid();
+        var chunk = new DocumentChunk(
+            Guid.NewGuid(), tenantId, documentId, 0, "v1", MakeVector(0.1f),
+            documentTypeCode: "Contract.Old", title: "Old Title", pageNumber: 1);
+
+        chunk.UpdateRecord(
+            tenantId, documentId, 1, "v2", MakeVector(0.2f),
+            documentTypeCode: "Contract.New", title: "New Title", pageNumber: 2);
+
+        chunk.DocumentTypeCode.ShouldBe("Contract.New");
+        chunk.Title.ShouldBe("New Title");
+        chunk.PageNumber.ShouldBe(2);
+    }
+
     private static DocumentChunk CreateChunk(Guid? tenantId, Guid documentId)
     {
         return new DocumentChunk(

--- a/host/src/Migrations/20260428071403_SliceB_DocumentChunkDenormalize.Designer.cs
+++ b/host/src/Migrations/20260428071403_SliceB_DocumentChunkDenormalize.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Dignite.Paperbase.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.Paperbase.Host.Migrations
 {
     [DbContext(typeof(PaperbaseHostDbContext))]
-    partial class PaperbaseHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428071403_SliceB_DocumentChunkDenormalize")]
+    partial class SliceB_DocumentChunkDenormalize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260428071403_SliceB_DocumentChunkDenormalize.cs
+++ b/host/src/Migrations/20260428071403_SliceB_DocumentChunkDenormalize.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.Paperbase.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class SliceB_DocumentChunkDenormalize : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentTypeCode",
+                table: "PaperbaseDocumentChunks",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PageNumber",
+                table: "PaperbaseDocumentChunks",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Title",
+                table: "PaperbaseDocumentChunks",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            // 反范式化字段 backfill：把 Document.DocumentTypeCode 复制到所有现有 chunk 行。
+            //
+            // 幂等性：只更新 c."DocumentTypeCode" IS NULL 的行，重跑（含部分失败重启）安全；
+            // 已被 embedding 重写填值或后续来源不同的行不会被覆盖。
+            //
+            // 并发插入：UPDATE ... FROM 在 PG READ COMMITTED 下持单语句快照——backfill 运行期间
+            // 由旧版应用插入的新 chunk 行不在 snapshot 内，会保持 DocumentTypeCode = NULL。
+            // **运维提示**：滚动部署时建议短暂暂停 embedding pipeline；停机部署无此问题。新版写路径
+            // (DocumentEmbeddingBackgroundJob → PgvectorDocumentVectorStore.UpsertAsync) 会在
+            // 写入时直接填值，所以新版上线后插入的 chunk 不依赖此 backfill。
+            //
+            // 性能注：DocumentChunks 当前最大量级（万级）下单 UPDATE 毫秒级；接近百万级时改为
+            // batch UPDATE ... WHERE "Id" IN (SELECT ... LIMIT N) 分批执行避免长事务。
+            //
+            // Title / PageNumber 不 backfill：当前 embedding pipeline 暂未生成 chunk-level
+            // title / page，旧记录保持 NULL 即可，未来增强会通过重新 embedding 写入。
+            migrationBuilder.Sql(@"
+                UPDATE ""PaperbaseDocumentChunks"" AS c
+                SET ""DocumentTypeCode"" = d.""DocumentTypeCode""
+                FROM ""PaperbaseDocuments"" AS d
+                WHERE c.""DocumentId"" = d.""Id""
+                  AND c.""DocumentTypeCode"" IS NULL
+                  AND d.""DocumentTypeCode"" IS NOT NULL;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaperbaseDocumentChunks_TenantId_DocumentTypeCode",
+                table: "PaperbaseDocumentChunks",
+                columns: new[] { "TenantId", "DocumentTypeCode" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PaperbaseDocumentChunks_TenantId_DocumentTypeCode",
+                table: "PaperbaseDocumentChunks");
+
+            migrationBuilder.DropColumn(
+                name: "DocumentTypeCode",
+                table: "PaperbaseDocumentChunks");
+
+            migrationBuilder.DropColumn(
+                name: "PageNumber",
+                table: "PaperbaseDocumentChunks");
+
+            migrationBuilder.DropColumn(
+                name: "Title",
+                table: "PaperbaseDocumentChunks");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Slice B from the vector-store decoupling roadmap (#37). Denormalizes `DocumentChunk` with `DocumentTypeCode` / `Title` / `PageNumber` (still inside the main `PaperbaseDbContext`) so the pgvector provider's search paths can drop their JOIN to `PaperbaseDocuments`. **This is the physical prerequisite for Slice C** — EF Core cannot LINQ-join across two DbContexts.

Closes #39.

> **Stacked PR**: base is `refactor/slice-a-document-chunk-physical-migration` (#46). GitHub auto-retargets to `main` once Slice A merges.

### What changed

| Layer | Change |
|---|---|
| `Rag.Pgvector.Domain` | `DocumentChunk` gains 3 denormalized fields. Constructor + `UpdateRecord` take them as optional (default null). `Title` is defensively truncated at `MaxTitleLength = 256`. |
| `Rag.Pgvector.Domain.Shared` | `DocumentChunkConsts.MaxTitleLength = 256`. |
| `Paperbase.EntityFrameworkCore` | `Entity<DocumentChunk>` config maps the 3 new nullable columns + adds composite index `(TenantId, DocumentTypeCode)`. Still on the main `PaperbaseDbContext` (Slice C splits it). |
| Host migration | `20260428071403_SliceB_DocumentChunkDenormalize` — adds columns + index + idempotent backfill SQL. |
| `Rag.Pgvector` | `PgvectorDocumentVectorStore.SearchVectorAsync` drops `.Join(dbContext.Set<Document>(), ...)`. `SearchKeywordAsync` raw SQL drops `INNER JOIN documentTable`. `UpsertAsync` propagates the 3 fields. |
| `Application` | `DocumentEmbeddingBackgroundJob` already populated `record.DocumentTypeCode` (pre-Slice-B) — now it actually reaches the chunk row via the new `UpsertAsync` propagation. |

### Backfill SQL — idempotency analysis

```sql
UPDATE \"PaperbaseDocumentChunks\" AS c
SET \"DocumentTypeCode\" = d.\"DocumentTypeCode\"
FROM \"PaperbaseDocuments\" AS d
WHERE c.\"DocumentId\" = d.\"Id\"
  AND c.\"DocumentTypeCode\" IS NULL
  AND d.\"DocumentTypeCode\" IS NOT NULL;
```

- ✅ **Re-run safety**: `IS NULL` guard skips already-backfilled rows.
- ✅ **Crash recovery**: same guard applies after a partial run.
- ✅ **Unclassified docs**: filter excludes them — chunk stays NULL, matching the document's state.
- ✅ **Orphaned chunks**: JOIN naturally excludes them.
- ⚠️ **Concurrent inserts during rolling deploy**: PG `READ COMMITTED` snapshot misses rows committed mid-UPDATE. Mitigation documented in the migration comment: pause embedding pipeline during the deploy window, **or** rely on the new write path (`PgvectorDocumentVectorStore.UpsertAsync`) which now writes `DocumentTypeCode` directly. Stop-the-world deploys avoid this entirely.
- ⚠️ **Performance**: single UPDATE is fine at the current tens-of-thousands scale; switch to batched `WHERE \"Id\" IN (SELECT ... LIMIT N)` near the millions scale.

### EF Migration safety review

Run via `ef-migration-safety-reviewer` agent. **No high-risk findings.** Notes captured in PR / migration comments:
- Concurrent-insert edge case during rolling deploys (above).
- (TenantId, DocumentTypeCode) is a full B-tree, not partial — fine at current scale.
- `CREATE INDEX` (non-CONCURRENTLY) acceptable at tens-of-thousands scale; flag for ops at millions scale.

### Acceptance checklist (#39)

- [x] DocumentChunk gains 3 fields in `Rag.Pgvector.Domain`
- [x] Migration adds columns + composite index + idempotent backfill SQL
- [x] `PgvectorDocumentVectorStore` zero `dbContext.Set<Document>()` hits — verified via grep
- [x] All existing tests green (21 + 141 + 3); 4 new domain tests added for new fields + truncation
- [x] Multi-tenancy: explicit `TenantId` filter on the new index path; no behaviour change

## Test plan

- [x] `dotnet build core/Dignite.Paperbase.slnx` — 0 warnings, 0 errors
- [x] `dotnet build host/Dignite.Paperbase.Host.slnx` — 0 errors (5 pre-existing warnings)
- [x] `dotnet test Dignite.Paperbase.Domain.Tests` — 25/25 (4 new) ✅
- [x] `dotnet test Dignite.Paperbase.Application.Tests` (excl. live-PG benchmark) — 141/141 ✅
- [x] `dotnet test Dignite.Paperbase.EntityFrameworkCore.Tests` — 3/3 ✅
- [ ] **Manual**: backfill verification on a populated dev DB (run migration, query chunks where `DocumentTypeCode IS NULL`, confirm only unclassified-document chunks remain NULL).
- [ ] **Manual**: hybrid-search benchmark recall / MRR no regression vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)