### PR TITLE
refactor(rag): Slice C — Rag.Pgvector.EntityFrameworkCore + isolated PgvectorRagDbContext (#40)

### DIFF
--- a/core/Dignite.Paperbase.slnx
+++ b/core/Dignite.Paperbase.slnx
@@ -16,6 +16,7 @@
         <Project Path="src/Dignite.Paperbase.Rag.Pgvector/Dignite.Paperbase.Rag.Pgvector.csproj" />
         <Project Path="src/Dignite.Paperbase.Rag.Pgvector.Domain/Dignite.Paperbase.Rag.Pgvector.Domain.csproj" />
         <Project Path="src/Dignite.Paperbase.Rag.Pgvector.Domain.Shared/Dignite.Paperbase.Rag.Pgvector.Domain.Shared.csproj" />
+        <Project Path="src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.csproj" />
         <Project Path="src/Dignite.Paperbase.TextExtraction/Dignite.Paperbase.TextExtraction.csproj" />
     </Folder>
     

--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs
@@ -85,7 +85,12 @@ public static class PaperbaseDbContextModelCreatingExtensions
 
         builder.Entity<DocumentChunk>(b =>
         {
-            b.ToTable(PaperbaseDbProperties.DbTablePrefix + "DocumentChunks", PaperbaseDbProperties.DbSchema);
+            // Slice C：chunk 表的 EF 迁移所有权已转移到独立的 PgvectorRagDbContext。
+            // 主 PaperbaseDbContext 仍保留 mapping（避免读旧数据时 navigation 等失效），
+            // 但 ExcludeFromMigrations 防止 host migration diff（PaperbaseHostDbContext 走的是
+            // 这条路径）和 RelationalDatabaseCreator.CreateTables 重复创建表 / 索引。
+            // Slice D cutover 后会从主 context 彻底移除该 mapping。
+            b.ToTable(PaperbaseDbProperties.DbTablePrefix + "DocumentChunks", PaperbaseDbProperties.DbSchema, t => t.ExcludeFromMigrations());
             b.ConfigureByConvention();
 
             b.Property(x => x.ChunkText)

--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseEntityFrameworkCoreModule.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseEntityFrameworkCoreModule.cs
@@ -1,5 +1,4 @@
 using Dignite.Paperbase.Documents;
-using Dignite.Paperbase.Rag.Pgvector.Documents;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.Modularity;
@@ -21,7 +20,9 @@ public class PaperbaseEntityFrameworkCoreModule : AbpModule
             options.AddRepository<Document, EfCoreDocumentRepository>();
             options.AddRepository<DocumentPipelineRun, EfCoreDocumentPipelineRunRepository>();
             options.AddRepository<DocumentRelation, EfCoreDocumentRelationRepository>();
-            options.AddRepository<DocumentChunk, EfCoreDocumentChunkRepository>();
+
+            // Slice C：DocumentChunk repository 已切到 PgvectorRagEntityFrameworkCoreModule，
+            // 不再在主 PaperbaseDbContext 上注册——chunk 的写入路径只走 PgvectorRagDbContext。
         });
 
     }

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.abppkg
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.abppkg
@@ -1,0 +1,4 @@
+{
+  "role": "lib.ef",
+  "projectId": "9c5d72e1-1a6b-4f3d-9c4f-7f2e84d5b6e0"
+}

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.csproj
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Dignite.Paperbase.Rag.Pgvector</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.EntityFrameworkCore" Version="10.2.0" />
+    <!-- ABP-flavored UseNpgsql(this AbpDbContextConfigurationContext<T>, ...) 扩展所在程序集 -->
+    <PackageReference Include="Volo.Abp.EntityFrameworkCore.PostgreSql" Version="10.2.0" />
+    <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
+    <!-- 显式指定 Npgsql 10.x 以匹配 EF Core 10，覆盖 Pgvector 带入的 9.0.1 -->
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <!-- 设计时工具：让 dotnet ef migrations add 直接在本项目目录工作（startup 即本项目）。 -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
+    <ProjectReference Include="..\Dignite.Paperbase.Rag\Dignite.Paperbase.Rag.csproj" />
+    <ProjectReference Include="..\Dignite.Paperbase.Rag.Pgvector.Domain\Dignite.Paperbase.Rag.Pgvector.Domain.csproj" />
+
+    <!-- Slice C：暂时仍依赖主 Paperbase EF Core 模块——chunks 表 schema 同时映射在两个 DbContext，
+         迁移期间 connection string 配置和模块装配也跟随主 host 流程。Slice D cutover 后此引用可移除。 -->
+    <ProjectReference Include="..\Dignite.Paperbase.EntityFrameworkCore\Dignite.Paperbase.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Documents/EfCoreDocumentChunkRepository.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Documents/EfCoreDocumentChunkRepository.cs
@@ -3,18 +3,22 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dignite.Paperbase.EntityFrameworkCore;
-using Dignite.Paperbase.Rag.Pgvector.Documents;
+using Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore;
 
-namespace Dignite.Paperbase.Documents;
+namespace Dignite.Paperbase.Rag.Pgvector.Documents;
 
+/// <summary>
+/// chunk repository 切到独立 <see cref="PgvectorRagDbContext"/>。
+/// Slice C 之前 base class 是 <c>EfCoreRepository&lt;PaperbaseDbContext, ...&gt;</c>，
+/// 切换后写入路径走独立 connection string + 独立 EF Core 迁移历史表。
+/// </summary>
 public class EfCoreDocumentChunkRepository
-    : EfCoreRepository<PaperbaseDbContext, DocumentChunk, Guid>, IDocumentChunkRepository
+    : EfCoreRepository<PgvectorRagDbContext, DocumentChunk, Guid>, IDocumentChunkRepository
 {
-    public EfCoreDocumentChunkRepository(IDbContextProvider<PaperbaseDbContext> dbContextProvider)
+    public EfCoreDocumentChunkRepository(IDbContextProvider<PgvectorRagDbContext> dbContextProvider)
         : base(dbContextProvider)
     {
     }

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Documents/PgvectorDocumentVectorStore.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/Documents/PgvectorDocumentVectorStore.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dignite.Paperbase.EntityFrameworkCore;
-using Dignite.Paperbase.Rag.Pgvector.Documents;
+using Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -15,12 +14,17 @@ using Volo.Abp.DependencyInjection;
 using Volo.Abp.EntityFrameworkCore;
 using Volo.Abp.MultiTenancy;
 
-namespace Dignite.Paperbase.Rag.Pgvector;
+namespace Dignite.Paperbase.Rag.Pgvector.Documents;
 
 /// <summary>
 /// pgvector-backed implementation of <see cref="IDocumentVectorStore"/>.
-/// Bridges the Rag abstraction to the existing <see cref="PaperbaseDbContext"/> /
-/// <see cref="DocumentChunk"/> infrastructure.
+/// Slice C 起改用独立的 <see cref="PgvectorRagDbContext"/>——在 Slice B 完成 chunk
+/// 反范式化（去 JOIN <c>Documents</c> 表）之后这次切换是干净的，没有任何 fallback 路径。
+///
+/// <para>
+/// 类名暂保留 <c>PgvectorDocumentVectorStore</c>；Slice F/G 接口改名为 <c>IDocumentKnowledgeIndex</c>
+/// 并引入 <c>UpsertDocumentAsync</c> 时一并改为 <c>PgvectorDocumentKnowledgeIndex</c>。
+/// </para>
 ///
 /// Supports three search modes:
 ///   - <see cref="VectorSearchMode.Vector"/>  — pgvector cosine similarity.
@@ -43,12 +47,12 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
     /// </summary>
     protected const int HybridRecallMultiplier = 2;
 
-    private readonly IDbContextProvider<PaperbaseDbContext> _dbContextProvider;
+    private readonly IDbContextProvider<PgvectorRagDbContext> _dbContextProvider;
     private readonly ICurrentTenant _currentTenant;
     private readonly IDataFilter _dataFilter;
 
     public PgvectorDocumentVectorStore(
-        IDbContextProvider<PaperbaseDbContext> dbContextProvider,
+        IDbContextProvider<PgvectorRagDbContext> dbContextProvider,
         ICurrentTenant currentTenant,
         IDataFilter dataFilter)
     {
@@ -57,7 +61,7 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
         _dataFilter = dataFilter;
     }
 
-    public VectorStoreCapabilities Capabilities { get; } = new VectorStoreCapabilities
+    public virtual VectorStoreCapabilities Capabilities { get; } = new VectorStoreCapabilities
     {
         SupportsVectorSearch = true,
         SupportsKeywordSearch = true,
@@ -120,7 +124,7 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
 
     /// <summary>
     /// Bulk-delete all chunks for a document. Executes immediately (bypasses UoW),
-    /// consistent with <see cref="Documents.EfCoreDocumentChunkRepository.DeleteByDocumentIdAsync"/>.
+    /// consistent with <see cref="EfCoreDocumentChunkRepository.DeleteByDocumentIdAsync"/>.
     ///
     /// Tenant scoping is explicit: the provider disables ABP's ambient multi-tenant
     /// filter for this operation and adds its own TenantId predicate, so background
@@ -399,10 +403,10 @@ public class PgvectorDocumentVectorStore : IDocumentVectorStore, ITransientDepen
             .ToList();
     }
 
-    protected virtual string GetDelimitedTableName(PaperbaseDbContext dbContext, Type entityClrType)
+    protected virtual string GetDelimitedTableName(PgvectorRagDbContext dbContext, Type entityClrType)
     {
         var entityType = dbContext.Model.FindEntityType(entityClrType)
-            ?? throw new InvalidOperationException($"Entity type {entityClrType.Name} is not part of the Paperbase EF Core model.");
+            ?? throw new InvalidOperationException($"Entity type {entityClrType.Name} is not part of the PgvectorRag EF Core model.");
         var tableName = entityType.GetTableName()
             ?? throw new InvalidOperationException($"Entity type {entityClrType.Name} is not mapped to a table.");
 

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagDbContext.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagDbContext.cs
@@ -1,0 +1,39 @@
+using Dignite.Paperbase.Rag.Pgvector.Documents;
+using Microsoft.EntityFrameworkCore;
+using Volo.Abp.Data;
+using Volo.Abp.EntityFrameworkCore;
+
+namespace Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
+
+/// <summary>
+/// pgvector-backed RAG provider 的独立 DbContext。仅承载 <see cref="DocumentChunk"/>（以及未来
+/// document-level vector 等向量索引相关聚合）；不感知 Paperbase 的业务实体（Document / PipelineRun…）。
+///
+/// <para>
+/// <b>分库的物理前置：</b>
+/// <list type="bullet">
+///   <item><description>connection string name <c>"PaperbaseRag"</c> 与主 <c>"Paperbase"</c> 显式分离，
+///     允许部署期把向量数据指向独立实例或独立 cluster。</description></item>
+///   <item><description>独立 <c>__EFMigrationsHistory_PgvectorRag</c>（在
+///     <see cref="PgvectorRagEntityFrameworkCoreModule"/> 内 <c>UseNpgsql</c> 显式配置），
+///     与主库 history 表分离，保证 cutover 安全。</description></item>
+/// </list>
+/// </para>
+/// </summary>
+[ConnectionStringName(PgvectorRagDbProperties.ConnectionStringName)]
+public class PgvectorRagDbContext : AbpDbContext<PgvectorRagDbContext>
+{
+    public DbSet<DocumentChunk> DocumentChunks { get; set; } = default!;
+
+    public PgvectorRagDbContext(DbContextOptions<PgvectorRagDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.ConfigurePgvectorRag(isNpgsql: Database.ProviderName?.Contains("Npgsql") == true);
+    }
+}

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagDbContextFactory.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagDbContextFactory.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
+
+/// <summary>
+/// 设计时工厂：让 <c>dotnet ef migrations add ...</c> 可以在本 EF Core 项目目录下直接生成
+/// <see cref="PgvectorRagDbContext"/> 的迁移文件。
+///
+/// <para>
+/// EF Core 设计时管线 <b>不会</b> 经过 ABP 的依赖注入，因此本工厂必须自行：
+/// <list type="number">
+///   <item><description>读取 host 项目的 <c>appsettings*.json</c>，取 <c>PaperbaseRag</c>
+///     connection string（缺失时 fallback 到 <c>Default</c>，仅供设计时使用）；</description></item>
+///   <item><description>显式 <c>UseNpgsql(b =&gt; { b.UseVector(); b.MigrationsHistoryTable(...); })</c>，
+///     与 <see cref="PgvectorRagEntityFrameworkCoreModule"/> 的运行时配置保持一致——任何一处遗漏
+///     <c>MigrationsHistoryTable</c> 都会让设计时和运行时使用不同的 history 表。</description></item>
+/// </list>
+/// </para>
+/// </summary>
+public class PgvectorRagDbContextFactory : IDesignTimeDbContextFactory<PgvectorRagDbContext>
+{
+    public PgvectorRagDbContext CreateDbContext(string[] args)
+    {
+        var configuration = BuildConfiguration();
+
+        // 严格匹配 PaperbaseRag——不 fallback 到 Default，避免设计时把迁移静默生成到主库。
+        // 仅在 host appsettings 都不可用时使用本地默认串作为"刚 clone 仓库就能跑命令"的兜底。
+        var connectionString =
+            configuration.GetConnectionString(PgvectorRagDbProperties.ConnectionStringName)
+            ?? "Host=127.0.0.1;Port=5432;Database=paperbase;Username=postgres;Password=postgres";
+
+        var builder = new DbContextOptionsBuilder<PgvectorRagDbContext>()
+            .UseNpgsql(connectionString, b =>
+            {
+                b.UseVector();
+                b.MigrationsHistoryTable(PgvectorRagDbProperties.MigrationsHistoryTableName);
+            });
+
+        return new PgvectorRagDbContext(builder.Options);
+    }
+
+    private static IConfigurationRoot BuildConfiguration()
+    {
+        // 路径：core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore → host/src
+        var hostBasePath = Path.GetFullPath(
+            Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "host", "src"));
+
+        return new ConfigurationBuilder()
+            .SetBasePath(hostBasePath)
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+    }
+}

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagDbContextModelCreatingExtensions.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Rag.Pgvector.Documents;
+using Microsoft.EntityFrameworkCore;
+using Pgvector;
+using Volo.Abp;
+using Volo.Abp.EntityFrameworkCore.Modeling;
+
+namespace Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
+
+/// <summary>
+/// pgvector RAG provider 的实体映射。Slice C 期间 chunk mapping 在主 <c>PaperbaseDbContext</c>
+/// 与本 <c>PgvectorRagDbContext</c> 同时存在——主 context 内已通过
+/// <c>ToTable(...).ExcludeFromMigrations()</c> 排除，确保 host migration diff 不会重复创建。
+/// 写入路径只走本 context（参见 <see cref="PgvectorRagEntityFrameworkCoreModule"/> 中的
+/// <c>AddRepository&lt;DocumentChunk, EfCoreDocumentChunkRepository&gt;</c>）。
+/// </summary>
+public static class PgvectorRagDbContextModelCreatingExtensions
+{
+    public static void ConfigurePgvectorRag(this ModelBuilder builder, bool isNpgsql = true)
+    {
+        Check.NotNull(builder, nameof(builder));
+
+        if (isNpgsql)
+            builder.HasPostgresExtension("vector");
+
+        builder.Entity<DocumentChunk>(b =>
+        {
+            // 表名沿用主库前缀（Slice D cutover 时不改表名，仅改 owning context + history 表）。
+            b.ToTable(PgvectorRagDbProperties.DbTablePrefix + "DocumentChunks", PgvectorRagDbProperties.DbSchema);
+            b.ConfigureByConvention();
+
+            b.Property(x => x.ChunkText)
+                .IsRequired()
+                .HasMaxLength(DocumentChunkConsts.MaxChunkTextLength);
+
+            // 反范式化字段（来自 Document 聚合）。Slice B 已在 chunk 上落地这些字段，
+            // provider 检索路径不再 JOIN PaperbaseDocuments——这是本 context 能独立运行（甚至跨 DBMS）的前提。
+            b.Property(x => x.DocumentTypeCode)
+                .HasMaxLength(DocumentConsts.MaxDocumentTypeCodeLength);
+            b.Property(x => x.Title)
+                .HasMaxLength(DocumentChunkConsts.MaxTitleLength);
+
+            if (isNpgsql)
+            {
+                // EmbeddingVector CLR 类型是 float[]；pgvector 列类型保持 vector(N)。
+                // HasConversion 负责在写入/读取时转换，CosineDistance 查询仍由 EFCore repository 通过 EF.Property<Vector>() 完成。
+                b.Property(x => x.EmbeddingVector)
+                    .IsRequired()
+                    .HasColumnType($"vector({PaperbaseDbProperties.EmbeddingVectorDimension})")
+                    .HasConversion(
+                        v => new Vector(v),
+                        v => v.ToArray());
+            }
+            else
+            {
+                // SQLite (test): serialize vector as comma-separated floats.
+                b.Property(x => x.EmbeddingVector)
+                    .IsRequired()
+                    .HasConversion(
+                        v => string.Join(",", v),
+                        s => s.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                              .Select(float.Parse).ToArray());
+            }
+
+            // 注意：本 context 不映射 Document 实体——chunk 与 document 之间的 FK CASCADE 关系
+            // 在 Slice C 期间仍由主 PaperbaseDbContext 上的同名 mapping 持有（两个 context 共用同一物理表）。
+            // Slice E 会引入 DocumentDeletingEventHandler 替代 EF FK CASCADE，跨 context 也安全。
+
+            // (DocumentId, ChunkIndex) 唯一；DocumentId 单列查询命中此索引前缀
+            b.HasIndex(x => new { x.DocumentId, x.ChunkIndex }).IsUnique();
+
+            // (TenantId, DocumentTypeCode) 复合索引：跨文档按文档类型 QA 的主路径
+            // （PgvectorDocumentVectorStore 在 vector / keyword 检索前先按这两个字段过滤）。
+            b.HasIndex(x => new { x.TenantId, x.DocumentTypeCode });
+        });
+    }
+}

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagEntityFrameworkCoreModule.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/EntityFrameworkCore/PgvectorRagEntityFrameworkCoreModule.cs
@@ -1,0 +1,67 @@
+using Dignite.Paperbase.EntityFrameworkCore;
+using Dignite.Paperbase.Rag.Pgvector.Documents;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.Modularity;
+
+namespace Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
+
+/// <summary>
+/// 注册独立的 <see cref="PgvectorRagDbContext"/>、其 chunk repository 和 pgvector
+/// provider 实现。
+///
+/// <para>
+/// 关键约束：<c>UseNpgsql(b =&gt; b.MigrationsHistoryTable(...))</c> 必须显式调用——
+/// 否则两个 DbContext 共用默认 <c>__EFMigrationsHistory</c> 表，让 Slice D 的 cutover
+/// 路径与实际行为对不上。
+/// </para>
+///
+/// <para>
+/// 依赖 <see cref="PaperbaseEntityFrameworkCoreModule"/> 是 Slice C 的过渡安排——
+/// chunks 表的物理迁移记录目前仍在主 host migrations 中（Slice D 才会转移），且
+/// host 上配置的 <c>AbpDbContextOptions</c> 默认 provider 也由主 EF Core 模块栈带入。
+/// 本模块同时复写 per-context 的 <c>PgvectorRagDbContext</c> options，使其指向
+/// <c>PaperbaseRag</c> connection string 并启用 pgvector + 独立 history 表。
+/// </para>
+/// </summary>
+[DependsOn(
+    typeof(PgvectorRagDomainModule),
+    typeof(AbpEntityFrameworkCoreModule),
+    typeof(PaperbaseEntityFrameworkCoreModule))]
+public class PgvectorRagEntityFrameworkCoreModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddAbpDbContext<PgvectorRagDbContext>(options =>
+        {
+            // 显式注册自定义 chunk repository。EfCoreDocumentChunkRepository 是 IDocumentChunkRepository
+            // 唯一的实现，所有上层（DocumentRelationInferenceBackgroundJob、Embedding job 等）都通过
+            // IDocumentChunkRepository 访问，因此一定走 PgvectorRagDbContext。
+            //
+            // 注意：host 上的 PaperbaseHostDbContext 通过 ConfigurePaperbase() 把 DocumentChunk 也带入
+            // 了它的 model（用于 migration 聚合），并以 AddDefaultRepositories(includeAllEntities: true)
+            // 注册了一遍 IRepository<DocumentChunk, Guid>——按 DI 后注册者优先的语义，
+            // 通用 IRepository<DocumentChunk, Guid> 的解析结果会落到 PaperbaseHostDbContext。
+            // 本仓库目前**没有任何代码**消费通用 IRepository<DocumentChunk, Guid>（grep 已确认零命中），
+            // 因此实际写入路径不受影响。但请勿将来在 Application 层 inject 通用 repo——一旦那么做，
+            // 写入会落到主 connection string 而非 PaperbaseRag。Slice D 把主 context 的 chunk mapping
+            // 彻底移除后，这个隐性风险窗口自动关闭。
+            options.AddRepository<DocumentChunk, EfCoreDocumentChunkRepository>();
+        });
+
+        Configure<AbpDbContextOptions>(options =>
+        {
+            options.Configure<PgvectorRagDbContext>(opts =>
+            {
+                opts.UseNpgsql(b =>
+                {
+                    b.UseVector();
+                    // 独立 history 表（重要）：与主 PaperbaseDbContext 默认的 __EFMigrationsHistory 分离，
+                    // Slice D 的 cutover SQL 会引用同名常量。
+                    b.MigrationsHistoryTable(PgvectorRagDbProperties.MigrationsHistoryTableName);
+                });
+            });
+        });
+    }
+}

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/FodyWeavers.xml
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/FodyWeavers.xml
@@ -1,0 +1,3 @@
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait ContinueOnCapturedContext="false" />
+</Weavers>

--- a/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/PgvectorRagDbProperties.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/PgvectorRagDbProperties.cs
@@ -1,0 +1,39 @@
+namespace Dignite.Paperbase.Rag.Pgvector;
+
+/// <summary>
+/// pgvector-backed RAG provider 的数据库相关常量。Slice C 期间存放在 EF Core 项目；
+/// Slice F 会将与 schema 相关的常量（含 <see cref="MigrationsHistoryTableName"/>）移到
+/// <c>Rag.Pgvector.Domain.Shared</c> 以便 Slice D 的 cutover SQL 脚本与 EF 配置共用同一组常量。
+/// </summary>
+public static class PgvectorRagDbProperties
+{
+    /// <summary>
+    /// 与主 <c>PaperbaseDbProperties.DbTablePrefix</c> 保持一致，确保 chunk 表名跨 DbContext 切换时不变。
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "Paperbase";
+
+    public static string? DbSchema { get; set; } = null;
+
+    /// <summary>
+    /// 显式独立的 connection string 名称（不与主 <c>"Paperbase"</c> 共用）。
+    /// <para>
+    /// 注意 ABP connection string 的 fallback 行为：找不到指定 name 时回退到 <c>"Default"</c>，
+    /// <b>不会</b> 回退到 <c>"Paperbase"</c>。开发环境 appsettings 必须显式配置这两个 key
+    /// （单库部署时两者值相同；生产可指向不同实例从而启用跨数据库部署）。
+    /// </para>
+    /// </summary>
+    public const string ConnectionStringName = "PaperbaseRag";
+
+    /// <summary>
+    /// 独立的 EF Core 迁移历史表名。
+    /// <para>
+    /// EF Core 默认所有 DbContext 共用 <c>__EFMigrationsHistory</c>——两个 context 不显式配置
+    /// 会共用同一张 history 表，导致 Slice D 的 cutover 路径与实际 EF 行为对不上。
+    /// 必须在 <c>UseNpgsql(...)</c> 内显式 <c>b.MigrationsHistoryTable(PgvectorRagDbProperties.MigrationsHistoryTableName)</c>。
+    /// </para>
+    /// <para>
+    /// 主 <c>PaperbaseDbContext</c> 沿用默认 <c>__EFMigrationsHistory</c>（不需修改）。
+    /// </para>
+    /// </summary>
+    public const string MigrationsHistoryTableName = "__EFMigrationsHistory_PgvectorRag";
+}

--- a/core/src/Dignite.Paperbase.Rag.Pgvector/Dignite.Paperbase.Rag.Pgvector.csproj
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector/Dignite.Paperbase.Rag.Pgvector.csproj
@@ -11,7 +11,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Dignite.Paperbase.Rag\Dignite.Paperbase.Rag.csproj" />
     <ProjectReference Include="..\Dignite.Paperbase.Rag.Pgvector.Domain\Dignite.Paperbase.Rag.Pgvector.Domain.csproj" />
-    <ProjectReference Include="..\Dignite.Paperbase.EntityFrameworkCore\Dignite.Paperbase.EntityFrameworkCore.csproj" />
+    <!-- Slice C：原本通过 PaperbaseDbContext 注入的 PgvectorDocumentVectorStore 已迁移到
+         Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore，本项目不再依赖主 EF Core。 -->
   </ItemGroup>
 
 </Project>

--- a/core/src/Dignite.Paperbase.Rag.Pgvector/PgvectorRagModule.cs
+++ b/core/src/Dignite.Paperbase.Rag.Pgvector/PgvectorRagModule.cs
@@ -1,15 +1,22 @@
-using Dignite.Paperbase.EntityFrameworkCore;
 using Volo.Abp.Modularity;
 
 namespace Dignite.Paperbase.Rag.Pgvector;
 
 /// <summary>
-/// Registers the pgvector-backed <see cref="IDocumentVectorStore"/> implementation.
-/// Depends on the Rag abstraction layer and the EF Core + pgvector data layer.
+/// pgvector RAG provider 的薄壳模块。
+///
+/// <para>
+/// Slice C 起，<c>PgvectorDocumentVectorStore</c> 与 chunk repository 都已迁移到
+/// <c>Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore</c>，本模块仅保留 <see cref="PgvectorRagOptions"/>
+/// 的命名空间承载和未来 provider 级 tuning options 的扩展点。
+/// </para>
+///
+/// <para>
+/// 真正注册 <c>IDocumentVectorStore</c> 实现的入口在
+/// <c>Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.PgvectorRagEntityFrameworkCoreModule</c>。
+/// </para>
 /// </summary>
-[DependsOn(
-    typeof(PaperbaseRagModule),
-    typeof(PaperbaseEntityFrameworkCoreModule))]
+[DependsOn(typeof(PaperbaseRagModule))]
 public class PgvectorRagModule : AbpModule
 {
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Benchmarks/ProductionHybridSearchBenchmark.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Benchmarks/ProductionHybridSearchBenchmark.cs
@@ -9,6 +9,7 @@ using Dignite.Paperbase.EntityFrameworkCore;
 using Dignite.Paperbase.Rag;
 using Dignite.Paperbase.Rag.Pgvector;
 using Dignite.Paperbase.Rag.Pgvector.Documents;
+using Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Npgsql.EntityFrameworkCore.PostgreSQL;
@@ -59,12 +60,16 @@ public class ProductionHybridSearchBenchmark
         _output.WriteLine($"Dataset: {dataset.Chunks.Count} chunks, {dataset.Queries.Count} queries.");
 
         var benchmarkTenantId = Guid.NewGuid();
-        await using var dbContext = CreateDbContext(connStr);
-        var vectorStore = CreateVectorStore(dbContext);
+        // Slice C 起 chunks 与 documents 物理上属于不同 DbContext，但 benchmark 只验向量检索行为，
+        // 仍可让两者共用同一物理库（同 connection string）。两个 context 各自持有连接，
+        // SaveChanges 互不影响——不依赖 ABP UoW。
+        await using var paperbaseDbContext = CreatePaperbaseDbContext(connStr);
+        await using var pgvectorRagDbContext = CreatePgvectorRagDbContext(connStr);
+        var vectorStore = CreateVectorStore(pgvectorRagDbContext);
 
         try
         {
-            await SeedAsync(dbContext, dataset, benchmarkTenantId);
+            await SeedAsync(paperbaseDbContext, pgvectorRagDbContext, dataset, benchmarkTenantId);
 
             var vectorResults = await RunQueriesAsync(vectorStore, dataset, benchmarkTenantId, VectorSearchMode.Vector);
             var hybridResults = await RunQueriesAsync(vectorStore, dataset, benchmarkTenantId, VectorSearchMode.Hybrid);
@@ -80,11 +85,11 @@ public class ProductionHybridSearchBenchmark
         }
         finally
         {
-            await CleanupAsync(dbContext, benchmarkTenantId);
+            await CleanupAsync(paperbaseDbContext, pgvectorRagDbContext, benchmarkTenantId);
         }
     }
 
-    private static PaperbaseDbContext CreateDbContext(string connStr)
+    private static PaperbaseDbContext CreatePaperbaseDbContext(string connStr)
     {
         var options = new DbContextOptionsBuilder<PaperbaseDbContext>()
             .UseNpgsql(connStr, o => o.UseVector())
@@ -93,7 +98,20 @@ public class ProductionHybridSearchBenchmark
         return new PaperbaseDbContext(options);
     }
 
-    private static IDocumentVectorStore CreateVectorStore(PaperbaseDbContext dbContext)
+    private static PgvectorRagDbContext CreatePgvectorRagDbContext(string connStr)
+    {
+        var options = new DbContextOptionsBuilder<PgvectorRagDbContext>()
+            .UseNpgsql(connStr, o =>
+            {
+                o.UseVector();
+                o.MigrationsHistoryTable(PgvectorRagDbProperties.MigrationsHistoryTableName);
+            })
+            .Options;
+
+        return new PgvectorRagDbContext(options);
+    }
+
+    private static IDocumentVectorStore CreateVectorStore(PgvectorRagDbContext dbContext)
     {
         return new PgvectorDocumentVectorStore(
             new StaticDbContextProvider(dbContext),
@@ -104,13 +122,16 @@ public class ProductionHybridSearchBenchmark
     // Seeding
 
     private static async Task SeedAsync(
-        PaperbaseDbContext dbContext,
+        PaperbaseDbContext paperbaseDbContext,
+        PgvectorRagDbContext pgvectorRagDbContext,
         ProductionBenchmarkDataset dataset,
         Guid tenantId)
     {
-        var documentIds = SeedDocuments(dbContext, dataset, tenantId);
-        SeedChunks(dbContext, dataset, documentIds, tenantId);
-        await dbContext.SaveChangesAsync();
+        var documentIds = SeedDocuments(paperbaseDbContext, dataset, tenantId);
+        await paperbaseDbContext.SaveChangesAsync();
+
+        SeedChunks(pgvectorRagDbContext, dataset, documentIds, tenantId);
+        await pgvectorRagDbContext.SaveChangesAsync();
     }
 
     private static Dictionary<string, Guid> SeedDocuments(
@@ -153,7 +174,7 @@ public class ProductionHybridSearchBenchmark
     }
 
     private static void SeedChunks(
-        PaperbaseDbContext dbContext,
+        PgvectorRagDbContext dbContext,
         ProductionBenchmarkDataset dataset,
         IReadOnlyDictionary<string, Guid> documentIds,
         Guid tenantId)
@@ -383,32 +404,35 @@ public class ProductionHybridSearchBenchmark
 
     // Cleanup
 
-    private static async Task CleanupAsync(PaperbaseDbContext dbContext, Guid tenantId)
+    private static async Task CleanupAsync(
+        PaperbaseDbContext paperbaseDbContext,
+        PgvectorRagDbContext pgvectorRagDbContext,
+        Guid tenantId)
     {
-        await dbContext.Set<DocumentChunk>()
+        await pgvectorRagDbContext.Set<DocumentChunk>()
             .Where(c => c.TenantId == tenantId)
             .ExecuteDeleteAsync();
 
-        await dbContext.Set<Document>()
+        await paperbaseDbContext.Set<Document>()
             .Where(d => d.TenantId == tenantId)
             .ExecuteDeleteAsync();
     }
 
-    private sealed class StaticDbContextProvider : IDbContextProvider<PaperbaseDbContext>
+    private sealed class StaticDbContextProvider : IDbContextProvider<PgvectorRagDbContext>
     {
-        private readonly PaperbaseDbContext _dbContext;
+        private readonly PgvectorRagDbContext _dbContext;
 
-        public StaticDbContextProvider(PaperbaseDbContext dbContext)
+        public StaticDbContextProvider(PgvectorRagDbContext dbContext)
         {
             _dbContext = dbContext;
         }
 
-        public PaperbaseDbContext GetDbContext()
+        public PgvectorRagDbContext GetDbContext()
         {
             return _dbContext;
         }
 
-        public Task<PaperbaseDbContext> GetDbContextAsync()
+        public Task<PgvectorRagDbContext> GetDbContextAsync()
         {
             return Task.FromResult(_dbContext);
         }

--- a/core/test/Dignite.Paperbase.Application.Tests/Dignite.Paperbase.Application.Tests.csproj
+++ b/core/test/Dignite.Paperbase.Application.Tests/Dignite.Paperbase.Application.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Dignite.Paperbase.Application\Dignite.Paperbase.Application.csproj" />
     <ProjectReference Include="..\..\src\Dignite.Paperbase.EntityFrameworkCore\Dignite.Paperbase.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Dignite.Paperbase.Rag.Pgvector\Dignite.Paperbase.Rag.Pgvector.csproj" />
+    <ProjectReference Include="..\..\src\Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore\Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Dignite.Paperbase.TextExtraction\Dignite.Paperbase.TextExtraction.csproj" />
     <ProjectReference Include="..\Dignite.Paperbase.Domain.Tests\Dignite.Paperbase.Domain.Tests.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/PaperbaseEntityFrameworkCoreTestModule.cs
+++ b/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/PaperbaseEntityFrameworkCoreTestModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Data.Sqlite;
+using Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -12,6 +13,7 @@ namespace Dignite.Paperbase.EntityFrameworkCore;
 [DependsOn(
     typeof(PaperbaseApplicationTestModule),
     typeof(PaperbaseEntityFrameworkCoreModule),
+    typeof(PgvectorRagEntityFrameworkCoreModule),
     typeof(AbpEntityFrameworkCoreSqliteModule)
 )]
 public class PaperbaseEntityFrameworkCoreTestModule : AbpModule
@@ -20,7 +22,7 @@ public class PaperbaseEntityFrameworkCoreTestModule : AbpModule
     {
         PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
     }
-    
+
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddAlwaysDisableUnitOfWorkTransaction();
@@ -33,6 +35,14 @@ public class PaperbaseEntityFrameworkCoreTestModule : AbpModule
             {
                 configurationContext.UseSqlite(sqliteConnection);
             });
+
+            // PgvectorRagEntityFrameworkCoreModule 默认把 PgvectorRagDbContext 配成 Npgsql + UseVector，
+            // 在 SQLite in-memory 测试里必须显式覆写为 SQLite。两个 context 共用同一个连接
+            // 即可在 ABP UoW 内共用事务，不需要再为 PaperbaseRag 单独配 connection string。
+            options.Configure<PgvectorRagDbContext>(configurationContext =>
+            {
+                configurationContext.UseSqlite(sqliteConnection);
+            });
         });
     }
 
@@ -41,8 +51,14 @@ public class PaperbaseEntityFrameworkCoreTestModule : AbpModule
         var connection = new SqliteConnection("Data Source=:memory:");
         connection.Open();
 
+        // 主 PaperbaseDbContext 创建除 chunks 之外的全部表（chunk 已 ExcludeFromMigrations）。
         new PaperbaseDbContext(
             new DbContextOptionsBuilder<PaperbaseDbContext>().UseSqlite(connection).Options
+        ).GetService<IRelationalDatabaseCreator>().CreateTables();
+
+        // 独立 PgvectorRagDbContext 仅创建 chunks 表 + 索引，与上一行互不重叠。
+        new PgvectorRagDbContext(
+            new DbContextOptionsBuilder<PgvectorRagDbContext>().UseSqlite(connection).Options
         ).GetService<IRelationalDatabaseCreator>().CreateTables();
 
         return connection;

--- a/host/src/Dignite.Paperbase.Host.csproj
+++ b/host/src/Dignite.Paperbase.Host.csproj
@@ -82,7 +82,8 @@
     <ProjectReference Include="..\..\core\src\Dignite.Paperbase.Application\Dignite.Paperbase.Application.csproj" />
     <ProjectReference Include="..\..\core\src\Dignite.Paperbase.EntityFrameworkCore\Dignite.Paperbase.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\core\src\Dignite.Paperbase.Rag.Pgvector\Dignite.Paperbase.Rag.Pgvector.csproj" />
-<ProjectReference Include="..\..\core\src\Dignite.Paperbase.TextExtraction\Dignite.Paperbase.TextExtraction.csproj" />
+    <ProjectReference Include="..\..\core\src\Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore\Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\core\src\Dignite.Paperbase.TextExtraction\Dignite.Paperbase.TextExtraction.csproj" />
     <ProjectReference Include="..\..\core\src\Dignite.Paperbase.Ocr.AzureDocumentIntelligence\Dignite.Paperbase.Ocr.AzureDocumentIntelligence.csproj" />
     <ProjectReference Include="..\..\modules\contracts\src\Dignite.Paperbase.Contracts.HttpApi\Dignite.Paperbase.Contracts.HttpApi.csproj" />
     <ProjectReference Include="..\..\modules\contracts\src\Dignite.Paperbase.Contracts.Application\Dignite.Paperbase.Contracts.Application.csproj" />

--- a/host/src/PaperbaseHostModule.cs
+++ b/host/src/PaperbaseHostModule.cs
@@ -7,6 +7,7 @@ using Dignite.Paperbase.Host.Localization;
 using Dignite.Paperbase.Localization;
 using Dignite.Paperbase.Ocr.AzureDocumentIntelligence;
 using Dignite.Paperbase.Rag.Pgvector;
+using Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore;
 using Dignite.Paperbase.TextExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.EntityFrameworkCore;
@@ -121,6 +122,7 @@ namespace Dignite.Paperbase.Host;
     typeof(PaperbaseTextExtractionModule),
     typeof(PaperbaseAzureDocumentIntelligenceModule),
     typeof(PgvectorRagModule),
+    typeof(PgvectorRagEntityFrameworkCoreModule),
 
     // Paperbase business modules
     typeof(ContractsHttpApiModule),

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -42,7 +42,9 @@
     ]
   },
   "ConnectionStrings": {
-    "Default": "Host=127.0.0.1;Port=5432;Database=paperbase;Username=postgres;Password=postgres"
+    "Default": "Host=127.0.0.1;Port=5432;Database=paperbase;Username=postgres;Password=postgres",
+    "Paperbase": "Host=127.0.0.1;Port=5432;Database=paperbase;Username=postgres;Password=postgres",
+    "PaperbaseRag": "Host=127.0.0.1;Port=5432;Database=paperbase;Username=postgres;Password=postgres"
   },
   "PaperbaseAI": {
     "Endpoint": "https://api.openai.com/v1",


### PR DESCRIPTION
## Summary

- Add `core/src/Dignite.Paperbase.Rag.Pgvector.EntityFrameworkCore/`: isolated `PgvectorRagDbContext` (`ConnectionStringName = "PaperbaseRag"`) + isolated EF migration history table `__EFMigrationsHistory_PgvectorRag`, and physically move `EfCoreDocumentChunkRepository` / `PgvectorDocumentVectorStore` here.
- The main `PaperbaseDbContext` temporarily retains the chunk mapping but uses `ToTable(...).ExcludeFromMigrations()` to prevent the host migration diff from creating it again; all writes go through the new context only. The physical cutover happens in Slice D.
- The design-time factory, runtime module configuration, and benchmark consistently reference the `PgvectorRagDbProperties.MigrationsHistoryTableName` constant; the design-time factory does not fall back to `Default`, avoiding silently generating migrations to the main database.
- `host/src/appsettings.json` now explicitly configures both `Paperbase` and `PaperbaseRag` connection strings (for single-database deployments both values are the same); does not rely on ABP's `Default` fallback.

## Key decisions and gotchas

- **MigrationsHistoryTable explicitly configured (runtime + design-time consistent)**: EF Core defaults to sharing `__EFMigrationsHistory` across two DbContexts. Both `PgvectorRagEntityFrameworkCoreModule.UseNpgsql` and `PgvectorRagDbContextFactory.UseNpgsql` explicitly call `b.MigrationsHistoryTable(PgvectorRagDbProperties.MigrationsHistoryTableName)` — the Slice D cutover SQL will also reference the same constant.
- **ABP connection string falls back to `"Default"` not `"Paperbase"`**: appsettings must explicitly configure both `Paperbase` and `PaperbaseRag`.
- **`AddDefaultRepositories(includeAllEntities: true)` on the host double-registers `IRepository<DocumentChunk, Guid>` to `PaperbaseHostDbContext`**: grep confirms zero code across the entire repo consumes the generic `IRepository<DocumentChunk, Guid>`; all chunk writes go through `IDocumentChunkRepository` or `IDbContextProvider<PgvectorRagDbContext>`. A comment has been added in the module code warning future contributors not to inject the generic interface. When Slice D fully removes the chunk mapping from the main context, this implicit window closes automatically.
- **Test SQLite bootstrap calls `CreateTables()` twice**: the main context's chunks are skipped due to `ExcludeFromMigrations`; the new context creates them exactly once — avoiding duplicate table creation.

## Test plan

- [x] `dotnet build core/Dignite.Paperbase.slnx` 0 warnings 0 errors
- [x] `dotnet build host/Dignite.Paperbase.Host.slnx` 0 errors (5 pre-existing nullable warnings, unrelated to this slice)
- [x] `dotnet test core/Dignite.Paperbase.slnx --filter "Category!=Production"`: Domain 25/25, Application 146/146, EntityFrameworkCore 3/3 all pass
- [x] Design-time factory dry-run: `dotnet ef migrations add` in the new EF project directory successfully generates `CreateTable PaperbaseDocumentChunks` + denormalized columns + indexes + `HasPostgresExtension("vector")`; immediately `rm`'d to verify only
- [x] Main host migration dry-run (`PaperbaseHostDbContext`): generates empty `Up/Down` — confirms `ExcludeFromMigrations` is effective
- [x] `grep dbContext.Set<Document>()` in `PgvectorDocumentVectorStore`: zero hits (confirms Slice B denormalization prerequisite is complete)
- [x] `grep IRepository<DocumentChunk` across entire repo: zero hits (confirms no generic repo path consumers)
- [ ] **Manual**: spin up a dev database and verify `dotnet ef database update` puts history in `__EFMigrationsHistory_PgvectorRag` (run once when Slice D adds a real migration)
- [ ] **Manual**: run a production hybrid-search benchmark (`PAPERBASE_BENCH_PGCONN=… dotnet test --filter "Category=Production"`) to confirm recall / MRR does not regress

## Acceptance criteria (issue #40)

| Item | Status |
|---|---|
| New project compiles | ✅ |
| Full build + tests pass | ✅ |
| `PgvectorDocumentVectorStore` works through `PgvectorRagDbContext` | ✅ |
| `grep dbContext.Set<Document>()` in `PgvectorDocumentVectorStore`: zero hits | ✅ |
| `PgvectorRagDbProperties.ConnectionStringName = "PaperbaseRag"` | ✅ |
| `PgvectorRagDbProperties.MigrationsHistoryTableName = "__EFMigrationsHistory_PgvectorRag"` | ✅ |
| `PgvectorRagEntityFrameworkCoreModule` explicitly calls `b.MigrationsHistoryTable(...)` | ✅ |
| Dev appsettings configures both `Paperbase` and `PaperbaseRag` | ✅ |
| Existing `Documents` / `DocumentChunks` table schema unchanged | ✅ (main context mapping untouched, only `ExcludeFromMigrations` added) |
| Existing QA / Hybrid search benchmark does not regress | ⏸ Pending one production run |
| Design-time factory can add migration (dry-run) | ✅ |

Closes #40 (after Slice D cutover and Slice E event-handler land — this slice ships the foundation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)