### PR TITLE
refactor(chat): expand telemetry with ToolCallSummary / GroundingSource (#98)

### DIFF
--- a/core/src/Dignite.Paperbase.Application.Contracts/Chat/GroundingSource.cs
+++ b/core/src/Dignite.Paperbase.Application.Contracts/Chat/GroundingSource.cs
@@ -1,0 +1,29 @@
+namespace Dignite.Paperbase.Chat;
+
+/// <summary>
+/// Categorizes which kinds of tools the model invoked in a single chat turn.
+/// Lets the project distinguish "no grounding at all" from "grounded via vector search"
+/// from "grounded via structured business tools" — not just a binary "did search run?".
+/// </summary>
+/// <remarks>
+/// Classification rule (Issue #98):
+/// <list type="bullet">
+///   <item><c>search_paperbase_documents</c> → <see cref="Vector"/></item>
+///   <item>everything else (business contributor tools: search_contracts, get_contract_detail, ...) → <see cref="Structured"/></item>
+/// </list>
+/// Both classes invoked in the same turn → <see cref="Mixed"/>.
+/// </remarks>
+public enum GroundingSource
+{
+    /// <summary>No tool was invoked. The model answered from prior context only (degraded).</summary>
+    None = 0,
+
+    /// <summary>Only vector search was invoked.</summary>
+    Vector = 1,
+
+    /// <summary>Only structured business tools were invoked (no vector search).</summary>
+    Structured = 2,
+
+    /// <summary>Both vector search and structured business tools were invoked.</summary>
+    Mixed = 3
+}

--- a/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
@@ -382,7 +382,7 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             capture,
             toolContext,
             _toolFactory,
-            functionName: "search_paperbase_documents",
+            functionName: ChatConsts.SearchPaperbaseDocumentsToolName,
             functionDescription:
                 "Search Paperbase documents within the conversation's scope. " +
                 "Returns relevant text chunks with source citations. " +

--- a/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatTelemetryRecorder.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatTelemetryRecorder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using System.Linq;
 using Dignite.Paperbase.Abstractions.Chat;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.Auditing;
@@ -103,41 +104,157 @@ public class DocumentChatTelemetryRecorder : ISingletonDependency
 
     public virtual void RecordTurn(DocumentChatTurnAuditEntry entry)
     {
-        AddTurnToAuditLog(entry);
+        // Derive ToolCallSummary / ToolCallDepth / GroundingSource from the per-tool
+        // entries already accumulated on the audit scope. Keeping the derivation here
+        // (rather than asking the AppService to re-aggregate) guarantees the per-turn
+        // counts always match the per-tool entries — they share one source of truth.
+        var enriched = EnrichTurnEntryFromAuditScope(entry);
+
+        AddTurnToAuditLog(enriched);
 
         // Turn count + duration + token usage are emitted by
         // Microsoft.Extensions.AI's OpenTelemetryChatClient as standard
         // gen_ai.* signals — don't duplicate here.
         // IsDegraded is the project's "honest signal" (CLAUDE.md) and has no
         // OTel-standard equivalent, so we count it explicitly.
-        if (entry.IsDegraded)
+        if (enriched.IsDegraded)
         {
-            DegradedTurns.Add(1, CreateTurnTags(entry));
+            DegradedTurns.Add(1, CreateTurnTags(enriched));
         }
 
-        if (entry.Outcome == DocumentChatTelemetryOutcome.Success)
+        if (enriched.Outcome == DocumentChatTelemetryOutcome.Success)
         {
             _logger.LogInformation(
-                "Document chat turn completed. ConversationId={ConversationId} TenantId={TenantId} DocumentTypeCode={DocumentTypeCode} Streaming={Streaming} IsDegraded={IsDegraded} CitationCount={CitationCount} ElapsedMs={ElapsedMs}",
-                entry.ConversationId,
-                entry.TenantId,
-                entry.DocumentTypeCode,
-                entry.Streaming,
-                entry.IsDegraded,
-                entry.CitationCount,
-                entry.ElapsedMs);
+                "Document chat turn completed. ConversationId={ConversationId} TenantId={TenantId} DocumentTypeCode={DocumentTypeCode} Streaming={Streaming} IsDegraded={IsDegraded} GroundingSource={GroundingSource} ToolCallDepth={ToolCallDepth} CitationCount={CitationCount} ElapsedMs={ElapsedMs}",
+                enriched.ConversationId,
+                enriched.TenantId,
+                enriched.DocumentTypeCode,
+                enriched.Streaming,
+                enriched.IsDegraded,
+                enriched.GroundingSource,
+                enriched.ToolCallDepth,
+                enriched.CitationCount,
+                enriched.ElapsedMs);
         }
         else
         {
             _logger.LogWarning(
-                "Document chat turn failed. ConversationId={ConversationId} TenantId={TenantId} DocumentTypeCode={DocumentTypeCode} Streaming={Streaming} ElapsedMs={ElapsedMs} ExceptionType={ExceptionType}",
-                entry.ConversationId,
-                entry.TenantId,
-                entry.DocumentTypeCode,
-                entry.Streaming,
-                entry.ElapsedMs,
-                entry.ExceptionType);
+                "Document chat turn failed. ConversationId={ConversationId} TenantId={TenantId} DocumentTypeCode={DocumentTypeCode} Streaming={Streaming} GroundingSource={GroundingSource} ToolCallDepth={ToolCallDepth} ElapsedMs={ElapsedMs} ExceptionType={ExceptionType}",
+                enriched.ConversationId,
+                enriched.TenantId,
+                enriched.DocumentTypeCode,
+                enriched.Streaming,
+                enriched.GroundingSource,
+                enriched.ToolCallDepth,
+                enriched.ElapsedMs,
+                enriched.ExceptionType);
         }
+    }
+
+    /// <summary>
+    /// Reads the per-tool entries already recorded on the current audit scope and
+    /// returns a copy of <paramref name="entry"/> enriched with the derived per-turn
+    /// dimensions (<see cref="DocumentChatTurnAuditEntry.ToolCallSummary"/>,
+    /// <see cref="DocumentChatTurnAuditEntry.ToolCallDepth"/>,
+    /// <see cref="DocumentChatTurnAuditEntry.GroundingSource"/>).
+    /// </summary>
+    /// <remarks>
+    /// Counts include both successful and failed tool invocations — failures still
+    /// reflect what the model attempted, which is what callers actually want to see in
+    /// telemetry (e.g. "model retried 3 times before giving up").
+    /// </remarks>
+    protected virtual DocumentChatTurnAuditEntry EnrichTurnEntryFromAuditScope(DocumentChatTurnAuditEntry entry)
+    {
+        var toolCalls = ReadToolCallsFromAuditScope();
+
+        var summary = toolCalls.Count == 0
+            ? null
+            : (IReadOnlyDictionary<string, int>)toolCalls
+                .GroupBy(t => t.ToolName, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+        return new DocumentChatTurnAuditEntry
+        {
+            ConversationId = entry.ConversationId,
+            UserId = entry.UserId,
+            TenantId = entry.TenantId,
+            DocumentId = entry.DocumentId,
+            DocumentTypeCode = entry.DocumentTypeCode,
+            TraceId = entry.TraceId,
+            Streaming = entry.Streaming,
+            CitationCount = entry.CitationCount,
+            IsDegraded = entry.IsDegraded,
+            ElapsedMs = entry.ElapsedMs,
+            Outcome = entry.Outcome,
+            ExceptionType = entry.ExceptionType,
+            ToolCallSummary = summary,
+            ToolCallDepth = toolCalls.Count,
+            GroundingSource = ClassifyGrounding(toolCalls)
+        };
+    }
+
+    /// <summary>
+    /// Classifies a turn's grounding source from the tool names invoked.
+    /// Override to extend classification (e.g. when a future business module
+    /// contributes another vector-style search tool).
+    /// </summary>
+    protected virtual GroundingSource ClassifyGrounding(IReadOnlyList<DocumentChatToolAuditEntry> toolCalls)
+    {
+        if (toolCalls.Count == 0)
+        {
+            return GroundingSource.None;
+        }
+
+        var hasVector = false;
+        var hasStructured = false;
+        foreach (var t in toolCalls)
+        {
+            if (IsVectorSearchTool(t.ToolName))
+            {
+                hasVector = true;
+            }
+            else
+            {
+                hasStructured = true;
+            }
+
+            if (hasVector && hasStructured)
+            {
+                break;
+            }
+        }
+
+        return (hasVector, hasStructured) switch
+        {
+            (true, true) => GroundingSource.Mixed,
+            (true, false) => GroundingSource.Vector,
+            (false, true) => GroundingSource.Structured,
+            _ => GroundingSource.None
+        };
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="toolName"/> identifies a vector-search tool
+    /// (currently just the built-in <see cref="ChatConsts.SearchPaperbaseDocumentsToolName"/>).
+    /// </summary>
+    protected virtual bool IsVectorSearchTool(string toolName)
+        => string.Equals(toolName, ChatConsts.SearchPaperbaseDocumentsToolName, StringComparison.Ordinal);
+
+    private IReadOnlyList<DocumentChatToolAuditEntry> ReadToolCallsFromAuditScope()
+    {
+        var scope = _auditingManager.Current;
+        if (scope?.Log == null)
+        {
+            return Array.Empty<DocumentChatToolAuditEntry>();
+        }
+
+        if (scope.Log.ExtraProperties.TryGetValue(AuditToolCallsPropertyName, out var existing)
+            && existing is List<DocumentChatToolAuditEntry> entries)
+        {
+            return entries;
+        }
+
+        return Array.Empty<DocumentChatToolAuditEntry>();
     }
 
     private void AddToolCallToAuditLog(DocumentChatToolAuditEntry entry)
@@ -182,7 +299,8 @@ public class DocumentChatTelemetryRecorder : ISingletonDependency
         {
             new KeyValuePair<string, object?>("outcome", entry.Outcome.ToString()),
             new KeyValuePair<string, object?>("document.type", entry.DocumentTypeCode ?? "(none)"),
-            new KeyValuePair<string, object?>("streaming", entry.Streaming)
+            new KeyValuePair<string, object?>("streaming", entry.Streaming),
+            new KeyValuePair<string, object?>("grounding_source", entry.GroundingSource.ToString())
         };
 }
 
@@ -228,4 +346,25 @@ public sealed class DocumentChatTurnAuditEntry
     public required double ElapsedMs { get; init; }
     public required DocumentChatTelemetryOutcome Outcome { get; init; }
     public string? ExceptionType { get; init; }
+
+    /// <summary>
+    /// Per-tool invocation count for this turn (tool name → count). <c>null</c> when no
+    /// tool was invoked. Derived from the audit scope's per-tool entries by
+    /// <see cref="DocumentChatTelemetryRecorder.RecordTurn"/> — callers do not need to
+    /// supply this; it is overwritten if they do.
+    /// </summary>
+    public IReadOnlyDictionary<string, int>? ToolCallSummary { get; init; }
+
+    /// <summary>
+    /// Total number of tool invocations in this turn (sum of <see cref="ToolCallSummary"/>
+    /// values). Includes failed invocations because they reflect the model's actual
+    /// behavior. Derived by the recorder.
+    /// </summary>
+    public int ToolCallDepth { get; init; }
+
+    /// <summary>
+    /// Categorizes which kinds of tools the model invoked in this turn. Derived by the
+    /// recorder. See <see cref="GroundingSource"/> for the classification rule.
+    /// </summary>
+    public GroundingSource GroundingSource { get; init; }
 }

--- a/core/src/Dignite.Paperbase.Domain.Shared/Chat/ChatConsts.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Chat/ChatConsts.cs
@@ -5,4 +5,12 @@ public static class ChatConsts
     public static int MaxMessageLength { get; set; } = 4000;
     public static int MaxTitleLength { get; set; } = 200;
     public static int MaxCitationsJsonLength { get; set; } = 8192;
+
+    /// <summary>
+    /// Canonical name of the built-in vector search tool exposed to the model.
+    /// Used both at registration (see <c>DocumentChatAppService.PrepareAgentSetupAsync</c>)
+    /// and at telemetry classification (see <c>DocumentChatTelemetryRecorder.ClassifyGrounding</c>)
+    /// so the two stay in sync.
+    /// </summary>
+    public const string SearchPaperbaseDocumentsToolName = "search_paperbase_documents";
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/DocumentChatToolInvocation_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/DocumentChatToolInvocation_Tests.cs
@@ -265,6 +265,14 @@ public class DocumentChatToolInvocation_Tests
         turn.CitationCount.ShouldBe(1);
         turn.IsDegraded.ShouldBeFalse();
         turn.Outcome.ShouldBe(DocumentChatTelemetryOutcome.Success);
+
+        // Issue #98: per-turn telemetry derives ToolCallSummary / ToolCallDepth /
+        // GroundingSource from the per-tool entries on the same audit scope. Here
+        // only search_paperbase_documents was invoked once → Vector grounding.
+        turn.ToolCallDepth.ShouldBe(1);
+        turn.ToolCallSummary.ShouldNotBeNull();
+        turn.ToolCallSummary!.ShouldContainKeyAndValue(ChatConsts.SearchPaperbaseDocumentsToolName, 1);
+        turn.GroundingSource.ShouldBe(GroundingSource.Vector);
     }
 
     [Fact]

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/Telemetry/DocumentChatTelemetryRecorder_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/Telemetry/DocumentChatTelemetryRecorder_Tests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using Dignite.Paperbase.Chat.Telemetry;
+using Shouldly;
+using Volo.Abp.Auditing;
+using Xunit;
+
+namespace Dignite.Paperbase.Chat;
+
+/// <summary>
+/// Focused tests for <see cref="DocumentChatTelemetryRecorder"/>'s per-turn enrichment
+/// (Issue #98): <c>ToolCallSummary</c>, <c>ToolCallDepth</c>, <c>GroundingSource</c>
+/// must be derived from the per-tool entries already on the audit scope.
+/// <para>
+/// These tests exercise the recorder directly inside an <see cref="IAuditingManager"/>
+/// scope rather than going through <c>SendMessageAsync</c> — that lets us cover the
+/// Structured / Mixed cases without standing up a fake business-module contributor.
+/// </para>
+/// </summary>
+public class DocumentChatTelemetryRecorder_Tests
+    : PaperbaseApplicationTestBase<DocumentChatAppServiceTestModule>
+{
+    private readonly DocumentChatTelemetryRecorder _recorder;
+    private readonly IAuditingManager _auditingManager;
+
+    private static readonly Guid ConversationId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    public DocumentChatTelemetryRecorder_Tests()
+    {
+        _recorder = GetRequiredService<DocumentChatTelemetryRecorder>();
+        _auditingManager = GetRequiredService<IAuditingManager>();
+    }
+
+    [Fact]
+    public void RecordTurn_GroundingNone_WhenNoToolsCalled()
+    {
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordTurn(BuildTurnEntry());
+
+        var turn = ReadTurnFromAuditScope();
+        turn.GroundingSource.ShouldBe(GroundingSource.None);
+        turn.ToolCallDepth.ShouldBe(0);
+        turn.ToolCallSummary.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RecordTurn_GroundingVector_WhenOnlySearchToolCalled()
+    {
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry(ChatConsts.SearchPaperbaseDocumentsToolName));
+
+        _recorder.RecordTurn(BuildTurnEntry());
+
+        var turn = ReadTurnFromAuditScope();
+        turn.GroundingSource.ShouldBe(GroundingSource.Vector);
+        turn.ToolCallDepth.ShouldBe(1);
+        turn.ToolCallSummary.ShouldNotBeNull();
+        turn.ToolCallSummary!.ShouldContainKeyAndValue(ChatConsts.SearchPaperbaseDocumentsToolName, 1);
+    }
+
+    [Fact]
+    public void RecordTurn_GroundingStructured_WhenOnlyBusinessToolsCalled()
+    {
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry("search_contracts"));
+        _recorder.RecordToolCall(BuildToolEntry("get_contract_detail"));
+
+        _recorder.RecordTurn(BuildTurnEntry());
+
+        var turn = ReadTurnFromAuditScope();
+        turn.GroundingSource.ShouldBe(GroundingSource.Structured);
+        turn.ToolCallDepth.ShouldBe(2);
+        turn.ToolCallSummary!.ShouldContainKeyAndValue("search_contracts", 1);
+        turn.ToolCallSummary!.ShouldContainKeyAndValue("get_contract_detail", 1);
+        turn.ToolCallSummary!.ShouldNotContainKey(ChatConsts.SearchPaperbaseDocumentsToolName);
+    }
+
+    [Fact]
+    public void RecordTurn_GroundingMixed_WhenBothCalled()
+    {
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry(ChatConsts.SearchPaperbaseDocumentsToolName));
+        _recorder.RecordToolCall(BuildToolEntry("get_contract_aggregate"));
+
+        _recorder.RecordTurn(BuildTurnEntry());
+
+        var turn = ReadTurnFromAuditScope();
+        turn.GroundingSource.ShouldBe(GroundingSource.Mixed);
+        turn.ToolCallDepth.ShouldBe(2);
+        turn.ToolCallSummary!.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void RecordTurn_AggregatesCountsAcrossMultipleInvocationsOfSameTool()
+    {
+        // Multi-step retrieval (motivating Issue #99): the model invokes
+        // search_paperbase_documents twice in a single turn (once per
+        // documentTypeCode). The telemetry must count both, not just the last.
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry(ChatConsts.SearchPaperbaseDocumentsToolName));
+        _recorder.RecordToolCall(BuildToolEntry(ChatConsts.SearchPaperbaseDocumentsToolName));
+        _recorder.RecordToolCall(BuildToolEntry("search_contracts"));
+
+        _recorder.RecordTurn(BuildTurnEntry());
+
+        var turn = ReadTurnFromAuditScope();
+        turn.ToolCallDepth.ShouldBe(3);
+        turn.ToolCallSummary!.ShouldContainKeyAndValue(ChatConsts.SearchPaperbaseDocumentsToolName, 2);
+        turn.ToolCallSummary!.ShouldContainKeyAndValue("search_contracts", 1);
+        turn.GroundingSource.ShouldBe(GroundingSource.Mixed);
+    }
+
+    [Fact]
+    public void RecordTurn_CountsFailedInvocations_BecauseTheyReflectModelBehavior()
+    {
+        // A failed tool call still counts toward ToolCallDepth — telemetry is about
+        // what the model attempted, not just what succeeded.
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry(
+            ChatConsts.SearchPaperbaseDocumentsToolName,
+            outcome: DocumentChatTelemetryOutcome.Failure));
+
+        _recorder.RecordTurn(BuildTurnEntry());
+
+        var turn = ReadTurnFromAuditScope();
+        turn.ToolCallDepth.ShouldBe(1);
+        turn.GroundingSource.ShouldBe(GroundingSource.Vector);
+    }
+
+    private DocumentChatTurnAuditEntry ReadTurnFromAuditScope()
+    {
+        var scope = _auditingManager.Current.ShouldNotBeNull();
+        scope.Log.ExtraProperties.ShouldContainKey(DocumentChatTelemetryRecorder.AuditTurnPropertyName);
+        return scope.Log.ExtraProperties[DocumentChatTelemetryRecorder.AuditTurnPropertyName]
+            .ShouldBeOfType<DocumentChatTurnAuditEntry>();
+    }
+
+    private static DocumentChatTurnAuditEntry BuildTurnEntry()
+        => new()
+        {
+            ConversationId = ConversationId,
+            Streaming = false,
+            ElapsedMs = 1.0,
+            Outcome = DocumentChatTelemetryOutcome.Success
+        };
+
+    private static DocumentChatToolAuditEntry BuildToolEntry(
+        string toolName,
+        DocumentChatTelemetryOutcome outcome = DocumentChatTelemetryOutcome.Success)
+        => new()
+        {
+            ConversationId = ConversationId,
+            ToolName = toolName,
+            ArgumentsSummary = new Dictionary<string, object?>(),
+            ElapsedMs = 1.0,
+            Outcome = outcome
+        };
+}


### PR DESCRIPTION
Closes #98.

## Summary

Per-turn audit currently reports only `CitationCount` and `IsDegraded`, which is insufficient to (a) decide later whether to graduate from single-agent multi-tool to MAF Workflow / Magentic, and (b) accurately label structured-only answers as grounded (refinement coming in #99).

This PR adds three derived dimensions to `DocumentChatTurnAuditEntry`, computed by the recorder from the per-tool entries already on the audit scope — single source of truth, no double-bookkeeping in callers.

## Changes

- **`Application.Contracts/Chat/GroundingSource.cs`** (new) — enum `None / Vector / Structured / Mixed`
- **`Domain.Shared/Chat/ChatConsts.cs`** — new const `SearchPaperbaseDocumentsToolName`; replaces the literal in `DocumentChatAppService`
- **`Application/Chat/Telemetry/DocumentChatTelemetryRecorder.cs`**:
  - `RecordTurn` now enriches the entry from the audit scope before writing
  - New `protected virtual` hooks: `EnrichTurnEntryFromAuditScope` / `ClassifyGrounding` / `IsVectorSearchTool` (overridable for future business modules that contribute another vector tool)
  - OTel `degraded` counter gains a `grounding_source` tag
  - Structured logs gain `GroundingSource` + `ToolCallDepth`
- **`DocumentChatTurnAuditEntry`**: new fields `ToolCallSummary` / `ToolCallDepth` / `GroundingSource`
- Failed tool calls **count toward** `ToolCallDepth` — telemetry reflects what the model attempted

## Test plan

- [x] `dotnet build` (whole solution): 0 errors, 5 pre-existing warnings unrelated
- [x] `dotnet test core/test/Dignite.Paperbase.Application.Tests`: 206 / 206 pass
- [x] Existing `SendMessageAsync_Records_Tool_Call_In_Abp_AuditLog_Scope` extended to assert `Vector` grounding + summary + depth
- [x] New focused tests in `Chat/Telemetry/DocumentChatTelemetryRecorder_Tests.cs` covering all four `GroundingSource` cases plus aggregation across repeated calls and counting of failed invocations

## Out of scope (separate Issues)

- `ChatTurnResultDto.IsDegraded` redefinition + `GroundingSource` on DTO → #99
- `DocumentSearchCapture` append/dedup → #99
- ChatConversation field slim-down + anchor prompt → #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)