### PR TITLE
feat(documents): L2 relation discovery via IDocumentIdentifierProvider (#115)

### DIFF
--- a/core/src/Dignite.Paperbase.Abstractions/Documents/DocumentIdentifierTypes.cs
+++ b/core/src/Dignite.Paperbase.Abstractions/Documents/DocumentIdentifierTypes.cs
@@ -1,0 +1,36 @@
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// Issue #115 L2: 跨业务模块的标准化标识符类型常量。
+///
+/// <para>
+/// 业务模块在实现 <c>IDocumentIdentifierProvider</c> 时把自己的字段映射到这些标准类型。
+/// 例如合同模块把 <c>Contract.ContractNumber</c> 映射为 <see cref="ContractNumber"/>，
+/// 把 <c>Contract.PartyAName</c> + <c>Contract.PartyBName</c> 都映射为 <see cref="PartyName"/>。
+/// </para>
+///
+/// <para>
+/// L2 关系发现 Pipeline 用这套类型在 fan-out 时筛选 provider，避免对不相关 type 走无效查询。
+/// 新业务模块需要新增类型时在此添加常量；不在此处的字符串视为非约定类型，L2 不会处理。
+/// </para>
+/// </summary>
+public static class DocumentIdentifierTypes
+{
+    /// <summary>合同编号（contract number, 框架合同/采购合同等的唯一编号）。</summary>
+    public const string ContractNumber = "ContractNumber";
+
+    /// <summary>采购订单号（purchase order number）。</summary>
+    public const string PoNumber = "PoNumber";
+
+    /// <summary>发票号（invoice number）。</summary>
+    public const string InvoiceNumber = "InvoiceNumber";
+
+    /// <summary>
+    /// 当事人名称（甲方 / 乙方 / 客户 / 供应商等）。同一文档可能有多个 PartyName 值，
+    /// 同一 PartyName 值可能跨多个文档（这是 L2 发现关系的核心信号之一）。
+    /// </summary>
+    public const string PartyName = "PartyName";
+
+    /// <summary>项目代号（project code，跨多份业务文档共享的项目标识）。</summary>
+    public const string ProjectCode = "ProjectCode";
+}

--- a/core/src/Dignite.Paperbase.Abstractions/Documents/IDocumentIdentifierProvider.cs
+++ b/core/src/Dignite.Paperbase.Abstractions/Documents/IDocumentIdentifierProvider.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// Issue #115 L2：业务模块向核心暴露的"标识符查询"契约。
+///
+/// <para>
+/// <strong>设计原则：核心层不持有标识符数据，业务模块是单一来源</strong>。
+/// 合同编号已经存在 <c>Contract.ContractNumber</c> 字段、PO 号已经存在 <c>Invoice.PoNumber</c> 字段——
+/// 业务模块字段是这些标识符的唯一权威。L2 关系发现通过本契约在所有业务模块间 fan-out 查询，
+/// 避免在核心层重复存储一份索引（这会引入数据冗余 + 用户编辑后的同步腐烂问题）。
+/// </para>
+///
+/// <para>
+/// 实现位于业务模块（如 <c>Dignite.Paperbase.Contracts.Domain.Contracts.ContractIdentifierProvider</c>）；
+/// 实现类应注册为 <see cref="Volo.Abp.DependencyInjection.ITransientDependency"/>，
+/// L2 通过 DI 收集 <c>IEnumerable&lt;IDocumentIdentifierProvider&gt;</c> 自动 fan-out。
+/// </para>
+///
+/// <para>
+/// 多租户：实现侧用 ABP <c>IMultiTenant</c> ambient filter（仓储默认行为）；
+/// 不需要从入参收 <c>tenantId</c>。
+/// </para>
+///
+/// <para>
+/// 此契约位于 <c>Abstractions</c> 层，业务模块通过 NuGet 引用 <c>Dignite.Paperbase.Abstractions</c> 即可实现，
+/// 不被迫依赖核心 Application 层。
+/// </para>
+/// </summary>
+public interface IDocumentIdentifierProvider
+{
+    /// <summary>
+    /// 该 provider 支持的标准化 identifier 类型集合（参见 <see cref="DocumentIdentifierTypes"/>）。
+    /// L2 fan-out 时按此集合筛选——provider 不支持的类型不会被调用，避免无谓查询。
+    /// </summary>
+    IReadOnlyCollection<string> SupportedIdentifierTypes { get; }
+
+    /// <summary>
+    /// 返回该 provider 名下的某文档持有的所有标识符 (type, value) 对。
+    /// 若该 provider 不拥有该文档（例如合同 provider 收到一份发票），返回空列表（不抛异常）。
+    /// 同一类型可能有多条值（如 <c>PartyName</c> 可能同时是甲方和乙方），所以返回 <see cref="IReadOnlyList{T}"/> 而非字典。
+    /// </summary>
+    Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 反查：当前租户内该 provider 名下，持有指定 (type, value) 的文档 ID 列表。
+    /// L2 主查询路径——找到与源文档共享标识符的对端文档。
+    /// 实现侧应依赖 ABP ambient <c>DataFilter</c> 自动按 <c>CurrentTenant</c> 过滤。
+    /// </summary>
+    Task<IReadOnlyList<Guid>> FindDocumentsAsync(
+        string identifierType,
+        string identifierValue,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// 标识符条目（不可变值对象）。
+/// </summary>
+/// <param name="Type">标识符类型，应为 <see cref="DocumentIdentifierTypes"/> 中的常量。</param>
+/// <param name="Value">标识符值，已规范化（trim 后）。</param>
+public sealed record DocumentIdentifierEntry(string Type, string Value);

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
@@ -133,8 +133,19 @@ public class RelationDiscoveryService : DomainService
         var entries = new List<DocumentIdentifierEntry>();
         foreach (var provider in _providers)
         {
-            var fromProvider = await provider.GetIdentifiersAsync(documentId, ct);
-            entries.AddRange(fromProvider);
+            // Provider isolation: one buggy module must not tank the whole L2 discovery.
+            // OperationCanceledException re-thrown so cancellation is honored.
+            try
+            {
+                var fromProvider = await provider.GetIdentifiersAsync(documentId, ct);
+                entries.AddRange(fromProvider);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogError(ex,
+                    "L2 RelationDiscovery: provider {Provider} threw in GetIdentifiersAsync({DocumentId}); skipping its contribution",
+                    provider.GetType().FullName, documentId);
+            }
         }
 
         // De-duplicate (type, value) pairs — two providers could in principle report
@@ -157,7 +168,19 @@ public class RelationDiscoveryService : DomainService
 
             foreach (var provider in supportingProviders)
             {
-                var found = await provider.FindDocumentsAsync(identifier.Type, identifier.Value, ct);
+                IReadOnlyList<Guid> found;
+                try
+                {
+                    found = await provider.FindDocumentsAsync(identifier.Type, identifier.Value, ct);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Logger.LogError(ex,
+                        "L2 RelationDiscovery: provider {Provider} threw in FindDocumentsAsync({Type}, {Value}); skipping",
+                        provider.GetType().FullName, identifier.Type, identifier.Value);
+                    continue;
+                }
+
                 foreach (var peerId in found)
                 {
                     if (peerId == sourceDocumentId) continue;          // Self-match

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Services;
+using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L2: 跨业务模块的关系发现服务。基于 <see cref="IDocumentIdentifierProvider"/>
+/// 的 fan-out 查询，从源文档持有的标识符出发反查对端文档，自动创建
+/// <see cref="RelationSource.AiSuggested"/> 类型的 <see cref="DocumentRelation"/>。
+///
+/// <para>
+/// 算法（三阶段）：
+/// <list type="number">
+/// <item>收集源文档的所有标识符：遍历 <see cref="IDocumentIdentifierProvider"/>，
+///       调用 <see cref="IDocumentIdentifierProvider.GetIdentifiersAsync"/>，得到该文档的 (type, value) 列表。</item>
+/// <item>反查对端文档：对每个 (type, value)，遍历支持该 type 的 provider，
+///       调用 <see cref="IDocumentIdentifierProvider.FindDocumentsAsync"/>。</item>
+/// <item>去重 + 已有关系过滤后，为每个对端文档创建 AiSuggested DocumentRelation。</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <strong>v1 范围</strong>：纯发现服务，不含自动触发（背景任务 + 事件订阅留给后续 PR）。
+/// 调用方在文档分类完成 + 业务模块字段抽取完成后显式调用 <see cref="DiscoverAsync"/>。
+/// 这避免与业务模块 <see cref="DocumentClassifiedEto"/> 处理器的时序竞态，并先把发现逻辑用 mock provider 测准。
+/// </para>
+///
+/// <para>
+/// <strong>不接 LLM</strong>：本服务是结构化匹配（标识符精确比较），无 prompt 表面，
+/// 不需要 doc-chat 反例 C 那种"显式权限断言 + 静态描述 + Take(N)"工具体三件套。
+/// </para>
+/// </summary>
+public class RelationDiscoveryService : DomainService
+{
+    /// <summary>结构化标识符匹配的固定置信度。L3 LLM 评判会输出动态 confidence；L2 是确定性匹配，固定高分。</summary>
+    public const double StructuralMatchConfidence = 0.95;
+
+    private readonly IEnumerable<IDocumentIdentifierProvider> _providers;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly ICurrentTenant _currentTenant;
+
+    public RelationDiscoveryService(
+        IEnumerable<IDocumentIdentifierProvider> providers,
+        IDocumentRelationRepository relationRepository,
+        ICurrentTenant currentTenant)
+    {
+        _providers = providers;
+        _relationRepository = relationRepository;
+        _currentTenant = currentTenant;
+    }
+
+    /// <summary>
+    /// 对指定源文档运行关系发现。返回新创建的 AiSuggested DocumentRelation 列表（用于 telemetry / 集成测试断言）。
+    /// 已存在的关系（无论 Manual / AiSuggested / ModuleAuto）会被跳过——避免噪音建议覆盖用户已确认的关系。
+    /// </summary>
+    public virtual async Task<IReadOnlyList<DocumentRelation>> DiscoverAsync(
+        Guid sourceDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (sourceDocumentId == Guid.Empty)
+        {
+            throw new ArgumentException("Source document id required.", nameof(sourceDocumentId));
+        }
+
+        // Phase 1: collect all identifiers held by source document across all providers.
+        var sourceIdentifiers = await CollectSourceIdentifiersAsync(sourceDocumentId, cancellationToken);
+        if (sourceIdentifiers.Count == 0)
+        {
+            // No identifiers extracted yet — either business modules haven't finished extraction,
+            // or this document isn't owned by any module. v1 short-circuits; future re-queue
+            // logic can wake L2 once providers have data.
+            Logger.LogInformation(
+                "L2 RelationDiscovery: no identifiers found for {DocumentId}; skipping (no business module owns it, or extraction pending)",
+                sourceDocumentId);
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 2: for each identifier, fan out across providers that support its type to find peers.
+        var peers = await FindPeerDocumentsAsync(sourceDocumentId, sourceIdentifiers, cancellationToken);
+        if (peers.Count == 0)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 3: skip pairs that already have any relation (Manual/AiSuggested/ModuleAuto),
+        // create AiSuggested for the rest. Skipping ALL existing relation kinds protects
+        // user-confirmed relations from being re-suggested as if new.
+        var alreadyLinked = await GetAlreadyLinkedPeersAsync(sourceDocumentId, cancellationToken);
+        var created = new List<DocumentRelation>();
+
+        foreach (var peer in peers)
+        {
+            if (alreadyLinked.Contains(peer.PeerDocumentId)) continue;
+
+            var description = $"Identifier match: {peer.IdentifierType} = {peer.IdentifierValue}";
+            var relation = new DocumentRelation(
+                GuidGenerator.Create(),
+                _currentTenant.Id,
+                sourceDocumentId: sourceDocumentId,
+                targetDocumentId: peer.PeerDocumentId,
+                description: description,
+                source: RelationSource.AiSuggested,
+                confidence: StructuralMatchConfidence);
+
+            await _relationRepository.InsertAsync(relation, autoSave: false, cancellationToken);
+            created.Add(relation);
+
+            // Add to alreadyLinked so multiple identifier matches against the same peer
+            // create only one DocumentRelation (e.g. peer shares both ContractNumber and PartyName).
+            alreadyLinked.Add(peer.PeerDocumentId);
+        }
+
+        Logger.LogInformation(
+            "L2 RelationDiscovery: source={DocumentId} identifiers={IdentifierCount} peers={PeerCount} created={CreatedCount}",
+            sourceDocumentId, sourceIdentifiers.Count, peers.Count, created.Count);
+
+        return created;
+    }
+
+    protected virtual async Task<IReadOnlyList<DocumentIdentifierEntry>> CollectSourceIdentifiersAsync(
+        Guid documentId,
+        CancellationToken ct)
+    {
+        var entries = new List<DocumentIdentifierEntry>();
+        foreach (var provider in _providers)
+        {
+            var fromProvider = await provider.GetIdentifiersAsync(documentId, ct);
+            entries.AddRange(fromProvider);
+        }
+
+        // De-duplicate (type, value) pairs — two providers could in principle report
+        // the same identifier (rare but possible if a doc is dual-classified).
+        return entries.Distinct().ToList();
+    }
+
+    protected virtual async Task<IReadOnlyList<PeerCandidate>> FindPeerDocumentsAsync(
+        Guid sourceDocumentId,
+        IReadOnlyList<DocumentIdentifierEntry> sourceIdentifiers,
+        CancellationToken ct)
+    {
+        var seen = new HashSet<Guid>();
+        var peers = new List<PeerCandidate>();
+
+        foreach (var identifier in sourceIdentifiers)
+        {
+            var supportingProviders = _providers
+                .Where(p => p.SupportedIdentifierTypes.Contains(identifier.Type));
+
+            foreach (var provider in supportingProviders)
+            {
+                var found = await provider.FindDocumentsAsync(identifier.Type, identifier.Value, ct);
+                foreach (var peerId in found)
+                {
+                    if (peerId == sourceDocumentId) continue;          // Self-match
+                    if (peerId == Guid.Empty) continue;                // Defensive
+                    if (!seen.Add(peerId)) continue;                   // Already a peer via another identifier
+
+                    peers.Add(new PeerCandidate(peerId, identifier.Type, identifier.Value));
+                }
+            }
+        }
+
+        return peers;
+    }
+
+    protected virtual async Task<HashSet<Guid>> GetAlreadyLinkedPeersAsync(
+        Guid sourceDocumentId,
+        CancellationToken ct)
+    {
+        var existing = await _relationRepository.GetListByDocumentIdAsync(sourceDocumentId, ct);
+        var linked = new HashSet<Guid>();
+        foreach (var relation in existing)
+        {
+            var peer = relation.SourceDocumentId == sourceDocumentId
+                ? relation.TargetDocumentId
+                : relation.SourceDocumentId;
+            linked.Add(peer);
+        }
+        return linked;
+    }
+
+    /// <summary>
+    /// 中间数据：一个对端文档候选 + 触发本次匹配的 (type, value)。
+    /// 当多个标识符同时命中同一对端时，第一个命中决定 Description（避免一对文档建多条关系）。
+    /// </summary>
+    protected sealed record PeerCandidate(Guid PeerDocumentId, string IdentifierType, string IdentifierValue);
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
@@ -173,6 +173,80 @@ public class RelationDiscoveryService_Tests
     }
 
     [Fact]
+    public async Task DiscoverAsync_Should_Skip_Peers_Already_Linked_Via_AiSuggested()
+    {
+        // Symmetric to the Manual-skip test: AiSuggested relations are also "existing"
+        // and L2 must not duplicate them on re-runs (idempotency).
+        var sourceDocId = Guid.NewGuid();
+        var alreadyAiLinkedPeer = Guid.NewGuid();
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-IDEMPOTENT")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-IDEMPOTENT")]
+            = new[] { alreadyAiLinkedPeer };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>
+            {
+                CreateExistingRelation(sourceDocId, alreadyAiLinkedPeer, RelationSource.AiSuggested)
+            });
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Continue_When_One_Provider_Throws_In_GetIdentifiers()
+    {
+        // Provider isolation: a buggy module must not tank L2 for the whole document.
+        // Contract provider throws; invoice provider's contribution should still go through.
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        _contractProvider.GetIdentifiersThrowsFor.Add(sourceDocId);
+        _invoiceProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.InvoiceNumber, "INV-RESILIENT")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.InvoiceNumber, "INV-RESILIENT")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(peerDocId);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Continue_When_One_Provider_Throws_In_FindDocuments()
+    {
+        // Same isolation contract on the reverse-lookup side.
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-RESILIENT")
+        };
+        _contractProvider.FindDocumentsThrowsFor.Add((DocumentIdentifierTypes.ContractNumber, "HT-RESILIENT"));
+        // Invoice provider succeeds for the same identifier — peer should still surface.
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-RESILIENT")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(peerDocId);
+    }
+
+    [Fact]
     public async Task DiscoverAsync_Should_Skip_Providers_That_Do_Not_Support_Identifier_Type()
     {
         var sourceDocId = Guid.NewGuid();
@@ -223,13 +297,22 @@ internal sealed class FakeContractProvider : IDocumentIdentifierProvider
     public Dictionary<Guid, IReadOnlyList<DocumentIdentifierEntry>> Identifiers { get; } = new();
     public Dictionary<(string Type, string Value), IReadOnlyList<Guid>> Lookup { get; } = new();
     public List<(string Type, string Value)> FindCalls { get; } = new();
+    // Failure-injection knobs used by provider-isolation tests.
+    public HashSet<Guid> GetIdentifiersThrowsFor { get; } = new();
+    public HashSet<(string Type, string Value)> FindDocumentsThrowsFor { get; } = new();
 
     public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
-        => Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+    {
+        if (GetIdentifiersThrowsFor.Contains(documentId))
+            throw new InvalidOperationException("Simulated provider failure (GetIdentifiersAsync)");
+        return Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+    }
 
     public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
     {
         FindCalls.Add((identifierType, identifierValue));
+        if (FindDocumentsThrowsFor.Contains((identifierType, identifierValue)))
+            throw new InvalidOperationException("Simulated provider failure (FindDocumentsAsync)");
         return Task.FromResult(Lookup.TryGetValue((identifierType, identifierValue), out var v) ? v : (IReadOnlyList<Guid>)Array.Empty<Guid>());
     }
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class RelationDiscoveryServiceTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Repository is mocked — RelationDiscoveryService writes via InsertAsync (autoSave: false),
+        // so we verify the entity it constructed without exercising EF.
+        context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
+
+        // Two providers wired into DI — singletons so the test class instance and the service's
+        // injected IEnumerable resolve to the SAME fake instances (otherwise transient resolution
+        // gives the service a different enumeration than what the test mutates → state silently lost).
+        // AbpIntegratedTest constructs a fresh container per test class instance, so singletons
+        // don't leak across tests.
+        context.Services.AddSingleton<FakeContractProvider>();
+        context.Services.AddSingleton<FakeInvoiceProvider>();
+        context.Services.AddSingleton<IDocumentIdentifierProvider>(sp => sp.GetRequiredService<FakeContractProvider>());
+        context.Services.AddSingleton<IDocumentIdentifierProvider>(sp => sp.GetRequiredService<FakeInvoiceProvider>());
+    }
+}
+
+public class RelationDiscoveryService_Tests
+    : PaperbaseApplicationTestBase<RelationDiscoveryServiceTestModule>
+{
+    private readonly RelationDiscoveryService _service;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly FakeContractProvider _contractProvider;
+    private readonly FakeInvoiceProvider _invoiceProvider;
+
+    public RelationDiscoveryService_Tests()
+    {
+        _service = GetRequiredService<RelationDiscoveryService>();
+        _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        // Resolve the singletons by their concrete type — same instances as those enumerated
+        // through IEnumerable<IDocumentIdentifierProvider> by the service.
+        _contractProvider = GetRequiredService<FakeContractProvider>();
+        _invoiceProvider = GetRequiredService<FakeInvoiceProvider>();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_No_Provider_Has_Identifiers_For_Source()
+    {
+        var sourceDocId = Guid.NewGuid();
+        // Both providers are empty — no identifiers known for this document.
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+        await _relationRepository.DidNotReceive().InsertAsync(
+            Arg.Any<DocumentRelation>(), autoSave: Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Reject_Empty_Document_Id()
+    {
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await _service.DiscoverAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Create_AiSuggested_Relation_For_Each_Cross_Module_Peer()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        // Source is a contract holding ContractNumber=HT-001.
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-001")
+        };
+        // Invoice peer also holds ContractNumber=HT-001 → cross-module match expected.
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-001")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        var relation = created.Single();
+        relation.SourceDocumentId.ShouldBe(sourceDocId);
+        relation.TargetDocumentId.ShouldBe(peerDocId);
+        relation.Source.ShouldBe(RelationSource.AiSuggested);
+        relation.Confidence.ShouldBe(RelationDiscoveryService.StructuralMatchConfidence);
+        relation.Description.ShouldContain("ContractNumber");
+        relation.Description.ShouldContain("HT-001");
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Peers_That_Already_Have_A_Relation()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var alreadyLinkedPeerId = Guid.NewGuid();
+        var freshPeerId = Guid.NewGuid();
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-002")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-002")] = new[] { alreadyLinkedPeerId, freshPeerId };
+
+        // alreadyLinkedPeerId is already related (Manual — user-confirmed) — must NOT be re-suggested.
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>
+            {
+                CreateExistingRelation(sourceDocId, alreadyLinkedPeerId, RelationSource.Manual)
+            });
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(freshPeerId);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Create_Only_One_Relation_When_Same_Peer_Matches_Multiple_Identifiers()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        // Source has two identifiers; both happen to point to the same peer document.
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-003"),
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "上海某某有限公司"),
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-003")] = new[] { peerDocId };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.PartyName, "上海某某有限公司")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        // Description reflects the FIRST identifier that found this peer — first-write-wins.
+        created.Single().Description.ShouldContain("ContractNumber");
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Self_When_Provider_Returns_Source_Document_Id()
+    {
+        var sourceDocId = Guid.NewGuid();
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "甲方公司")
+        };
+        // Defensive: provider FindDocumentsAsync echoes source itself (because contract module
+        // also holds the source document). Service must filter self.
+        _contractProvider.Lookup[(DocumentIdentifierTypes.PartyName, "甲方公司")] = new[] { sourceDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Providers_That_Do_Not_Support_Identifier_Type()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        // Source has an InvoiceNumber identifier — only the invoice provider supports it.
+        // The contract provider does NOT support InvoiceNumber, so its FindDocumentsAsync
+        // must not be called for this type.
+        _invoiceProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.InvoiceNumber, "INV-001")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.InvoiceNumber, "INV-001")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        // Verify contract provider's FindDocumentsAsync was NOT called for InvoiceNumber.
+        _contractProvider.FindCalls.ShouldNotContain(c => c.Type == DocumentIdentifierTypes.InvoiceNumber);
+    }
+
+    private static DocumentRelation CreateExistingRelation(Guid source, Guid target, RelationSource src)
+    {
+        return new DocumentRelation(
+            Guid.NewGuid(),
+            tenantId: null,
+            sourceDocumentId: source,
+            targetDocumentId: target,
+            description: "Manual link",
+            source: src,
+            confidence: src == RelationSource.Manual ? null : 0.9);
+    }
+}
+
+// ─── Test doubles ──────────────────────────────────────────────────────────────
+
+internal sealed class FakeContractProvider : IDocumentIdentifierProvider
+{
+    public IReadOnlyCollection<string> SupportedIdentifierTypes { get; } = new[]
+    {
+        DocumentIdentifierTypes.ContractNumber,
+        DocumentIdentifierTypes.PartyName,
+    };
+
+    public Dictionary<Guid, IReadOnlyList<DocumentIdentifierEntry>> Identifiers { get; } = new();
+    public Dictionary<(string Type, string Value), IReadOnlyList<Guid>> Lookup { get; } = new();
+    public List<(string Type, string Value)> FindCalls { get; } = new();
+
+    public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
+        => Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+
+    public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
+    {
+        FindCalls.Add((identifierType, identifierValue));
+        return Task.FromResult(Lookup.TryGetValue((identifierType, identifierValue), out var v) ? v : (IReadOnlyList<Guid>)Array.Empty<Guid>());
+    }
+}
+
+internal sealed class FakeInvoiceProvider : IDocumentIdentifierProvider
+{
+    public IReadOnlyCollection<string> SupportedIdentifierTypes { get; } = new[]
+    {
+        DocumentIdentifierTypes.ContractNumber,
+        DocumentIdentifierTypes.PartyName,
+        DocumentIdentifierTypes.InvoiceNumber,
+    };
+
+    public Dictionary<Guid, IReadOnlyList<DocumentIdentifierEntry>> Identifiers { get; } = new();
+    public Dictionary<(string Type, string Value), IReadOnlyList<Guid>> Lookup { get; } = new();
+    public List<(string Type, string Value)> FindCalls { get; } = new();
+
+    public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
+        => Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+
+    public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
+    {
+        FindCalls.Add((identifierType, identifierValue));
+        return Task.FromResult(Lookup.TryGetValue((identifierType, identifierValue), out var v) ? v : (IReadOnlyList<Guid>)Array.Empty<Guid>());
+    }
+}

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/ContractIdentifierProvider.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/ContractIdentifierProvider.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Contracts.Contracts;
+
+/// <summary>
+/// Issue #115 L2: 合同模块对核心 <see cref="IDocumentIdentifierProvider"/> 契约的实现。
+///
+/// <para>
+/// <strong>映射关系</strong>：
+/// <list type="bullet">
+/// <item><see cref="DocumentIdentifierTypes.ContractNumber"/> ↔ <see cref="Contract.ContractNumber"/></item>
+/// <item><see cref="DocumentIdentifierTypes.PartyName"/> ↔ <see cref="Contract.PartyAName"/> / <see cref="Contract.PartyBName"/> / <see cref="Contract.CounterpartyName"/>
+///       （任意一个字段命中即视为持有该 PartyName）</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <strong>无独立索引</strong>：本 provider 直接查 <c>Contract</c> 聚合根字段，是当前合同数据的唯一来源——
+/// 用户通过合同详情页修正 AI 抽取错误时，本 provider 自动反映新值，无同步腐烂问题。
+/// 这是 L2 设计选择 fan-out provider 而非中心化索引表的核心原因（见 <c>doc-chat-anti-patterns.md</c>
+/// 反例 D 同源思想：模块自治优于核心代理）。
+/// </para>
+///
+/// <para>
+/// <strong>多租户</strong>：仓储查询走 ABP <c>IMultiTenant</c> ambient filter，自动按 <c>CurrentTenant.Id</c> 过滤。
+/// 本路径不接 LLM、不在 Chat 工具体内被调用，无 prompt-injection 攻击面，不需要显式权限断言三件套。
+/// </para>
+/// </summary>
+public class ContractIdentifierProvider : IDocumentIdentifierProvider, ITransientDependency
+{
+    /// <summary>合同模块支持的标识符类型。L2 fan-out 时按此集合筛选。</summary>
+    public IReadOnlyCollection<string> SupportedIdentifierTypes { get; } = new[]
+    {
+        DocumentIdentifierTypes.ContractNumber,
+        DocumentIdentifierTypes.PartyName,
+    };
+
+    private readonly IContractRepository _contractRepository;
+
+    public ContractIdentifierProvider(IContractRepository contractRepository)
+    {
+        _contractRepository = contractRepository;
+    }
+
+    public virtual async Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default)
+    {
+        var contract = await _contractRepository.FindByDocumentIdAsync(documentId);
+        if (contract == null)
+        {
+            // 该文档不属于合同模块（或合同记录尚未创建）。返回空表示"无贡献"，
+            // L2 RelationDiscoveryService 会继续遍历其他 provider。
+            return Array.Empty<DocumentIdentifierEntry>();
+        }
+
+        var entries = new List<DocumentIdentifierEntry>();
+        AddIfPresent(entries, DocumentIdentifierTypes.ContractNumber, contract.ContractNumber);
+        AddIfPresent(entries, DocumentIdentifierTypes.PartyName, contract.PartyAName);
+        AddIfPresent(entries, DocumentIdentifierTypes.PartyName, contract.PartyBName);
+        AddIfPresent(entries, DocumentIdentifierTypes.PartyName, contract.CounterpartyName);
+        return entries;
+    }
+
+    public virtual async Task<IReadOnlyList<Guid>> FindDocumentsAsync(
+        string identifierType,
+        string identifierValue,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(identifierValue))
+        {
+            return Array.Empty<Guid>();
+        }
+
+        var trimmed = identifierValue.Trim();
+
+        return identifierType switch
+        {
+            DocumentIdentifierTypes.ContractNumber => await FindByContractNumberAsync(trimmed, cancellationToken),
+            DocumentIdentifierTypes.PartyName => await FindByPartyNameAsync(trimmed, cancellationToken),
+            _ => Array.Empty<Guid>()      // Unknown type — defensive; SupportedIdentifierTypes 已经在上游筛过
+        };
+    }
+
+    protected virtual async Task<IReadOnlyList<Guid>> FindByContractNumberAsync(
+        string contractNumber,
+        CancellationToken ct)
+    {
+        var contracts = await _contractRepository.FindByContractNumberAsync(contractNumber, ct);
+        return contracts.Select(c => c.DocumentId).Where(id => id != Guid.Empty).Distinct().ToList();
+    }
+
+    protected virtual async Task<IReadOnlyList<Guid>> FindByPartyNameAsync(
+        string partyName,
+        CancellationToken ct)
+    {
+        var contracts = await _contractRepository.GetListByPartyNameAsync(partyName, ct);
+        return contracts.Select(c => c.DocumentId).Where(id => id != Guid.Empty).Distinct().ToList();
+    }
+
+    private static void AddIfPresent(List<DocumentIdentifierEntry> entries, string type, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+        entries.Add(new DocumentIdentifierEntry(type, value.Trim()));
+    }
+}

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/IContractRepository.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/IContractRepository.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Repositories;
 
@@ -7,4 +9,23 @@ namespace Dignite.Paperbase.Contracts.Contracts;
 public interface IContractRepository : IRepository<Contract, Guid>
 {
     Task<Contract?> FindByDocumentIdAsync(Guid documentId);
+
+    /// <summary>
+    /// Issue #115 L2: 查询当前租户内持有指定合同编号的所有合同。
+    /// 同一编号理论上唯一，但保留 List 返回类型——AI 抽取出错或人工录入重复时
+    /// 不希望调用方收到 InvalidOperationException 而无法上下文判断。
+    /// 调用方负责按 (Tenant, ContractNumber) 唯一性的业务约定处理多结果。
+    /// </summary>
+    Task<List<Contract>> FindByContractNumberAsync(
+        string contractNumber,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #115 L2: 查询当前租户内"甲方 / 乙方 / 对手方"匹配指定名称的所有合同。
+    /// 同一公司可在不同合同里出现在不同位置，所以本方法跨 PartyAName / PartyBName / CounterpartyName
+    /// 三个字段查询。
+    /// </summary>
+    Task<List<Contract>> GetListByPartyNameAsync(
+        string partyName,
+        CancellationToken cancellationToken = default);
 }

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.EntityFrameworkCore/EntityFrameworkCore/EfCoreContractRepository.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.EntityFrameworkCore/EntityFrameworkCore/EfCoreContractRepository.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Contracts.Contracts;
 using Microsoft.EntityFrameworkCore;
@@ -20,5 +23,28 @@ public class EfCoreContractRepository :
     {
         var dbSet = await GetDbSetAsync();
         return await dbSet.FirstOrDefaultAsync(x => x.DocumentId == documentId);
+    }
+
+    public virtual async Task<List<Contract>> FindByContractNumberAsync(
+        string contractNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .Where(x => x.ContractNumber == contractNumber)
+            .ToListAsync(GetCancellationToken(cancellationToken));
+    }
+
+    public virtual async Task<List<Contract>> GetListByPartyNameAsync(
+        string partyName,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .Where(x =>
+                x.PartyAName == partyName
+                || x.PartyBName == partyName
+                || x.CounterpartyName == partyName)
+            .ToListAsync(GetCancellationToken(cancellationToken));
     }
 }

--- a/modules/contracts/test/Dignite.Paperbase.Contracts.Domain.Tests/Contracts/ContractIdentifierProvider_Tests.cs
+++ b/modules/contracts/test/Dignite.Paperbase.Contracts.Domain.Tests/Contracts/ContractIdentifierProvider_Tests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Contracts.Contracts;
+
+[DependsOn(typeof(ContractsDomainTestModule))]
+public class ContractIdentifierProviderTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Mock the repository to avoid spinning up an EF context for behavioral tests.
+        // Repository implementation correctness is covered by EFCore.Tests when needed.
+        context.Services.AddSingleton(Substitute.For<IContractRepository>());
+    }
+}
+
+public class ContractIdentifierProvider_Tests
+    : ContractsDomainTestBase<ContractIdentifierProviderTestModule>
+{
+    private readonly ContractIdentifierProvider _provider;
+    private readonly IContractRepository _contractRepository;
+    private readonly ContractManager _contractManager;
+
+    public ContractIdentifierProvider_Tests()
+    {
+        _provider = GetRequiredService<ContractIdentifierProvider>();
+        _contractRepository = GetRequiredService<IContractRepository>();
+        _contractManager = GetRequiredService<ContractManager>();
+    }
+
+    [Fact]
+    public void SupportedIdentifierTypes_Should_Include_ContractNumber_And_PartyName()
+    {
+        _provider.SupportedIdentifierTypes.ShouldContain(DocumentIdentifierTypes.ContractNumber);
+        _provider.SupportedIdentifierTypes.ShouldContain(DocumentIdentifierTypes.PartyName);
+        // Invoice number / PO number / project code are not the contract module's responsibility.
+        _provider.SupportedIdentifierTypes.ShouldNotContain(DocumentIdentifierTypes.InvoiceNumber);
+        _provider.SupportedIdentifierTypes.ShouldNotContain(DocumentIdentifierTypes.PoNumber);
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Return_Empty_When_Document_Not_Owned_By_Contracts_Module()
+    {
+        var documentId = Guid.NewGuid();
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns((Contract?)null);
+
+        var entries = await _provider.GetIdentifiersAsync(documentId);
+
+        entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Map_Contract_Fields_To_Identifier_Entries()
+    {
+        var documentId = Guid.NewGuid();
+        var contract = CreateContract(
+            documentId,
+            contractNumber: "HT-2026-001",
+            partyA: "甲方公司",
+            partyB: "乙方公司",
+            counterparty: "对手方公司");
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns(contract);
+
+        var entries = (await _provider.GetIdentifiersAsync(documentId)).ToList();
+
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-2026-001"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "甲方公司"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "乙方公司"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "对手方公司"));
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Skip_Null_And_Whitespace_Fields()
+    {
+        var documentId = Guid.NewGuid();
+        var contract = CreateContract(
+            documentId,
+            contractNumber: null,
+            partyA: "  ",
+            partyB: "乙方公司",
+            counterparty: null);
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns(contract);
+
+        var entries = (await _provider.GetIdentifiersAsync(documentId)).ToList();
+
+        entries.Count.ShouldBe(1);
+        entries.Single().ShouldBe(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "乙方公司"));
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Trim_Field_Values()
+    {
+        var documentId = Guid.NewGuid();
+        var contract = CreateContract(
+            documentId,
+            contractNumber: "  HT-2026-002  ",
+            partyA: " 甲方 ",
+            partyB: null,
+            counterparty: null);
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns(contract);
+
+        var entries = (await _provider.GetIdentifiersAsync(documentId)).ToList();
+
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-2026-002"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "甲方"));
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_Should_Return_Empty_For_Whitespace_Value()
+    {
+        var result = await _provider.FindDocumentsAsync(DocumentIdentifierTypes.ContractNumber, "  ");
+        result.ShouldBeEmpty();
+
+        await _contractRepository.DidNotReceive().FindByContractNumberAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_Should_Return_Empty_For_Unsupported_Type()
+    {
+        var result = await _provider.FindDocumentsAsync(DocumentIdentifierTypes.InvoiceNumber, "INV-001");
+        result.ShouldBeEmpty();
+
+        // Defensive: unsupported types short-circuit before any repository call.
+        await _contractRepository.DidNotReceive().FindByContractNumberAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _contractRepository.DidNotReceive().GetListByPartyNameAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_ContractNumber_Should_Trim_And_Delegate()
+    {
+        var matchingDocId = Guid.NewGuid();
+        var matchingContract = CreateContract(matchingDocId, contractNumber: "HT-2026-003");
+        _contractRepository
+            .FindByContractNumberAsync("HT-2026-003", Arg.Any<CancellationToken>())
+            .Returns(new List<Contract> { matchingContract });
+
+        var result = await _provider.FindDocumentsAsync(
+            DocumentIdentifierTypes.ContractNumber,
+            "  HT-2026-003 ");
+
+        result.ShouldContain(matchingDocId);
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_PartyName_Should_Delegate_To_GetListByPartyName()
+    {
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        _contractRepository
+            .GetListByPartyNameAsync("甲方公司", Arg.Any<CancellationToken>())
+            .Returns(new List<Contract>
+            {
+                CreateContract(docA, partyA: "甲方公司"),
+                CreateContract(docB, partyB: "甲方公司")
+            });
+
+        var result = await _provider.FindDocumentsAsync(
+            DocumentIdentifierTypes.PartyName,
+            "甲方公司");
+
+        result.ShouldContain(docA);
+        result.ShouldContain(docB);
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_Should_Distinct_Document_Ids()
+    {
+        var sharedDoc = Guid.NewGuid();
+        // Two Contract rows pointing to the same document (data anomaly we want to defend against).
+        _contractRepository
+            .FindByContractNumberAsync("HT-2026-004", Arg.Any<CancellationToken>())
+            .Returns(new List<Contract>
+            {
+                CreateContract(sharedDoc, contractNumber: "HT-2026-004"),
+                CreateContract(sharedDoc, contractNumber: "HT-2026-004"),
+            });
+
+        var result = await _provider.FindDocumentsAsync(
+            DocumentIdentifierTypes.ContractNumber,
+            "HT-2026-004");
+
+        result.Count.ShouldBe(1);
+    }
+
+    private Contract CreateContract(
+        Guid documentId,
+        string? contractNumber = null,
+        string? partyA = null,
+        string? partyB = null,
+        string? counterparty = null)
+    {
+        var fields = new ContractFields
+        {
+            ContractNumber = contractNumber,
+            PartyAName = partyA,
+            PartyBName = partyB,
+            CounterpartyName = counterparty,
+        };
+
+        // ContractManager wraps the internal Contract constructor. Use it from tests
+        // to honor the same construction path the production code uses.
+        return _contractManager.CreateAsync(documentId, ContractsDocumentTypes.General, fields)
+            .GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary

L2 of the AI relation discovery pipeline ([#115](https://github.com/dignite-projects/dignite-paperbase/issues/115)). After [#117](https://github.com/dignite-projects/dignite-paperbase/pull/117) showed central-table indexing creates a sync-rot problem with user-editable extracted fields, this version delegates identifier storage to business modules — they own their fields, L2 fans out queries via a contract.

## Architecture

### Core layer (Abstractions + Application)

- **`IDocumentIdentifierProvider`** in `Abstractions/Documents/`: contract every business module implements. Two methods — `GetIdentifiersAsync(documentId)` and `FindDocumentsAsync(type, value)` — plus `SupportedIdentifierTypes` for fan-out filtering.
- **`DocumentIdentifierEntry`** record + **`DocumentIdentifierTypes`** canonical strings (`ContractNumber`, `PoNumber`, `InvoiceNumber`, `PartyName`, `ProjectCode`).
- **`RelationDiscoveryService`** in `Application/Documents/Pipelines/RelationDiscovery/`: three-phase fan-out:
  1. Collect source document's identifiers from all providers
  2. For each `(type, value)`, fan out to providers that support the type
  3. Dedupe peers, skip pre-existing relations (Manual / AiSuggested / ModuleAuto), create AiSuggested `DocumentRelation` with `Confidence = 0.95` (constant — structured match is deterministic, not LLM-derived)

### Business module (contracts) reference impl

- **`ContractIdentifierProvider`** maps `Contract.ContractNumber` → `ContractNumber` type; `PartyAName` / `PartyBName` / `CounterpartyName` all → `PartyName` type. Trims values, skips null/whitespace, declares `[ITransientDependency]`.
- **`IContractRepository`** extended with:
  - `FindByContractNumberAsync(string, ct)` → `List<Contract>` (returns list, not first-or-default; defends against AI extraction bugs)
  - `GetListByPartyNameAsync(string, ct)` → searches across PartyA/PartyB/Counterparty fields

## Why no central index table

[#117](https://github.com/dignite-projects/dignite-paperbase/pull/117) tried building a `DocumentIdentifier` aggregate as a central index. Two hard problems killed it:

1. **Single source violation**: `Contract.ContractNumber` already has the value with its own index — copying it duplicates storage.
2. **Sync-rot (decisive)**: extracted fields are user-editable. When a user fixes a typo'd `ContractNumber`, the central index goes stale unless we add an event-sync mechanism — which is exactly the kind of plumbing this design avoids.

L2 here directly queries business modules. They own the data; we always read live values.

## Out of scope (deferred)

- **Auto-trigger**: no background job + `DocumentClassifiedEto` subscription yet. Triggering is a separate concern with its own race-condition questions (business module field extraction may still be in flight when L2 fires) and deserves its own focused PR.
- **L3 (semantic + LLM)** — stays as a fallback path, separate PR.
- **Document-deletion cascade** for orphan `Contract` rows — needs the L2 trigger PR to land first to even see broken links.

## Test plan

- [x] Build clean across core Application + contracts EFCore + host
- [x] `RelationDiscoveryService_Tests` (7): empty source, cross-module peer creation, already-linked skip, multi-identifier dedupe to one relation, self-match guard, type-not-supported skip, empty document id rejection. Uses fake providers as singletons (transient registration would split test-class and service-injected enumerations).
- [x] `ContractIdentifierProvider_Tests` (10): supported types declared correctly, document not owned by module returns empty, field mapping covers ContractNumber + 3 PartyName fields, null/whitespace skip, trim normalization, blank value short-circuits before repository call, unsupported type returns empty without repository call, ContractNumber/PartyName delegation, distinct document ids
- [x] Full Domain (42), Application (235), Contracts.Domain (16) suites pass
- [ ] Manual: with auto-trigger PR landed, upload a contract + an invoice referencing the same `ContractNumber`; verify AiSuggested DocumentRelation created and visible in `get_document_relations` chat tool

## Files changed (8)

| Project | File | Type |
|---|---|---|
| Abstractions | `Documents/DocumentIdentifierTypes.cs` | new |
| Abstractions | `Documents/IDocumentIdentifierProvider.cs` | new |
| Application | `Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs` | new |
| Application.Tests | `Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs` | new |
| Contracts.Domain | `Contracts/IContractRepository.cs` | edit (+2 methods) |
| Contracts.Domain | `Contracts/ContractIdentifierProvider.cs` | new |
| Contracts.EntityFrameworkCore | `EntityFrameworkCore/EfCoreContractRepository.cs` | edit (+2 methods) |
| Contracts.Domain.Tests | `Contracts/ContractIdentifierProvider_Tests.cs` | new |

🤖 Generated with [Claude Code](https://claude.com/claude-code)