### PR TITLE
fix(ci): rewrite host/Dockerfile pre-restore tree to follow current sources (#112)

### DIFF
--- a/host/Dockerfile
+++ b/host/Dockerfile
@@ -6,22 +6,21 @@ EXPOSE 443
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-COPY ["host/src/Dignite.Paperbase.Host.csproj", "host/src/"]
-COPY ["core/src/Dignite.Paperbase.Abstractions/Dignite.Paperbase.Abstractions.csproj", "core/src/Dignite.Paperbase.Abstractions/"]
-COPY ["core/src/Dignite.Paperbase.Domain.Shared/Dignite.Paperbase.Domain.Shared.csproj", "core/src/Dignite.Paperbase.Domain.Shared/"]
-COPY ["core/src/Dignite.Paperbase.Domain/Dignite.Paperbase.Domain.csproj", "core/src/Dignite.Paperbase.Domain/"]
-COPY ["core/src/Dignite.Paperbase.Application.Contracts/Dignite.Paperbase.Application.Contracts.csproj", "core/src/Dignite.Paperbase.Application.Contracts/"]
-COPY ["core/src/Dignite.Paperbase.Application/Dignite.Paperbase.Application.csproj", "core/src/Dignite.Paperbase.Application/"]
-COPY ["core/src/Dignite.Paperbase.EntityFrameworkCore/Dignite.Paperbase.EntityFrameworkCore.csproj", "core/src/Dignite.Paperbase.EntityFrameworkCore/"]
-COPY ["core/src/Dignite.Paperbase.HttpApi/Dignite.Paperbase.HttpApi.csproj", "core/src/Dignite.Paperbase.HttpApi/"]
-COPY ["host/common.props", "host/"]
-COPY ["core/common.props", "core/"]
+# Issue #112: copy the whole source tree before restore. The previous Slice-0
+# pattern of per-csproj COPY directives existed only to keep the restore-cache
+# layer stable across pure source edits, but it silently broke the moment
+# Slice 1+ added projects (KnowledgeIndex.Qdrant, TextExtraction*,
+# Ocr.PaddleOcr, Contracts.*) and moved the Slice-0 per-tier props files into
+# the consolidated root common.props + Directory.Packages.props. Trading the
+# restore-cache for a build that doesn't need a Dockerfile audit on every
+# project add — the Host image is rebuilt by CI per push, not in tight inner
+# loops, so the lost cache cost is negligible.
+COPY common.props Directory.Packages.props Dignite.Paperbase.slnx ./
+COPY core/ core/
+COPY modules/ modules/
+COPY host/ host/
 
 RUN dotnet restore "host/src/Dignite.Paperbase.Host.csproj"
-
-COPY host/ host/
-COPY core/src/ core/src/
-
 RUN dotnet build "host/src/Dignite.Paperbase.Host.csproj" -c Release -o /app/build
 
 FROM build AS publish


### PR DESCRIPTION
Closes #112.

## Summary

\`host/Dockerfile\` was scaffolded in Slice 0 (\`f9178c4\`) and has never been touched since. The \`COPY\` block before \`dotnet restore\` references files that no longer exist (\`host/common.props\`, \`core/common.props\` — both consolidated into the root-level \`./common.props\`) and is missing every project added in Slice 1+ (\`KnowledgeIndex.Qdrant\`, \`TextExtraction\` / \`TextExtraction.ElBrunoMarkItDown\`, \`Ocr.PaddleOcr\`, the three \`Contracts.*\` modules), as well as \`Directory.Packages.props\` (central PVM).

Result: every CI run since the props consolidation has failed at \`build-and-test → Build Docker image\`. Visible in #105 / #109 / #102 / #103 / #110 / #111 — branch protection isn't enforcing CI so the chain keeps merging, but the workflow stays red.

## Change

Drop the per-csproj granular \`COPY\` block in favor of a single bulk copy of the source tree before \`dotnet restore\`. The granular pattern's only value was Docker-layer caching for restore across pure source edits — a benefit that became void in Slice 1 and would keep going void on every project add. The Host image is rebuilt by CI per push, not in tight inner loops, so trading a few seconds of CI restore time for a Dockerfile that doesn't need a hand-edit on every project add is the right call.

\`\`\`Dockerfile
COPY common.props Directory.Packages.props Dignite.Paperbase.slnx ./
COPY core/ core/
COPY modules/ modules/
COPY host/ host/

RUN dotnet restore \"host/src/Dignite.Paperbase.Host.csproj\"
RUN dotnet build   \"host/src/Dignite.Paperbase.Host.csproj\" -c Release -o /app/build
\`\`\`

## Test plan

- [x] Local: \`docker build -f host/Dockerfile -t paperbase-api:dockerfile-test .\` succeeds end-to-end (restore + build + publish + final image), reproducing the same five warnings already present on \`main\` (no new diagnostics)
- [ ] CI \`build-and-test/Build Docker image\` step turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)