### PR TITLE
feat(chat): wire get_document_relations into anchor + multi-step prompt

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Chat/ChatInstructionsBuilder.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/ChatInstructionsBuilder.cs
@@ -20,10 +20,19 @@ internal static class ChatInstructionsBuilder
     /// </summary>
     public const string MultiStepReasoningGuidance =
         "You can chain tools across one turn:\n" +
+        "  0) [Optional — when an anchor document id is present AND the question implies linked documents " +
+             "(payments, receipts, attachments, amendments, predecessors)] " +
+             "call get_document_relations(anchorDocumentId) first to discover related document ids. " +
+             "Pass those ids into search_paperbase_documents(documentIds=[...]) for precise retrieval.\n" +
         "  1) Pull structured fields with a business tool (e.g. get_contract_detail, search_contracts, get_contract_aggregate).\n" +
-        "  2) If reconciliation or cross-document evidence is needed, follow up with search_paperbase_documents — pass documentIds returned by step 1, and/or a documentTypeCode (e.g. 'receipt.general') to focus the vector search.\n" +
+        "  2) Follow up with search_paperbase_documents if cross-document evidence is needed — " +
+             "pass documentIds returned by step 0 or step 1, and/or a documentTypeCode (e.g. 'receipt.general') to focus the vector search.\n" +
         "  3) Compare structured values against retrieved chunks before answering.\n" +
-        "Reconciliation example: 'has this contract been paid?' → get_contract_detail → search_paperbase_documents(documentTypeCode='receipt.*', query=<party / amount>) → match → answer.\n" +
+        "get_document_relations vs search_paperbase_documents: use get_document_relations when you know " +
+             "a specific document id and want its explicit graph neighbors (manual or AI-suggested links); " +
+             "use search_paperbase_documents when the question is semantic with no known starting document.\n" +
+        "Reconciliation example: 'has this contract been paid?' → get_document_relations(anchorId) → " +
+             "search_paperbase_documents(documentIds=returned_ids, documentTypeCode='receipt.general') → match → answer.\n" +
         "If a question references multiple document types or implies cross-document evidence, do not stay inside the anchor document. The anchor is a hint, never a hard scope.";
 
     public static string Build(

--- a/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
@@ -594,6 +594,8 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         var anchor =
             $"User opened this conversation from a document detail page. Anchor: id={document.Id}, type={typeCode}.\n" +
             "Anchor is a soft hint, not a retrieval constraint — cross-document searches are encouraged whenever the question implies it. " +
+            "When the question implies related documents (payments, receipts, amendments, linked files), " +
+            "call get_document_relations with this anchor id before falling back to vector search. " +
             "If you need the anchor's title, fields, or full content, call the structured business tool that matches its DocumentTypeCode (e.g. get_contract_detail when type starts with 'contract.').";
 
         return PromptBoundary.WrapAnchor(anchor);


### PR DESCRIPTION
## Summary

`get_document_relations` (Issue #101) was registered but the system prompt never told the model when to reach for it. This PR adds two prompt-level hints so the model uses the relation graph as the natural entry point when an anchor document is present.

- `MultiStepReasoningGuidance`: new step 0 — when an anchor id is present and the question implies linked documents (payments, receipts, attachments, amendments, predecessors), call `get_document_relations(anchorDocumentId)` first, then drill via `search_paperbase_documents(documentIds=[...])`. Adds an explicit "use which tool when" note distinguishing graph traversal vs semantic search.
- `BuildAnchorContextAsync`: anchor block now nudges the model to call `get_document_relations` with the anchor id before falling back to vector search.

Wiki-style framing: the conversation anchor becomes an entry point into the document relation graph, not just a soft hint for vector search. Aligns with the wiki principle that explicit links beat semantic similarity for cross-document reasoning ("which receipts are tied to this contract?").

## Safety

Both strings stay safe:

- `MultiStepReasoningGuidance` remains a compile-time string-literal constant — no variable interpolation (anti-pattern reverse example C #4).
- Anchor block only interpolates `document.Id` (Guid) and `typeCode` (system-managed `DocumentTypeCode`), never user-controlled fields like Title (anti-pattern reverse example E).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test --filter "FullyQualifiedName~Chat"` — 81 passed, 0 failed (existing anchor / instructions tests don't pin the literal text)
- [ ] Manual: open a chat anchored on a contract, ask "has this contract been paid?" — telemetry `ToolCallSummary` should show `get_document_relations` invoked before `search_paperbase_documents`
- [ ] Manual: open a chat with no anchor, ask a semantic question — `get_document_relations` should not be invoked (no starting id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)