### PR TITLE
fix(chat): bound capture + redefine IsDegraded via GroundingSource (#99)

### DIFF
--- a/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaDto.cs
+++ b/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaDto.cs
@@ -31,10 +31,20 @@ public class ChatTurnDeltaDto
     public Guid? AssistantMessageId { get; set; }
 
     /// <summary>
-    /// True when the model did not invoke the document-search tool, so the answer is
-    /// ungrounded. The UI should display a "no sources used" notice to the user.
+    /// True when the model declined to invoke ANY tool in this turn, so the answer
+    /// has no traceable grounding. Equivalent to
+    /// <c>GroundingSource == GroundingSource.None</c>. The UI should surface a
+    /// "no sources used" notice when this is true. Set on the
+    /// <see cref="ChatTurnDeltaKind.Done"/> event only.
     /// </summary>
     public bool IsDegraded { get; set; }
+
+    /// <summary>
+    /// Categorizes which kinds of tools the model invoked (vector search vs. structured
+    /// business tools vs. both vs. none). Set on the <see cref="ChatTurnDeltaKind.Done"/>
+    /// event only. See <see cref="ChatTurnResultDto.GroundingSource"/>.
+    /// </summary>
+    public GroundingSource GroundingSource { get; set; }
 
     /// <summary>
     /// Client-safe error message. Present only when <see cref="Kind"/> is

--- a/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnResultDto.cs
+++ b/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnResultDto.cs
@@ -13,5 +13,26 @@ public class ChatTurnResultDto
 
     public IList<ChatCitationDto> Citations { get; set; } = new List<ChatCitationDto>();
 
+    /// <summary>
+    /// True when the model declined to invoke ANY tool in this turn, so the answer
+    /// has no traceable grounding (vector or structured). Equivalent to
+    /// <c>GroundingSource == GroundingSource.None</c>. The UI should surface a
+    /// "no sources used" notice when this is true.
+    /// </summary>
+    /// <remarks>
+    /// Issue #99 redefined this from "<c>!HasSearches</c>" (vector-only signal) to
+    /// "<c>HasAnyToolCall == false</c>". A turn that answered using only structured
+    /// business tools (e.g. <c>get_contract_aggregate</c>) was previously misclassified
+    /// as degraded; that misclassification is fixed by deriving from
+    /// <see cref="GroundingSource"/>.
+    /// </remarks>
     public bool IsDegraded { get; set; }
+
+    /// <summary>
+    /// Categorizes which kinds of tools the model invoked to produce this answer
+    /// (vector search vs. structured business tools vs. both vs. none). Lets the UI
+    /// distinguish "grounded via RAG" from "grounded via business data" rather than
+    /// only knowing whether grounding happened at all.
+    /// </summary>
+    public GroundingSource GroundingSource { get; set; }
 }

--- a/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
@@ -75,4 +75,13 @@ public class PaperbaseAIBehaviorOptions
     /// <see cref="ChatCompactionOptions"/>。
     /// </summary>
     public ChatCompactionOptions ChatCompaction { get; set; } = new();
+
+    /// <summary>
+    /// Hard upper bound on the number of distinct vector-search hits captured per
+    /// chat turn (across all <c>search_paperbase_documents</c> invocations). Excess
+    /// hits are dropped and a <c>citations_trimmed</c> telemetry signal is recorded.
+    /// Bounds prompt-context growth and protects against pathological LLM retry loops.
+    /// Set to 0 to disable the cap (not recommended in production).
+    /// </summary>
+    public int MaxCapturedCitations { get; set; } = 50;
 }

--- a/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
@@ -210,7 +210,13 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
 
         conversation.AppendUserMessage(Clock, userMessageId, input.Message, input.ClientTurnId);
 
-        var isDegraded = !run.Capture.HasSearches;
+        // Issue #99: derive IsDegraded from the recorder's audit-scope view, not from
+        // run.Capture.HasSearches alone. A turn that answered using only structured
+        // business tools (e.g. get_contract_aggregate) is also grounded — flagging it
+        // as degraded would mislead the UI into showing "no sources used" for a
+        // perfectly grounded answer.
+        var grounding = _telemetryRecorder.GetCurrentTurnGroundingSource();
+        var isDegraded = grounding == GroundingSource.None;
         var citationsJson = SerializeCitations(run.Capture.Results);
         conversation.AppendAssistantMessage(Clock, assistantMessageId, run.Text, citationsJson, isDegraded);
         if (shouldGenerateTitle)
@@ -233,7 +239,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             streaming: false,
             sw.Elapsed.TotalMilliseconds,
             isDegraded,
-            citations.Count);
+            citations.Count,
+            run.Capture.WasTruncated);
 
         return new ChatTurnResultDto
         {
@@ -241,9 +248,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             AssistantMessageId = assistantMessageId,
             Answer = run.Text,
             Citations = citations,
-            // HasSearches=false means the model never invoked the search tool — answer is
-            // ungrounded; the UI should surface this so users know there are no sources.
-            IsDegraded = isDegraded
+            IsDegraded = isDegraded,
+            GroundingSource = grounding
         };
     }
 
@@ -267,7 +273,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
                 UserMessageId = priorResult.UserMessageId,
                 AssistantMessageId = priorResult.AssistantMessageId,
                 Citations = priorResult.Citations,
-                IsDegraded = priorResult.IsDegraded
+                IsDegraded = priorResult.IsDegraded,
+                GroundingSource = priorResult.GroundingSource
             };
             yield break;
         }
@@ -374,7 +381,11 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         //
         // Security note: function name and description are static string literals —
         // they MUST NOT contain user input or conversation metadata (prompt-injection risk).
-        var capture = new DocumentSearchCapture();
+        // Bound the per-turn citation set so a pathological LLM retry loop or a
+        // very wide query cannot blow up the citations payload (or the Markdown
+        // assistant message it gets serialized into). Hits past the cap are dropped
+        // and surfaced via setup.Capture.WasTruncated → telemetry CitationsTrimmed.
+        var capture = new DocumentSearchCapture(_aiOptions.MaxCapturedCitations);
         var toolContext = CreateToolContext(conversation);
         var searchFn = _textSearchAdapter.CreateSearchFunction(
             conversation.TenantId,
@@ -515,13 +526,29 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             ? new List<ChatCitationDto>()
             : (DeserializeCitations(assistantMessage!.CitationsJson!) ?? new List<ChatCitationDto>());
 
+        // Idempotent replay can only approximate the original GroundingSource — the
+        // per-turn audit scope is gone by now, and ChatMessage doesn't persist it
+        // (would require a schema change). Best-effort reconstruction:
+        //   IsDegraded=true                         → None
+        //   IsDegraded=false && citations.Count>0   → Vector (Mixed indistinguishable here)
+        //   IsDegraded=false && citations.Count==0  → Structured
+        // If callers need a guaranteed-accurate replay value, they should not rely on
+        // GroundingSource for idempotent retries.
+        var isDegraded = assistantMessage?.IsDegraded ?? false;
+        var grounding = isDegraded
+            ? GroundingSource.None
+            : citations.Count > 0
+                ? GroundingSource.Vector
+                : GroundingSource.Structured;
+
         return new ChatTurnResultDto
         {
             UserMessageId = userMessage.Id,
             AssistantMessageId = assistantMessage?.Id ?? Guid.Empty,
             Answer = assistantMessage?.Content ?? string.Empty,
             Citations = citations,
-            IsDegraded = assistantMessage?.IsDegraded ?? false
+            IsDegraded = isDegraded,
+            GroundingSource = grounding
         };
     }
 
@@ -590,7 +617,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         bool streaming,
         double elapsedMs,
         bool isDegraded,
-        int citationCount)
+        int citationCount,
+        bool citationsTrimmed = false)
     {
         _telemetryRecorder.RecordTurn(new DocumentChatTurnAuditEntry
         {
@@ -604,7 +632,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             CitationCount = citationCount,
             IsDegraded = isDegraded,
             ElapsedMs = elapsedMs,
-            Outcome = DocumentChatTelemetryOutcome.Success
+            Outcome = DocumentChatTelemetryOutcome.Success,
+            CitationsTrimmed = citationsTrimmed
         });
     }
 
@@ -669,7 +698,10 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             var fullText = sb.ToString();
             var shouldGenerateTitle = ShouldGenerateTitle(conversation);
             conversation.AppendUserMessage(Clock, userMessageId, input.Message, input.ClientTurnId);
-            var isDegraded = !setup.Capture.HasSearches;
+            // Issue #99: see SendMessageAsync for the rationale behind sourcing
+            // grounding from the telemetry recorder rather than capture.HasSearches.
+            var grounding = _telemetryRecorder.GetCurrentTurnGroundingSource();
+            var isDegraded = grounding == GroundingSource.None;
             var citationsJson = SerializeCitations(setup.Capture.Results);
             conversation.AppendAssistantMessage(Clock, assistantMessageId, fullText, citationsJson, isDegraded);
             if (shouldGenerateTitle)
@@ -684,7 +716,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
                 streaming: true,
                 sw.Elapsed.TotalMilliseconds,
                 isDegraded,
-                citations.Count);
+                citations.Count,
+                setup.Capture.WasTruncated);
 
             await writer.WriteAsync(new ChatTurnDeltaDto
             {
@@ -692,9 +725,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
                 UserMessageId = userMessageId,
                 AssistantMessageId = assistantMessageId,
                 Citations = citations,
-                // HasSearches=false → the model never invoked the search tool; answer is
-                // ungrounded so the UI should surface "no sources" to the user.
-                IsDegraded = isDegraded
+                IsDegraded = isDegraded,
+                GroundingSource = grounding
             }, ct);
 
             writer.Complete();

--- a/core/src/Dignite.Paperbase.Application/Chat/Search/DocumentSearchCapture.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Search/DocumentSearchCapture.cs
@@ -9,9 +9,42 @@ namespace Dignite.Paperbase.Chat.Search;
 /// search AIFunction during one agent turn. Created fresh per turn and bound by
 /// closure into the search AIFunction — never shared between concurrent requests.
 /// </summary>
+/// <remarks>
+/// The model may invoke the search tool multiple times per turn (e.g. once on contracts,
+/// then a second time on receipts after a structured tool returned candidate IDs). The
+/// previous <c>Set</c> name suggested overwrite semantics — the body was already
+/// append+dedup, but the name was a footgun. The class is now explicitly append-only,
+/// dedups by chunk identity, and enforces an upper bound (<see cref="MaxResults"/>)
+/// to bound prompt-context growth and prevent pathological retry loops from blowing up
+/// the citations payload.
+/// </remarks>
 public sealed class DocumentSearchCapture
 {
+    /// <summary>
+    /// Default per-turn citation cap, used when no explicit limit is supplied.
+    /// Aligned with <c>PaperbaseAIBehaviorOptions.MaxCapturedCitations</c>; the
+    /// AppService normally constructs the capture with the configured value, so this
+    /// constant is mainly here for tests and stand-alone usage.
+    /// </summary>
+    public const int DefaultMaxResults = 50;
+
     private readonly List<VectorSearchResult> _results = new();
+
+    public DocumentSearchCapture(int maxResults = DefaultMaxResults)
+    {
+        // <= 0 disables the cap (treated as unbounded). Keeps the test helpers in
+        // DocumentTextSearchAdapter_Tests trivially compatible — they construct
+        // captures without an explicit limit.
+        MaxResults = maxResults;
+    }
+
+    /// <summary>
+    /// Hard upper bound on the number of distinct chunks retained across all search
+    /// invocations in one turn. Excess hits are silently dropped after the bound is
+    /// reached and <see cref="WasTruncated"/> is set so the caller can surface the
+    /// signal in telemetry.
+    /// </summary>
+    public int MaxResults { get; }
 
     /// <summary>
     /// All vector search results captured during this turn, accumulated across every
@@ -23,13 +56,22 @@ public sealed class DocumentSearchCapture
 
     /// <summary>
     /// <c>true</c> after the search AIFunction is invoked at least once, even if that
-    /// invocation returned no hits. Distinguishes "model declined to search" (false →
-    /// <c>ChatTurnResultDto.IsDegraded = true</c>; answer ungrounded) from "model
-    /// searched but found nothing" (true → IsDegraded = false; honest empty citations).
+    /// invocation returned no hits. Distinguishes "model declined to search" (false)
+    /// from "model searched but found nothing" (true). Used by the AppService together
+    /// with the per-turn grounding source to decide
+    /// <see cref="ChatTurnResultDto.IsDegraded"/>.
     /// </summary>
     public bool HasSearches { get; private set; }
 
-    internal void Set(IReadOnlyList<VectorSearchResult> results)
+    /// <summary>
+    /// <c>true</c> if at least one search hit was dropped because the cumulative count
+    /// would have exceeded <see cref="MaxResults"/>. Lets the AppService record a
+    /// <c>citations_trimmed</c> telemetry signal — useful for spotting pathological
+    /// LLM retry loops or queries that fan out into very large recall sets.
+    /// </summary>
+    public bool WasTruncated { get; private set; }
+
+    internal void Append(IReadOnlyList<VectorSearchResult> results)
     {
         HasSearches = true;
 
@@ -37,6 +79,15 @@ public sealed class DocumentSearchCapture
         {
             if (_results.Any(existing => IsSameChunk(existing, result)))
                 continue;
+
+            if (MaxResults > 0 && _results.Count >= MaxResults)
+            {
+                WasTruncated = true;
+                // Bail on the rest of this batch as well — preserving the natural
+                // ordering of the first MaxResults hits is more useful for citations
+                // than mixing partial later batches.
+                return;
+            }
 
             _results.Add(result);
         }

--- a/core/src/Dignite.Paperbase.Application/Chat/Search/DocumentTextSearchAdapter.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Search/DocumentTextSearchAdapter.cs
@@ -206,7 +206,7 @@ public class DocumentTextSearchAdapter : ITransientDependency
                 : _baseScope;
 
             var vectorResults = await _adapter.SearchVectorAsync(_tenantId, scope, query, cancellationToken);
-            _capture.Set(vectorResults);
+            _capture.Append(vectorResults);
 
             sw.Stop();
             // Argument hashing + audit are recorded by AuditedDocumentChatFunction; do not

--- a/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatTelemetryRecorder.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatTelemetryRecorder.cs
@@ -189,9 +189,24 @@ public class DocumentChatTelemetryRecorder : ISingletonDependency
             ExceptionType = entry.ExceptionType,
             ToolCallSummary = summary,
             ToolCallDepth = toolCalls.Count,
-            GroundingSource = ClassifyGrounding(toolCalls)
+            GroundingSource = ClassifyGrounding(toolCalls),
+            CitationsTrimmed = entry.CitationsTrimmed
         };
     }
+
+    /// <summary>
+    /// Returns the <see cref="GroundingSource"/> for the in-flight turn, derived from
+    /// the per-tool entries already on the current audit scope. Used by
+    /// <c>DocumentChatAppService</c> to derive the user-facing
+    /// <see cref="ChatTurnResultDto.IsDegraded"/> signal from the same source of truth
+    /// as the audit entry — guaranteeing the two never disagree.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="GroundingSource.None"/> when no audit scope is active or no
+    /// tool has been invoked yet; the caller will treat that as "answer not grounded".
+    /// </remarks>
+    public virtual GroundingSource GetCurrentTurnGroundingSource()
+        => ClassifyGrounding(ReadToolCallsFromAuditScope());
 
     /// <summary>
     /// Classifies a turn's grounding source from the tool names invoked.
@@ -367,4 +382,11 @@ public sealed class DocumentChatTurnAuditEntry
     /// recorder. See <see cref="GroundingSource"/> for the classification rule.
     /// </summary>
     public GroundingSource GroundingSource { get; init; }
+
+    /// <summary>
+    /// True when the per-turn citation cap (see <c>PaperbaseAIBehaviorOptions.MaxCapturedCitations</c>)
+    /// was hit and additional vector-search hits were dropped. Surfaces pathological LLM
+    /// retry loops or queries that fan out into very large recall sets — both worth alerting on.
+    /// </summary>
+    public bool CitationsTrimmed { get; init; }
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/DocumentChatDegradedSignal_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/DocumentChatDegradedSignal_Tests.cs
@@ -65,9 +65,11 @@ public class DocumentChatDegradedSignal_Tests
             }
         });
 
-        // The substituted IChatClient never returns FunctionCallContent, so the search
-        // AIFunction is never invoked → HasSearches stays false → IsDegraded.
+        // The substituted IChatClient never returns FunctionCallContent, so no tool
+        // (search or otherwise) is invoked. Issue #99 redefined IsDegraded as
+        // "GroundingSource == None"; both signals must agree.
         result.IsDegraded.ShouldBeTrue();
+        result.GroundingSource.ShouldBe(GroundingSource.None);
     }
 
     [Fact]
@@ -159,6 +161,7 @@ public class DocumentChatDegradedSignal_Tests
 
         done.ShouldNotBeNull();
         done!.IsDegraded.ShouldBeTrue();
+        done.GroundingSource.ShouldBe(GroundingSource.None);
     }
 
     [Fact]

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/DocumentChatToolInvocation_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/DocumentChatToolInvocation_Tests.cs
@@ -103,6 +103,9 @@ public class DocumentChatToolInvocation_Tests
         });
 
         result.IsDegraded.ShouldBeFalse();
+        // Issue #99: GroundingSource on the DTO. Only search_paperbase_documents was
+        // invoked → Vector (Mixed only when a structured tool is also called).
+        result.GroundingSource.ShouldBe(GroundingSource.Vector);
         result.Citations.Count.ShouldBe(1);
         result.Citations[0].DocumentId.ShouldBe(docId);
         result.Citations[0].ChunkIndex.ShouldBe(0);

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/Search/DocumentSearchCapture_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/Search/DocumentSearchCapture_Tests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using Dignite.Paperbase.Chat.Search;
+using Dignite.Paperbase.KnowledgeIndex;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Chat;
+
+/// <summary>
+/// Focused tests for <see cref="DocumentSearchCapture"/> (Issue #99 — pre-condition for
+/// the multi-step retrieval rollout in #100). Verifies append + dedup + the new upper
+/// bound (<see cref="DocumentSearchCapture.MaxResults"/>) so the model can call the
+/// search AIFunction multiple times per turn without losing citations from earlier
+/// invocations or blowing up the citations payload via a retry loop.
+/// </summary>
+public class DocumentSearchCapture_Tests
+{
+    [Fact]
+    public void Append_AccumulatesAcrossMultipleInvocations()
+    {
+        var capture = new DocumentSearchCapture();
+
+        capture.Append(new[]
+        {
+            BuildResult(documentId: "11111111-1111-1111-1111-111111111111", chunkIndex: 0)
+        });
+        capture.Append(new[]
+        {
+            BuildResult(documentId: "22222222-2222-2222-2222-222222222222", chunkIndex: 0),
+            BuildResult(documentId: "22222222-2222-2222-2222-222222222222", chunkIndex: 1)
+        });
+
+        capture.HasSearches.ShouldBeTrue();
+        capture.Results.Count.ShouldBe(3);
+        capture.WasTruncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Append_DedupsSameChunkAcrossInvocations()
+    {
+        // Same (documentId, chunkIndex, pageNumber) must not be added twice — typical
+        // when two queries in the same turn happen to return overlapping top-K hits.
+        var capture = new DocumentSearchCapture();
+        var doc = "11111111-1111-1111-1111-111111111111";
+
+        capture.Append(new[]
+        {
+            BuildResult(doc, chunkIndex: 0),
+            BuildResult(doc, chunkIndex: 1)
+        });
+        capture.Append(new[]
+        {
+            BuildResult(doc, chunkIndex: 0), // duplicate of the first call's hit
+            BuildResult(doc, chunkIndex: 2)
+        });
+
+        capture.Results.Count.ShouldBe(3); // chunkIndex 0/1/2, no duplicate of 0
+    }
+
+    [Fact]
+    public void Append_DedupsByRecordIdWhenAvailable()
+    {
+        var capture = new DocumentSearchCapture();
+        var sharedRecordId = Guid.NewGuid();
+
+        capture.Append(new[]
+        {
+            new VectorSearchResult { RecordId = sharedRecordId, DocumentId = Guid.NewGuid(), ChunkIndex = 0 }
+        });
+        capture.Append(new[]
+        {
+            // Different DocumentId / ChunkIndex but same RecordId — dedup must use the
+            // record id when present (it's the strongest identity signal from the store).
+            new VectorSearchResult { RecordId = sharedRecordId, DocumentId = Guid.NewGuid(), ChunkIndex = 99 }
+        });
+
+        capture.Results.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Append_DropsHitsBeyondMaxResults_AndSetsWasTruncated()
+    {
+        // Pathological case: model retries search 5x and each call returns 10 distinct
+        // hits → 50 cumulative. With cap=20 we keep the first 20, drop the rest, and
+        // surface the WasTruncated flag for telemetry.
+        var capture = new DocumentSearchCapture(maxResults: 20);
+
+        for (var batch = 0; batch < 5; batch++)
+        {
+            var hits = new List<VectorSearchResult>();
+            for (var i = 0; i < 10; i++)
+            {
+                hits.Add(BuildResult(
+                    documentId: Guid.NewGuid().ToString(),
+                    chunkIndex: i));
+            }
+            capture.Append(hits);
+        }
+
+        capture.Results.Count.ShouldBe(20);
+        capture.WasTruncated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Append_PreservesNaturalOrderingOfFirstHits_WhenTruncating()
+    {
+        // When the cap kicks in mid-batch we bail on the rest of that batch (and all
+        // subsequent batches). Citations stay in the natural order of the first hits
+        // returned, which is what users see surfaced.
+        var capture = new DocumentSearchCapture(maxResults: 3);
+
+        capture.Append(new[]
+        {
+            BuildResult("11111111-1111-1111-1111-111111111111", chunkIndex: 0),
+            BuildResult("22222222-2222-2222-2222-222222222222", chunkIndex: 0)
+        });
+        capture.Append(new[]
+        {
+            BuildResult("33333333-3333-3333-3333-333333333333", chunkIndex: 0),
+            BuildResult("44444444-4444-4444-4444-444444444444", chunkIndex: 0), // exceeds cap
+            BuildResult("55555555-5555-5555-5555-555555555555", chunkIndex: 0)
+        });
+
+        capture.Results.Count.ShouldBe(3);
+        capture.Results[0].DocumentId.ShouldBe(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        capture.Results[2].DocumentId.ShouldBe(Guid.Parse("33333333-3333-3333-3333-333333333333"));
+        capture.WasTruncated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasSearches_BecomesTrue_EvenForEmptyAppend()
+    {
+        // "Model searched but found nothing" is honestly grounded (IsDegraded should
+        // remain false). The signal that disambiguates "didn't search" from "searched
+        // and got zero" is HasSearches — must flip on first Append regardless of count.
+        var capture = new DocumentSearchCapture();
+
+        capture.Append(Array.Empty<VectorSearchResult>());
+
+        capture.HasSearches.ShouldBeTrue();
+        capture.Results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MaxResults_ZeroOrNegative_DisablesCap()
+    {
+        // The default constructor protects production usage. Tests / future callers
+        // that explicitly want unbounded behavior can opt out by passing 0.
+        var capture = new DocumentSearchCapture(maxResults: 0);
+
+        for (var i = 0; i < 200; i++)
+        {
+            capture.Append(new[] { BuildResult(Guid.NewGuid().ToString(), chunkIndex: 0) });
+        }
+
+        capture.Results.Count.ShouldBe(200);
+        capture.WasTruncated.ShouldBeFalse();
+    }
+
+    private static VectorSearchResult BuildResult(string documentId, int chunkIndex, int? pageNumber = null)
+        => new()
+        {
+            DocumentId = Guid.Parse(documentId),
+            ChunkIndex = chunkIndex,
+            PageNumber = pageNumber,
+            Text = $"chunk {chunkIndex} of {documentId}"
+        };
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/Telemetry/DocumentChatTelemetryRecorder_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/Telemetry/DocumentChatTelemetryRecorder_Tests.cs
@@ -116,6 +116,47 @@ public class DocumentChatTelemetryRecorder_Tests
     }
 
     [Fact]
+    public void RecordTurn_PreservesCitationsTrimmedFromCaller()
+    {
+        // The capture knows whether MaxCapturedCitations clamped the result set; the
+        // AppService passes that flag through to the recorder so the audit row carries
+        // a single, faithful per-turn signal.
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry(ChatConsts.SearchPaperbaseDocumentsToolName));
+
+        _recorder.RecordTurn(BuildTurnEntry(citationsTrimmed: true));
+
+        var turn = ReadTurnFromAuditScope();
+        turn.CitationsTrimmed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetCurrentTurnGroundingSource_DelegatesToClassify()
+    {
+        // The AppService uses this helper to derive ChatTurnResultDto.GroundingSource
+        // (and IsDegraded) BEFORE RecordTurn fires. It must produce the same
+        // classification the audit entry will eventually receive — single source of truth.
+        using var auditScope = _auditingManager.BeginScope();
+
+        _recorder.RecordToolCall(BuildToolEntry("get_contract_aggregate"));
+
+        _recorder.GetCurrentTurnGroundingSource().ShouldBe(GroundingSource.Structured);
+    }
+
+    [Fact]
+    public void GetCurrentTurnGroundingSource_ReturnsNone_WhenNoScopeOrNoToolsCalled()
+    {
+        // No audit scope active (e.g. a code path that runs outside a scope by mistake)
+        // must still return a sane value rather than throw — the AppService treats
+        // None as "answer not grounded → IsDegraded".
+        _recorder.GetCurrentTurnGroundingSource().ShouldBe(GroundingSource.None);
+
+        using var auditScope = _auditingManager.BeginScope();
+        _recorder.GetCurrentTurnGroundingSource().ShouldBe(GroundingSource.None);
+    }
+
+    [Fact]
     public void RecordTurn_CountsFailedInvocations_BecauseTheyReflectModelBehavior()
     {
         // A failed tool call still counts toward ToolCallDepth — telemetry is about
@@ -141,13 +182,14 @@ public class DocumentChatTelemetryRecorder_Tests
             .ShouldBeOfType<DocumentChatTurnAuditEntry>();
     }
 
-    private static DocumentChatTurnAuditEntry BuildTurnEntry()
+    private static DocumentChatTurnAuditEntry BuildTurnEntry(bool citationsTrimmed = false)
         => new()
         {
             ConversationId = ConversationId,
             Streaming = false,
             ElapsedMs = 1.0,
-            Outcome = DocumentChatTelemetryOutcome.Success
+            Outcome = DocumentChatTelemetryOutcome.Success,
+            CitationsTrimmed = citationsTrimmed
         };
 
     private static DocumentChatToolAuditEntry BuildToolEntry(


### PR DESCRIPTION
Closes #99. **Stacked on #102** (rebases onto `main` once that lands).

## Summary

`DocumentSearchCapture` is **already** append+dedup despite the misleading `Set` name — but the contract is unsafe because nothing prevents a future "fix" back to overwrite, and there is no upper bound on accumulation. Multi-step retrieval (#100) is the first usage that calls the search AIFunction more than once per turn, so the contract has to be unambiguous before that lands.

This PR pre-positions both pre-conditions for #100:

### Bug A — capture API + bound

- `Set` → `Append` (rename + identical body) — name now matches semantics
- New `MaxResults` constructor parameter, default 50, configurable via `PaperbaseAIBehaviorOptions.MaxCapturedCitations`
- New `WasTruncated` flag → threaded into `DocumentChatTurnAuditEntry.CitationsTrimmed` so a runaway LLM retry loop is observable
- Truncation preserves natural ordering of first hits (cleaner UX than mixing partial later batches)

### Bug B — `IsDegraded` redefinition

- Old: `!run.Capture.HasSearches` (vector-only signal)
- New: `GroundingSource == None` — equivalent to "model invoked NO tool"
- A turn answered solely via a structured business tool (e.g. `get_contract_aggregate`) is now correctly flagged as **grounded**
- Sourced from `DocumentChatTelemetryRecorder.GetCurrentTurnGroundingSource` (introduced in #102) so the user-facing `IsDegraded` and the audit-row `GroundingSource` cannot disagree

### DTO additions

- `ChatTurnResultDto.GroundingSource` + `ChatTurnDeltaDto.GroundingSource` — UI can now distinguish "grounded via RAG" / "grounded via business data" / "mixed" / "no grounding"
- `ChatMessage` schema is intentionally **not** changed (would be a migration); idempotent replay reconstructs `GroundingSource` best-effort with an inline caveat

## Changes

- `Application/Chat/Search/DocumentSearchCapture.cs` — `Set`→`Append`, `MaxResults`, `WasTruncated`
- `Application/Ai/PaperbaseAIBehaviorOptions.cs` — `MaxCapturedCitations` (default 50)
- `Application.Contracts/Chat/ChatTurnResultDto.cs` — `GroundingSource` + redefined `IsDegraded` doc
- `Application.Contracts/Chat/ChatTurnDeltaDto.cs` — `GroundingSource` on `Done` event
- `Application/Chat/Telemetry/DocumentChatTelemetryRecorder.cs` — public `GetCurrentTurnGroundingSource()` + `CitationsTrimmed` audit field
- `Application/Chat/DocumentChatAppService.cs` — both sync & streaming paths derive grounding from recorder; `RecordTurnSuccess` plumbs `citationsTrimmed`
- `Application/Chat/Search/DocumentTextSearchAdapter.cs` — call site `Set`→`Append`

## Test plan

- [x] `dotnet build` (whole solution): 0 errors, 5 pre-existing warnings unrelated
- [x] `dotnet test core/test/Dignite.Paperbase.Application.Tests`: 216 / 216 pass (10 added, 0 removed)
- [x] `Chat/Search/DocumentSearchCapture_Tests.cs` (new): 7 focused tests
  - Append accumulates across invocations
  - Dedup by `(documentId, chunkIndex, pageNumber)` and by `RecordId` when present
  - `MaxResults` cap drops excess + sets `WasTruncated`
  - Cap preserves natural ordering of first hits
  - `HasSearches = true` even on empty `Append` (honest "searched but found nothing")
  - `MaxResults = 0` disables cap
- [x] Existing `DocumentChatDegradedSignal_Tests` extended to assert `GroundingSource == None` (sync + streaming)
- [x] Existing `SendMessageAsync_Invokes_Search_Tool_And_Persists_Citations` extended to assert `GroundingSource == Vector`
- [x] `DocumentChatTelemetryRecorder_Tests` extended with: `CitationsTrimmed` flow-through, `GetCurrentTurnGroundingSource` delegation + null-scope safety

## Out of scope (separate Issues)

- ChatConversation field slim-down + anchor prompt + tools always-on → #100
- `get_document_relations` tool → #101
- Persisting `GroundingSource` on `ChatMessage` for exact replay (only required if/when business needs guaranteed-accurate replay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)