### PR TITLE
refactor(documents): L2 tenant via Document.TenantId, not ICurrentTenant (#121)

### DIFF
--- a/core/src/Dignite.Paperbase.Abstractions/Documents/DocumentIdentifierTypes.cs
+++ b/core/src/Dignite.Paperbase.Abstractions/Documents/DocumentIdentifierTypes.cs
@@ -1,0 +1,36 @@
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// Issue #115 L2: 跨业务模块的标准化标识符类型常量。
+///
+/// <para>
+/// 业务模块在实现 <c>IDocumentIdentifierProvider</c> 时把自己的字段映射到这些标准类型。
+/// 例如合同模块把 <c>Contract.ContractNumber</c> 映射为 <see cref="ContractNumber"/>，
+/// 把 <c>Contract.PartyAName</c> + <c>Contract.PartyBName</c> 都映射为 <see cref="PartyName"/>。
+/// </para>
+///
+/// <para>
+/// L2 关系发现 Pipeline 用这套类型在 fan-out 时筛选 provider，避免对不相关 type 走无效查询。
+/// 新业务模块需要新增类型时在此添加常量；不在此处的字符串视为非约定类型，L2 不会处理。
+/// </para>
+/// </summary>
+public static class DocumentIdentifierTypes
+{
+    /// <summary>合同编号（contract number, 框架合同/采购合同等的唯一编号）。</summary>
+    public const string ContractNumber = "ContractNumber";
+
+    /// <summary>采购订单号（purchase order number）。</summary>
+    public const string PoNumber = "PoNumber";
+
+    /// <summary>发票号（invoice number）。</summary>
+    public const string InvoiceNumber = "InvoiceNumber";
+
+    /// <summary>
+    /// 当事人名称（甲方 / 乙方 / 客户 / 供应商等）。同一文档可能有多个 PartyName 值，
+    /// 同一 PartyName 值可能跨多个文档（这是 L2 发现关系的核心信号之一）。
+    /// </summary>
+    public const string PartyName = "PartyName";
+
+    /// <summary>项目代号（project code，跨多份业务文档共享的项目标识）。</summary>
+    public const string ProjectCode = "ProjectCode";
+}

--- a/core/src/Dignite.Paperbase.Abstractions/Documents/IDocumentIdentifierProvider.cs
+++ b/core/src/Dignite.Paperbase.Abstractions/Documents/IDocumentIdentifierProvider.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// Issue #115 L2：业务模块向核心暴露的"标识符查询"契约。
+///
+/// <para>
+/// <strong>设计原则：核心层不持有标识符数据，业务模块是单一来源</strong>。
+/// 合同编号已经存在 <c>Contract.ContractNumber</c> 字段、PO 号已经存在 <c>Invoice.PoNumber</c> 字段——
+/// 业务模块字段是这些标识符的唯一权威。L2 关系发现通过本契约在所有业务模块间 fan-out 查询，
+/// 避免在核心层重复存储一份索引（这会引入数据冗余 + 用户编辑后的同步腐烂问题）。
+/// </para>
+///
+/// <para>
+/// 实现位于业务模块（如 <c>Dignite.Paperbase.Contracts.Domain.Contracts.ContractIdentifierProvider</c>）；
+/// 实现类应注册为 <see cref="Volo.Abp.DependencyInjection.ITransientDependency"/>，
+/// L2 通过 DI 收集 <c>IEnumerable&lt;IDocumentIdentifierProvider&gt;</c> 自动 fan-out。
+/// </para>
+///
+/// <para>
+/// 多租户：实现侧用 ABP <c>IMultiTenant</c> ambient filter（仓储默认行为）；
+/// 不需要从入参收 <c>tenantId</c>。
+/// </para>
+///
+/// <para>
+/// 此契约位于 <c>Abstractions</c> 层，业务模块通过 NuGet 引用 <c>Dignite.Paperbase.Abstractions</c> 即可实现，
+/// 不被迫依赖核心 Application 层。
+/// </para>
+/// </summary>
+public interface IDocumentIdentifierProvider
+{
+    /// <summary>
+    /// 该 provider 支持的标准化 identifier 类型集合（参见 <see cref="DocumentIdentifierTypes"/>）。
+    /// L2 fan-out 时按此集合筛选——provider 不支持的类型不会被调用，避免无谓查询。
+    /// </summary>
+    IReadOnlyCollection<string> SupportedIdentifierTypes { get; }
+
+    /// <summary>
+    /// 返回该 provider 名下的某文档持有的所有标识符 (type, value) 对。
+    /// 若该 provider 不拥有该文档（例如合同 provider 收到一份发票），返回空列表（不抛异常）。
+    /// 同一类型可能有多条值（如 <c>PartyName</c> 可能同时是甲方和乙方），所以返回 <see cref="IReadOnlyList{T}"/> 而非字典。
+    /// </summary>
+    Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 反查：当前租户内该 provider 名下，持有指定 (type, value) 的文档 ID 列表。
+    /// L2 主查询路径——找到与源文档共享标识符的对端文档。
+    /// 实现侧应依赖 ABP ambient <c>DataFilter</c> 自动按 <c>CurrentTenant</c> 过滤。
+    /// </summary>
+    Task<IReadOnlyList<Guid>> FindDocumentsAsync(
+        string identifierType,
+        string identifierValue,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// 标识符条目（不可变值对象）。
+/// </summary>
+/// <param name="Type">标识符类型，应为 <see cref="DocumentIdentifierTypes"/> 中的常量。</param>
+/// <param name="Value">标识符值，已规范化（trim 后）。</param>
+public sealed record DocumentIdentifierEntry(string Type, string Value);

--- a/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
@@ -103,4 +103,29 @@ public class PaperbaseAIBehaviorOptions
     /// Set to 0 to disable the cap (not recommended in production).
     /// </summary>
     public int MaxCapturedCitations { get; set; } = 50;
+
+    /// <summary>
+    /// Issue #115 L3: 启用基于"向量召回 + LLM 评判"的语义关系发现作为 L2 兜底。
+    /// 默认 <c>false</c>——LLM 调用按文档数线性增长，操作员需明确开启并自行控制成本。
+    /// 关闭时 L2 找不到关系的文档保持无 AiSuggested 状态，等待用户手动建立。
+    /// </summary>
+    public bool EnableSemanticRelationDiscovery { get; set; } = false;
+
+    /// <summary>
+    /// L3 向量召回 top-K——LLM 评判前的候选数量上限。
+    /// 越大召回越宽，但 LLM 调用成本线性增长。建议 5–10。
+    /// </summary>
+    public int SemanticRelationDiscoveryTopK { get; set; } = 5;
+
+    /// <summary>
+    /// L3 向量召回最低分数。低于此分数的候选直接淘汰，不送 LLM。
+    /// 高于普通 chat RAG 的 <see cref="DocumentChatMinScore"/>——L3 只关心强语义匹配，弱匹配是噪音。
+    /// </summary>
+    public double SemanticRelationDiscoveryMinScore { get; set; } = 0.65;
+
+    /// <summary>
+    /// L3 LLM 评判的 confidence 下限。LLM 输出 <see cref="RelationInferenceResult.Confidence"/>
+    /// 低于此值的候选不创建 AiSuggested 关系。建议 0.7+。
+    /// </summary>
+    public double SemanticRelationDiscoveryConfidenceThreshold { get; set; } = 0.7;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/DocumentPipelineJobScheduler.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/DocumentPipelineJobScheduler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Documents.Pipelines.Classification;
 using Dignite.Paperbase.Documents.Pipelines.Embedding;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 using Dignite.Paperbase.Documents.Pipelines.TextExtraction;
 using Microsoft.Extensions.Logging;
 using Volo.Abp;
@@ -58,6 +59,12 @@ public class DocumentPipelineJobScheduler : ITransientDependency
                 }),
             PaperbasePipelines.Embedding => _backgroundJobManager.EnqueueAsync(
                 new DocumentEmbeddingJobArgs
+                {
+                    DocumentId = documentId,
+                    PipelineRunId = pipelineRunId
+                }),
+            PaperbasePipelines.RelationDiscovery => _backgroundJobManager.EnqueueAsync(
+                new RelationDiscoveryJobArgs
                 {
                     DocumentId = documentId,
                     PipelineRunId = pipelineRunId

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Uow;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L2 自动触发：执行 <see cref="RelationDiscoveryService.DiscoverAsync"/>，
+/// 用 <see cref="DocumentPipelineRun"/> 跟踪运行状态以便观察 / 后续诊断。
+///
+/// <para>
+/// 短 UoW 模式（参见 <c>.claude/rules/background-jobs.md</c>）：
+/// <list type="number">
+/// <item>Begin：UoW1 加载 Document，标记 PipelineRun 为 Running，提交。</item>
+/// <item>Discovery：UoW2 调用 <see cref="RelationDiscoveryService"/>，创建 AiSuggested 关系，提交。</item>
+/// <item>Complete / Fail：UoW3 重新加载 Document，标记 PipelineRun 状态，提交。</item>
+/// </list>
+/// L2 本身只做 DB 查询（无 LLM / 文件 IO / 长 CPU），但仍然分阶段——
+/// 保持与其他 pipeline 一致的运行模型，便于将来加 telemetry / 重试。
+/// </para>
+///
+/// <para>
+/// 失败处理：DiscoverAsync 内部已对 provider 异常做隔离（见 #118 commit ffe745a）；
+/// 此层 try/catch 兜底捕获基础设施异常（DB 连接断开 / 序列化错误），
+/// 不会因为某个有 bug 的 provider 把整个 PipelineRun 拖成 Failed。
+/// </para>
+/// </summary>
+[BackgroundJobName("Paperbase.RelationDiscovery")]
+public class RelationDiscoveryBackgroundJob
+    : AsyncBackgroundJob<RelationDiscoveryJobArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineRunManager _pipelineRunManager;
+    private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
+    private readonly RelationDiscoveryService _discoveryService;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public RelationDiscoveryBackgroundJob(
+        IDocumentRepository documentRepository,
+        DocumentPipelineRunManager pipelineRunManager,
+        DocumentPipelineRunAccessor pipelineRunAccessor,
+        RelationDiscoveryService discoveryService,
+        IUnitOfWorkManager unitOfWorkManager)
+    {
+        _documentRepository = documentRepository;
+        _pipelineRunManager = pipelineRunManager;
+        _pipelineRunAccessor = pipelineRunAccessor;
+        _discoveryService = discoveryService;
+        _unitOfWorkManager = unitOfWorkManager;
+    }
+
+    public override async Task ExecuteAsync(RelationDiscoveryJobArgs args)
+    {
+        var workItem = await BeginRunAsync(args);
+        if (workItem == null)
+        {
+            return;
+        }
+
+        int createdCount;
+        try
+        {
+            createdCount = await DiscoverAsync(workItem.DocumentId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "L2 RelationDiscovery failed for document {DocumentId}. PipelineRun marked failed; document lifecycle unchanged (non-key pipeline).",
+                workItem.DocumentId);
+            await FailRunAsync(workItem.DocumentId, workItem.RunId, ex.Message);
+            return;
+        }
+
+        await CompleteRunAsync(workItem.DocumentId, workItem.RunId, createdCount);
+    }
+
+    protected virtual async Task<DiscoveryWorkItem?> BeginRunAsync(RelationDiscoveryJobArgs args)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.FindAsync(args.DocumentId, includeDetails: true);
+        if (document == null)
+        {
+            // Document was hard-deleted between event publish and job pickup — silently drop.
+            // No PipelineRun to mark; Document carrying the run is gone.
+            Logger.LogInformation(
+                "L2 RelationDiscovery: document {DocumentId} no longer exists; dropping job.",
+                args.DocumentId);
+            await uow.CompleteAsync();
+            return null;
+        }
+
+        var run = await _pipelineRunAccessor.BeginOrStartAsync(
+            document, args.PipelineRunId, PaperbasePipelines.RelationDiscovery);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+
+        return new DiscoveryWorkItem(run.Id, document.Id);
+    }
+
+    protected virtual async Task<int> DiscoverAsync(Guid documentId)
+    {
+        // L2 service inserts DocumentRelation aggregates with autoSave: false; wrap in a UoW
+        // so the writes commit. Pure DB work — no external IO — but the rule "begin → external → complete"
+        // is honored in spirit by isolating the discovery write transaction from the run-state writes.
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        var created = await _discoveryService.DiscoverAsync(documentId);
+        await uow.CompleteAsync();
+        return created.Count;
+    }
+
+    protected virtual async Task CompleteRunAsync(Guid documentId, Guid runId, int createdCount)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.GetAsync(documentId, includeDetails: true);
+        var run = document.GetRun(runId)
+            ?? await _pipelineRunAccessor.BeginOrStartAsync(
+                document, runId, PaperbasePipelines.RelationDiscovery);
+
+        await _pipelineRunManager.CompleteAsync(document, run);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+
+        Logger.LogInformation(
+            "L2 RelationDiscovery: document {DocumentId} run {RunId} succeeded; created {CreatedCount} AiSuggested relations.",
+            documentId, runId, createdCount);
+    }
+
+    protected virtual async Task FailRunAsync(Guid documentId, Guid runId, string errorMessage)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.GetAsync(documentId, includeDetails: true);
+        var run = document.GetRun(runId)
+            ?? await _pipelineRunAccessor.BeginOrStartAsync(
+                document, runId, PaperbasePipelines.RelationDiscovery);
+
+        await _pipelineRunManager.FailAsync(document, run, errorMessage);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+    }
+
+    protected sealed record DiscoveryWorkItem(Guid RunId, Guid DocumentId);
+}
+
+public class RelationDiscoveryJobArgs
+{
+    public Guid DocumentId { get; set; }
+    public Guid? PipelineRunId { get; set; }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
@@ -37,6 +37,7 @@ public class RelationDiscoveryBackgroundJob
     private readonly DocumentPipelineRunManager _pipelineRunManager;
     private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
     private readonly RelationDiscoveryService _discoveryService;
+    private readonly SemanticRelationDiscoveryService _semanticDiscoveryService;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
 
     public RelationDiscoveryBackgroundJob(
@@ -44,12 +45,14 @@ public class RelationDiscoveryBackgroundJob
         DocumentPipelineRunManager pipelineRunManager,
         DocumentPipelineRunAccessor pipelineRunAccessor,
         RelationDiscoveryService discoveryService,
+        SemanticRelationDiscoveryService semanticDiscoveryService,
         IUnitOfWorkManager unitOfWorkManager)
     {
         _documentRepository = documentRepository;
         _pipelineRunManager = pipelineRunManager;
         _pipelineRunAccessor = pipelineRunAccessor;
         _discoveryService = discoveryService;
+        _semanticDiscoveryService = semanticDiscoveryService;
         _unitOfWorkManager = unitOfWorkManager;
     }
 
@@ -105,13 +108,29 @@ public class RelationDiscoveryBackgroundJob
 
     protected virtual async Task<int> DiscoverAsync(Guid documentId)
     {
-        // L2 service inserts DocumentRelation aggregates with autoSave: false; wrap in a UoW
-        // so the writes commit. Pure DB work — no external IO — but the rule "begin → external → complete"
-        // is honored in spirit by isolating the discovery write transaction from the run-state writes.
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
-        var created = await _discoveryService.DiscoverAsync(documentId);
-        await uow.CompleteAsync();
-        return created.Count;
+        // L2: structured fan-out across business-module providers. Cheap (DB queries only).
+        // L2 writes commit in a dedicated UoW (autoSave: false on inserts ⇒ uow.CompleteAsync()).
+        int l2Count;
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var created = await _discoveryService.DiscoverAsync(documentId);
+            await uow.CompleteAsync();
+            l2Count = created.Count;
+        }
+
+        if (l2Count > 0)
+        {
+            // L2 found structured matches — that's strong signal; don't run L3 (expensive LLM)
+            // on top. L3 is the fallback for "structured matching found nothing".
+            return l2Count;
+        }
+
+        // L3 fallback: vector recall + LLM evaluation. Disabled by default (operator opt-in).
+        // NOT wrapped in an outer UoW: SemanticRelationDiscoveryService uses autoSave: true on
+        // each relation insert (per-call implicit UoW), so LLM calls between candidates run with
+        // no ambient UoW — satisfies the "no DB connection during external work" rule.
+        var l3Created = await _semanticDiscoveryService.DiscoverAsync(documentId);
+        return l3Created.Count;
     }
 
     protected virtual async Task CompleteRunAsync(Guid documentId, Guid runId, int createdCount)

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Documents;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.EventBus.Distributed;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L2 自动触发：订阅 <see cref="DocumentClassifiedEto"/>，
+/// 在文档分类完成后排队 L2 背景任务。
+///
+/// <para>
+/// <strong>触发时序</strong>：核心层与业务模块都订阅 <see cref="DocumentClassifiedEto"/>。
+/// ABP 分布式事件总线本地实现按注册顺序串行调用所有订阅者；本订阅者只做"排队后台任务"
+/// 这种轻量动作（不直接执行 L2），所以不会阻塞业务模块的字段抽取。
+/// 后台任务实际执行时，业务模块（如 contracts）的 <c>autoSave: true</c> 抽取已经完成，
+/// L2 通过 <c>IDocumentIdentifierProvider</c> 反查能拿到刚抽取的字段。
+/// </para>
+///
+/// <para>
+/// <strong>orphan 文档</strong>：分类失败的文档不会发布 <see cref="DocumentClassifiedEto"/>，
+/// 自然跳过 L2。这与 #115 设计 "v1 orphan 走 L3 兜底" 一致。
+/// </para>
+///
+/// <para>
+/// <strong>幂等性</strong>：<see cref="DocumentPipelineJobScheduler.QueueAsync"/> 每次创建新的
+/// <c>DocumentPipelineRun</c>。同一文档分类事件理论上只触发一次（除非分类被人工重跑），
+/// 重复运行 L2 也安全：<see cref="RelationDiscoveryService"/> 对已存在关系做完全跳过，
+/// 不会创建重复 AiSuggested 行。
+/// </para>
+/// </summary>
+public class RelationDiscoveryEventHandler
+    : IDistributedEventHandler<DocumentClassifiedEto>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly ILogger<RelationDiscoveryEventHandler> _logger;
+
+    public RelationDiscoveryEventHandler(
+        IDocumentRepository documentRepository,
+        DocumentPipelineJobScheduler pipelineJobScheduler,
+        ILogger<RelationDiscoveryEventHandler> logger)
+    {
+        _documentRepository = documentRepository;
+        _pipelineJobScheduler = pipelineJobScheduler;
+        _logger = logger;
+    }
+
+    public virtual async Task HandleEventAsync(DocumentClassifiedEto eventData)
+    {
+        if (eventData.DocumentId == Guid.Empty)
+        {
+            return;
+        }
+
+        // Document might have been hard-deleted between classification publish and handler dispatch.
+        // FindAsync (not GetAsync) → silently drop instead of throwing into the event bus.
+        var document = await _documentRepository.FindAsync(eventData.DocumentId, includeDetails: true);
+        if (document == null)
+        {
+            _logger.LogInformation(
+                "L2 RelationDiscovery handler: document {DocumentId} no longer exists; skipping enqueue.",
+                eventData.DocumentId);
+            return;
+        }
+
+        await _pipelineJobScheduler.QueueAsync(document, PaperbasePipelines.RelationDiscovery);
+    }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
@@ -8,7 +8,6 @@ using Volo.Abp;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Services;
 using Volo.Abp.Guids;
-using Volo.Abp.MultiTenancy;
 
 namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 
@@ -46,16 +45,20 @@ public class RelationDiscoveryService : DomainService
 
     private readonly IEnumerable<IDocumentIdentifierProvider> _providers;
     private readonly IDocumentRelationRepository _relationRepository;
-    private readonly ICurrentTenant _currentTenant;
+    private readonly IDocumentRepository _documentRepository;
 
+    // No ICurrentTenant injection (Issue #121): tenant flows through Document.TenantId
+    // (loaded from the source document at the start of DiscoverAsync). Background jobs may
+    // run without an ambient ICurrentTenant restored — explicit Document-derived tenant is
+    // Hangfire-safe and matches L3's strategy in SemanticRelationDiscoveryService.
     public RelationDiscoveryService(
         IEnumerable<IDocumentIdentifierProvider> providers,
         IDocumentRelationRepository relationRepository,
-        ICurrentTenant currentTenant)
+        IDocumentRepository documentRepository)
     {
         _providers = providers;
         _relationRepository = relationRepository;
-        _currentTenant = currentTenant;
+        _documentRepository = documentRepository;
     }
 
     /// <summary>
@@ -70,6 +73,18 @@ public class RelationDiscoveryService : DomainService
         {
             throw new ArgumentException("Source document id required.", nameof(sourceDocumentId));
         }
+
+        // Phase 0: load source to capture authoritative TenantId (Issue #121).
+        // Document hard-deleted between event publish and L2 execution → drop silently.
+        var source = await _documentRepository.FindAsync(sourceDocumentId, cancellationToken: cancellationToken);
+        if (source == null)
+        {
+            Logger.LogInformation(
+                "L2 RelationDiscovery: document {DocumentId} no longer exists; skipping",
+                sourceDocumentId);
+            return Array.Empty<DocumentRelation>();
+        }
+        var sourceTenantId = source.TenantId;
 
         // Phase 1: collect all identifiers held by source document across all providers.
         var sourceIdentifiers = await CollectSourceIdentifiersAsync(sourceDocumentId, cancellationToken);
@@ -102,9 +117,12 @@ public class RelationDiscoveryService : DomainService
             if (alreadyLinked.Contains(peer.PeerDocumentId)) continue;
 
             var description = $"Identifier match: {peer.IdentifierType} = {peer.IdentifierValue}";
+            // TenantId from source.TenantId (Hangfire-safe, Issue #121). Source and peers
+            // must be in the same tenant: providers query through ABP's IMultiTenant filter
+            // which scopes by ambient or by source — peers never cross tenant by design.
             var relation = new DocumentRelation(
                 GuidGenerator.Create(),
-                _currentTenant.Id,
+                sourceTenantId,
                 sourceDocumentId: sourceDocumentId,
                 targetDocumentId: peer.PeerDocumentId,
                 description: description,

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
@@ -133,8 +133,19 @@ public class RelationDiscoveryService : DomainService
         var entries = new List<DocumentIdentifierEntry>();
         foreach (var provider in _providers)
         {
-            var fromProvider = await provider.GetIdentifiersAsync(documentId, ct);
-            entries.AddRange(fromProvider);
+            // Provider isolation: one buggy module must not tank the whole L2 discovery.
+            // OperationCanceledException re-thrown so cancellation is honored.
+            try
+            {
+                var fromProvider = await provider.GetIdentifiersAsync(documentId, ct);
+                entries.AddRange(fromProvider);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogError(ex,
+                    "L2 RelationDiscovery: provider {Provider} threw in GetIdentifiersAsync({DocumentId}); skipping its contribution",
+                    provider.GetType().FullName, documentId);
+            }
         }
 
         // De-duplicate (type, value) pairs — two providers could in principle report
@@ -157,7 +168,19 @@ public class RelationDiscoveryService : DomainService
 
             foreach (var provider in supportingProviders)
             {
-                var found = await provider.FindDocumentsAsync(identifier.Type, identifier.Value, ct);
+                IReadOnlyList<Guid> found;
+                try
+                {
+                    found = await provider.FindDocumentsAsync(identifier.Type, identifier.Value, ct);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Logger.LogError(ex,
+                        "L2 RelationDiscovery: provider {Provider} threw in FindDocumentsAsync({Type}, {Value}); skipping",
+                        provider.GetType().FullName, identifier.Type, identifier.Value);
+                    continue;
+                }
+
                 foreach (var peerId in found)
                 {
                     if (peerId == sourceDocumentId) continue;          // Self-match

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Services;
+using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L2: 跨业务模块的关系发现服务。基于 <see cref="IDocumentIdentifierProvider"/>
+/// 的 fan-out 查询，从源文档持有的标识符出发反查对端文档，自动创建
+/// <see cref="RelationSource.AiSuggested"/> 类型的 <see cref="DocumentRelation"/>。
+///
+/// <para>
+/// 算法（三阶段）：
+/// <list type="number">
+/// <item>收集源文档的所有标识符：遍历 <see cref="IDocumentIdentifierProvider"/>，
+///       调用 <see cref="IDocumentIdentifierProvider.GetIdentifiersAsync"/>，得到该文档的 (type, value) 列表。</item>
+/// <item>反查对端文档：对每个 (type, value)，遍历支持该 type 的 provider，
+///       调用 <see cref="IDocumentIdentifierProvider.FindDocumentsAsync"/>。</item>
+/// <item>去重 + 已有关系过滤后，为每个对端文档创建 AiSuggested DocumentRelation。</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <strong>v1 范围</strong>：纯发现服务，不含自动触发（背景任务 + 事件订阅留给后续 PR）。
+/// 调用方在文档分类完成 + 业务模块字段抽取完成后显式调用 <see cref="DiscoverAsync"/>。
+/// 这避免与业务模块 <see cref="DocumentClassifiedEto"/> 处理器的时序竞态，并先把发现逻辑用 mock provider 测准。
+/// </para>
+///
+/// <para>
+/// <strong>不接 LLM</strong>：本服务是结构化匹配（标识符精确比较），无 prompt 表面，
+/// 不需要 doc-chat 反例 C 那种"显式权限断言 + 静态描述 + Take(N)"工具体三件套。
+/// </para>
+/// </summary>
+public class RelationDiscoveryService : DomainService
+{
+    /// <summary>结构化标识符匹配的固定置信度。L3 LLM 评判会输出动态 confidence；L2 是确定性匹配，固定高分。</summary>
+    public const double StructuralMatchConfidence = 0.95;
+
+    private readonly IEnumerable<IDocumentIdentifierProvider> _providers;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly ICurrentTenant _currentTenant;
+
+    public RelationDiscoveryService(
+        IEnumerable<IDocumentIdentifierProvider> providers,
+        IDocumentRelationRepository relationRepository,
+        ICurrentTenant currentTenant)
+    {
+        _providers = providers;
+        _relationRepository = relationRepository;
+        _currentTenant = currentTenant;
+    }
+
+    /// <summary>
+    /// 对指定源文档运行关系发现。返回新创建的 AiSuggested DocumentRelation 列表（用于 telemetry / 集成测试断言）。
+    /// 已存在的关系（无论 Manual / AiSuggested / ModuleAuto）会被跳过——避免噪音建议覆盖用户已确认的关系。
+    /// </summary>
+    public virtual async Task<IReadOnlyList<DocumentRelation>> DiscoverAsync(
+        Guid sourceDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (sourceDocumentId == Guid.Empty)
+        {
+            throw new ArgumentException("Source document id required.", nameof(sourceDocumentId));
+        }
+
+        // Phase 1: collect all identifiers held by source document across all providers.
+        var sourceIdentifiers = await CollectSourceIdentifiersAsync(sourceDocumentId, cancellationToken);
+        if (sourceIdentifiers.Count == 0)
+        {
+            // No identifiers extracted yet — either business modules haven't finished extraction,
+            // or this document isn't owned by any module. v1 short-circuits; future re-queue
+            // logic can wake L2 once providers have data.
+            Logger.LogInformation(
+                "L2 RelationDiscovery: no identifiers found for {DocumentId}; skipping (no business module owns it, or extraction pending)",
+                sourceDocumentId);
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 2: for each identifier, fan out across providers that support its type to find peers.
+        var peers = await FindPeerDocumentsAsync(sourceDocumentId, sourceIdentifiers, cancellationToken);
+        if (peers.Count == 0)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 3: skip pairs that already have any relation (Manual/AiSuggested/ModuleAuto),
+        // create AiSuggested for the rest. Skipping ALL existing relation kinds protects
+        // user-confirmed relations from being re-suggested as if new.
+        var alreadyLinked = await GetAlreadyLinkedPeersAsync(sourceDocumentId, cancellationToken);
+        var created = new List<DocumentRelation>();
+
+        foreach (var peer in peers)
+        {
+            if (alreadyLinked.Contains(peer.PeerDocumentId)) continue;
+
+            var description = $"Identifier match: {peer.IdentifierType} = {peer.IdentifierValue}";
+            var relation = new DocumentRelation(
+                GuidGenerator.Create(),
+                _currentTenant.Id,
+                sourceDocumentId: sourceDocumentId,
+                targetDocumentId: peer.PeerDocumentId,
+                description: description,
+                source: RelationSource.AiSuggested,
+                confidence: StructuralMatchConfidence);
+
+            await _relationRepository.InsertAsync(relation, autoSave: false, cancellationToken);
+            created.Add(relation);
+
+            // Add to alreadyLinked so multiple identifier matches against the same peer
+            // create only one DocumentRelation (e.g. peer shares both ContractNumber and PartyName).
+            alreadyLinked.Add(peer.PeerDocumentId);
+        }
+
+        Logger.LogInformation(
+            "L2 RelationDiscovery: source={DocumentId} identifiers={IdentifierCount} peers={PeerCount} created={CreatedCount}",
+            sourceDocumentId, sourceIdentifiers.Count, peers.Count, created.Count);
+
+        return created;
+    }
+
+    protected virtual async Task<IReadOnlyList<DocumentIdentifierEntry>> CollectSourceIdentifiersAsync(
+        Guid documentId,
+        CancellationToken ct)
+    {
+        var entries = new List<DocumentIdentifierEntry>();
+        foreach (var provider in _providers)
+        {
+            var fromProvider = await provider.GetIdentifiersAsync(documentId, ct);
+            entries.AddRange(fromProvider);
+        }
+
+        // De-duplicate (type, value) pairs — two providers could in principle report
+        // the same identifier (rare but possible if a doc is dual-classified).
+        return entries.Distinct().ToList();
+    }
+
+    protected virtual async Task<IReadOnlyList<PeerCandidate>> FindPeerDocumentsAsync(
+        Guid sourceDocumentId,
+        IReadOnlyList<DocumentIdentifierEntry> sourceIdentifiers,
+        CancellationToken ct)
+    {
+        var seen = new HashSet<Guid>();
+        var peers = new List<PeerCandidate>();
+
+        foreach (var identifier in sourceIdentifiers)
+        {
+            var supportingProviders = _providers
+                .Where(p => p.SupportedIdentifierTypes.Contains(identifier.Type));
+
+            foreach (var provider in supportingProviders)
+            {
+                var found = await provider.FindDocumentsAsync(identifier.Type, identifier.Value, ct);
+                foreach (var peerId in found)
+                {
+                    if (peerId == sourceDocumentId) continue;          // Self-match
+                    if (peerId == Guid.Empty) continue;                // Defensive
+                    if (!seen.Add(peerId)) continue;                   // Already a peer via another identifier
+
+                    peers.Add(new PeerCandidate(peerId, identifier.Type, identifier.Value));
+                }
+            }
+        }
+
+        return peers;
+    }
+
+    protected virtual async Task<HashSet<Guid>> GetAlreadyLinkedPeersAsync(
+        Guid sourceDocumentId,
+        CancellationToken ct)
+    {
+        var existing = await _relationRepository.GetListByDocumentIdAsync(sourceDocumentId, ct);
+        var linked = new HashSet<Guid>();
+        foreach (var relation in existing)
+        {
+            var peer = relation.SourceDocumentId == sourceDocumentId
+                ? relation.TargetDocumentId
+                : relation.SourceDocumentId;
+            linked.Add(peer);
+        }
+        return linked;
+    }
+
+    /// <summary>
+    /// 中间数据：一个对端文档候选 + 触发本次匹配的 (type, value)。
+    /// 当多个标识符同时命中同一对端时，第一个命中决定 Description（避免一对文档建多条关系）。
+    /// </summary>
+    protected sealed record PeerCandidate(Guid PeerDocumentId, string IdentifierType, string IdentifierValue);
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
@@ -33,7 +33,10 @@ namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 /// </summary>
 public class RelationInferenceAgent : ITransientDependency
 {
-    /// <summary>编译期常量，禁止变量插值。</summary>
+    /// <summary>
+    /// 编译期常量，禁止变量插值。末尾追加 <see cref="PromptBoundary.BoundaryRule"/>——document
+    /// markdown 是用户上传文档抽取出来的弱签名输入，需要明确告诉模型"标签内是数据非指令"。
+    /// </summary>
     public const string InferenceInstructions =
         "You are a strict business-document relationship judge. Given two documents (their type codes plus markdown excerpts), " +
         "decide whether they reference the SAME business event or entity (same contract / same project / same parties / same case / same transaction). " +
@@ -49,7 +52,9 @@ public class RelationInferenceAgent : ITransientDependency
         "\n" +
         "Description: when isRelated=true, write one short sentence (Chinese or English, match document language) " +
         "explaining the link, mentioning the key shared identifier or signal. Keep under 100 characters. " +
-        "When isRelated=false, leave description empty.";
+        "When isRelated=false, leave description empty.\n" +
+        "\n" +
+        PromptBoundary.BoundaryRule;
 
     private readonly IChatClient _chatClient;
     private readonly PaperbaseAIBehaviorOptions _aiOptions;
@@ -80,11 +85,14 @@ public class RelationInferenceAgent : ITransientDependency
         // headers (which usually carry the unique identifier) survive truncation.
         var perDocLimit = _aiOptions.MaxTextLengthPerExtraction / 2;
 
+        // Markdown 是 OCR/抽取出来的弱签名输入；用 PromptBoundary.WrapDocument 包裹 + 转义 '<'，
+        // 与 InferenceInstructions 末尾的 BoundaryRule 配合形成"标签内是数据非指令"防御。
+        // DocumentTypeCode 是系统管理字段（注册表常量），不需要包裹。
         var sb = new StringBuilder(perDocLimit * 2 + 256);
         sb.Append("DOCUMENT 1 — type: ").Append(source.DocumentTypeCode ?? "(unclassified)").Append('\n');
-        sb.Append(Truncate(source.Markdown, perDocLimit));
+        sb.Append(PromptBoundary.WrapDocument(Truncate(source.Markdown, perDocLimit)));
         sb.Append("\n\nDOCUMENT 2 — type: ").Append(candidate.DocumentTypeCode ?? "(unclassified)").Append('\n');
-        sb.Append(Truncate(candidate.Markdown, perDocLimit));
+        sb.Append(PromptBoundary.WrapDocument(Truncate(candidate.Markdown, perDocLimit)));
         return sb.ToString();
     }
 
@@ -98,5 +106,11 @@ public class RelationInferenceAgent : ITransientDependency
 /// <summary>
 /// L3 在 LLM 调用前把 <see cref="Document"/> 的关键字段拷出来——避免在背景任务的 external phase
 /// 里持有 EF 加载的实体（防止懒加载/UoW 越界）。
+///
+/// <para>
+/// 携带 <c>TenantId</c>：调用方在 Hangfire 等无 ambient <c>ICurrentTenant</c> 的背景任务里
+/// 可以直接从 snapshot 取租户 id 写入新建的 <c>DocumentRelation</c>，而不是依赖 ambient——
+/// 与 <c>RecallCandidatesAsync</c> 用 <c>source.TenantId</c> 做向量搜索的策略保持一致。
+/// </para>
 /// </summary>
-public sealed record DocumentSnapshot(string? DocumentTypeCode, string Markdown);
+public sealed record DocumentSnapshot(Guid? TenantId, string? DocumentTypeCode, string Markdown);

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L3: 把两份文档的 Markdown 摘要喂给 LLM，让它判断是否有业务关联并给出 confidence。
+///
+/// <para>
+/// <strong>fail-closed 设计</strong>：仅 <see cref="IChatClient"/> + 静态 system instructions，
+/// <strong>不挂 <c>AIContextProviders</c> / <c>ChatHistoryProvider</c></strong>。
+/// 见 <c>.claude/rules/doc-chat-anti-patterns.md</c> 反例 A：字段抽取/关系评判类 agent
+/// 一旦挂 RAG provider 会把无关文档的 chunk 注入 prompt，导致结构化字段被错误文档影响。
+/// </para>
+///
+/// <para>
+/// <strong>Markdown 截断</strong>：两份文档总长度可能超过 LLM context window。每份截到
+/// <see cref="PaperbaseAIBehaviorOptions.MaxTextLengthPerExtraction"/> 的一半，
+/// 头部信息（合同的标题/编号/当事人通常在开头）保留率最高。
+/// </para>
+///
+/// <para>
+/// <strong>system instructions 是编译期常量</strong>（<see cref="InferenceInstructions"/>），
+/// 不含任何用户控制字段，符合反例 C #4 的 prompt-injection 防御要求。
+/// </para>
+/// </summary>
+public class RelationInferenceAgent : ITransientDependency
+{
+    /// <summary>编译期常量，禁止变量插值。</summary>
+    public const string InferenceInstructions =
+        "You are a strict business-document relationship judge. Given two documents (their type codes plus markdown excerpts), " +
+        "decide whether they reference the SAME business event or entity (same contract / same project / same parties / same case / same transaction). " +
+        "Return JSON matching the response schema strictly.\n" +
+        "\n" +
+        "Set isRelated=true ONLY when both documents contain concrete evidence pointing to the same thing — same contract number, " +
+        "same party names appearing in both, same project code, same dates with overlapping parties, etc. " +
+        "DO NOT set true based on superficial similarity (both being 'contracts', both mentioning 'payment', etc.) — that's noise.\n" +
+        "\n" +
+        "Confidence calibration: 0.95+ when there's a unique identifier match (contract number, invoice number); " +
+        "0.75-0.9 when multiple soft signals align (party + date + amount); " +
+        "below 0.7 means you're not sure — set isRelated=false in that case.\n" +
+        "\n" +
+        "Description: when isRelated=true, write one short sentence (Chinese or English, match document language) " +
+        "explaining the link, mentioning the key shared identifier or signal. Keep under 100 characters. " +
+        "When isRelated=false, leave description empty.";
+
+    private readonly IChatClient _chatClient;
+    private readonly PaperbaseAIBehaviorOptions _aiOptions;
+
+    public RelationInferenceAgent(
+        IChatClient chatClient,
+        IOptions<PaperbaseAIBehaviorOptions> aiOptions)
+    {
+        _chatClient = chatClient;
+        _aiOptions = aiOptions.Value;
+    }
+
+    public virtual async Task<RelationInferenceResult> EvaluateAsync(
+        DocumentSnapshot source,
+        DocumentSnapshot candidate,
+        CancellationToken cancellationToken = default)
+    {
+        var agent = new ChatClientAgent(_chatClient, instructions: InferenceInstructions);
+
+        var prompt = BuildPrompt(source, candidate);
+        var run = await agent.RunAsync<RelationInferenceResult>(prompt, cancellationToken: cancellationToken);
+        return run.Result ?? new RelationInferenceResult { IsRelated = false };
+    }
+
+    protected virtual string BuildPrompt(DocumentSnapshot source, DocumentSnapshot candidate)
+    {
+        // Per-document budget = half of the per-extraction limit. Both documents get equal share;
+        // headers (which usually carry the unique identifier) survive truncation.
+        var perDocLimit = _aiOptions.MaxTextLengthPerExtraction / 2;
+
+        var sb = new StringBuilder(perDocLimit * 2 + 256);
+        sb.Append("DOCUMENT 1 — type: ").Append(source.DocumentTypeCode ?? "(unclassified)").Append('\n');
+        sb.Append(Truncate(source.Markdown, perDocLimit));
+        sb.Append("\n\nDOCUMENT 2 — type: ").Append(candidate.DocumentTypeCode ?? "(unclassified)").Append('\n');
+        sb.Append(Truncate(candidate.Markdown, perDocLimit));
+        return sb.ToString();
+    }
+
+    private static string Truncate(string text, int max)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= max) return text ?? string.Empty;
+        return text.Substring(0, max);
+    }
+}
+
+/// <summary>
+/// L3 在 LLM 调用前把 <see cref="Document"/> 的关键字段拷出来——避免在背景任务的 external phase
+/// 里持有 EF 加载的实体（防止懒加载/UoW 越界）。
+/// </summary>
+public sealed record DocumentSnapshot(string? DocumentTypeCode, string Markdown);

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceResult.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceResult.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L3: <see cref="RelationInferenceAgent"/> 的 LLM 结构化输出。
+///
+/// <para>
+/// 字段含义直接喂给 <c>ChatClientAgent.RunAsync&lt;RelationInferenceResult&gt;()</c>，
+/// 由 MAF 框架解析为 JSON schema 提示给 LLM。<see cref="DescriptionAttribute"/> 是给 LLM 看的字段说明，
+/// 影响输出准确度——慎改措辞。
+/// </para>
+/// </summary>
+public class RelationInferenceResult
+{
+    [Description("Whether the two documents reference the same business event/entity (same contract, same project, same parties, same case). Set true ONLY when there is concrete evidence in BOTH documents pointing to the same thing.")]
+    public bool IsRelated { get; set; }
+
+    [Description("Concise (under 100 chars) human-readable explanation of the relationship. Examples: '该发票对应订单 PO-2024-001 的货款', '本协议是主合同 HT-2024-001 的补充条款'. Empty when IsRelated is false.")]
+    public string? Description { get; set; }
+
+    [Description("Confidence in the inference, in [0, 1]. 0 = completely unrelated; 1 = certain. Below 0.7 is treated as 'not confident enough' by the discovery service and the relation is dropped.")]
+    public double Confidence { get; set; }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Services;
-using Volo.Abp.MultiTenancy;
 
 namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 
@@ -51,16 +50,16 @@ public class SemanticRelationDiscoveryService : DomainService
     private readonly IDocumentKnowledgeIndex _knowledgeIndex;
     private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
     private readonly RelationInferenceAgent _inferenceAgent;
-    private readonly ICurrentTenant _currentTenant;
     private readonly PaperbaseAIBehaviorOptions _aiOptions;
 
+    // No ICurrentTenant injection: tenant flows through DocumentSnapshot.TenantId, sourced from
+    // Document.TenantId (Hangfire-safe). Background jobs may run without an ambient ICurrentTenant.
     public SemanticRelationDiscoveryService(
         IDocumentRepository documentRepository,
         IDocumentRelationRepository relationRepository,
         IDocumentKnowledgeIndex knowledgeIndex,
         IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
         RelationInferenceAgent inferenceAgent,
-        ICurrentTenant currentTenant,
         IOptions<PaperbaseAIBehaviorOptions> aiOptions)
     {
         _documentRepository = documentRepository;
@@ -68,7 +67,6 @@ public class SemanticRelationDiscoveryService : DomainService
         _knowledgeIndex = knowledgeIndex;
         _embeddingGenerator = embeddingGenerator;
         _inferenceAgent = inferenceAgent;
-        _currentTenant = currentTenant;
         _aiOptions = aiOptions.Value;
     }
 
@@ -116,8 +114,10 @@ public class SemanticRelationDiscoveryService : DomainService
         }
 
         // Phase 4: per-candidate LLM evaluation. Provider-isolation: one bad LLM call must not
-        // tank the rest of the candidates.
-        var sourceSnapshot = new DocumentSnapshot(source.DocumentTypeCode, source.Markdown);
+        // tank the rest of the candidates. TenantId carried via snapshot so the write path
+        // (EvaluateAndCreateAsync) doesn't depend on ambient ICurrentTenant — Hangfire-safe,
+        // matches the explicit-tenant strategy used by RecallCandidatesAsync.
+        var sourceSnapshot = new DocumentSnapshot(source.TenantId, source.DocumentTypeCode, source.Markdown);
         var created = new List<DocumentRelation>();
 
         foreach (var candidateId in freshCandidates)
@@ -198,7 +198,7 @@ public class SemanticRelationDiscoveryService : DomainService
             return null;
         }
 
-        var candidateSnapshot = new DocumentSnapshot(candidate.DocumentTypeCode, candidate.Markdown);
+        var candidateSnapshot = new DocumentSnapshot(candidate.TenantId, candidate.DocumentTypeCode, candidate.Markdown);
 
         RelationInferenceResult inference;
         try
@@ -223,9 +223,12 @@ public class SemanticRelationDiscoveryService : DomainService
             ? "Semantic match (LLM-evaluated)"
             : inference.Description!.Trim();
 
+        // TenantId from sourceSnapshot (Hangfire-safe — no ambient context dependency).
+        // Source and candidate must be in the same tenant: ABP IMultiTenant filter on the
+        // vector search guarantees that. We trust source.TenantId as the authoritative value.
         var relation = new DocumentRelation(
             GuidGenerator.Create(),
-            _currentTenant.Id,
+            sourceSnapshot.TenantId,
             sourceDocumentId: sourceDocumentId,
             targetDocumentId: candidateId,
             description: description,

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Services;
+using Volo.Abp.MultiTenancy;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L3：基于"向量召回 + LLM 评判"的语义关系发现，作为 L2 (<see cref="RelationDiscoveryService"/>)
+/// 找不到任何结构化匹配时的兜底路径。
+///
+/// <para>
+/// <strong>触发时机</strong>：仅在 L2 返回 0 关系时由 <see cref="RelationDiscoveryBackgroundJob"/> 调用，
+/// 且 <see cref="PaperbaseAIBehaviorOptions.EnableSemanticRelationDiscovery"/> 必须为 <c>true</c>
+/// （默认关闭——LLM 成本按文档数线性增长）。
+/// </para>
+///
+/// <para>
+/// <strong>三阶段流水线</strong>：
+/// <list type="number">
+/// <item>向量召回：用源文档 Markdown 头部生成 embedding，在向量库取 top-K 高相似度文档（高于普通 RAG 阈值）。</item>
+/// <item>预过滤：排除自身 / 已存在关系的文档。</item>
+/// <item>LLM 评判：把每对文档的 Markdown 摘要交给 <see cref="RelationInferenceAgent"/>，
+///       confidence 超阈值才创建 AiSuggested DocumentRelation；description 来自 LLM 输出。</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <strong>orphan 文档支持</strong>：源文档不属于任何业务模块（DocumentTypeCode 已分类但未注册业务模块）
+/// 也能走 L3——本路径不依赖 <c>IDocumentIdentifierProvider</c>，只看 Markdown 与向量库。
+/// </para>
+///
+/// <para>
+/// <strong>fail-closed</strong>：tenant 显式从 <c>Document.TenantId</c> 取（不依赖 ambient
+/// <c>CurrentTenant</c>，与 Embedding pipeline 同一逻辑）；候选异常隔离（一个 LLM 调用失败不打断后续）。
+/// </para>
+/// </summary>
+public class SemanticRelationDiscoveryService : DomainService
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly IDocumentKnowledgeIndex _knowledgeIndex;
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
+    private readonly RelationInferenceAgent _inferenceAgent;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly PaperbaseAIBehaviorOptions _aiOptions;
+
+    public SemanticRelationDiscoveryService(
+        IDocumentRepository documentRepository,
+        IDocumentRelationRepository relationRepository,
+        IDocumentKnowledgeIndex knowledgeIndex,
+        IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
+        RelationInferenceAgent inferenceAgent,
+        ICurrentTenant currentTenant,
+        IOptions<PaperbaseAIBehaviorOptions> aiOptions)
+    {
+        _documentRepository = documentRepository;
+        _relationRepository = relationRepository;
+        _knowledgeIndex = knowledgeIndex;
+        _embeddingGenerator = embeddingGenerator;
+        _inferenceAgent = inferenceAgent;
+        _currentTenant = currentTenant;
+        _aiOptions = aiOptions.Value;
+    }
+
+    /// <summary>
+    /// 对源文档运行 L3 发现。返回新创建的 AiSuggested 关系列表。
+    /// 如果 <see cref="PaperbaseAIBehaviorOptions.EnableSemanticRelationDiscovery"/>=false，
+    /// 立即返回空列表（短路，不走任何 IO/LLM）。
+    /// </summary>
+    public virtual async Task<IReadOnlyList<DocumentRelation>> DiscoverAsync(
+        Guid sourceDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_aiOptions.EnableSemanticRelationDiscovery)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        if (sourceDocumentId == Guid.Empty)
+        {
+            throw new ArgumentException("Source document id required.", nameof(sourceDocumentId));
+        }
+
+        // Phase 1: load source. Reject docs without Markdown — no semantic signal to search on.
+        var source = await _documentRepository.FindAsync(sourceDocumentId, cancellationToken: cancellationToken);
+        if (source == null || string.IsNullOrWhiteSpace(source.Markdown))
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 2: vector recall — search by source's Markdown head (where titles / unique identifiers
+        // typically live). Use Document.TenantId explicitly (Hangfire-safe; no ambient context dependency).
+        var candidates = await RecallCandidatesAsync(source, cancellationToken);
+        if (candidates.Count == 0)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 3: filter peers already linked by ANY relation kind. Same rule as L2 — don't
+        // re-suggest what user already saw / dismissed / confirmed.
+        var alreadyLinked = await GetAlreadyLinkedAsync(sourceDocumentId, cancellationToken);
+        var freshCandidates = candidates.Where(id => !alreadyLinked.Contains(id)).ToList();
+        if (freshCandidates.Count == 0)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 4: per-candidate LLM evaluation. Provider-isolation: one bad LLM call must not
+        // tank the rest of the candidates.
+        var sourceSnapshot = new DocumentSnapshot(source.DocumentTypeCode, source.Markdown);
+        var created = new List<DocumentRelation>();
+
+        foreach (var candidateId in freshCandidates)
+        {
+            var relation = await EvaluateAndCreateAsync(
+                sourceDocumentId, sourceSnapshot, candidateId, cancellationToken);
+            if (relation != null)
+            {
+                created.Add(relation);
+            }
+        }
+
+        Logger.LogInformation(
+            "L3 SemanticRelationDiscovery: source={DocumentId} candidates={CandidateCount} fresh={FreshCount} llmConfirmed={CreatedCount}",
+            sourceDocumentId, candidates.Count, freshCandidates.Count, created.Count);
+
+        return created;
+    }
+
+    protected virtual async Task<IReadOnlyList<Guid>> RecallCandidatesAsync(
+        Document source,
+        CancellationToken ct)
+    {
+        // Use the markdown head — typically carries title + first paragraph + key identifiers.
+        // Cheaper than embedding the entire markdown and usually more representative for short queries.
+        var queryText = TruncateForEmbedding(source.Markdown!);
+
+        Embedding<float> queryEmbedding;
+        try
+        {
+            var batch = await _embeddingGenerator.GenerateAsync(new[] { queryText }, cancellationToken: ct);
+            queryEmbedding = batch[0];
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "L3 SemanticRelationDiscovery: embedding generation failed for {DocumentId}; skipping",
+                source.Id);
+            return Array.Empty<Guid>();
+        }
+
+        IReadOnlyList<VectorSearchResult> results;
+        try
+        {
+            results = await _knowledgeIndex.SearchAsync(new VectorSearchRequest
+            {
+                TenantId = source.TenantId,
+                QueryVector = queryEmbedding.Vector,
+                TopK = _aiOptions.SemanticRelationDiscoveryTopK,
+                MinScore = _aiOptions.SemanticRelationDiscoveryMinScore,
+            }, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "L3 SemanticRelationDiscovery: vector search failed for {DocumentId}; skipping",
+                source.Id);
+            return Array.Empty<Guid>();
+        }
+
+        // Aggregate chunk hits by DocumentId; exclude self.
+        return results
+            .Select(r => r.DocumentId)
+            .Where(id => id != source.Id && id != Guid.Empty)
+            .Distinct()
+            .ToList();
+    }
+
+    protected virtual async Task<DocumentRelation?> EvaluateAndCreateAsync(
+        Guid sourceDocumentId,
+        DocumentSnapshot sourceSnapshot,
+        Guid candidateId,
+        CancellationToken ct)
+    {
+        var candidate = await _documentRepository.FindAsync(candidateId, cancellationToken: ct);
+        if (candidate == null || string.IsNullOrWhiteSpace(candidate.Markdown))
+        {
+            return null;
+        }
+
+        var candidateSnapshot = new DocumentSnapshot(candidate.DocumentTypeCode, candidate.Markdown);
+
+        RelationInferenceResult inference;
+        try
+        {
+            inference = await _inferenceAgent.EvaluateAsync(sourceSnapshot, candidateSnapshot, ct);
+        }
+        catch (Exception ex)
+        {
+            // Per-candidate LLM failure: log & skip. Other candidates still get evaluated.
+            Logger.LogError(ex,
+                "L3 SemanticRelationDiscovery: LLM evaluation failed for ({Source}, {Candidate}); skipping pair",
+                sourceDocumentId, candidateId);
+            return null;
+        }
+
+        if (!inference.IsRelated || inference.Confidence < _aiOptions.SemanticRelationDiscoveryConfidenceThreshold)
+        {
+            return null;
+        }
+
+        var description = string.IsNullOrWhiteSpace(inference.Description)
+            ? "Semantic match (LLM-evaluated)"
+            : inference.Description!.Trim();
+
+        var relation = new DocumentRelation(
+            GuidGenerator.Create(),
+            _currentTenant.Id,
+            sourceDocumentId: sourceDocumentId,
+            targetDocumentId: candidateId,
+            description: description,
+            source: RelationSource.AiSuggested,
+            confidence: inference.Confidence);
+
+        // autoSave: true (vs L2's autoSave: false). Reason: L3 mixes external LLM calls with
+        // repository writes inside the loop. Wrapping all of L3 in an outer UoW would hold a
+        // DB connection during LLM calls — direct violation of .claude/rules/background-jobs.md.
+        // Per-insert auto-save uses an implicit per-call UoW; LLM calls between candidates
+        // happen with NO ambient UoW, satisfying the rule.
+        await _relationRepository.InsertAsync(relation, autoSave: true, ct);
+        return relation;
+    }
+
+    protected virtual async Task<HashSet<Guid>> GetAlreadyLinkedAsync(Guid sourceDocumentId, CancellationToken ct)
+    {
+        var existing = await _relationRepository.GetListByDocumentIdAsync(sourceDocumentId, ct);
+        var linked = new HashSet<Guid>();
+        foreach (var rel in existing)
+        {
+            var peer = rel.SourceDocumentId == sourceDocumentId ? rel.TargetDocumentId : rel.SourceDocumentId;
+            linked.Add(peer);
+        }
+        return linked;
+    }
+
+    private string TruncateForEmbedding(string markdown)
+    {
+        // Embedding models have token limits (typically ~8K tokens). MaxTextLengthPerExtraction
+        // is in chars, conservatively ~half the embedding model limit. We embed the head, not the
+        // middle/tail, because document headers carry the highest-signal text (titles, identifiers).
+        var max = _aiOptions.MaxTextLengthPerExtraction;
+        return markdown.Length <= max ? markdown : markdown.Substring(0, max);
+    }
+}

--- a/core/src/Dignite.Paperbase.Domain.Shared/Documents/PaperbasePipelines.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Documents/PaperbasePipelines.cs
@@ -18,6 +18,12 @@ public static class PaperbasePipelines
     /// <summary>文本分块 + 向量化。非关键流水线，失败降级为全文检索。</summary>
     public const string Embedding = "embedding";
 
+    /// <summary>
+    /// Issue #115 L2: 关系发现（基于业务模块 <c>IDocumentIdentifierProvider</c> fan-out）。
+    /// 非关键流水线——失败不影响 Document 生命周期；orphan 文档（无业务模块认领）会自然短路成 0 关系。
+    /// </summary>
+    public const string RelationDiscovery = "relation-discovery";
+
     /// <summary>生命周期派生时视为"关键"的流水线集合。</summary>
     public static readonly IReadOnlyCollection<string> KeyPipelines = new[]
     {

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -30,10 +30,11 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
         // Replace RelationDiscoveryService entirely — this test only verifies the JOB's
         // PipelineRun lifecycle wiring, not the discovery logic (covered separately by
         // RelationDiscoveryService_Tests).
+        // Issue #121: L2 ctor now takes IDocumentRepository instead of ICurrentTenant.
         context.Services.AddSingleton(Substitute.For<RelationDiscoveryService>(
             Array.Empty<IDocumentIdentifierProvider>(),
             Substitute.For<IDocumentRelationRepository>(),
-            Substitute.For<ICurrentTenant>()));
+            Substitute.For<IDocumentRepository>()));
 
         // Same treatment for L3 — substitute so this test stays focused on the job's lifecycle
         // and L2 → L3 fallback chaining; L3's own logic is covered by SemanticRelationDiscoveryService_Tests.

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class RelationDiscoveryBackgroundJobTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
+
+        // Replace RelationDiscoveryService entirely — this test only verifies the JOB's
+        // PipelineRun lifecycle wiring, not the discovery logic (covered separately by
+        // RelationDiscoveryService_Tests).
+        context.Services.AddSingleton(Substitute.For<RelationDiscoveryService>(
+            Array.Empty<IDocumentIdentifierProvider>(),
+            Substitute.For<IDocumentRelationRepository>(),
+            Substitute.For<ICurrentTenant>()));
+    }
+}
+
+/// <summary>
+/// Verifies <see cref="RelationDiscoveryBackgroundJob"/>'s short-UoW lifecycle:
+/// PipelineRun is created → Running → Succeeded/Failed in three separate UoWs;
+/// service throwing surfaces as Failed without crashing the job.
+/// </summary>
+public class RelationDiscoveryBackgroundJob_Tests
+    : PaperbaseApplicationTestBase<RelationDiscoveryBackgroundJobTestModule>
+{
+    private readonly RelationDiscoveryBackgroundJob _job;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly RelationDiscoveryService _discoveryService;
+
+    public RelationDiscoveryBackgroundJob_Tests()
+    {
+        _job = GetRequiredService<RelationDiscoveryBackgroundJob>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _discoveryService = GetRequiredService<RelationDiscoveryService>();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Mark_Run_Succeeded_When_Discovery_Returns_Successfully()
+    {
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        var run = doc.GetLatestRun(PaperbasePipelines.RelationDiscovery);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Mark_Run_Failed_When_Discovery_Throws()
+    {
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<DocumentRelation>>(_ => throw new InvalidOperationException("DB connection lost"));
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        var run = doc.GetLatestRun(PaperbasePipelines.RelationDiscovery);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Failed);
+        run.StatusMessage.ShouldBe("DB connection lost");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Drop_Job_Silently_When_Document_Not_Found()
+    {
+        // Document hard-deleted between event publish and job pickup — drop without throwing.
+        var documentId = Guid.NewGuid();
+        _documentRepository
+            .FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = documentId });
+
+        await _discoveryService.DidNotReceive().DiscoverAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Reuse_Pending_Run_When_PipelineRunId_Provided()
+    {
+        // The scheduler creates a Pending run before enqueue and passes its id in args.
+        // Job must pick it up rather than start a fresh one.
+        var doc = CreateDocument();
+        var pipelineRunManager = GetRequiredService<DocumentPipelineRunManager>();
+        var pendingRun = await pipelineRunManager.QueueAsync(doc, PaperbasePipelines.RelationDiscovery);
+        SetupDocumentRepository(doc);
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs
+        {
+            DocumentId = doc.Id,
+            PipelineRunId = pendingRun.Id
+        });
+
+        pendingRun.Status.ShouldBe(PipelineRunStatus.Succeeded);
+        pendingRun.AttemptNumber.ShouldBe(1);
+        doc.PipelineRuns.Count.ShouldBe(1);   // No duplicate run created
+    }
+
+    private void SetupDocumentRepository(Document doc)
+    {
+        _documentRepository
+            .FindAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+        _documentRepository
+            .GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private static Document CreateDocument()
+    {
+        return new Document(
+            Guid.NewGuid(), tenantId: null,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -3,10 +3,14 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Documents;
 using Dignite.Paperbase.Documents.Pipelines;
 using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.MultiTenancy;
@@ -30,6 +34,19 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
             Array.Empty<IDocumentIdentifierProvider>(),
             Substitute.For<IDocumentRelationRepository>(),
             Substitute.For<ICurrentTenant>()));
+
+        // Same treatment for L3 — substitute so this test stays focused on the job's lifecycle
+        // and L2 → L3 fallback chaining; L3's own logic is covered by SemanticRelationDiscoveryService_Tests.
+        context.Services.AddSingleton(Substitute.For<SemanticRelationDiscoveryService>(
+            Substitute.For<IDocumentRepository>(),
+            Substitute.For<IDocumentRelationRepository>(),
+            Substitute.For<IDocumentKnowledgeIndex>(),
+            Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>(),
+            Substitute.For<RelationInferenceAgent>(
+                Substitute.For<IChatClient>(),
+                Options.Create(new PaperbaseAIBehaviorOptions())),
+            Substitute.For<ICurrentTenant>(),
+            Options.Create(new PaperbaseAIBehaviorOptions())));
     }
 }
 
@@ -44,12 +61,20 @@ public class RelationDiscoveryBackgroundJob_Tests
     private readonly RelationDiscoveryBackgroundJob _job;
     private readonly IDocumentRepository _documentRepository;
     private readonly RelationDiscoveryService _discoveryService;
+    private readonly SemanticRelationDiscoveryService _semanticDiscoveryService;
 
     public RelationDiscoveryBackgroundJob_Tests()
     {
         _job = GetRequiredService<RelationDiscoveryBackgroundJob>();
         _documentRepository = GetRequiredService<IDocumentRepository>();
         _discoveryService = GetRequiredService<RelationDiscoveryService>();
+        _semanticDiscoveryService = GetRequiredService<SemanticRelationDiscoveryService>();
+
+        // Default: L3 fallback returns empty (most lifecycle tests don't care about L3 results).
+        // Tests exercising the fallback path override this explicitly.
+        _semanticDiscoveryService
+            .DiscoverAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
     }
 
     [Fact]
@@ -97,6 +122,62 @@ public class RelationDiscoveryBackgroundJob_Tests
         await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = documentId });
 
         await _discoveryService.DidNotReceive().DiscoverAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Fall_Back_To_L3_When_L2_Returns_Empty()
+    {
+        // L2 finds nothing → background job invokes L3. L3 returns one relation.
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
+
+        var l3Relation = new DocumentRelation(
+            Guid.NewGuid(), null,
+            sourceDocumentId: doc.Id,
+            targetDocumentId: Guid.NewGuid(),
+            description: "semantic match",
+            source: RelationSource.AiSuggested,
+            confidence: 0.85);
+
+        _semanticDiscoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation> { l3Relation });
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        await _semanticDiscoveryService.Received(1).DiscoverAsync(doc.Id, Arg.Any<CancellationToken>());
+        var run = doc.GetLatestRun(PaperbasePipelines.RelationDiscovery);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Skip_L3_When_L2_Found_Relations()
+    {
+        // L2 found ≥1 relation → L3 (expensive LLM) must NOT be invoked.
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+
+        var l2Relation = new DocumentRelation(
+            Guid.NewGuid(), null,
+            sourceDocumentId: doc.Id,
+            targetDocumentId: Guid.NewGuid(),
+            description: "structured match",
+            source: RelationSource.AiSuggested,
+            confidence: 0.95);
+
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation> { l2Relation });
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        await _semanticDiscoveryService.DidNotReceive().DiscoverAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -45,7 +45,6 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
             Substitute.For<RelationInferenceAgent>(
                 Substitute.For<IChatClient>(),
                 Options.Create(new PaperbaseAIBehaviorOptions())),
-            Substitute.For<ICurrentTenant>(),
             Options.Create(new PaperbaseAIBehaviorOptions())));
     }
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryEventHandler_Tests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Abstractions.Documents;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class RelationDiscoveryEventHandlerTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        // Substitute the scheduler entirely so we verify the handler queues with the correct
+        // pipeline code without exercising the real PipelineRun creation / job enqueue path.
+        // The scheduler ctor needs valid args; pass cheap substitutes.
+        context.Services.AddSingleton(provider =>
+            Substitute.For<DocumentPipelineJobScheduler>(
+                Substitute.For<IDocumentRepository>(),
+                provider.GetRequiredService<DocumentPipelineRunManager>(),
+                Substitute.For<IBackgroundJobManager>()));
+    }
+}
+
+public class RelationDiscoveryEventHandler_Tests
+    : PaperbaseApplicationTestBase<RelationDiscoveryEventHandlerTestModule>
+{
+    private readonly RelationDiscoveryEventHandler _handler;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineJobScheduler _scheduler;
+
+    public RelationDiscoveryEventHandler_Tests()
+    {
+        _handler = GetRequiredService<RelationDiscoveryEventHandler>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _scheduler = GetRequiredService<DocumentPipelineJobScheduler>();
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_Should_Queue_Job_When_Document_Exists()
+    {
+        var document = CreateDocument();
+        _documentRepository
+            .FindAsync(document.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(document);
+        _scheduler
+            .QueueAsync(Arg.Any<Document>(), Arg.Any<string>())
+            .Returns(Task.FromResult<DocumentPipelineRun>(null!));
+
+        await _handler.HandleEventAsync(new DocumentClassifiedEto
+        {
+            DocumentId = document.Id,
+            DocumentTypeCode = "contract.general",
+            ClassificationConfidence = 0.95
+        });
+
+        await _scheduler.Received(1).QueueAsync(
+            Arg.Is<Document>(d => d.Id == document.Id),
+            PaperbasePipelines.RelationDiscovery);
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_Should_Skip_When_Document_Has_Empty_Id()
+    {
+        await _handler.HandleEventAsync(new DocumentClassifiedEto
+        {
+            DocumentId = Guid.Empty,
+            DocumentTypeCode = "contract.general"
+        });
+
+        await _scheduler.DidNotReceive().QueueAsync(Arg.Any<Document>(), Arg.Any<string>());
+        await _documentRepository.DidNotReceive().FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_Should_Skip_When_Document_No_Longer_Exists()
+    {
+        // Hard-deleted between classification publish and handler dispatch.
+        var documentId = Guid.NewGuid();
+        _documentRepository
+            .FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+
+        await _handler.HandleEventAsync(new DocumentClassifiedEto
+        {
+            DocumentId = documentId,
+            DocumentTypeCode = "contract.general"
+        });
+
+        await _scheduler.DidNotReceive().QueueAsync(Arg.Any<Document>(), Arg.Any<string>());
+    }
+
+    private static Document CreateDocument()
+    {
+        return new Document(
+            Guid.NewGuid(), tenantId: null,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
@@ -22,6 +22,10 @@ public class RelationDiscoveryServiceTestModule : AbpModule
         // so we verify the entity it constructed without exercising EF.
         context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
 
+        // Issue #121: L2 now loads source Document for tenant id (Hangfire-safe). Mock the
+        // document repository; tests configure FindAsync per-case via SetupSource.
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+
         // Two providers wired into DI — singletons so the test class instance and the service's
         // injected IEnumerable resolve to the SAME fake instances (otherwise transient resolution
         // gives the service a different enumeration than what the test mutates → state silently lost).
@@ -39,6 +43,7 @@ public class RelationDiscoveryService_Tests
 {
     private readonly RelationDiscoveryService _service;
     private readonly IDocumentRelationRepository _relationRepository;
+    private readonly IDocumentRepository _documentRepository;
     private readonly FakeContractProvider _contractProvider;
     private readonly FakeInvoiceProvider _invoiceProvider;
 
@@ -46,10 +51,45 @@ public class RelationDiscoveryService_Tests
     {
         _service = GetRequiredService<RelationDiscoveryService>();
         _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
         // Resolve the singletons by their concrete type — same instances as those enumerated
         // through IEnumerable<IDocumentIdentifierProvider> by the service.
         _contractProvider = GetRequiredService<FakeContractProvider>();
         _invoiceProvider = GetRequiredService<FakeInvoiceProvider>();
+
+        // Default: any document id resolves to a tenantless Document. Tests that exercise
+        // tenant-stamping or "doc not found" override this via SetupSource / SetupSourceMissing.
+        _documentRepository
+            .FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => CreateDocumentWithId((Guid)callInfo[0], tenantId: null));
+    }
+
+    // ── Issue #121 helper: wire FindAsync(documentId) → Document with optional tenant ──
+    private void SetupSource(Guid documentId, Guid? tenantId = null)
+    {
+        var doc = CreateDocumentWithId(documentId, tenantId);
+        _documentRepository.FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private void SetupSourceMissing(Guid documentId)
+    {
+        _documentRepository.FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+    }
+
+    private static Document CreateDocumentWithId(Guid id, Guid? tenantId)
+    {
+        return new Document(
+            id, tenantId,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
     }
 
     [Fact]
@@ -70,6 +110,80 @@ public class RelationDiscoveryService_Tests
     {
         await Should.ThrowAsync<ArgumentException>(async () =>
             await _service.DiscoverAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Drop_Silently_When_Source_Document_Hard_Deleted()
+    {
+        // Issue #121: source loaded for tenant resolution. If document was hard-deleted between
+        // event publish and L2 execution → drop without throwing (matches handler / job pattern).
+        var sourceDocId = Guid.NewGuid();
+        SetupSourceMissing(sourceDocId);
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+        // Providers must not be queried — short-circuit on document-not-found is the cheapest path.
+        _contractProvider.FindCalls.ShouldBeEmpty();
+        _invoiceProvider.FindCalls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Stamp_New_Relation_With_Source_Document_TenantId()
+    {
+        // Issue #121: TenantId on the new DocumentRelation must come from Document.TenantId,
+        // NOT from ambient ICurrentTenant (Hangfire-safe). Test asserts a non-null source
+        // tenant ID propagates correctly without ICurrentTenant.Change(...).
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+        var sourceTenantId = Guid.NewGuid();
+
+        SetupSource(sourceDocId, tenantId: sourceTenantId);
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-TENANT")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-TENANT")] = new[] { peerDocId };
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TenantId.ShouldBe(sourceTenantId);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Run_Provider_Calls_Without_Ambient_UoW()
+    {
+        // .claude/rules/background-jobs.md § Tests: regression guard at the provider call boundary.
+        // L2 itself only does DB queries, but providers are pluggable (third-party modules may
+        // do HTTP / cache / LLM in future iterations) — we must not open an ambient UoW around them.
+        // OnGetIdentifiersInvoked / OnFindDocumentsInvoked callbacks fire INSIDE provider methods,
+        // so the assertion captures UoW state at exactly the boundary the rule cares about.
+        var uowManager = GetRequiredService<Volo.Abp.Uow.IUnitOfWorkManager>();
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        var getIdentifiersUowState = (object?)"unset";
+        var findDocumentsUowState = (object?)"unset";
+
+        _contractProvider.OnGetIdentifiersInvoked = () => getIdentifiersUowState = uowManager.Current;
+        _contractProvider.OnFindDocumentsInvoked = () => findDocumentsUowState = uowManager.Current;
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-UOW-CHECK")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-UOW-CHECK")] = new[] { peerDocId };
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        await _service.DiscoverAsync(sourceDocId);
+
+        getIdentifiersUowState.ShouldBeNull("provider GetIdentifiersAsync ran with ambient UoW");
+        findDocumentsUowState.ShouldBeNull("provider FindDocumentsAsync ran with ambient UoW");
     }
 
     [Fact]
@@ -300,9 +414,13 @@ internal sealed class FakeContractProvider : IDocumentIdentifierProvider
     // Failure-injection knobs used by provider-isolation tests.
     public HashSet<Guid> GetIdentifiersThrowsFor { get; } = new();
     public HashSet<(string Type, string Value)> FindDocumentsThrowsFor { get; } = new();
+    // Inspection hook used by UoW-null-assertion tests; runs at the provider call boundary.
+    public Action? OnGetIdentifiersInvoked { get; set; }
+    public Action? OnFindDocumentsInvoked { get; set; }
 
     public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
     {
+        OnGetIdentifiersInvoked?.Invoke();
         if (GetIdentifiersThrowsFor.Contains(documentId))
             throw new InvalidOperationException("Simulated provider failure (GetIdentifiersAsync)");
         return Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
@@ -310,6 +428,7 @@ internal sealed class FakeContractProvider : IDocumentIdentifierProvider
 
     public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
     {
+        OnFindDocumentsInvoked?.Invoke();
         FindCalls.Add((identifierType, identifierValue));
         if (FindDocumentsThrowsFor.Contains((identifierType, identifierValue)))
             throw new InvalidOperationException("Simulated provider failure (FindDocumentsAsync)");

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
@@ -173,6 +173,80 @@ public class RelationDiscoveryService_Tests
     }
 
     [Fact]
+    public async Task DiscoverAsync_Should_Skip_Peers_Already_Linked_Via_AiSuggested()
+    {
+        // Symmetric to the Manual-skip test: AiSuggested relations are also "existing"
+        // and L2 must not duplicate them on re-runs (idempotency).
+        var sourceDocId = Guid.NewGuid();
+        var alreadyAiLinkedPeer = Guid.NewGuid();
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-IDEMPOTENT")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-IDEMPOTENT")]
+            = new[] { alreadyAiLinkedPeer };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>
+            {
+                CreateExistingRelation(sourceDocId, alreadyAiLinkedPeer, RelationSource.AiSuggested)
+            });
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Continue_When_One_Provider_Throws_In_GetIdentifiers()
+    {
+        // Provider isolation: a buggy module must not tank L2 for the whole document.
+        // Contract provider throws; invoice provider's contribution should still go through.
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        _contractProvider.GetIdentifiersThrowsFor.Add(sourceDocId);
+        _invoiceProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.InvoiceNumber, "INV-RESILIENT")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.InvoiceNumber, "INV-RESILIENT")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(peerDocId);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Continue_When_One_Provider_Throws_In_FindDocuments()
+    {
+        // Same isolation contract on the reverse-lookup side.
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-RESILIENT")
+        };
+        _contractProvider.FindDocumentsThrowsFor.Add((DocumentIdentifierTypes.ContractNumber, "HT-RESILIENT"));
+        // Invoice provider succeeds for the same identifier — peer should still surface.
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-RESILIENT")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(peerDocId);
+    }
+
+    [Fact]
     public async Task DiscoverAsync_Should_Skip_Providers_That_Do_Not_Support_Identifier_Type()
     {
         var sourceDocId = Guid.NewGuid();
@@ -223,13 +297,22 @@ internal sealed class FakeContractProvider : IDocumentIdentifierProvider
     public Dictionary<Guid, IReadOnlyList<DocumentIdentifierEntry>> Identifiers { get; } = new();
     public Dictionary<(string Type, string Value), IReadOnlyList<Guid>> Lookup { get; } = new();
     public List<(string Type, string Value)> FindCalls { get; } = new();
+    // Failure-injection knobs used by provider-isolation tests.
+    public HashSet<Guid> GetIdentifiersThrowsFor { get; } = new();
+    public HashSet<(string Type, string Value)> FindDocumentsThrowsFor { get; } = new();
 
     public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
-        => Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+    {
+        if (GetIdentifiersThrowsFor.Contains(documentId))
+            throw new InvalidOperationException("Simulated provider failure (GetIdentifiersAsync)");
+        return Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+    }
 
     public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
     {
         FindCalls.Add((identifierType, identifierValue));
+        if (FindDocumentsThrowsFor.Contains((identifierType, identifierValue)))
+            throw new InvalidOperationException("Simulated provider failure (FindDocumentsAsync)");
         return Task.FromResult(Lookup.TryGetValue((identifierType, identifierValue), out var v) ? v : (IReadOnlyList<Guid>)Array.Empty<Guid>());
     }
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class RelationDiscoveryServiceTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Repository is mocked — RelationDiscoveryService writes via InsertAsync (autoSave: false),
+        // so we verify the entity it constructed without exercising EF.
+        context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
+
+        // Two providers wired into DI — singletons so the test class instance and the service's
+        // injected IEnumerable resolve to the SAME fake instances (otherwise transient resolution
+        // gives the service a different enumeration than what the test mutates → state silently lost).
+        // AbpIntegratedTest constructs a fresh container per test class instance, so singletons
+        // don't leak across tests.
+        context.Services.AddSingleton<FakeContractProvider>();
+        context.Services.AddSingleton<FakeInvoiceProvider>();
+        context.Services.AddSingleton<IDocumentIdentifierProvider>(sp => sp.GetRequiredService<FakeContractProvider>());
+        context.Services.AddSingleton<IDocumentIdentifierProvider>(sp => sp.GetRequiredService<FakeInvoiceProvider>());
+    }
+}
+
+public class RelationDiscoveryService_Tests
+    : PaperbaseApplicationTestBase<RelationDiscoveryServiceTestModule>
+{
+    private readonly RelationDiscoveryService _service;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly FakeContractProvider _contractProvider;
+    private readonly FakeInvoiceProvider _invoiceProvider;
+
+    public RelationDiscoveryService_Tests()
+    {
+        _service = GetRequiredService<RelationDiscoveryService>();
+        _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        // Resolve the singletons by their concrete type — same instances as those enumerated
+        // through IEnumerable<IDocumentIdentifierProvider> by the service.
+        _contractProvider = GetRequiredService<FakeContractProvider>();
+        _invoiceProvider = GetRequiredService<FakeInvoiceProvider>();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_No_Provider_Has_Identifiers_For_Source()
+    {
+        var sourceDocId = Guid.NewGuid();
+        // Both providers are empty — no identifiers known for this document.
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+        await _relationRepository.DidNotReceive().InsertAsync(
+            Arg.Any<DocumentRelation>(), autoSave: Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Reject_Empty_Document_Id()
+    {
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await _service.DiscoverAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Create_AiSuggested_Relation_For_Each_Cross_Module_Peer()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        // Source is a contract holding ContractNumber=HT-001.
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-001")
+        };
+        // Invoice peer also holds ContractNumber=HT-001 → cross-module match expected.
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-001")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        var relation = created.Single();
+        relation.SourceDocumentId.ShouldBe(sourceDocId);
+        relation.TargetDocumentId.ShouldBe(peerDocId);
+        relation.Source.ShouldBe(RelationSource.AiSuggested);
+        relation.Confidence.ShouldBe(RelationDiscoveryService.StructuralMatchConfidence);
+        relation.Description.ShouldContain("ContractNumber");
+        relation.Description.ShouldContain("HT-001");
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Peers_That_Already_Have_A_Relation()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var alreadyLinkedPeerId = Guid.NewGuid();
+        var freshPeerId = Guid.NewGuid();
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-002")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-002")] = new[] { alreadyLinkedPeerId, freshPeerId };
+
+        // alreadyLinkedPeerId is already related (Manual — user-confirmed) — must NOT be re-suggested.
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>
+            {
+                CreateExistingRelation(sourceDocId, alreadyLinkedPeerId, RelationSource.Manual)
+            });
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(freshPeerId);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Create_Only_One_Relation_When_Same_Peer_Matches_Multiple_Identifiers()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        // Source has two identifiers; both happen to point to the same peer document.
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-003"),
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "上海某某有限公司"),
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-003")] = new[] { peerDocId };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.PartyName, "上海某某有限公司")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        // Description reflects the FIRST identifier that found this peer — first-write-wins.
+        created.Single().Description.ShouldContain("ContractNumber");
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Self_When_Provider_Returns_Source_Document_Id()
+    {
+        var sourceDocId = Guid.NewGuid();
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "甲方公司")
+        };
+        // Defensive: provider FindDocumentsAsync echoes source itself (because contract module
+        // also holds the source document). Service must filter self.
+        _contractProvider.Lookup[(DocumentIdentifierTypes.PartyName, "甲方公司")] = new[] { sourceDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Providers_That_Do_Not_Support_Identifier_Type()
+    {
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        // Source has an InvoiceNumber identifier — only the invoice provider supports it.
+        // The contract provider does NOT support InvoiceNumber, so its FindDocumentsAsync
+        // must not be called for this type.
+        _invoiceProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.InvoiceNumber, "INV-001")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.InvoiceNumber, "INV-001")] = new[] { peerDocId };
+
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        // Verify contract provider's FindDocumentsAsync was NOT called for InvoiceNumber.
+        _contractProvider.FindCalls.ShouldNotContain(c => c.Type == DocumentIdentifierTypes.InvoiceNumber);
+    }
+
+    private static DocumentRelation CreateExistingRelation(Guid source, Guid target, RelationSource src)
+    {
+        return new DocumentRelation(
+            Guid.NewGuid(),
+            tenantId: null,
+            sourceDocumentId: source,
+            targetDocumentId: target,
+            description: "Manual link",
+            source: src,
+            confidence: src == RelationSource.Manual ? null : 0.9);
+    }
+}
+
+// ─── Test doubles ──────────────────────────────────────────────────────────────
+
+internal sealed class FakeContractProvider : IDocumentIdentifierProvider
+{
+    public IReadOnlyCollection<string> SupportedIdentifierTypes { get; } = new[]
+    {
+        DocumentIdentifierTypes.ContractNumber,
+        DocumentIdentifierTypes.PartyName,
+    };
+
+    public Dictionary<Guid, IReadOnlyList<DocumentIdentifierEntry>> Identifiers { get; } = new();
+    public Dictionary<(string Type, string Value), IReadOnlyList<Guid>> Lookup { get; } = new();
+    public List<(string Type, string Value)> FindCalls { get; } = new();
+
+    public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
+        => Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+
+    public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
+    {
+        FindCalls.Add((identifierType, identifierValue));
+        return Task.FromResult(Lookup.TryGetValue((identifierType, identifierValue), out var v) ? v : (IReadOnlyList<Guid>)Array.Empty<Guid>());
+    }
+}
+
+internal sealed class FakeInvoiceProvider : IDocumentIdentifierProvider
+{
+    public IReadOnlyCollection<string> SupportedIdentifierTypes { get; } = new[]
+    {
+        DocumentIdentifierTypes.ContractNumber,
+        DocumentIdentifierTypes.PartyName,
+        DocumentIdentifierTypes.InvoiceNumber,
+    };
+
+    public Dictionary<Guid, IReadOnlyList<DocumentIdentifierEntry>> Identifiers { get; } = new();
+    public Dictionary<(string Type, string Value), IReadOnlyList<Guid>> Lookup { get; } = new();
+    public List<(string Type, string Value)> FindCalls { get; } = new();
+
+    public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
+        => Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
+
+    public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
+    {
+        FindCalls.Add((identifierType, identifierValue));
+        return Task.FromResult(Lookup.TryGetValue((identifierType, identifierValue), out var v) ? v : (IReadOnlyList<Guid>)Array.Empty<Guid>());
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class SemanticRelationDiscoveryServiceTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
+        context.Services.AddSingleton(Substitute.For<IDocumentKnowledgeIndex>());
+        context.Services.AddSingleton(Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>());
+
+        // Replace RelationInferenceAgent entirely so tests don't need a real IChatClient.
+        // Construct with cheap substitutes for its dependencies.
+        context.Services.AddSingleton(Substitute.For<RelationInferenceAgent>(
+            Substitute.For<IChatClient>(),
+            Options.Create(new PaperbaseAIBehaviorOptions())));
+
+        // Default: enable semantic discovery so most tests exercise the full path.
+        // The "disabled" test overrides this via direct field manipulation on the resolved options.
+        context.Services.Configure<PaperbaseAIBehaviorOptions>(opts =>
+        {
+            opts.EnableSemanticRelationDiscovery = true;
+            opts.SemanticRelationDiscoveryTopK = 5;
+            opts.SemanticRelationDiscoveryMinScore = 0.65;
+            opts.SemanticRelationDiscoveryConfidenceThreshold = 0.7;
+        });
+    }
+}
+
+public class SemanticRelationDiscoveryService_Tests
+    : PaperbaseApplicationTestBase<SemanticRelationDiscoveryServiceTestModule>
+{
+    private readonly SemanticRelationDiscoveryService _service;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly IDocumentKnowledgeIndex _knowledgeIndex;
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
+    private readonly RelationInferenceAgent _inferenceAgent;
+    private readonly PaperbaseAIBehaviorOptions _aiOptions;
+
+    public SemanticRelationDiscoveryService_Tests()
+    {
+        _service = GetRequiredService<SemanticRelationDiscoveryService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        _knowledgeIndex = GetRequiredService<IDocumentKnowledgeIndex>();
+        _embeddingGenerator = GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+        _inferenceAgent = GetRequiredService<RelationInferenceAgent>();
+        _aiOptions = GetRequiredService<IOptions<PaperbaseAIBehaviorOptions>>().Value;
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Short_Circuit_When_Disabled()
+    {
+        _aiOptions.EnableSemanticRelationDiscovery = false;
+        var sourceId = Guid.NewGuid();
+
+        var created = await _service.DiscoverAsync(sourceId);
+
+        created.ShouldBeEmpty();
+        // Short-circuit means NO IO at all — not even a document load.
+        await _documentRepository.DidNotReceive().FindAsync(
+            Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Reject_Empty_Source_Id()
+    {
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await _service.DiscoverAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_Source_Not_Found()
+    {
+        var sourceId = Guid.NewGuid();
+        _documentRepository.FindAsync(sourceId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+
+        var created = await _service.DiscoverAsync(sourceId);
+
+        created.ShouldBeEmpty();
+        await _embeddingGenerator.DidNotReceive().GenerateAsync(
+            Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_Source_Has_No_Markdown()
+    {
+        var source = CreateDocument(markdown: null);
+        SetupSource(source);
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_Vector_Search_Yields_No_Candidates()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        SetupSource(source);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, Array.Empty<VectorSearchResult>());
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Filter_Self_From_Vector_Results()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        SetupSource(source);
+        SetupEmbedding();
+        // Vector search returns the source itself as the top hit (always — every doc
+        // is most similar to itself). Service must filter it out.
+        SetupVectorSearch(source.Id, new[]
+        {
+            CreateVectorResult(source.Id, 0.95),
+        });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _inferenceAgent.DidNotReceive().EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Already_Linked_Candidates()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var linkedPeer = CreateDocument(markdown: "已关联文档");
+        SetupSource(source);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[]
+        {
+            CreateVectorResult(linkedPeer.Id, 0.85),
+        });
+        // Pre-existing relation → must skip.
+        _relationRepository.GetListByDocumentIdAsync(source.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>
+            {
+                new(Guid.NewGuid(), null, source.Id, linkedPeer.Id,
+                    "manual link", RelationSource.Manual)
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _inferenceAgent.DidNotReceive().EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_When_LLM_Says_Not_Related()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "无关文档");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidate.Id, 0.7) });
+        SetupNoExistingRelations(source.Id);
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult { IsRelated = false, Confidence = 0.2 });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _relationRepository.DidNotReceive().InsertAsync(
+            Arg.Any<DocumentRelation>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_When_Confidence_Below_Threshold()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "弱相关文档");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidate.Id, 0.7) });
+        SetupNoExistingRelations(source.Id);
+
+        // LLM says related but confidence is below threshold (0.7).
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult
+            {
+                IsRelated = true,
+                Confidence = 0.5,
+                Description = "可能有关"
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Create_AiSuggested_When_LLM_Confirms()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "强相关发票");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidate.Id, 0.85) });
+        SetupNoExistingRelations(source.Id);
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult
+            {
+                IsRelated = true,
+                Confidence = 0.85,
+                Description = "该发票对应该合同"
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.Count.ShouldBe(1);
+        var rel = created.Single();
+        rel.SourceDocumentId.ShouldBe(source.Id);
+        rel.TargetDocumentId.ShouldBe(candidate.Id);
+        rel.Source.ShouldBe(RelationSource.AiSuggested);
+        rel.Confidence.ShouldBe(0.85);
+        rel.Description.ShouldBe("该发票对应该合同");
+        // autoSave: true — LLM/DB rule (no UoW during external work).
+        await _relationRepository.Received(1).InsertAsync(
+            Arg.Any<DocumentRelation>(), autoSave: true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Continue_When_LLM_Throws_For_One_Candidate()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var failCandidate = CreateDocument(markdown: "LLM 调用失败");
+        var goodCandidate = CreateDocument(markdown: "正常候选");
+        SetupSource(source);
+        SetupCandidate(failCandidate);
+        SetupCandidate(goodCandidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[]
+        {
+            CreateVectorResult(failCandidate.Id, 0.85),
+            CreateVectorResult(goodCandidate.Id, 0.8),
+        });
+        SetupNoExistingRelations(source.Id);
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Is<DocumentSnapshot>(s => s.Markdown == "合同内容"),
+                Arg.Is<DocumentSnapshot>(c => c.Markdown == "LLM 调用失败"),
+                Arg.Any<CancellationToken>())
+            .Returns<RelationInferenceResult>(_ => throw new InvalidOperationException("LLM provider down"));
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Is<DocumentSnapshot>(s => s.Markdown == "合同内容"),
+                Arg.Is<DocumentSnapshot>(c => c.Markdown == "正常候选"),
+                Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult
+            {
+                IsRelated = true, Confidence = 0.8, Description = "match"
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(goodCandidate.Id);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Candidate_With_No_Markdown()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidateWithoutMarkdown = CreateDocument(markdown: null);
+        SetupSource(source);
+        SetupCandidate(candidateWithoutMarkdown);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidateWithoutMarkdown.Id, 0.9) });
+        SetupNoExistingRelations(source.Id);
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _inferenceAgent.DidNotReceive().EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private void SetupSource(Document doc)
+    {
+        _documentRepository.FindAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private void SetupCandidate(Document doc)
+    {
+        _documentRepository.FindAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private void SetupNoExistingRelations(Guid sourceId)
+    {
+        _relationRepository.GetListByDocumentIdAsync(sourceId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+    }
+
+    private void SetupEmbedding()
+    {
+        _embeddingGenerator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GeneratedEmbeddings<Embedding<float>>(new[]
+            {
+                new Embedding<float>(new[] { 0.1f, 0.2f, 0.3f })
+            }));
+    }
+
+    private void SetupVectorSearch(Guid sourceDocId, IReadOnlyList<VectorSearchResult> results)
+    {
+        _knowledgeIndex.SearchAsync(
+                Arg.Any<VectorSearchRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(results);
+    }
+
+    private static VectorSearchResult CreateVectorResult(Guid documentId, double score)
+    {
+        return new VectorSearchResult
+        {
+            RecordId = Guid.NewGuid(),
+            DocumentId = documentId,
+            ChunkIndex = 0,
+            Text = "chunk",
+            Score = score,
+        };
+    }
+
+    private static Document CreateDocument(string? markdown)
+    {
+        var doc = new Document(
+            Guid.NewGuid(), tenantId: null,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+
+        if (markdown != null)
+        {
+            typeof(Document)
+                .GetProperty(nameof(Document.Markdown))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(doc, new object[] { markdown });
+        }
+
+        return doc;
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
@@ -294,6 +294,67 @@ public class SemanticRelationDiscoveryService_Tests
     }
 
     [Fact]
+    public async Task DiscoverAsync_Should_Run_LLM_And_Vector_Search_Without_Ambient_UoW()
+    {
+        // .claude/rules/background-jobs.md § Tests: regression guard against future code
+        // accidentally wrapping L3 in an outer UoW that holds a DB connection during LLM calls.
+        // L3 service itself opens NO UoW; when called from the background job (after L2's UoW
+        // has been disposed), ambient ICurrentUnitOfWork must be null at every external boundary.
+        var uowManager = GetRequiredService<Volo.Abp.Uow.IUnitOfWorkManager>();
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "强相关发票");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupNoExistingRelations(source.Id);
+
+        // Assert NO ambient UoW at the embedding boundary.
+        _embeddingGenerator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uowManager.Current.ShouldBeNull();
+                return new GeneratedEmbeddings<Embedding<float>>(new[]
+                {
+                    new Embedding<float>(new[] { 0.1f, 0.2f, 0.3f })
+                });
+            });
+
+        // Assert NO ambient UoW at the vector search boundary.
+        _knowledgeIndex.SearchAsync(
+                Arg.Any<VectorSearchRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uowManager.Current.ShouldBeNull();
+                return (IReadOnlyList<VectorSearchResult>)new[] { CreateVectorResult(candidate.Id, 0.9) };
+            });
+
+        // Assert NO ambient UoW at the LLM evaluation boundary.
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uowManager.Current.ShouldBeNull();
+                return new RelationInferenceResult
+                {
+                    IsRelated = true, Confidence = 0.85, Description = "match"
+                };
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.Count.ShouldBe(1);
+        // Sanity: all three external boundaries were actually hit (the assertion ran).
+        await _embeddingGenerator.Received(1).GenerateAsync(
+            Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions>(), Arg.Any<CancellationToken>());
+        await _knowledgeIndex.Received(1).SearchAsync(Arg.Any<VectorSearchRequest>(), Arg.Any<CancellationToken>());
+        await _inferenceAgent.Received(1).EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task DiscoverAsync_Should_Skip_Candidate_With_No_Markdown()
     {
         var source = CreateDocument(markdown: "合同内容");

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/ContractIdentifierProvider.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/ContractIdentifierProvider.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Contracts.Contracts;
+
+/// <summary>
+/// Issue #115 L2: 合同模块对核心 <see cref="IDocumentIdentifierProvider"/> 契约的实现。
+///
+/// <para>
+/// <strong>映射关系</strong>：
+/// <list type="bullet">
+/// <item><see cref="DocumentIdentifierTypes.ContractNumber"/> ↔ <see cref="Contract.ContractNumber"/></item>
+/// <item><see cref="DocumentIdentifierTypes.PartyName"/> ↔ <see cref="Contract.PartyAName"/> / <see cref="Contract.PartyBName"/> / <see cref="Contract.CounterpartyName"/>
+///       （任意一个字段命中即视为持有该 PartyName）</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <strong>无独立索引</strong>：本 provider 直接查 <c>Contract</c> 聚合根字段，是当前合同数据的唯一来源——
+/// 用户通过合同详情页修正 AI 抽取错误时，本 provider 自动反映新值，无同步腐烂问题。
+/// 这是 L2 设计选择 fan-out provider 而非中心化索引表的核心原因（见 <c>doc-chat-anti-patterns.md</c>
+/// 反例 D 同源思想：模块自治优于核心代理）。
+/// </para>
+///
+/// <para>
+/// <strong>多租户</strong>：仓储查询走 ABP <c>IMultiTenant</c> ambient filter，自动按 <c>CurrentTenant.Id</c> 过滤。
+/// 本路径不接 LLM、不在 Chat 工具体内被调用，无 prompt-injection 攻击面，不需要显式权限断言三件套。
+/// </para>
+/// </summary>
+public class ContractIdentifierProvider : IDocumentIdentifierProvider, ITransientDependency
+{
+    /// <summary>合同模块支持的标识符类型。L2 fan-out 时按此集合筛选。</summary>
+    public IReadOnlyCollection<string> SupportedIdentifierTypes { get; } = new[]
+    {
+        DocumentIdentifierTypes.ContractNumber,
+        DocumentIdentifierTypes.PartyName,
+    };
+
+    private readonly IContractRepository _contractRepository;
+
+    public ContractIdentifierProvider(IContractRepository contractRepository)
+    {
+        _contractRepository = contractRepository;
+    }
+
+    public virtual async Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default)
+    {
+        var contract = await _contractRepository.FindByDocumentIdAsync(documentId);
+        if (contract == null)
+        {
+            // 该文档不属于合同模块（或合同记录尚未创建）。返回空表示"无贡献"，
+            // L2 RelationDiscoveryService 会继续遍历其他 provider。
+            return Array.Empty<DocumentIdentifierEntry>();
+        }
+
+        var entries = new List<DocumentIdentifierEntry>();
+        AddIfPresent(entries, DocumentIdentifierTypes.ContractNumber, contract.ContractNumber);
+        AddIfPresent(entries, DocumentIdentifierTypes.PartyName, contract.PartyAName);
+        AddIfPresent(entries, DocumentIdentifierTypes.PartyName, contract.PartyBName);
+        AddIfPresent(entries, DocumentIdentifierTypes.PartyName, contract.CounterpartyName);
+        return entries;
+    }
+
+    public virtual async Task<IReadOnlyList<Guid>> FindDocumentsAsync(
+        string identifierType,
+        string identifierValue,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(identifierValue))
+        {
+            return Array.Empty<Guid>();
+        }
+
+        var trimmed = identifierValue.Trim();
+
+        return identifierType switch
+        {
+            DocumentIdentifierTypes.ContractNumber => await FindByContractNumberAsync(trimmed, cancellationToken),
+            DocumentIdentifierTypes.PartyName => await FindByPartyNameAsync(trimmed, cancellationToken),
+            _ => Array.Empty<Guid>()      // Unknown type — defensive; SupportedIdentifierTypes 已经在上游筛过
+        };
+    }
+
+    protected virtual async Task<IReadOnlyList<Guid>> FindByContractNumberAsync(
+        string contractNumber,
+        CancellationToken ct)
+    {
+        var contracts = await _contractRepository.FindByContractNumberAsync(contractNumber, ct);
+        return contracts.Select(c => c.DocumentId).Where(id => id != Guid.Empty).Distinct().ToList();
+    }
+
+    protected virtual async Task<IReadOnlyList<Guid>> FindByPartyNameAsync(
+        string partyName,
+        CancellationToken ct)
+    {
+        var contracts = await _contractRepository.GetListByPartyNameAsync(partyName, ct);
+        return contracts.Select(c => c.DocumentId).Where(id => id != Guid.Empty).Distinct().ToList();
+    }
+
+    private static void AddIfPresent(List<DocumentIdentifierEntry> entries, string type, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+        entries.Add(new DocumentIdentifierEntry(type, value.Trim()));
+    }
+}

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/IContractRepository.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.Domain/Contracts/IContractRepository.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Repositories;
 
@@ -7,4 +9,23 @@ namespace Dignite.Paperbase.Contracts.Contracts;
 public interface IContractRepository : IRepository<Contract, Guid>
 {
     Task<Contract?> FindByDocumentIdAsync(Guid documentId);
+
+    /// <summary>
+    /// Issue #115 L2: 查询当前租户内持有指定合同编号的所有合同。
+    /// 同一编号理论上唯一，但保留 List 返回类型——AI 抽取出错或人工录入重复时
+    /// 不希望调用方收到 InvalidOperationException 而无法上下文判断。
+    /// 调用方负责按 (Tenant, ContractNumber) 唯一性的业务约定处理多结果。
+    /// </summary>
+    Task<List<Contract>> FindByContractNumberAsync(
+        string contractNumber,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Issue #115 L2: 查询当前租户内"甲方 / 乙方 / 对手方"匹配指定名称的所有合同。
+    /// 同一公司可在不同合同里出现在不同位置，所以本方法跨 PartyAName / PartyBName / CounterpartyName
+    /// 三个字段查询。
+    /// </summary>
+    Task<List<Contract>> GetListByPartyNameAsync(
+        string partyName,
+        CancellationToken cancellationToken = default);
 }

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.EntityFrameworkCore/EntityFrameworkCore/EfCoreContractRepository.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.EntityFrameworkCore/EntityFrameworkCore/EfCoreContractRepository.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Contracts.Contracts;
 using Microsoft.EntityFrameworkCore;
@@ -20,5 +23,28 @@ public class EfCoreContractRepository :
     {
         var dbSet = await GetDbSetAsync();
         return await dbSet.FirstOrDefaultAsync(x => x.DocumentId == documentId);
+    }
+
+    public virtual async Task<List<Contract>> FindByContractNumberAsync(
+        string contractNumber,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .Where(x => x.ContractNumber == contractNumber)
+            .ToListAsync(GetCancellationToken(cancellationToken));
+    }
+
+    public virtual async Task<List<Contract>> GetListByPartyNameAsync(
+        string partyName,
+        CancellationToken cancellationToken = default)
+    {
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .Where(x =>
+                x.PartyAName == partyName
+                || x.PartyBName == partyName
+                || x.CounterpartyName == partyName)
+            .ToListAsync(GetCancellationToken(cancellationToken));
     }
 }

--- a/modules/contracts/test/Dignite.Paperbase.Contracts.Domain.Tests/Contracts/ContractIdentifierProvider_Tests.cs
+++ b/modules/contracts/test/Dignite.Paperbase.Contracts.Domain.Tests/Contracts/ContractIdentifierProvider_Tests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Contracts.Contracts;
+
+[DependsOn(typeof(ContractsDomainTestModule))]
+public class ContractIdentifierProviderTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Mock the repository to avoid spinning up an EF context for behavioral tests.
+        // Repository implementation correctness is covered by EFCore.Tests when needed.
+        context.Services.AddSingleton(Substitute.For<IContractRepository>());
+    }
+}
+
+public class ContractIdentifierProvider_Tests
+    : ContractsDomainTestBase<ContractIdentifierProviderTestModule>
+{
+    private readonly ContractIdentifierProvider _provider;
+    private readonly IContractRepository _contractRepository;
+    private readonly ContractManager _contractManager;
+
+    public ContractIdentifierProvider_Tests()
+    {
+        _provider = GetRequiredService<ContractIdentifierProvider>();
+        _contractRepository = GetRequiredService<IContractRepository>();
+        _contractManager = GetRequiredService<ContractManager>();
+    }
+
+    [Fact]
+    public void SupportedIdentifierTypes_Should_Include_ContractNumber_And_PartyName()
+    {
+        _provider.SupportedIdentifierTypes.ShouldContain(DocumentIdentifierTypes.ContractNumber);
+        _provider.SupportedIdentifierTypes.ShouldContain(DocumentIdentifierTypes.PartyName);
+        // Invoice number / PO number / project code are not the contract module's responsibility.
+        _provider.SupportedIdentifierTypes.ShouldNotContain(DocumentIdentifierTypes.InvoiceNumber);
+        _provider.SupportedIdentifierTypes.ShouldNotContain(DocumentIdentifierTypes.PoNumber);
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Return_Empty_When_Document_Not_Owned_By_Contracts_Module()
+    {
+        var documentId = Guid.NewGuid();
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns((Contract?)null);
+
+        var entries = await _provider.GetIdentifiersAsync(documentId);
+
+        entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Map_Contract_Fields_To_Identifier_Entries()
+    {
+        var documentId = Guid.NewGuid();
+        var contract = CreateContract(
+            documentId,
+            contractNumber: "HT-2026-001",
+            partyA: "甲方公司",
+            partyB: "乙方公司",
+            counterparty: "对手方公司");
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns(contract);
+
+        var entries = (await _provider.GetIdentifiersAsync(documentId)).ToList();
+
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-2026-001"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "甲方公司"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "乙方公司"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "对手方公司"));
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Skip_Null_And_Whitespace_Fields()
+    {
+        var documentId = Guid.NewGuid();
+        var contract = CreateContract(
+            documentId,
+            contractNumber: null,
+            partyA: "  ",
+            partyB: "乙方公司",
+            counterparty: null);
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns(contract);
+
+        var entries = (await _provider.GetIdentifiersAsync(documentId)).ToList();
+
+        entries.Count.ShouldBe(1);
+        entries.Single().ShouldBe(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "乙方公司"));
+    }
+
+    [Fact]
+    public async Task GetIdentifiersAsync_Should_Trim_Field_Values()
+    {
+        var documentId = Guid.NewGuid();
+        var contract = CreateContract(
+            documentId,
+            contractNumber: "  HT-2026-002  ",
+            partyA: " 甲方 ",
+            partyB: null,
+            counterparty: null);
+        _contractRepository.FindByDocumentIdAsync(documentId).Returns(contract);
+
+        var entries = (await _provider.GetIdentifiersAsync(documentId)).ToList();
+
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-2026-002"));
+        entries.ShouldContain(new DocumentIdentifierEntry(DocumentIdentifierTypes.PartyName, "甲方"));
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_Should_Return_Empty_For_Whitespace_Value()
+    {
+        var result = await _provider.FindDocumentsAsync(DocumentIdentifierTypes.ContractNumber, "  ");
+        result.ShouldBeEmpty();
+
+        await _contractRepository.DidNotReceive().FindByContractNumberAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_Should_Return_Empty_For_Unsupported_Type()
+    {
+        var result = await _provider.FindDocumentsAsync(DocumentIdentifierTypes.InvoiceNumber, "INV-001");
+        result.ShouldBeEmpty();
+
+        // Defensive: unsupported types short-circuit before any repository call.
+        await _contractRepository.DidNotReceive().FindByContractNumberAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _contractRepository.DidNotReceive().GetListByPartyNameAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_ContractNumber_Should_Trim_And_Delegate()
+    {
+        var matchingDocId = Guid.NewGuid();
+        var matchingContract = CreateContract(matchingDocId, contractNumber: "HT-2026-003");
+        _contractRepository
+            .FindByContractNumberAsync("HT-2026-003", Arg.Any<CancellationToken>())
+            .Returns(new List<Contract> { matchingContract });
+
+        var result = await _provider.FindDocumentsAsync(
+            DocumentIdentifierTypes.ContractNumber,
+            "  HT-2026-003 ");
+
+        result.ShouldContain(matchingDocId);
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_PartyName_Should_Delegate_To_GetListByPartyName()
+    {
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        _contractRepository
+            .GetListByPartyNameAsync("甲方公司", Arg.Any<CancellationToken>())
+            .Returns(new List<Contract>
+            {
+                CreateContract(docA, partyA: "甲方公司"),
+                CreateContract(docB, partyB: "甲方公司")
+            });
+
+        var result = await _provider.FindDocumentsAsync(
+            DocumentIdentifierTypes.PartyName,
+            "甲方公司");
+
+        result.ShouldContain(docA);
+        result.ShouldContain(docB);
+    }
+
+    [Fact]
+    public async Task FindDocumentsAsync_Should_Distinct_Document_Ids()
+    {
+        var sharedDoc = Guid.NewGuid();
+        // Two Contract rows pointing to the same document (data anomaly we want to defend against).
+        _contractRepository
+            .FindByContractNumberAsync("HT-2026-004", Arg.Any<CancellationToken>())
+            .Returns(new List<Contract>
+            {
+                CreateContract(sharedDoc, contractNumber: "HT-2026-004"),
+                CreateContract(sharedDoc, contractNumber: "HT-2026-004"),
+            });
+
+        var result = await _provider.FindDocumentsAsync(
+            DocumentIdentifierTypes.ContractNumber,
+            "HT-2026-004");
+
+        result.Count.ShouldBe(1);
+    }
+
+    private Contract CreateContract(
+        Guid documentId,
+        string? contractNumber = null,
+        string? partyA = null,
+        string? partyB = null,
+        string? counterparty = null)
+    {
+        var fields = new ContractFields
+        {
+            ContractNumber = contractNumber,
+            PartyAName = partyA,
+            PartyBName = partyB,
+            CounterpartyName = counterparty,
+        };
+
+        // ContractManager wraps the internal Contract constructor. Use it from tests
+        // to honor the same construction path the production code uses.
+        return _contractManager.CreateAsync(documentId, ContractsDocumentTypes.General, fields)
+            .GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#121](https://github.com/dignite-projects/dignite-paperbase/issues/121). Apply L3's Hangfire-safe tenant pattern (introduced by [#120](https://github.com/dignite-projects/dignite-paperbase/pull/120)) to L2's `RelationDiscoveryService`.

> **Stacked PR**: based on `feat/issue-115-l3-semantic-fallback` (#120). Merge order: #118 → #119 → #120 → this.

## Why

L3 reads `Document.TenantId` at the start of `DiscoverAsync` and threads it through `DocumentSnapshot` to the write path. L2 still depended on ambient `ICurrentTenant.Id` when stamping new `DocumentRelations`. Under normal Hangfire flow ABP restores tenant context from job args so both produced the same result, but pathological code paths (scheduled batches outside both HTTP and Hangfire contexts) could leak — and the inconsistency itself was a maintenance trap.

## Changes

`RelationDiscoveryService`:
- Drop `ICurrentTenant` dependency
- Inject `IDocumentRepository` instead
- New Phase 0: load source `Document`, capture `TenantId`
- Document hard-deleted between event and execution → drop silently (matches `RelationDiscoveryEventHandler` / `RelationDiscoveryBackgroundJob` pattern)
- New `DocumentRelation` stamped with `sourceTenantId`, not `_currentTenant.Id`

## Tests (3 new + existing 12 still pass)

- `DiscoverAsync_Should_Drop_Silently_When_Source_Document_Hard_Deleted` — short-circuit before any provider call when `FindAsync` returns null
- `DiscoverAsync_Should_Stamp_New_Relation_With_Source_Document_TenantId` — asserts the new pattern: tenant comes from `Document.TenantId` without any `ICurrentTenant.Change(...)` call in the test setup
- `DiscoverAsync_Should_Run_Provider_Calls_Without_Ambient_UoW` — `background-jobs.md § Tests` regression guard. Adds `OnGetIdentifiersInvoked` / `OnFindDocumentsInvoked` hooks to `FakeContractProvider` so the assertion fires INSIDE the provider call boundary

Existing 12 L2 tests adapted via a default `FindAsync` stub in the ctor — unconfigured document IDs resolve to a tenantless Document so legacy tests don't need explicit setup.

Application 263 + Domain 42 + Contracts.Domain 16 all green.

## Symmetry achieved

| Aspect | L2 (this PR) | L3 (#120) |
|---|---|---|
| Source loaded for tenant capture | ✅ Phase 0 | ✅ Phase 1 |
| `TenantId` source | `source.TenantId` | `sourceSnapshot.TenantId` (← `source.TenantId`) |
| `ICurrentTenant` injection | ❌ removed | ❌ removed |
| Hard-delete short-circuit | ✅ silent drop | ✅ silent drop |
| UoW null assertion test | ✅ at provider boundary | ✅ at LLM/embedding/vector boundary |

🤖 Generated with [Claude Code](https://claude.com/claude-code)