### PR TITLE
feat(chat): add get_document_relations tool (#101)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
@@ -14,6 +14,7 @@ using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Chat.Compaction;
 using Dignite.Paperbase.Chat.Search;
 using Dignite.Paperbase.Chat.Telemetry;
+using Dignite.Paperbase.Chat.Tools;
 using Dignite.Paperbase.Documents;
 using Dignite.Paperbase.Permissions;
 using Dignite.Paperbase.KnowledgeIndex;
@@ -56,6 +57,7 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
     private readonly IChatConversationRepository _conversationRepository;
     private readonly IDocumentRepository _documentRepository;
     private readonly DocumentTextSearchAdapter _textSearchAdapter;
+    private readonly DocumentRelationsTool _documentRelationsTool;
     private readonly IChatClient _chatClient;
     private readonly IPromptProvider _promptProvider;
     private readonly DocumentChatHistoryProvider _historyProvider;
@@ -69,6 +71,7 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         IChatConversationRepository conversationRepository,
         IDocumentRepository documentRepository,
         DocumentTextSearchAdapter textSearchAdapter,
+        DocumentRelationsTool documentRelationsTool,
         IChatClient chatClient,
         IPromptProvider promptProvider,
         DocumentChatHistoryProvider historyProvider,
@@ -81,6 +84,7 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         _conversationRepository = conversationRepository;
         _documentRepository = documentRepository;
         _textSearchAdapter = textSearchAdapter;
+        _documentRelationsTool = documentRelationsTool;
         _chatClient = chatClient;
         _promptProvider = promptProvider;
         _historyProvider = historyProvider;
@@ -398,7 +402,15 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
                 "Optional documentTypeCode: restrict to one type (e.g. 'contract.general', 'receipt.general'). " +
                 "Optional topK / minScore: override the configured defaults for this call (raise topK 10–15 for cross-document reconciliation).");
 
-        var tools = new List<AITool> { searchFn };
+        var tools = new List<AITool>
+        {
+            searchFn,
+            // Issue #101: get_document_relations is a core tool (graph walker over the
+            // DocumentRelation aggregate). Sits next to search_paperbase_documents because
+            // it's the natural pre-step for cross-document reasoning ("anchor → related →
+            // drill-into-content").
+            _documentRelationsTool.CreateAIFunction(toolContext, _toolFactory)
+        };
         tools.AddRange(CollectContributorTools(conversation));
 
         // Idiomatic MAF wiring:

--- a/core/src/Dignite.Paperbase.Application/Chat/Tools/DocumentRelationsTool.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Tools/DocumentRelationsTool.cs
@@ -1,0 +1,152 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Chat;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Permissions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.AI;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Linq;
+
+namespace Dignite.Paperbase.Chat.Tools;
+
+/// <summary>
+/// Issue #101: contributes the <c>get_document_relations</c> AIFunction to the
+/// chat agent. Lets the model walk the <see cref="DocumentRelation"/> graph from
+/// an anchor document to the documents it has been linked to (manually by users
+/// or by a future AI inference workflow). Closes the gap that pure vector search
+/// cannot bridge — "what receipts are tied to this contract?" — without forcing
+/// the model to guess document IDs from raw user input.
+/// <para>
+/// Lives in the core tool stack (alongside <c>search_paperbase_documents</c>),
+/// not in any business module: <see cref="DocumentRelation"/> is a Core
+/// aggregate, and the relationship is owner-agnostic (any pair of documents
+/// regardless of business module).
+/// </para>
+/// <para>
+/// fail-closed safety contract — see <c>.claude/rules/doc-chat-anti-patterns.md</c>
+/// reverse example C: explicit <c>Documents.Default</c> permission check, explicit
+/// tenant predicate (never rely on ambient ABP <c>DataFilter</c>), hard <see cref="MaxResultRows"/>
+/// upper bound, static-constant tool name &amp; description.
+/// </para>
+/// </summary>
+public class DocumentRelationsTool : ITransientDependency
+{
+    private const int MaxResultRows = 20;
+
+    private readonly IDocumentRelationRepository _repository;
+    private readonly IAsyncQueryableExecuter _asyncExecuter;
+    private readonly IAuthorizationService _authorizationService;
+
+    public DocumentRelationsTool(
+        IDocumentRelationRepository repository,
+        IAsyncQueryableExecuter asyncExecuter,
+        IAuthorizationService authorizationService)
+    {
+        _repository = repository;
+        _asyncExecuter = asyncExecuter;
+        _authorizationService = authorizationService;
+    }
+
+    public virtual AIFunction CreateAIFunction(
+        DocumentChatToolContext ctx,
+        IDocumentChatToolFactory toolFactory)
+    {
+        var binding = new Binding(_repository, _asyncExecuter, _authorizationService, ctx.TenantId);
+        return toolFactory.Create(
+            ctx,
+            binding.GetRelationsAsync,
+            name: "get_document_relations",
+            description:
+                "Look up the documents related to a given document via the DocumentRelation graph " +
+                "(both manual user-confirmed links and AI-suggested links). " +
+                "Use this BEFORE search_paperbase_documents when the question implies cross-document evidence " +
+                "(e.g. 'has this contract been paid?' → call get_document_relations on the contract, then " +
+                "drill into the returned documentIds with search_paperbase_documents). " +
+                "Returns up to 20 entries, ordered with manual links first, then AI-suggested links by confidence descending.");
+    }
+
+    /// <summary>
+    /// Holds the bound context for the <c>get_document_relations</c> AIFunction.
+    /// Factored so parameter-level <see cref="DescriptionAttribute"/>s are accessible
+    /// via reflection (lambda parameters cannot carry attributes in C#).
+    /// </summary>
+    private sealed class Binding
+    {
+        private readonly IDocumentRelationRepository _repository;
+        private readonly IAsyncQueryableExecuter _asyncExecuter;
+        private readonly IAuthorizationService _authorizationService;
+        private readonly Guid? _tenantId;
+
+        public Binding(
+            IDocumentRelationRepository repository,
+            IAsyncQueryableExecuter asyncExecuter,
+            IAuthorizationService authorizationService,
+            Guid? tenantId)
+        {
+            _repository = repository;
+            _asyncExecuter = asyncExecuter;
+            _authorizationService = authorizationService;
+            _tenantId = tenantId;
+        }
+
+        public async Task<string> GetRelationsAsync(
+            [Description("Anchor document ID to look up relations for. Returns documents linked to it (in either direction).")]
+            Guid documentId,
+            CancellationToken cancellationToken = default)
+        {
+            await _authorizationService.CheckAsync(PaperbasePermissions.Documents.Default);
+
+            var queryable = await _repository.GetQueryableAsync();
+
+            // Explicit tenant predicate — defense-in-depth against any code path that
+            // disables ABP's ambient DataFilter (background jobs, non-HTTP contexts).
+            queryable = _tenantId.HasValue
+                ? queryable.Where(r => r.TenantId == _tenantId)
+                : queryable.Where(r => r.TenantId == null);
+
+            // Bidirectional lookup: relations are symmetric in semantics even though
+            // SourceDocumentId / TargetDocumentId encode a directed edge — the user is
+            // equally interested in "what does X link to" and "what links to X".
+            queryable = queryable.Where(r =>
+                r.SourceDocumentId == documentId || r.TargetDocumentId == documentId);
+
+            // Manual relations come first (user-confirmed = highest signal); within the
+            // AI-suggested bucket, descending by Confidence. Source enum: Manual=0,
+            // AiSuggested=1, so OrderBy(Source) naturally puts Manual first. Take(N)
+            // bounds context-window cost.
+            var relations = await _asyncExecuter.ToListAsync(
+                queryable
+                    .OrderBy(r => r.Source)
+                    .ThenByDescending(r => r.Confidence)
+                    .Take(MaxResultRows),
+                cancellationToken);
+
+            var payload = new
+            {
+                anchorDocumentId = documentId,
+                count = relations.Count,
+                relations = relations.Select(r => new
+                {
+                    id = r.Id,
+                    sourceDocumentId = r.SourceDocumentId,
+                    targetDocumentId = r.TargetDocumentId,
+                    // The "other side" relative to the anchor — convenience field so the
+                    // model doesn't have to reason about edge direction itself.
+                    relatedDocumentId = r.SourceDocumentId == documentId
+                        ? r.TargetDocumentId
+                        : r.SourceDocumentId,
+                    description = r.Description,
+                    source = r.Source.ToString(),   // "Manual" / "AiSuggested"
+                    confidence = r.Confidence
+                })
+            };
+
+            return JsonSerializer.Serialize(payload);
+        }
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/Tools/DocumentRelationsTool_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/Tools/DocumentRelationsTool_Tests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Chat;
+using Dignite.Paperbase.Chat.Tools;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.AI;
+using Shouldly;
+using Volo.Abp.MultiTenancy;
+using Xunit;
+
+namespace Dignite.Paperbase.Chat;
+
+/// <summary>
+/// Issue #101 — guards for the <c>get_document_relations</c> AIFunction. Verifies the
+/// fail-closed contract from <c>.claude/rules/doc-chat-anti-patterns.md</c> reverse
+/// example C: explicit tenant predicate (don't rely on ambient DataFilter), bidirectional
+/// lookup, ordering (manual first, then AI-suggested by confidence), and the result-set
+/// upper bound that protects the LLM context from a relation explosion.
+/// </summary>
+public class DocumentRelationsTool_Tests
+    : PaperbaseApplicationTestBase<DocumentChatAppServiceTestModule>
+{
+    private readonly DocumentRelationsTool _tool;
+    private readonly IDocumentChatToolFactory _toolFactory;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly ICurrentTenant _currentTenant;
+
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public DocumentRelationsTool_Tests()
+    {
+        _tool = GetRequiredService<DocumentRelationsTool>();
+        _toolFactory = GetRequiredService<IDocumentChatToolFactory>();
+        _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        _currentTenant = GetRequiredService<ICurrentTenant>();
+    }
+
+    [Fact]
+    public async Task Returns_Empty_Payload_When_Anchor_Has_No_Relations()
+    {
+        var anchor = Guid.NewGuid();
+        var ctx = BuildContext(TenantA);
+
+        var payload = await InvokeAsync(ctx, anchor);
+
+        payload.GetProperty("anchorDocumentId").GetGuid().ShouldBe(anchor);
+        payload.GetProperty("count").GetInt32().ShouldBe(0);
+        payload.GetProperty("relations").GetArrayLength().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Returns_Bidirectional_Relations_For_The_Anchor()
+    {
+        // Anchor X has both an outgoing edge (X → Y) and an incoming edge (Z → X).
+        // The model must see both — both edges represent something the user might
+        // care about ("what does X link to" vs "what links to X").
+        var anchor = Guid.NewGuid();
+        var outgoingTarget = Guid.NewGuid();
+        var incomingSource = Guid.NewGuid();
+
+        await SeedRelationsAsync(
+            CreateRelation(TenantA, source: anchor, target: outgoingTarget, kind: RelationSource.Manual),
+            CreateRelation(TenantA, source: incomingSource, target: anchor, kind: RelationSource.Manual));
+
+        var payload = await InvokeAsync(BuildContext(TenantA), anchor);
+
+        payload.GetProperty("count").GetInt32().ShouldBe(2);
+        var relatedIds = payload.GetProperty("relations").EnumerateArray()
+            .Select(r => r.GetProperty("relatedDocumentId").GetGuid())
+            .ToHashSet();
+        relatedIds.ShouldContain(outgoingTarget);
+        relatedIds.ShouldContain(incomingSource);
+    }
+
+    [Fact]
+    public async Task RelatedDocumentId_Is_The_Other_Side_Of_The_Edge()
+    {
+        // Tests the convenience field BuildAnchorContextAsync's prompt advice depends on:
+        // the model should not have to reason about edge direction, and the payload
+        // surfaces relatedDocumentId = whichever side is NOT the anchor.
+        var anchor = Guid.NewGuid();
+        var counterpart = Guid.NewGuid();
+
+        await SeedRelationsAsync(
+            CreateRelation(TenantA, source: counterpart, target: anchor, kind: RelationSource.Manual));
+
+        var payload = await InvokeAsync(BuildContext(TenantA), anchor);
+
+        var relation = payload.GetProperty("relations")[0];
+        relation.GetProperty("sourceDocumentId").GetGuid().ShouldBe(counterpart);
+        relation.GetProperty("targetDocumentId").GetGuid().ShouldBe(anchor);
+        relation.GetProperty("relatedDocumentId").GetGuid().ShouldBe(counterpart);
+    }
+
+    [Fact]
+    public async Task Manual_Relations_Come_Before_AiSuggested_Ordered_By_Confidence_Desc()
+    {
+        var anchor = Guid.NewGuid();
+        await SeedRelationsAsync(
+            CreateRelation(TenantA, source: anchor, target: Guid.NewGuid(),
+                kind: RelationSource.AiSuggested, confidence: 0.6),
+            CreateRelation(TenantA, source: anchor, target: Guid.NewGuid(),
+                kind: RelationSource.Manual),
+            CreateRelation(TenantA, source: anchor, target: Guid.NewGuid(),
+                kind: RelationSource.AiSuggested, confidence: 0.95));
+
+        var payload = await InvokeAsync(BuildContext(TenantA), anchor);
+
+        var relations = payload.GetProperty("relations").EnumerateArray().ToList();
+        relations.Count.ShouldBe(3);
+        relations[0].GetProperty("source").GetString().ShouldBe("Manual");
+        relations[1].GetProperty("source").GetString().ShouldBe("AiSuggested");
+        relations[1].GetProperty("confidence").GetDouble().ShouldBe(0.95);
+        relations[2].GetProperty("source").GetString().ShouldBe("AiSuggested");
+        relations[2].GetProperty("confidence").GetDouble().ShouldBe(0.6);
+    }
+
+    [Fact]
+    public async Task Tenant_Predicate_Drops_Relations_Belonging_To_Other_Tenants()
+    {
+        // Seed an edge under TenantB; querying as TenantA must NOT return it. This
+        // is the explicit-tenant-predicate check from reverse example C #2 — even if
+        // the ambient DataFilter is bypassed in some future code path, the tool's
+        // closure-captured _tenantId is the binding boundary.
+        var anchor = Guid.NewGuid();
+        var leakedTarget = Guid.NewGuid();
+
+        await SeedRelationsAsync(
+            CreateRelation(TenantB, source: anchor, target: leakedTarget, kind: RelationSource.Manual));
+
+        var payload = await InvokeAsync(BuildContext(TenantA), anchor);
+
+        payload.GetProperty("count").GetInt32().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Caps_Result_Set_At_The_Documented_Maximum_Of_Twenty()
+    {
+        // A pathological case: many relations for one anchor. The cap exists to keep
+        // a single tool call from blowing up the LLM context window.
+        const int seedCount = 35;
+        var anchor = Guid.NewGuid();
+
+        var relations = Enumerable.Range(0, seedCount)
+            .Select(_ => CreateRelation(TenantA, source: anchor, target: Guid.NewGuid(),
+                kind: RelationSource.Manual))
+            .ToArray();
+        await SeedRelationsAsync(relations);
+
+        var payload = await InvokeAsync(BuildContext(TenantA), anchor);
+
+        payload.GetProperty("count").GetInt32().ShouldBe(20);
+        payload.GetProperty("relations").GetArrayLength().ShouldBe(20);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private async Task<JsonElement> InvokeAsync(DocumentChatToolContext ctx, Guid documentId)
+    {
+        var function = _tool.CreateAIFunction(ctx, _toolFactory);
+        var args = new AIFunctionArguments
+        {
+            ["documentId"] = documentId
+        };
+
+        // Production callers (FunctionInvokingChatClient) invoke the AIFunction inside
+        // (a) the chat turn's active UoW (EF DbContext) and (b) the same ABP tenant
+        // scope as the conversation. Tests must mirror both — without the tenant scope
+        // the ambient ABP IMultiTenant filter would still hide our seeded rows even
+        // though the tool's explicit predicate already covers the safety property.
+        var raw = await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(ctx.TenantId))
+            {
+                return await function.InvokeAsync(args);
+            }
+        });
+        var json = raw?.ToString() ?? "{}";
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    private static DocumentChatToolContext BuildContext(Guid tenantId) => new()
+    {
+        TenantId = tenantId,
+        ConversationId = Guid.NewGuid(),
+        UserId = Guid.NewGuid()
+    };
+
+    private static DocumentRelation CreateRelation(
+        Guid tenantId,
+        Guid source,
+        Guid target,
+        RelationSource kind,
+        double? confidence = null)
+        => new(
+            id: Guid.NewGuid(),
+            tenantId: tenantId,
+            sourceDocumentId: source,
+            targetDocumentId: target,
+            description: $"test relation {source}->{target}",
+            source: kind,
+            confidence: kind == RelationSource.AiSuggested ? (confidence ?? 0.5) : null);
+
+    private async Task SeedRelationsAsync(params DocumentRelation[] relations)
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            foreach (var r in relations)
+            {
+                await _relationRepository.InsertAsync(r, autoSave: true);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Closes #101. **Stacked on #110** (rebases as the chain lands).

## Summary

Pure vector search cannot answer cross-document questions like *"what receipts are tied to this contract?"* — it has no access to the human-or-AI-curated relationships in the `DocumentRelation` aggregate. #110's multi-step prompt advice already points the model at this step (`get_contract_detail` → `get_document_relations` → `search_paperbase_documents` on the returned IDs), but the tool itself was missing. Now the model can actually take that path instead of guessing document IDs from raw user input.

## Tool surface

`get_document_relations(documentId) → JSON`

Payload:
```json
{
  "anchorDocumentId": "...",
  "count": 3,
  "relations": [
    {
      "id": "...",
      "sourceDocumentId": "...",
      "targetDocumentId": "...",
      "relatedDocumentId": "...",   // the OTHER side of the edge
      "description": "...",
      "source": "Manual" | "AiSuggested",
      "confidence": 0.92            // null for Manual
    }
  ]
}
```

## Behavior

- **Bidirectional lookup** — relations where `SourceDocumentId == documentId` OR `TargetDocumentId == documentId`. The convenience field `relatedDocumentId` exposes the "other side" so the model doesn't have to reason about edge direction
- **Ordering** — Manual links first (user-confirmed = highest signal), then AI-suggested by `Confidence DESC`
- **Cap** — `Take(20)`, hard-coded so a relation explosion can't blow up the LLM context

## Safety (`.claude/rules/doc-chat-anti-patterns.md` reverse example C)

- Static-constant tool name + description (no user input concatenation)
- Explicit `Documents.Default` permission check
- Explicit `TenantId` predicate — does not rely on the ambient ABP `DataFilter`
- Wrapped in `IDocumentChatToolFactory` so audit / OpenTelemetry signals fire identically to every other contributor tool

## Placement

Lives in core (`Application/Chat/Tools/`) next to `search_paperbase_documents`. `DocumentRelation` is a Core aggregate and the relationship is owner-agnostic — it's not the property of any business module, so it doesn't belong in a contributor.

## DB

`PaperbaseDocumentRelations.SourceDocumentId` and `.TargetDocumentId` already have `HasIndex` declarations (see [PaperbaseDbContextModelCreatingExtensions.cs:77-78](core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs)) — no new migration needed.

## Test plan

- [x] `dotnet build` (whole solution): 0 errors, 8 pre-existing warnings unrelated
- [x] `dotnet test core/test/Dignite.Paperbase.Application.Tests`: 224 / 224 pass (6 added)
- [x] `Chat/Tools/DocumentRelationsTool_Tests.cs`:
  - Empty payload when anchor has no relations
  - Bidirectional lookup returns both outgoing + incoming edges
  - `relatedDocumentId` correctly identifies the "other side" of the edge
  - Manual relations come before AiSuggested, ordered by Confidence DESC
  - Tenant predicate drops cross-tenant rows (defense-in-depth even with DataFilter)
  - Cap respected at 20

## Out of scope (future Issues)

- AI inference workflow that auto-populates `DocumentRelation` (today the table is populated by the manual `IDocumentRelationAppService` flow only — but the tool is fully functional against either source)
- Receipt business module (the canonical "other side" of the contract → receipt reconciliation chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)