### PR TITLE
feat(documents): L2 auto-trigger on DocumentClassifiedEto (#115)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/DocumentPipelineJobScheduler.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/DocumentPipelineJobScheduler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Documents.Pipelines.Classification;
 using Dignite.Paperbase.Documents.Pipelines.Embedding;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 using Dignite.Paperbase.Documents.Pipelines.TextExtraction;
 using Microsoft.Extensions.Logging;
 using Volo.Abp;
@@ -58,6 +59,12 @@ public class DocumentPipelineJobScheduler : ITransientDependency
                 }),
             PaperbasePipelines.Embedding => _backgroundJobManager.EnqueueAsync(
                 new DocumentEmbeddingJobArgs
+                {
+                    DocumentId = documentId,
+                    PipelineRunId = pipelineRunId
+                }),
+            PaperbasePipelines.RelationDiscovery => _backgroundJobManager.EnqueueAsync(
+                new RelationDiscoveryJobArgs
                 {
                     DocumentId = documentId,
                     PipelineRunId = pipelineRunId

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Uow;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L2 自动触发：执行 <see cref="RelationDiscoveryService.DiscoverAsync"/>，
+/// 用 <see cref="DocumentPipelineRun"/> 跟踪运行状态以便观察 / 后续诊断。
+///
+/// <para>
+/// 短 UoW 模式（参见 <c>.claude/rules/background-jobs.md</c>）：
+/// <list type="number">
+/// <item>Begin：UoW1 加载 Document，标记 PipelineRun 为 Running，提交。</item>
+/// <item>Discovery：UoW2 调用 <see cref="RelationDiscoveryService"/>，创建 AiSuggested 关系，提交。</item>
+/// <item>Complete / Fail：UoW3 重新加载 Document，标记 PipelineRun 状态，提交。</item>
+/// </list>
+/// L2 本身只做 DB 查询（无 LLM / 文件 IO / 长 CPU），但仍然分阶段——
+/// 保持与其他 pipeline 一致的运行模型，便于将来加 telemetry / 重试。
+/// </para>
+///
+/// <para>
+/// 失败处理：DiscoverAsync 内部已对 provider 异常做隔离（见 #118 commit ffe745a）；
+/// 此层 try/catch 兜底捕获基础设施异常（DB 连接断开 / 序列化错误），
+/// 不会因为某个有 bug 的 provider 把整个 PipelineRun 拖成 Failed。
+/// </para>
+/// </summary>
+[BackgroundJobName("Paperbase.RelationDiscovery")]
+public class RelationDiscoveryBackgroundJob
+    : AsyncBackgroundJob<RelationDiscoveryJobArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineRunManager _pipelineRunManager;
+    private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
+    private readonly RelationDiscoveryService _discoveryService;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public RelationDiscoveryBackgroundJob(
+        IDocumentRepository documentRepository,
+        DocumentPipelineRunManager pipelineRunManager,
+        DocumentPipelineRunAccessor pipelineRunAccessor,
+        RelationDiscoveryService discoveryService,
+        IUnitOfWorkManager unitOfWorkManager)
+    {
+        _documentRepository = documentRepository;
+        _pipelineRunManager = pipelineRunManager;
+        _pipelineRunAccessor = pipelineRunAccessor;
+        _discoveryService = discoveryService;
+        _unitOfWorkManager = unitOfWorkManager;
+    }
+
+    public override async Task ExecuteAsync(RelationDiscoveryJobArgs args)
+    {
+        var workItem = await BeginRunAsync(args);
+        if (workItem == null)
+        {
+            return;
+        }
+
+        int createdCount;
+        try
+        {
+            createdCount = await DiscoverAsync(workItem.DocumentId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "L2 RelationDiscovery failed for document {DocumentId}. PipelineRun marked failed; document lifecycle unchanged (non-key pipeline).",
+                workItem.DocumentId);
+            await FailRunAsync(workItem.DocumentId, workItem.RunId, ex.Message);
+            return;
+        }
+
+        await CompleteRunAsync(workItem.DocumentId, workItem.RunId, createdCount);
+    }
+
+    protected virtual async Task<DiscoveryWorkItem?> BeginRunAsync(RelationDiscoveryJobArgs args)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.FindAsync(args.DocumentId, includeDetails: true);
+        if (document == null)
+        {
+            // Document was hard-deleted between event publish and job pickup — silently drop.
+            // No PipelineRun to mark; Document carrying the run is gone.
+            Logger.LogInformation(
+                "L2 RelationDiscovery: document {DocumentId} no longer exists; dropping job.",
+                args.DocumentId);
+            await uow.CompleteAsync();
+            return null;
+        }
+
+        var run = await _pipelineRunAccessor.BeginOrStartAsync(
+            document, args.PipelineRunId, PaperbasePipelines.RelationDiscovery);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+
+        return new DiscoveryWorkItem(run.Id, document.Id);
+    }
+
+    protected virtual async Task<int> DiscoverAsync(Guid documentId)
+    {
+        // L2 service inserts DocumentRelation aggregates with autoSave: false; wrap in a UoW
+        // so the writes commit. Pure DB work — no external IO — but the rule "begin → external → complete"
+        // is honored in spirit by isolating the discovery write transaction from the run-state writes.
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        var created = await _discoveryService.DiscoverAsync(documentId);
+        await uow.CompleteAsync();
+        return created.Count;
+    }
+
+    protected virtual async Task CompleteRunAsync(Guid documentId, Guid runId, int createdCount)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.GetAsync(documentId, includeDetails: true);
+        var run = document.GetRun(runId)
+            ?? await _pipelineRunAccessor.BeginOrStartAsync(
+                document, runId, PaperbasePipelines.RelationDiscovery);
+
+        await _pipelineRunManager.CompleteAsync(document, run);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+
+        Logger.LogInformation(
+            "L2 RelationDiscovery: document {DocumentId} run {RunId} succeeded; created {CreatedCount} AiSuggested relations.",
+            documentId, runId, createdCount);
+    }
+
+    protected virtual async Task FailRunAsync(Guid documentId, Guid runId, string errorMessage)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.GetAsync(documentId, includeDetails: true);
+        var run = document.GetRun(runId)
+            ?? await _pipelineRunAccessor.BeginOrStartAsync(
+                document, runId, PaperbasePipelines.RelationDiscovery);
+
+        await _pipelineRunManager.FailAsync(document, run, errorMessage);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+    }
+
+    protected sealed record DiscoveryWorkItem(Guid RunId, Guid DocumentId);
+}
+
+public class RelationDiscoveryJobArgs
+{
+    public Guid DocumentId { get; set; }
+    public Guid? PipelineRunId { get; set; }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Documents;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.EventBus.Distributed;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L2 自动触发：订阅 <see cref="DocumentClassifiedEto"/>，
+/// 在文档分类完成后排队 L2 背景任务。
+///
+/// <para>
+/// <strong>触发时序</strong>：核心层与业务模块都订阅 <see cref="DocumentClassifiedEto"/>。
+/// ABP 分布式事件总线本地实现按注册顺序串行调用所有订阅者；本订阅者只做"排队后台任务"
+/// 这种轻量动作（不直接执行 L2），所以不会阻塞业务模块的字段抽取。
+/// 后台任务实际执行时，业务模块（如 contracts）的 <c>autoSave: true</c> 抽取已经完成，
+/// L2 通过 <c>IDocumentIdentifierProvider</c> 反查能拿到刚抽取的字段。
+/// </para>
+///
+/// <para>
+/// <strong>orphan 文档</strong>：分类失败的文档不会发布 <see cref="DocumentClassifiedEto"/>，
+/// 自然跳过 L2。这与 #115 设计 "v1 orphan 走 L3 兜底" 一致。
+/// </para>
+///
+/// <para>
+/// <strong>幂等性</strong>：<see cref="DocumentPipelineJobScheduler.QueueAsync"/> 每次创建新的
+/// <c>DocumentPipelineRun</c>。同一文档分类事件理论上只触发一次（除非分类被人工重跑），
+/// 重复运行 L2 也安全：<see cref="RelationDiscoveryService"/> 对已存在关系做完全跳过，
+/// 不会创建重复 AiSuggested 行。
+/// </para>
+/// </summary>
+public class RelationDiscoveryEventHandler
+    : IDistributedEventHandler<DocumentClassifiedEto>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly ILogger<RelationDiscoveryEventHandler> _logger;
+
+    public RelationDiscoveryEventHandler(
+        IDocumentRepository documentRepository,
+        DocumentPipelineJobScheduler pipelineJobScheduler,
+        ILogger<RelationDiscoveryEventHandler> logger)
+    {
+        _documentRepository = documentRepository;
+        _pipelineJobScheduler = pipelineJobScheduler;
+        _logger = logger;
+    }
+
+    public virtual async Task HandleEventAsync(DocumentClassifiedEto eventData)
+    {
+        if (eventData.DocumentId == Guid.Empty)
+        {
+            return;
+        }
+
+        // Document might have been hard-deleted between classification publish and handler dispatch.
+        // FindAsync (not GetAsync) → silently drop instead of throwing into the event bus.
+        var document = await _documentRepository.FindAsync(eventData.DocumentId, includeDetails: true);
+        if (document == null)
+        {
+            _logger.LogInformation(
+                "L2 RelationDiscovery handler: document {DocumentId} no longer exists; skipping enqueue.",
+                eventData.DocumentId);
+            return;
+        }
+
+        await _pipelineJobScheduler.QueueAsync(document, PaperbasePipelines.RelationDiscovery);
+    }
+}

--- a/core/src/Dignite.Paperbase.Domain.Shared/Documents/PaperbasePipelines.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Documents/PaperbasePipelines.cs
@@ -18,6 +18,12 @@ public static class PaperbasePipelines
     /// <summary>文本分块 + 向量化。非关键流水线，失败降级为全文检索。</summary>
     public const string Embedding = "embedding";
 
+    /// <summary>
+    /// Issue #115 L2: 关系发现（基于业务模块 <c>IDocumentIdentifierProvider</c> fan-out）。
+    /// 非关键流水线——失败不影响 Document 生命周期；orphan 文档（无业务模块认领）会自然短路成 0 关系。
+    /// </summary>
+    public const string RelationDiscovery = "relation-discovery";
+
     /// <summary>生命周期派生时视为"关键"的流水线集合。</summary>
     public static readonly IReadOnlyCollection<string> KeyPipelines = new[]
     {

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class RelationDiscoveryBackgroundJobTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
+
+        // Replace RelationDiscoveryService entirely — this test only verifies the JOB's
+        // PipelineRun lifecycle wiring, not the discovery logic (covered separately by
+        // RelationDiscoveryService_Tests).
+        context.Services.AddSingleton(Substitute.For<RelationDiscoveryService>(
+            Array.Empty<IDocumentIdentifierProvider>(),
+            Substitute.For<IDocumentRelationRepository>(),
+            Substitute.For<ICurrentTenant>()));
+    }
+}
+
+/// <summary>
+/// Verifies <see cref="RelationDiscoveryBackgroundJob"/>'s short-UoW lifecycle:
+/// PipelineRun is created → Running → Succeeded/Failed in three separate UoWs;
+/// service throwing surfaces as Failed without crashing the job.
+/// </summary>
+public class RelationDiscoveryBackgroundJob_Tests
+    : PaperbaseApplicationTestBase<RelationDiscoveryBackgroundJobTestModule>
+{
+    private readonly RelationDiscoveryBackgroundJob _job;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly RelationDiscoveryService _discoveryService;
+
+    public RelationDiscoveryBackgroundJob_Tests()
+    {
+        _job = GetRequiredService<RelationDiscoveryBackgroundJob>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _discoveryService = GetRequiredService<RelationDiscoveryService>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Mark_Run_Succeeded_When_Discovery_Returns_Successfully()
+    {
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        var run = doc.GetLatestRun(PaperbasePipelines.RelationDiscovery);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Mark_Run_Failed_When_Discovery_Throws()
+    {
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<DocumentRelation>>(_ => throw new InvalidOperationException("DB connection lost"));
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        var run = doc.GetLatestRun(PaperbasePipelines.RelationDiscovery);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Failed);
+        run.StatusMessage.ShouldBe("DB connection lost");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Drop_Job_Silently_When_Document_Not_Found()
+    {
+        // Document hard-deleted between event publish and job pickup — drop without throwing.
+        var documentId = Guid.NewGuid();
+        _documentRepository
+            .FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = documentId });
+
+        await _discoveryService.DidNotReceive().DiscoverAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Reuse_Pending_Run_When_PipelineRunId_Provided()
+    {
+        // The scheduler creates a Pending run before enqueue and passes its id in args.
+        // Job must pick it up rather than start a fresh one.
+        var doc = CreateDocument();
+        var pipelineRunManager = GetRequiredService<DocumentPipelineRunManager>();
+        var pendingRun = await pipelineRunManager.QueueAsync(doc, PaperbasePipelines.RelationDiscovery);
+        SetupDocumentRepository(doc);
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs
+        {
+            DocumentId = doc.Id,
+            PipelineRunId = pendingRun.Id
+        });
+
+        pendingRun.Status.ShouldBe(PipelineRunStatus.Succeeded);
+        pendingRun.AttemptNumber.ShouldBe(1);
+        doc.PipelineRuns.Count.ShouldBe(1);   // No duplicate run created
+    }
+
+    private void SetupDocumentRepository(Document doc)
+    {
+        _documentRepository
+            .FindAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+        _documentRepository
+            .GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private static Document CreateDocument()
+    {
+        return new Document(
+            Guid.NewGuid(), tenantId: null,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler_Tests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Documents;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class RelationDiscoveryEventHandlerTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        // Substitute the scheduler entirely so we verify the handler queues with the correct
+        // pipeline code without exercising the real PipelineRun creation / job enqueue path.
+        // The scheduler ctor needs valid args; pass cheap substitutes.
+        context.Services.AddSingleton(provider =>
+            Substitute.For<DocumentPipelineJobScheduler>(
+                Substitute.For<IDocumentRepository>(),
+                provider.GetRequiredService<DocumentPipelineRunManager>(),
+                Substitute.For<IBackgroundJobManager>()));
+    }
+}
+
+public class RelationDiscoveryEventHandler_Tests
+    : PaperbaseApplicationTestBase<RelationDiscoveryEventHandlerTestModule>
+{
+    private readonly RelationDiscoveryEventHandler _handler;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineJobScheduler _scheduler;
+
+    public RelationDiscoveryEventHandler_Tests()
+    {
+        _handler = GetRequiredService<RelationDiscoveryEventHandler>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _scheduler = GetRequiredService<DocumentPipelineJobScheduler>();
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_Should_Queue_Job_When_Document_Exists()
+    {
+        var document = CreateDocument();
+        _documentRepository
+            .FindAsync(document.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(document);
+        _scheduler
+            .QueueAsync(Arg.Any<Document>(), Arg.Any<string>())
+            .Returns(Task.FromResult<DocumentPipelineRun>(null!));
+
+        await _handler.HandleEventAsync(new DocumentClassifiedEto
+        {
+            DocumentId = document.Id,
+            DocumentTypeCode = "contract.general",
+            ClassificationConfidence = 0.95
+        });
+
+        await _scheduler.Received(1).QueueAsync(
+            Arg.Is<Document>(d => d.Id == document.Id),
+            PaperbasePipelines.RelationDiscovery);
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_Should_Skip_When_Document_Has_Empty_Id()
+    {
+        await _handler.HandleEventAsync(new DocumentClassifiedEto
+        {
+            DocumentId = Guid.Empty,
+            DocumentTypeCode = "contract.general"
+        });
+
+        await _scheduler.DidNotReceive().QueueAsync(Arg.Any<Document>(), Arg.Any<string>());
+        await _documentRepository.DidNotReceive().FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_Should_Skip_When_Document_No_Longer_Exists()
+    {
+        // Hard-deleted between classification publish and handler dispatch.
+        var documentId = Guid.NewGuid();
+        _documentRepository
+            .FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+
+        await _handler.HandleEventAsync(new DocumentClassifiedEto
+        {
+            DocumentId = documentId,
+            DocumentTypeCode = "contract.general"
+        });
+
+        await _scheduler.DidNotReceive().QueueAsync(Arg.Any<Document>(), Arg.Any<string>());
+    }
+
+    private static Document CreateDocument()
+    {
+        return new Document(
+            Guid.NewGuid(), tenantId: null,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+    }
+}


### PR DESCRIPTION
## Summary

Auto-trigger for L2 RelationDiscovery (Issue [#115](https://github.com/dignite-projects/dignite-paperbase/issues/115)). After [#118](https://github.com/dignite-projects/dignite-paperbase/pull/118) shipped the discovery service + provider contract + reference impl, this PR closes the loop: when a document finishes classification, the L2 pipeline runs automatically as a background job.

> **Stacked PR**: based on `feat/issue-115-l2-discovery-service` (#118). Merge order: #118 → this.

## Wiring

- **`PaperbasePipelines.RelationDiscovery`** — new pipeline code constant. Non-key (excluded from `KeyPipelines`) — failure does not affect Document lifecycle. Not in `RetryablePipelines` either: L2 is internal background inference, not a user-retryable operation.
- **`DocumentPipelineJobScheduler.EnqueueAsync`** — new switch case for `RelationDiscovery` → enqueues `RelationDiscoveryJobArgs`.
- **`RelationDiscoveryEventHandler`** — subscribes to `DocumentClassifiedEto`. Loads the document via `FindAsync` (silently drops if hard-deleted between publish and dispatch), then calls `scheduler.QueueAsync`. Lightweight — defers actual L2 work to the background job, doesn't block sibling event handlers (e.g. `ContractDocumentHandler`) from running.
- **`RelationDiscoveryBackgroundJob`** — short-UoW lifecycle per `.claude/rules/background-jobs.md` — Begin (mark Running) / Discovery (commit relations) / Complete (mark Succeeded) in three separate UoWs. Service exceptions surface as Failed run state without re-throwing.

## Trigger timing — race-free without artificial delay

Order between distributed event handlers is not guaranteed, but the background job runs **asynchronously after `PublishAsync` returns**. By that point all sibling sync handlers (`ContractDocumentHandler` etc.) have completed their `autoSave: true` field extraction, so providers see live data when L2 queries them.

orphan documents (failed classification) skip L2 naturally — they don't publish `DocumentClassifiedEto`. This matches the #115 design: "v1 orphan goes to L3 fallback".

## What this PR does NOT do

- **L3 (semantic + LLM fallback)** — separate PR. L2 covers structured-identifier matches; L3 will handle docs L2 finds no relations for.
- **Document deletion linkage** — Contract orphans cleanup is a separate concern (provider returns empty for deleted docs, so no incorrect relations created; broken existing relations are a pre-existing concern).
- **Telemetry beyond logs** — `Logger.LogInformation` records created count per run; structured metrics deferred.

## Test plan

- [x] Build clean (Application project)
- [x] `RelationDiscoveryEventHandler_Tests` (3): queues with correct pipeline code on success, skips on empty document id, skips on doc-not-found
- [x] `RelationDiscoveryBackgroundJob_Tests` (4): run marked Succeeded on service success, marked Failed on service throw, dropped silently on doc-not-found, reuses pending run when PipelineRunId provided
- [x] Full Application suite: 245/245 pass (was 235; 10 new RelationDiscovery tests)
- [ ] Manual: upload a contract (DocumentClassifiedEto fires) — verify a `relation-discovery` PipelineRun appears against the Document and reaches Succeeded state

🤖 Generated with [Claude Code](https://claude.com/claude-code)