### PR TITLE
refactor(chat): adopt MAF ChatHistoryProvider; remove manual history prepend

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
@@ -393,11 +393,11 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         //   wraps IChatClient with .UseFunctionInvocation(); skipping the agent's default
         //   wrapping prevents a redundant FunctionInvokingChatClient layer and ensures the
         //   host's MaxToolIterations cap is the only one in effect.
-        // - No ChatHistoryProvider on agent options: verified empirically that MAF v1.2.0
-        //   does not auto-call ProvideChatHistoryAsync during RunAsync against our wiring
-        //   (multi-turn count test captures 1/3/5 messages, no duplication). History is
-        //   loaded directly via DocumentChatHistoryProvider and prepended in InvokeAgentAsync /
-        //   FillStreamingChannelAsync; persistence is owned by the ChatConversation aggregate.
+        // - ChatHistoryProvider = _historyProvider: MAF auto-calls ProvideChatHistoryAsync
+        //   on each RunAsync; history is loaded from the ChatConversation aggregate keyed
+        //   by ConversationId stashed in AgentSession.StateBag below. Persistence stays in
+        //   DocumentChatAppService (citations / IsDegraded are not on MAF ChatMessage), so
+        //   StoreChatHistoryAsync remains the base-class no-op.
         // - Instructions live inside ChatOptions because ChatClientAgentOptions does not
         //   expose a top-level Instructions property in v1.2.0 (only the convenience
         //   ChatClientAgent(client, instructions: "...") constructor does); the docs'
@@ -405,6 +405,7 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         var agentOptions = new ChatClientAgentOptions
         {
             UseProvidedChatClientAsIs = true,
+            ChatHistoryProvider = _historyProvider,
             ChatOptions = new ChatOptions
             {
                 Instructions = instructions,
@@ -415,6 +416,13 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
 
         var agent = new ChatClientAgent(_chatClient, agentOptions);
         var session = await agent.CreateSessionAsync(cancellationToken);
+
+        // Stash conversation id so DocumentChatHistoryProvider can resolve which
+        // conversation to load in ProvideChatHistoryAsync — the provider contract
+        // forbids storing session-specific state in provider fields.
+        session.StateBag.SetValue(
+            DocumentChatHistoryProvider.SessionStateKey,
+            new DocumentChatSessionState(conversation.Id));
 
         return new AgentSetup(agent, session, capture);
     }
@@ -454,11 +462,15 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         CancellationToken cancellationToken = default)
     {
         var setup = await PrepareAgentSetupAsync(conversation, cancellationToken);
-        var history = await _historyProvider.GetHistoryAsync(conversation.Id, cancellationToken);
-        var messages = history
-            .Concat([new MeAi.ChatMessage(MeAi.ChatRole.User, message)])
-            .ToList();
-        var response = await setup.Agent.RunAsync(messages, setup.Session, options: null, cancellationToken);
+        // History prepending is handled by MAF: ChatClientAgent calls
+        // DocumentChatHistoryProvider.InvokingAsync inside RunAsync, which reads the
+        // conversation id from the session StateBag and prepends history with the
+        // ChatHistory source-stamp. We only pass the new turn's user message here.
+        var response = await setup.Agent.RunAsync(
+            new MeAi.ChatMessage(MeAi.ChatRole.User, message),
+            setup.Session,
+            options: null,
+            cancellationToken);
         return new AgentRunOutcome(response.Text, setup.Capture);
     }
 
@@ -613,13 +625,10 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         try
         {
             var setup = await PrepareAgentSetupAsync(conversation, ct);
-            var history = await _historyProvider.GetHistoryAsync(conversation.Id, ct);
-            var messages = history
-                .Concat([new MeAi.ChatMessage(MeAi.ChatRole.User, input.Message)])
-                .ToList();
-
+            // MAF prepends history via DocumentChatHistoryProvider — see InvokeAgentAsync.
+            var newUserMessage = new MeAi.ChatMessage(MeAi.ChatRole.User, input.Message);
             await foreach (var update in setup.Agent.RunStreamingAsync(
-                messages, setup.Session, options: null, ct))
+                newUserMessage, setup.Session, options: null, ct))
             {
                 var text = update.Text;
                 if (!string.IsNullOrEmpty(text))

--- a/core/src/Dignite.Paperbase.Application/Chat/History/DocumentChatHistoryProvider.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/History/DocumentChatHistoryProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.DependencyInjection;
 using MeAi = Microsoft.Extensions.AI;
@@ -10,30 +11,25 @@ using MeAi = Microsoft.Extensions.AI;
 namespace Dignite.Paperbase.Chat;
 
 /// <summary>
-/// Provides prior chat messages for a document-chat conversation, returning them in
-/// MAF's <see cref="MeAi.ChatMessage"/> shape ready to be prepended to the next
-/// agent turn.
+/// MAF <see cref="ChatHistoryProvider"/> backed by the <c>ChatConversation</c> aggregate.
+/// Read-only: persistence (including <c>CitationsJson</c> and <c>IsDegraded</c>, neither
+/// of which exists on <see cref="MeAi.ChatMessage"/>) is owned by
+/// <see cref="DocumentChatAppService"/> via <c>ChatConversation.AppendUserMessage</c>
+/// / <c>AppendAssistantMessage</c>; <see cref="StoreChatHistoryAsync"/> stays at the
+/// base class no-op default.
 ///
 /// <para>
-/// This is a plain ABP service following the project's <c>*Provider</c> convention
-/// (cf. <see cref="IPromptProvider"/>); it does NOT inherit from MAF's
-/// <c>ChatHistoryProvider</c> and is not wired into the agent pipeline. Empirically
-/// MAF v1.2.0's <c>ChatClientAgent</c> does not auto-load history through that
-/// pipeline against our wiring, so <see cref="DocumentChatAppService"/> calls
-/// <see cref="GetHistoryAsync"/> directly and prepends the result to
-/// <c>ChatClientAgent.RunAsync</c> messages.
-/// </para>
-///
-/// <para>
-/// Persistence is owned by the <c>ChatConversation</c> aggregate root, written
-/// via <c>ChatConversation.AppendUserMessage</c> / <c>AppendAssistantMessage</c>;
-/// this provider is read-only and uses <see cref="IChatConversationRepository"/>
-/// (storage backend irrelevant — Postgres in production, SQLite in tests).
+/// The conversation id is taken from <see cref="AgentSession.StateBag"/> under
+/// <see cref="SessionStateKey"/> rather than ambient context, because per the
+/// <see cref="ChatHistoryProvider"/> contract a provider instance must be safe to
+/// share across many sessions.
 /// </para>
 /// </summary>
-public class DocumentChatHistoryProvider : ITransientDependency
+public class DocumentChatHistoryProvider : ChatHistoryProvider, ITransientDependency
 {
-    private const int HistoryMessageTake = 50;
+    public const string SessionStateKey = "Paperbase.DocumentChat";
+
+    protected virtual int MaxHistoryMessages => 50;
 
     private readonly IServiceScopeFactory _scopeFactory;
 
@@ -42,18 +38,40 @@ public class DocumentChatHistoryProvider : ITransientDependency
         _scopeFactory = scopeFactory;
     }
 
-    /// <summary>
-    /// Returns the most recent <see cref="HistoryMessageTake"/> messages of
-    /// <paramref name="conversationId"/> in chronological order. Returns an empty
-    /// list if the conversation is missing — callers treat that as "no prior
-    /// history" rather than an error.
-    /// </summary>
+    /// <inheritdoc />
     /// <remarks>
-    /// Uses a fresh DI scope per call so the provider can be invoked safely from
-    /// background threads / Hangfire / any context where the ambient scope might
-    /// be missing or stale.
+    /// A fresh DI scope is used per call so the provider can be invoked from background
+    /// or non-HTTP contexts where the ambient scope might be missing or stale.
+    /// Returns an empty enumerable when the StateBag has no conversation id, or when the
+    /// conversation has been deleted between authorization and load — callers treat that
+    /// as "no prior history" rather than an error.
     /// </remarks>
-    public virtual async Task<IReadOnlyList<MeAi.ChatMessage>> GetHistoryAsync(
+    protected override async ValueTask<IEnumerable<MeAi.ChatMessage>> ProvideChatHistoryAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var session = context.Session;
+        if (session is null)
+        {
+            return [];
+        }
+
+        var state = session.StateBag.GetValue<DocumentChatSessionState>(SessionStateKey);
+        if (state is null || state.ConversationId == Guid.Empty)
+        {
+            return [];
+        }
+
+        return await LoadHistoryAsync(state.ConversationId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Loads history without going through the MAF invocation pipeline. Exposed as
+    /// <c>internal virtual</c> so tests can exercise the database adapter directly
+    /// without constructing an <see cref="InvokingContext"/> (which carries the
+    /// experimental <c>MAAI001</c> diagnostic).
+    /// </summary>
+    internal virtual async Task<IReadOnlyList<MeAi.ChatMessage>> LoadHistoryAsync(
         Guid conversationId,
         CancellationToken cancellationToken = default)
     {
@@ -62,7 +80,7 @@ public class DocumentChatHistoryProvider : ITransientDependency
 
         var conversation = await repository.FindByIdWithMessagesAsync(
             conversationId,
-            HistoryMessageTake,
+            MaxHistoryMessages,
             cancellationToken);
 
         if (conversation is null)

--- a/core/src/Dignite.Paperbase.Application/Chat/History/DocumentChatSessionState.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/History/DocumentChatSessionState.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Dignite.Paperbase.Chat;
+
+/// <summary>
+/// State carried in <see cref="Microsoft.Agents.AI.AgentSession.StateBag"/> by
+/// <see cref="DocumentChatAppService"/> so <see cref="DocumentChatHistoryProvider"/>
+/// can resolve the conversation aggregate to load history from.
+///
+/// <para>
+/// Class (not record struct) is required because <see cref="Microsoft.Agents.AI.AgentSessionStateBag.SetValue{T}"/>
+/// is constrained to <c>T : class</c>. JSON-serializable via the parameterless constructor
+/// + public setter — required by <c>AgentSessionStateBagJsonConverter</c>.
+/// </para>
+/// </summary>
+public sealed class DocumentChatSessionState
+{
+    public DocumentChatSessionState() { }
+
+    public DocumentChatSessionState(Guid conversationId)
+    {
+        ConversationId = conversationId;
+    }
+
+    public Guid ConversationId { get; set; }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/History/DocumentChatHistoryProvider_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/History/DocumentChatHistoryProvider_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -32,7 +33,7 @@ public class DocumentChatHistoryProvider_Tests
         var conversationId = await CreateConversationWithMessagesAsync();
         var provider = new DocumentChatHistoryProvider(_scopeFactory);
 
-        var messages = (await provider.GetHistoryAsync(conversationId)).ToList();
+        var messages = (await provider.LoadHistoryAsync(conversationId)).ToList();
 
         messages.Count.ShouldBe(2);
         messages[0].Role.ShouldBe(ChatRole.User);
@@ -49,7 +50,7 @@ public class DocumentChatHistoryProvider_Tests
         // even if the conversation has been deleted between authorization and load.
         var provider = new DocumentChatHistoryProvider(_scopeFactory);
 
-        var messages = await provider.GetHistoryAsync(Guid.NewGuid());
+        var messages = await provider.LoadHistoryAsync(Guid.NewGuid());
 
         messages.ShouldBeEmpty();
     }
@@ -88,8 +89,8 @@ public class DocumentChatHistoryProvider_Tests
 
         var provider = new DocumentChatHistoryProvider(scopeFactory);
 
-        await provider.GetHistoryAsync(conversationId);
-        await provider.GetHistoryAsync(conversationId);
+        await provider.LoadHistoryAsync(conversationId);
+        await provider.LoadHistoryAsync(conversationId);
 
         scopeFactory.Received(2).CreateScope();
     }
@@ -97,21 +98,90 @@ public class DocumentChatHistoryProvider_Tests
     [Fact]
     public async Task Should_Return_Messages_In_Chronological_Order()
     {
-        // Caller (DocumentChatAppService) prepends history to the new user message and
-        // passes the lot to RunAsync; ordering must be ascending by creation time so the
-        // LLM sees the conversation as it actually unfolded.
+        // MAF prepends history into the LLM request in the order returned, so ordering
+        // must be ascending by creation time. Role alternation (user → assistant) of the
+        // seeded data is the proxy for creation-time ordering since CreationTime is not
+        // observable on MeAi.ChatMessage.
         var conversationId = await CreateConversationWithMessagesAsync();
         var provider = new DocumentChatHistoryProvider(_scopeFactory);
 
-        var messages = (await provider.GetHistoryAsync(conversationId)).ToList();
+        var messages = (await provider.LoadHistoryAsync(conversationId)).ToList();
 
         for (var i = 1; i < messages.Count; i++)
         {
-            // CreationTime ordering can't be observed on MeAi.ChatMessage directly, but
-            // role alternation (user → assistant) of the seeded data is the proxy.
             messages[i - 1].Role.ShouldBe(ChatRole.User);
             messages[i].Role.ShouldBe(ChatRole.Assistant);
         }
+    }
+
+    [Fact]
+    public async Task Provider_Returns_Empty_When_StateBag_Missing_ConversationId()
+    {
+        // ProvideChatHistoryAsync is the entry point MAF actually uses (via
+        // InvokingAsync inside the agent pipeline). With no conversation id stashed in
+        // the session StateBag, the provider must yield an empty history rather than
+        // failing — that's how a freshly-created session behaves before the AppService
+        // wires it up.
+        var provider = new DocumentChatHistoryProvider(_scopeFactory);
+        var session = new TestAgentSession();
+
+        var messages = (await InvokeProviderAsync(provider, session)).ToList();
+
+        // Default InvokingCoreAsync concatenates [] history with the request messages
+        // we passed in, so we expect just the request message back unchanged.
+        messages.Count.ShouldBe(1);
+        messages[0].Role.ShouldBe(ChatRole.User);
+        messages[0].Text.ShouldBe("ping");
+    }
+
+    [Fact]
+    public async Task Provider_Loads_History_From_StateBag_ConversationId()
+    {
+        // End-to-end through the MAF entry point: write the conversation id to the
+        // session StateBag (the AppService side of the contract), then verify the
+        // provider's InvokingAsync returns history-then-request, with the history
+        // messages stamped as ChatHistory source so downstream context providers
+        // (CompactionProvider) can distinguish them.
+        var conversationId = await CreateConversationWithMessagesAsync();
+        var provider = new DocumentChatHistoryProvider(_scopeFactory);
+        var session = new TestAgentSession();
+
+        session.StateBag.SetValue(
+            DocumentChatHistoryProvider.SessionStateKey,
+            new DocumentChatSessionState(conversationId));
+
+        var messages = (await InvokeProviderAsync(provider, session)).ToList();
+
+        // History (2) + new request (1)
+        messages.Count.ShouldBe(3);
+        messages[0].Text.ShouldBe("hello");
+        messages[1].Text.ShouldBe("hi");
+        messages[2].Text.ShouldBe("ping");
+
+        // History entries must be source-stamped so CompactionProvider treats them as
+        // chat history rather than fresh request when it integrates next.
+        messages[0].GetAgentRequestMessageSourceType().ShouldBe(AgentRequestMessageSourceType.ChatHistory);
+        messages[1].GetAgentRequestMessageSourceType().ShouldBe(AgentRequestMessageSourceType.ChatHistory);
+        messages[2].GetAgentRequestMessageSourceType().ShouldNotBe(AgentRequestMessageSourceType.ChatHistory);
+    }
+
+    private static async Task<IEnumerable<MeAi.ChatMessage>> InvokeProviderAsync(
+        DocumentChatHistoryProvider provider,
+        AgentSession session)
+    {
+        // InvokingContext ctor is annotated [Experimental(MAAI001)]; suppression is
+        // scoped to this helper so production code stays clean of the diagnostic.
+        // NSubstitute can stand in for AIAgent (an abstract class) since we only need
+        // a non-null reference for the ctor's null-guard — InvokingCoreAsync never
+        // touches its members.
+#pragma warning disable MAAI001
+        var agent = Substitute.For<AIAgent>();
+        var ctx = new ChatHistoryProvider.InvokingContext(
+            agent,
+            session,
+            [new MeAi.ChatMessage(ChatRole.User, "ping")]);
+#pragma warning restore MAAI001
+        return await provider.InvokingAsync(ctx);
     }
 
     private async Task<Guid> CreateConversationWithMessagesAsync()
@@ -138,5 +208,15 @@ public class DocumentChatHistoryProvider_Tests
 
             return conversation.Id;
         });
+    }
+
+    /// <summary>
+    /// Minimal in-test <see cref="AgentSession"/>: real ChatClient sessions are created
+    /// by <c>ChatClientAgent.CreateSessionAsync</c> which requires a live LLM client;
+    /// this stand-in avoids that dependency since the provider only touches StateBag.
+    /// </summary>
+    private sealed class TestAgentSession : AgentSession
+    {
+        public TestAgentSession() : base(new AgentSessionStateBag()) { }
     }
 }


### PR DESCRIPTION
Closes #104.

## Summary

- `DocumentChatHistoryProvider` now subclasses MAF's `ChatHistoryProvider` and is registered via `ChatClientAgentOptions.ChatHistoryProvider`, so MAF's pipeline auto-prepends history with `AgentRequestMessageSourceType.ChatHistory` source-stamp on every `RunAsync`.
- Manual `history.Concat([userMessage])` in `InvokeAgentAsync` / `FillStreamingChannelAsync` removed.
- `ChatConversation` aggregate ownership of persistence unchanged (citations + `IsDegraded` aren't on MAF `ChatMessage`).
- New `DocumentChatSessionState` carries `ConversationId` through `AgentSession.StateBag` per the MAF contract that provider instances must not hold session-specific state.

Unblocks the next slice: `CompactionProvider` integration (it relies on the `ChatHistory` source-stamp that only the MAF pipeline applies).

## Test plan

- [x] `dotnet build` clean (Application + Application.Tests)
- [x] `DocumentChatHistoryProvider_Tests` — 6/6 pass (4 existing + 2 new for MAF entry point + source-stamp)
- [x] Chat test suite — 55/55 pass (`--filter "FullyQualifiedName~Chat"`)
- [x] Domain tests — 43/43 pass
- [ ] Host smoke: multi-turn conversation → second turn references first turn (manual)

> Note: bulk `dotnet test` failures observed locally are inotify-limit exhaustion (host has `fs.inotify.max_user_instances=128`); failing tests pass in isolation and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)