### PR TITLE
feat(documents): L3 semantic + LLM relation discovery fallback (#115)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
@@ -103,4 +103,29 @@ public class PaperbaseAIBehaviorOptions
     /// Set to 0 to disable the cap (not recommended in production).
     /// </summary>
     public int MaxCapturedCitations { get; set; } = 50;
+
+    /// <summary>
+    /// Issue #115 L3: 启用基于"向量召回 + LLM 评判"的语义关系发现作为 L2 兜底。
+    /// 默认 <c>false</c>——LLM 调用按文档数线性增长，操作员需明确开启并自行控制成本。
+    /// 关闭时 L2 找不到关系的文档保持无 AiSuggested 状态，等待用户手动建立。
+    /// </summary>
+    public bool EnableSemanticRelationDiscovery { get; set; } = false;
+
+    /// <summary>
+    /// L3 向量召回 top-K——LLM 评判前的候选数量上限。
+    /// 越大召回越宽，但 LLM 调用成本线性增长。建议 5–10。
+    /// </summary>
+    public int SemanticRelationDiscoveryTopK { get; set; } = 5;
+
+    /// <summary>
+    /// L3 向量召回最低分数。低于此分数的候选直接淘汰，不送 LLM。
+    /// 高于普通 chat RAG 的 <see cref="DocumentChatMinScore"/>——L3 只关心强语义匹配，弱匹配是噪音。
+    /// </summary>
+    public double SemanticRelationDiscoveryMinScore { get; set; } = 0.65;
+
+    /// <summary>
+    /// L3 LLM 评判的 confidence 下限。LLM 输出 <see cref="RelationInferenceResult.Confidence"/>
+    /// 低于此值的候选不创建 AiSuggested 关系。建议 0.7+。
+    /// </summary>
+    public double SemanticRelationDiscoveryConfidenceThreshold { get; set; } = 0.7;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
@@ -37,6 +37,7 @@ public class RelationDiscoveryBackgroundJob
     private readonly DocumentPipelineRunManager _pipelineRunManager;
     private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
     private readonly RelationDiscoveryService _discoveryService;
+    private readonly SemanticRelationDiscoveryService _semanticDiscoveryService;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
 
     public RelationDiscoveryBackgroundJob(
@@ -44,12 +45,14 @@ public class RelationDiscoveryBackgroundJob
         DocumentPipelineRunManager pipelineRunManager,
         DocumentPipelineRunAccessor pipelineRunAccessor,
         RelationDiscoveryService discoveryService,
+        SemanticRelationDiscoveryService semanticDiscoveryService,
         IUnitOfWorkManager unitOfWorkManager)
     {
         _documentRepository = documentRepository;
         _pipelineRunManager = pipelineRunManager;
         _pipelineRunAccessor = pipelineRunAccessor;
         _discoveryService = discoveryService;
+        _semanticDiscoveryService = semanticDiscoveryService;
         _unitOfWorkManager = unitOfWorkManager;
     }
 
@@ -105,13 +108,29 @@ public class RelationDiscoveryBackgroundJob
 
     protected virtual async Task<int> DiscoverAsync(Guid documentId)
     {
-        // L2 service inserts DocumentRelation aggregates with autoSave: false; wrap in a UoW
-        // so the writes commit. Pure DB work — no external IO — but the rule "begin → external → complete"
-        // is honored in spirit by isolating the discovery write transaction from the run-state writes.
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
-        var created = await _discoveryService.DiscoverAsync(documentId);
-        await uow.CompleteAsync();
-        return created.Count;
+        // L2: structured fan-out across business-module providers. Cheap (DB queries only).
+        // L2 writes commit in a dedicated UoW (autoSave: false on inserts ⇒ uow.CompleteAsync()).
+        int l2Count;
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var created = await _discoveryService.DiscoverAsync(documentId);
+            await uow.CompleteAsync();
+            l2Count = created.Count;
+        }
+
+        if (l2Count > 0)
+        {
+            // L2 found structured matches — that's strong signal; don't run L3 (expensive LLM)
+            // on top. L3 is the fallback for "structured matching found nothing".
+            return l2Count;
+        }
+
+        // L3 fallback: vector recall + LLM evaluation. Disabled by default (operator opt-in).
+        // NOT wrapped in an outer UoW: SemanticRelationDiscoveryService uses autoSave: true on
+        // each relation insert (per-call implicit UoW), so LLM calls between candidates run with
+        // no ambient UoW — satisfies the "no DB connection during external work" rule.
+        var l3Created = await _semanticDiscoveryService.DiscoverAsync(documentId);
+        return l3Created.Count;
     }
 
     protected virtual async Task CompleteRunAsync(Guid documentId, Guid runId, int createdCount)

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
@@ -33,7 +33,10 @@ namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 /// </summary>
 public class RelationInferenceAgent : ITransientDependency
 {
-    /// <summary>编译期常量，禁止变量插值。</summary>
+    /// <summary>
+    /// 编译期常量，禁止变量插值。末尾追加 <see cref="PromptBoundary.BoundaryRule"/>——document
+    /// markdown 是用户上传文档抽取出来的弱签名输入，需要明确告诉模型"标签内是数据非指令"。
+    /// </summary>
     public const string InferenceInstructions =
         "You are a strict business-document relationship judge. Given two documents (their type codes plus markdown excerpts), " +
         "decide whether they reference the SAME business event or entity (same contract / same project / same parties / same case / same transaction). " +
@@ -49,7 +52,9 @@ public class RelationInferenceAgent : ITransientDependency
         "\n" +
         "Description: when isRelated=true, write one short sentence (Chinese or English, match document language) " +
         "explaining the link, mentioning the key shared identifier or signal. Keep under 100 characters. " +
-        "When isRelated=false, leave description empty.";
+        "When isRelated=false, leave description empty.\n" +
+        "\n" +
+        PromptBoundary.BoundaryRule;
 
     private readonly IChatClient _chatClient;
     private readonly PaperbaseAIBehaviorOptions _aiOptions;
@@ -80,11 +85,14 @@ public class RelationInferenceAgent : ITransientDependency
         // headers (which usually carry the unique identifier) survive truncation.
         var perDocLimit = _aiOptions.MaxTextLengthPerExtraction / 2;
 
+        // Markdown 是 OCR/抽取出来的弱签名输入；用 PromptBoundary.WrapDocument 包裹 + 转义 '<'，
+        // 与 InferenceInstructions 末尾的 BoundaryRule 配合形成"标签内是数据非指令"防御。
+        // DocumentTypeCode 是系统管理字段（注册表常量），不需要包裹。
         var sb = new StringBuilder(perDocLimit * 2 + 256);
         sb.Append("DOCUMENT 1 — type: ").Append(source.DocumentTypeCode ?? "(unclassified)").Append('\n');
-        sb.Append(Truncate(source.Markdown, perDocLimit));
+        sb.Append(PromptBoundary.WrapDocument(Truncate(source.Markdown, perDocLimit)));
         sb.Append("\n\nDOCUMENT 2 — type: ").Append(candidate.DocumentTypeCode ?? "(unclassified)").Append('\n');
-        sb.Append(Truncate(candidate.Markdown, perDocLimit));
+        sb.Append(PromptBoundary.WrapDocument(Truncate(candidate.Markdown, perDocLimit)));
         return sb.ToString();
     }
 
@@ -98,5 +106,11 @@ public class RelationInferenceAgent : ITransientDependency
 /// <summary>
 /// L3 在 LLM 调用前把 <see cref="Document"/> 的关键字段拷出来——避免在背景任务的 external phase
 /// 里持有 EF 加载的实体（防止懒加载/UoW 越界）。
+///
+/// <para>
+/// 携带 <c>TenantId</c>：调用方在 Hangfire 等无 ambient <c>ICurrentTenant</c> 的背景任务里
+/// 可以直接从 snapshot 取租户 id 写入新建的 <c>DocumentRelation</c>，而不是依赖 ambient——
+/// 与 <c>RecallCandidatesAsync</c> 用 <c>source.TenantId</c> 做向量搜索的策略保持一致。
+/// </para>
 /// </summary>
-public sealed record DocumentSnapshot(string? DocumentTypeCode, string Markdown);
+public sealed record DocumentSnapshot(Guid? TenantId, string? DocumentTypeCode, string Markdown);

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceAgent.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L3: 把两份文档的 Markdown 摘要喂给 LLM，让它判断是否有业务关联并给出 confidence。
+///
+/// <para>
+/// <strong>fail-closed 设计</strong>：仅 <see cref="IChatClient"/> + 静态 system instructions，
+/// <strong>不挂 <c>AIContextProviders</c> / <c>ChatHistoryProvider</c></strong>。
+/// 见 <c>.claude/rules/doc-chat-anti-patterns.md</c> 反例 A：字段抽取/关系评判类 agent
+/// 一旦挂 RAG provider 会把无关文档的 chunk 注入 prompt，导致结构化字段被错误文档影响。
+/// </para>
+///
+/// <para>
+/// <strong>Markdown 截断</strong>：两份文档总长度可能超过 LLM context window。每份截到
+/// <see cref="PaperbaseAIBehaviorOptions.MaxTextLengthPerExtraction"/> 的一半，
+/// 头部信息（合同的标题/编号/当事人通常在开头）保留率最高。
+/// </para>
+///
+/// <para>
+/// <strong>system instructions 是编译期常量</strong>（<see cref="InferenceInstructions"/>），
+/// 不含任何用户控制字段，符合反例 C #4 的 prompt-injection 防御要求。
+/// </para>
+/// </summary>
+public class RelationInferenceAgent : ITransientDependency
+{
+    /// <summary>编译期常量，禁止变量插值。</summary>
+    public const string InferenceInstructions =
+        "You are a strict business-document relationship judge. Given two documents (their type codes plus markdown excerpts), " +
+        "decide whether they reference the SAME business event or entity (same contract / same project / same parties / same case / same transaction). " +
+        "Return JSON matching the response schema strictly.\n" +
+        "\n" +
+        "Set isRelated=true ONLY when both documents contain concrete evidence pointing to the same thing — same contract number, " +
+        "same party names appearing in both, same project code, same dates with overlapping parties, etc. " +
+        "DO NOT set true based on superficial similarity (both being 'contracts', both mentioning 'payment', etc.) — that's noise.\n" +
+        "\n" +
+        "Confidence calibration: 0.95+ when there's a unique identifier match (contract number, invoice number); " +
+        "0.75-0.9 when multiple soft signals align (party + date + amount); " +
+        "below 0.7 means you're not sure — set isRelated=false in that case.\n" +
+        "\n" +
+        "Description: when isRelated=true, write one short sentence (Chinese or English, match document language) " +
+        "explaining the link, mentioning the key shared identifier or signal. Keep under 100 characters. " +
+        "When isRelated=false, leave description empty.";
+
+    private readonly IChatClient _chatClient;
+    private readonly PaperbaseAIBehaviorOptions _aiOptions;
+
+    public RelationInferenceAgent(
+        IChatClient chatClient,
+        IOptions<PaperbaseAIBehaviorOptions> aiOptions)
+    {
+        _chatClient = chatClient;
+        _aiOptions = aiOptions.Value;
+    }
+
+    public virtual async Task<RelationInferenceResult> EvaluateAsync(
+        DocumentSnapshot source,
+        DocumentSnapshot candidate,
+        CancellationToken cancellationToken = default)
+    {
+        var agent = new ChatClientAgent(_chatClient, instructions: InferenceInstructions);
+
+        var prompt = BuildPrompt(source, candidate);
+        var run = await agent.RunAsync<RelationInferenceResult>(prompt, cancellationToken: cancellationToken);
+        return run.Result ?? new RelationInferenceResult { IsRelated = false };
+    }
+
+    protected virtual string BuildPrompt(DocumentSnapshot source, DocumentSnapshot candidate)
+    {
+        // Per-document budget = half of the per-extraction limit. Both documents get equal share;
+        // headers (which usually carry the unique identifier) survive truncation.
+        var perDocLimit = _aiOptions.MaxTextLengthPerExtraction / 2;
+
+        var sb = new StringBuilder(perDocLimit * 2 + 256);
+        sb.Append("DOCUMENT 1 — type: ").Append(source.DocumentTypeCode ?? "(unclassified)").Append('\n');
+        sb.Append(Truncate(source.Markdown, perDocLimit));
+        sb.Append("\n\nDOCUMENT 2 — type: ").Append(candidate.DocumentTypeCode ?? "(unclassified)").Append('\n');
+        sb.Append(Truncate(candidate.Markdown, perDocLimit));
+        return sb.ToString();
+    }
+
+    private static string Truncate(string text, int max)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= max) return text ?? string.Empty;
+        return text.Substring(0, max);
+    }
+}
+
+/// <summary>
+/// L3 在 LLM 调用前把 <see cref="Document"/> 的关键字段拷出来——避免在背景任务的 external phase
+/// 里持有 EF 加载的实体（防止懒加载/UoW 越界）。
+/// </summary>
+public sealed record DocumentSnapshot(string? DocumentTypeCode, string Markdown);

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceResult.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationInferenceResult.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L3: <see cref="RelationInferenceAgent"/> 的 LLM 结构化输出。
+///
+/// <para>
+/// 字段含义直接喂给 <c>ChatClientAgent.RunAsync&lt;RelationInferenceResult&gt;()</c>，
+/// 由 MAF 框架解析为 JSON schema 提示给 LLM。<see cref="DescriptionAttribute"/> 是给 LLM 看的字段说明，
+/// 影响输出准确度——慎改措辞。
+/// </para>
+/// </summary>
+public class RelationInferenceResult
+{
+    [Description("Whether the two documents reference the same business event/entity (same contract, same project, same parties, same case). Set true ONLY when there is concrete evidence in BOTH documents pointing to the same thing.")]
+    public bool IsRelated { get; set; }
+
+    [Description("Concise (under 100 chars) human-readable explanation of the relationship. Examples: '该发票对应订单 PO-2024-001 的货款', '本协议是主合同 HT-2024-001 的补充条款'. Empty when IsRelated is false.")]
+    public string? Description { get; set; }
+
+    [Description("Confidence in the inference, in [0, 1]. 0 = completely unrelated; 1 = certain. Below 0.7 is treated as 'not confident enough' by the discovery service and the relation is dropped.")]
+    public double Confidence { get; set; }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Services;
-using Volo.Abp.MultiTenancy;
 
 namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 
@@ -51,16 +50,16 @@ public class SemanticRelationDiscoveryService : DomainService
     private readonly IDocumentKnowledgeIndex _knowledgeIndex;
     private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
     private readonly RelationInferenceAgent _inferenceAgent;
-    private readonly ICurrentTenant _currentTenant;
     private readonly PaperbaseAIBehaviorOptions _aiOptions;
 
+    // No ICurrentTenant injection: tenant flows through DocumentSnapshot.TenantId, sourced from
+    // Document.TenantId (Hangfire-safe). Background jobs may run without an ambient ICurrentTenant.
     public SemanticRelationDiscoveryService(
         IDocumentRepository documentRepository,
         IDocumentRelationRepository relationRepository,
         IDocumentKnowledgeIndex knowledgeIndex,
         IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
         RelationInferenceAgent inferenceAgent,
-        ICurrentTenant currentTenant,
         IOptions<PaperbaseAIBehaviorOptions> aiOptions)
     {
         _documentRepository = documentRepository;
@@ -68,7 +67,6 @@ public class SemanticRelationDiscoveryService : DomainService
         _knowledgeIndex = knowledgeIndex;
         _embeddingGenerator = embeddingGenerator;
         _inferenceAgent = inferenceAgent;
-        _currentTenant = currentTenant;
         _aiOptions = aiOptions.Value;
     }
 
@@ -116,8 +114,10 @@ public class SemanticRelationDiscoveryService : DomainService
         }
 
         // Phase 4: per-candidate LLM evaluation. Provider-isolation: one bad LLM call must not
-        // tank the rest of the candidates.
-        var sourceSnapshot = new DocumentSnapshot(source.DocumentTypeCode, source.Markdown);
+        // tank the rest of the candidates. TenantId carried via snapshot so the write path
+        // (EvaluateAndCreateAsync) doesn't depend on ambient ICurrentTenant — Hangfire-safe,
+        // matches the explicit-tenant strategy used by RecallCandidatesAsync.
+        var sourceSnapshot = new DocumentSnapshot(source.TenantId, source.DocumentTypeCode, source.Markdown);
         var created = new List<DocumentRelation>();
 
         foreach (var candidateId in freshCandidates)
@@ -198,7 +198,7 @@ public class SemanticRelationDiscoveryService : DomainService
             return null;
         }
 
-        var candidateSnapshot = new DocumentSnapshot(candidate.DocumentTypeCode, candidate.Markdown);
+        var candidateSnapshot = new DocumentSnapshot(candidate.TenantId, candidate.DocumentTypeCode, candidate.Markdown);
 
         RelationInferenceResult inference;
         try
@@ -223,9 +223,12 @@ public class SemanticRelationDiscoveryService : DomainService
             ? "Semantic match (LLM-evaluated)"
             : inference.Description!.Trim();
 
+        // TenantId from sourceSnapshot (Hangfire-safe — no ambient context dependency).
+        // Source and candidate must be in the same tenant: ABP IMultiTenant filter on the
+        // vector search guarantees that. We trust source.TenantId as the authoritative value.
         var relation = new DocumentRelation(
             GuidGenerator.Create(),
-            _currentTenant.Id,
+            sourceSnapshot.TenantId,
             sourceDocumentId: sourceDocumentId,
             targetDocumentId: candidateId,
             description: description,

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Services;
+using Volo.Abp.MultiTenancy;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #115 L3：基于"向量召回 + LLM 评判"的语义关系发现，作为 L2 (<see cref="RelationDiscoveryService"/>)
+/// 找不到任何结构化匹配时的兜底路径。
+///
+/// <para>
+/// <strong>触发时机</strong>：仅在 L2 返回 0 关系时由 <see cref="RelationDiscoveryBackgroundJob"/> 调用，
+/// 且 <see cref="PaperbaseAIBehaviorOptions.EnableSemanticRelationDiscovery"/> 必须为 <c>true</c>
+/// （默认关闭——LLM 成本按文档数线性增长）。
+/// </para>
+///
+/// <para>
+/// <strong>三阶段流水线</strong>：
+/// <list type="number">
+/// <item>向量召回：用源文档 Markdown 头部生成 embedding，在向量库取 top-K 高相似度文档（高于普通 RAG 阈值）。</item>
+/// <item>预过滤：排除自身 / 已存在关系的文档。</item>
+/// <item>LLM 评判：把每对文档的 Markdown 摘要交给 <see cref="RelationInferenceAgent"/>，
+///       confidence 超阈值才创建 AiSuggested DocumentRelation；description 来自 LLM 输出。</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <strong>orphan 文档支持</strong>：源文档不属于任何业务模块（DocumentTypeCode 已分类但未注册业务模块）
+/// 也能走 L3——本路径不依赖 <c>IDocumentIdentifierProvider</c>，只看 Markdown 与向量库。
+/// </para>
+///
+/// <para>
+/// <strong>fail-closed</strong>：tenant 显式从 <c>Document.TenantId</c> 取（不依赖 ambient
+/// <c>CurrentTenant</c>，与 Embedding pipeline 同一逻辑）；候选异常隔离（一个 LLM 调用失败不打断后续）。
+/// </para>
+/// </summary>
+public class SemanticRelationDiscoveryService : DomainService
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly IDocumentKnowledgeIndex _knowledgeIndex;
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
+    private readonly RelationInferenceAgent _inferenceAgent;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly PaperbaseAIBehaviorOptions _aiOptions;
+
+    public SemanticRelationDiscoveryService(
+        IDocumentRepository documentRepository,
+        IDocumentRelationRepository relationRepository,
+        IDocumentKnowledgeIndex knowledgeIndex,
+        IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
+        RelationInferenceAgent inferenceAgent,
+        ICurrentTenant currentTenant,
+        IOptions<PaperbaseAIBehaviorOptions> aiOptions)
+    {
+        _documentRepository = documentRepository;
+        _relationRepository = relationRepository;
+        _knowledgeIndex = knowledgeIndex;
+        _embeddingGenerator = embeddingGenerator;
+        _inferenceAgent = inferenceAgent;
+        _currentTenant = currentTenant;
+        _aiOptions = aiOptions.Value;
+    }
+
+    /// <summary>
+    /// 对源文档运行 L3 发现。返回新创建的 AiSuggested 关系列表。
+    /// 如果 <see cref="PaperbaseAIBehaviorOptions.EnableSemanticRelationDiscovery"/>=false，
+    /// 立即返回空列表（短路，不走任何 IO/LLM）。
+    /// </summary>
+    public virtual async Task<IReadOnlyList<DocumentRelation>> DiscoverAsync(
+        Guid sourceDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_aiOptions.EnableSemanticRelationDiscovery)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        if (sourceDocumentId == Guid.Empty)
+        {
+            throw new ArgumentException("Source document id required.", nameof(sourceDocumentId));
+        }
+
+        // Phase 1: load source. Reject docs without Markdown — no semantic signal to search on.
+        var source = await _documentRepository.FindAsync(sourceDocumentId, cancellationToken: cancellationToken);
+        if (source == null || string.IsNullOrWhiteSpace(source.Markdown))
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 2: vector recall — search by source's Markdown head (where titles / unique identifiers
+        // typically live). Use Document.TenantId explicitly (Hangfire-safe; no ambient context dependency).
+        var candidates = await RecallCandidatesAsync(source, cancellationToken);
+        if (candidates.Count == 0)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 3: filter peers already linked by ANY relation kind. Same rule as L2 — don't
+        // re-suggest what user already saw / dismissed / confirmed.
+        var alreadyLinked = await GetAlreadyLinkedAsync(sourceDocumentId, cancellationToken);
+        var freshCandidates = candidates.Where(id => !alreadyLinked.Contains(id)).ToList();
+        if (freshCandidates.Count == 0)
+        {
+            return Array.Empty<DocumentRelation>();
+        }
+
+        // Phase 4: per-candidate LLM evaluation. Provider-isolation: one bad LLM call must not
+        // tank the rest of the candidates.
+        var sourceSnapshot = new DocumentSnapshot(source.DocumentTypeCode, source.Markdown);
+        var created = new List<DocumentRelation>();
+
+        foreach (var candidateId in freshCandidates)
+        {
+            var relation = await EvaluateAndCreateAsync(
+                sourceDocumentId, sourceSnapshot, candidateId, cancellationToken);
+            if (relation != null)
+            {
+                created.Add(relation);
+            }
+        }
+
+        Logger.LogInformation(
+            "L3 SemanticRelationDiscovery: source={DocumentId} candidates={CandidateCount} fresh={FreshCount} llmConfirmed={CreatedCount}",
+            sourceDocumentId, candidates.Count, freshCandidates.Count, created.Count);
+
+        return created;
+    }
+
+    protected virtual async Task<IReadOnlyList<Guid>> RecallCandidatesAsync(
+        Document source,
+        CancellationToken ct)
+    {
+        // Use the markdown head — typically carries title + first paragraph + key identifiers.
+        // Cheaper than embedding the entire markdown and usually more representative for short queries.
+        var queryText = TruncateForEmbedding(source.Markdown!);
+
+        Embedding<float> queryEmbedding;
+        try
+        {
+            var batch = await _embeddingGenerator.GenerateAsync(new[] { queryText }, cancellationToken: ct);
+            queryEmbedding = batch[0];
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "L3 SemanticRelationDiscovery: embedding generation failed for {DocumentId}; skipping",
+                source.Id);
+            return Array.Empty<Guid>();
+        }
+
+        IReadOnlyList<VectorSearchResult> results;
+        try
+        {
+            results = await _knowledgeIndex.SearchAsync(new VectorSearchRequest
+            {
+                TenantId = source.TenantId,
+                QueryVector = queryEmbedding.Vector,
+                TopK = _aiOptions.SemanticRelationDiscoveryTopK,
+                MinScore = _aiOptions.SemanticRelationDiscoveryMinScore,
+            }, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "L3 SemanticRelationDiscovery: vector search failed for {DocumentId}; skipping",
+                source.Id);
+            return Array.Empty<Guid>();
+        }
+
+        // Aggregate chunk hits by DocumentId; exclude self.
+        return results
+            .Select(r => r.DocumentId)
+            .Where(id => id != source.Id && id != Guid.Empty)
+            .Distinct()
+            .ToList();
+    }
+
+    protected virtual async Task<DocumentRelation?> EvaluateAndCreateAsync(
+        Guid sourceDocumentId,
+        DocumentSnapshot sourceSnapshot,
+        Guid candidateId,
+        CancellationToken ct)
+    {
+        var candidate = await _documentRepository.FindAsync(candidateId, cancellationToken: ct);
+        if (candidate == null || string.IsNullOrWhiteSpace(candidate.Markdown))
+        {
+            return null;
+        }
+
+        var candidateSnapshot = new DocumentSnapshot(candidate.DocumentTypeCode, candidate.Markdown);
+
+        RelationInferenceResult inference;
+        try
+        {
+            inference = await _inferenceAgent.EvaluateAsync(sourceSnapshot, candidateSnapshot, ct);
+        }
+        catch (Exception ex)
+        {
+            // Per-candidate LLM failure: log & skip. Other candidates still get evaluated.
+            Logger.LogError(ex,
+                "L3 SemanticRelationDiscovery: LLM evaluation failed for ({Source}, {Candidate}); skipping pair",
+                sourceDocumentId, candidateId);
+            return null;
+        }
+
+        if (!inference.IsRelated || inference.Confidence < _aiOptions.SemanticRelationDiscoveryConfidenceThreshold)
+        {
+            return null;
+        }
+
+        var description = string.IsNullOrWhiteSpace(inference.Description)
+            ? "Semantic match (LLM-evaluated)"
+            : inference.Description!.Trim();
+
+        var relation = new DocumentRelation(
+            GuidGenerator.Create(),
+            _currentTenant.Id,
+            sourceDocumentId: sourceDocumentId,
+            targetDocumentId: candidateId,
+            description: description,
+            source: RelationSource.AiSuggested,
+            confidence: inference.Confidence);
+
+        // autoSave: true (vs L2's autoSave: false). Reason: L3 mixes external LLM calls with
+        // repository writes inside the loop. Wrapping all of L3 in an outer UoW would hold a
+        // DB connection during LLM calls — direct violation of .claude/rules/background-jobs.md.
+        // Per-insert auto-save uses an implicit per-call UoW; LLM calls between candidates
+        // happen with NO ambient UoW, satisfying the rule.
+        await _relationRepository.InsertAsync(relation, autoSave: true, ct);
+        return relation;
+    }
+
+    protected virtual async Task<HashSet<Guid>> GetAlreadyLinkedAsync(Guid sourceDocumentId, CancellationToken ct)
+    {
+        var existing = await _relationRepository.GetListByDocumentIdAsync(sourceDocumentId, ct);
+        var linked = new HashSet<Guid>();
+        foreach (var rel in existing)
+        {
+            var peer = rel.SourceDocumentId == sourceDocumentId ? rel.TargetDocumentId : rel.SourceDocumentId;
+            linked.Add(peer);
+        }
+        return linked;
+    }
+
+    private string TruncateForEmbedding(string markdown)
+    {
+        // Embedding models have token limits (typically ~8K tokens). MaxTextLengthPerExtraction
+        // is in chars, conservatively ~half the embedding model limit. We embed the head, not the
+        // middle/tail, because document headers carry the highest-signal text (titles, identifiers).
+        var max = _aiOptions.MaxTextLengthPerExtraction;
+        return markdown.Length <= max ? markdown : markdown.Substring(0, max);
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -3,10 +3,14 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Documents;
 using Dignite.Paperbase.Documents.Pipelines;
 using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.MultiTenancy;
@@ -30,6 +34,19 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
             Array.Empty<IDocumentIdentifierProvider>(),
             Substitute.For<IDocumentRelationRepository>(),
             Substitute.For<ICurrentTenant>()));
+
+        // Same treatment for L3 — substitute so this test stays focused on the job's lifecycle
+        // and L2 → L3 fallback chaining; L3's own logic is covered by SemanticRelationDiscoveryService_Tests.
+        context.Services.AddSingleton(Substitute.For<SemanticRelationDiscoveryService>(
+            Substitute.For<IDocumentRepository>(),
+            Substitute.For<IDocumentRelationRepository>(),
+            Substitute.For<IDocumentKnowledgeIndex>(),
+            Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>(),
+            Substitute.For<RelationInferenceAgent>(
+                Substitute.For<IChatClient>(),
+                Options.Create(new PaperbaseAIBehaviorOptions())),
+            Substitute.For<ICurrentTenant>(),
+            Options.Create(new PaperbaseAIBehaviorOptions())));
     }
 }
 
@@ -44,12 +61,20 @@ public class RelationDiscoveryBackgroundJob_Tests
     private readonly RelationDiscoveryBackgroundJob _job;
     private readonly IDocumentRepository _documentRepository;
     private readonly RelationDiscoveryService _discoveryService;
+    private readonly SemanticRelationDiscoveryService _semanticDiscoveryService;
 
     public RelationDiscoveryBackgroundJob_Tests()
     {
         _job = GetRequiredService<RelationDiscoveryBackgroundJob>();
         _documentRepository = GetRequiredService<IDocumentRepository>();
         _discoveryService = GetRequiredService<RelationDiscoveryService>();
+        _semanticDiscoveryService = GetRequiredService<SemanticRelationDiscoveryService>();
+
+        // Default: L3 fallback returns empty (most lifecycle tests don't care about L3 results).
+        // Tests exercising the fallback path override this explicitly.
+        _semanticDiscoveryService
+            .DiscoverAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
     }
 
     [Fact]
@@ -97,6 +122,62 @@ public class RelationDiscoveryBackgroundJob_Tests
         await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = documentId });
 
         await _discoveryService.DidNotReceive().DiscoverAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Fall_Back_To_L3_When_L2_Returns_Empty()
+    {
+        // L2 finds nothing → background job invokes L3. L3 returns one relation.
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation>());
+
+        var l3Relation = new DocumentRelation(
+            Guid.NewGuid(), null,
+            sourceDocumentId: doc.Id,
+            targetDocumentId: Guid.NewGuid(),
+            description: "semantic match",
+            source: RelationSource.AiSuggested,
+            confidence: 0.85);
+
+        _semanticDiscoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation> { l3Relation });
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        await _semanticDiscoveryService.Received(1).DiscoverAsync(doc.Id, Arg.Any<CancellationToken>());
+        var run = doc.GetLatestRun(PaperbasePipelines.RelationDiscovery);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Skip_L3_When_L2_Found_Relations()
+    {
+        // L2 found ≥1 relation → L3 (expensive LLM) must NOT be invoked.
+        var doc = CreateDocument();
+        SetupDocumentRepository(doc);
+
+        var l2Relation = new DocumentRelation(
+            Guid.NewGuid(), null,
+            sourceDocumentId: doc.Id,
+            targetDocumentId: Guid.NewGuid(),
+            description: "structured match",
+            source: RelationSource.AiSuggested,
+            confidence: 0.95);
+
+        _discoveryService
+            .DiscoverAsync(doc.Id, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<DocumentRelation>)new List<DocumentRelation> { l2Relation });
+
+        await _job.ExecuteAsync(new RelationDiscoveryJobArgs { DocumentId = doc.Id });
+
+        await _semanticDiscoveryService.DidNotReceive().DiscoverAsync(
             Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -45,7 +45,6 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
             Substitute.For<RelationInferenceAgent>(
                 Substitute.For<IChatClient>(),
                 Options.Create(new PaperbaseAIBehaviorOptions())),
-            Substitute.For<ICurrentTenant>(),
             Options.Create(new PaperbaseAIBehaviorOptions())));
     }
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class SemanticRelationDiscoveryServiceTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
+        context.Services.AddSingleton(Substitute.For<IDocumentKnowledgeIndex>());
+        context.Services.AddSingleton(Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>());
+
+        // Replace RelationInferenceAgent entirely so tests don't need a real IChatClient.
+        // Construct with cheap substitutes for its dependencies.
+        context.Services.AddSingleton(Substitute.For<RelationInferenceAgent>(
+            Substitute.For<IChatClient>(),
+            Options.Create(new PaperbaseAIBehaviorOptions())));
+
+        // Default: enable semantic discovery so most tests exercise the full path.
+        // The "disabled" test overrides this via direct field manipulation on the resolved options.
+        context.Services.Configure<PaperbaseAIBehaviorOptions>(opts =>
+        {
+            opts.EnableSemanticRelationDiscovery = true;
+            opts.SemanticRelationDiscoveryTopK = 5;
+            opts.SemanticRelationDiscoveryMinScore = 0.65;
+            opts.SemanticRelationDiscoveryConfidenceThreshold = 0.7;
+        });
+    }
+}
+
+public class SemanticRelationDiscoveryService_Tests
+    : PaperbaseApplicationTestBase<SemanticRelationDiscoveryServiceTestModule>
+{
+    private readonly SemanticRelationDiscoveryService _service;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentRelationRepository _relationRepository;
+    private readonly IDocumentKnowledgeIndex _knowledgeIndex;
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
+    private readonly RelationInferenceAgent _inferenceAgent;
+    private readonly PaperbaseAIBehaviorOptions _aiOptions;
+
+    public SemanticRelationDiscoveryService_Tests()
+    {
+        _service = GetRequiredService<SemanticRelationDiscoveryService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        _knowledgeIndex = GetRequiredService<IDocumentKnowledgeIndex>();
+        _embeddingGenerator = GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+        _inferenceAgent = GetRequiredService<RelationInferenceAgent>();
+        _aiOptions = GetRequiredService<IOptions<PaperbaseAIBehaviorOptions>>().Value;
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Short_Circuit_When_Disabled()
+    {
+        _aiOptions.EnableSemanticRelationDiscovery = false;
+        var sourceId = Guid.NewGuid();
+
+        var created = await _service.DiscoverAsync(sourceId);
+
+        created.ShouldBeEmpty();
+        // Short-circuit means NO IO at all — not even a document load.
+        await _documentRepository.DidNotReceive().FindAsync(
+            Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Reject_Empty_Source_Id()
+    {
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await _service.DiscoverAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_Source_Not_Found()
+    {
+        var sourceId = Guid.NewGuid();
+        _documentRepository.FindAsync(sourceId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+
+        var created = await _service.DiscoverAsync(sourceId);
+
+        created.ShouldBeEmpty();
+        await _embeddingGenerator.DidNotReceive().GenerateAsync(
+            Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_Source_Has_No_Markdown()
+    {
+        var source = CreateDocument(markdown: null);
+        SetupSource(source);
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Return_Empty_When_Vector_Search_Yields_No_Candidates()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        SetupSource(source);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, Array.Empty<VectorSearchResult>());
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Filter_Self_From_Vector_Results()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        SetupSource(source);
+        SetupEmbedding();
+        // Vector search returns the source itself as the top hit (always — every doc
+        // is most similar to itself). Service must filter it out.
+        SetupVectorSearch(source.Id, new[]
+        {
+            CreateVectorResult(source.Id, 0.95),
+        });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _inferenceAgent.DidNotReceive().EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Already_Linked_Candidates()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var linkedPeer = CreateDocument(markdown: "已关联文档");
+        SetupSource(source);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[]
+        {
+            CreateVectorResult(linkedPeer.Id, 0.85),
+        });
+        // Pre-existing relation → must skip.
+        _relationRepository.GetListByDocumentIdAsync(source.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>
+            {
+                new(Guid.NewGuid(), null, source.Id, linkedPeer.Id,
+                    "manual link", RelationSource.Manual)
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _inferenceAgent.DidNotReceive().EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_When_LLM_Says_Not_Related()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "无关文档");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidate.Id, 0.7) });
+        SetupNoExistingRelations(source.Id);
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult { IsRelated = false, Confidence = 0.2 });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _relationRepository.DidNotReceive().InsertAsync(
+            Arg.Any<DocumentRelation>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_When_Confidence_Below_Threshold()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "弱相关文档");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidate.Id, 0.7) });
+        SetupNoExistingRelations(source.Id);
+
+        // LLM says related but confidence is below threshold (0.7).
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult
+            {
+                IsRelated = true,
+                Confidence = 0.5,
+                Description = "可能有关"
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Create_AiSuggested_When_LLM_Confirms()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "强相关发票");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidate.Id, 0.85) });
+        SetupNoExistingRelations(source.Id);
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult
+            {
+                IsRelated = true,
+                Confidence = 0.85,
+                Description = "该发票对应该合同"
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.Count.ShouldBe(1);
+        var rel = created.Single();
+        rel.SourceDocumentId.ShouldBe(source.Id);
+        rel.TargetDocumentId.ShouldBe(candidate.Id);
+        rel.Source.ShouldBe(RelationSource.AiSuggested);
+        rel.Confidence.ShouldBe(0.85);
+        rel.Description.ShouldBe("该发票对应该合同");
+        // autoSave: true — LLM/DB rule (no UoW during external work).
+        await _relationRepository.Received(1).InsertAsync(
+            Arg.Any<DocumentRelation>(), autoSave: true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Continue_When_LLM_Throws_For_One_Candidate()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var failCandidate = CreateDocument(markdown: "LLM 调用失败");
+        var goodCandidate = CreateDocument(markdown: "正常候选");
+        SetupSource(source);
+        SetupCandidate(failCandidate);
+        SetupCandidate(goodCandidate);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[]
+        {
+            CreateVectorResult(failCandidate.Id, 0.85),
+            CreateVectorResult(goodCandidate.Id, 0.8),
+        });
+        SetupNoExistingRelations(source.Id);
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Is<DocumentSnapshot>(s => s.Markdown == "合同内容"),
+                Arg.Is<DocumentSnapshot>(c => c.Markdown == "LLM 调用失败"),
+                Arg.Any<CancellationToken>())
+            .Returns<RelationInferenceResult>(_ => throw new InvalidOperationException("LLM provider down"));
+
+        _inferenceAgent.EvaluateAsync(
+                Arg.Is<DocumentSnapshot>(s => s.Markdown == "合同内容"),
+                Arg.Is<DocumentSnapshot>(c => c.Markdown == "正常候选"),
+                Arg.Any<CancellationToken>())
+            .Returns(new RelationInferenceResult
+            {
+                IsRelated = true, Confidence = 0.8, Description = "match"
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.Count.ShouldBe(1);
+        created.Single().TargetDocumentId.ShouldBe(goodCandidate.Id);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Skip_Candidate_With_No_Markdown()
+    {
+        var source = CreateDocument(markdown: "合同内容");
+        var candidateWithoutMarkdown = CreateDocument(markdown: null);
+        SetupSource(source);
+        SetupCandidate(candidateWithoutMarkdown);
+        SetupEmbedding();
+        SetupVectorSearch(source.Id, new[] { CreateVectorResult(candidateWithoutMarkdown.Id, 0.9) });
+        SetupNoExistingRelations(source.Id);
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.ShouldBeEmpty();
+        await _inferenceAgent.DidNotReceive().EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private void SetupSource(Document doc)
+    {
+        _documentRepository.FindAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private void SetupCandidate(Document doc)
+    {
+        _documentRepository.FindAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private void SetupNoExistingRelations(Guid sourceId)
+    {
+        _relationRepository.GetListByDocumentIdAsync(sourceId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+    }
+
+    private void SetupEmbedding()
+    {
+        _embeddingGenerator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GeneratedEmbeddings<Embedding<float>>(new[]
+            {
+                new Embedding<float>(new[] { 0.1f, 0.2f, 0.3f })
+            }));
+    }
+
+    private void SetupVectorSearch(Guid sourceDocId, IReadOnlyList<VectorSearchResult> results)
+    {
+        _knowledgeIndex.SearchAsync(
+                Arg.Any<VectorSearchRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(results);
+    }
+
+    private static VectorSearchResult CreateVectorResult(Guid documentId, double score)
+    {
+        return new VectorSearchResult
+        {
+            RecordId = Guid.NewGuid(),
+            DocumentId = documentId,
+            ChunkIndex = 0,
+            Text = "chunk",
+            Score = score,
+        };
+    }
+
+    private static Document CreateDocument(string? markdown)
+    {
+        var doc = new Document(
+            Guid.NewGuid(), tenantId: null,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+
+        if (markdown != null)
+        {
+            typeof(Document)
+                .GetProperty(nameof(Document.Markdown))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(doc, new object[] { markdown });
+        }
+
+        return doc;
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService_Tests.cs
@@ -294,6 +294,67 @@ public class SemanticRelationDiscoveryService_Tests
     }
 
     [Fact]
+    public async Task DiscoverAsync_Should_Run_LLM_And_Vector_Search_Without_Ambient_UoW()
+    {
+        // .claude/rules/background-jobs.md § Tests: regression guard against future code
+        // accidentally wrapping L3 in an outer UoW that holds a DB connection during LLM calls.
+        // L3 service itself opens NO UoW; when called from the background job (after L2's UoW
+        // has been disposed), ambient ICurrentUnitOfWork must be null at every external boundary.
+        var uowManager = GetRequiredService<Volo.Abp.Uow.IUnitOfWorkManager>();
+        var source = CreateDocument(markdown: "合同内容");
+        var candidate = CreateDocument(markdown: "强相关发票");
+        SetupSource(source);
+        SetupCandidate(candidate);
+        SetupNoExistingRelations(source.Id);
+
+        // Assert NO ambient UoW at the embedding boundary.
+        _embeddingGenerator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uowManager.Current.ShouldBeNull();
+                return new GeneratedEmbeddings<Embedding<float>>(new[]
+                {
+                    new Embedding<float>(new[] { 0.1f, 0.2f, 0.3f })
+                });
+            });
+
+        // Assert NO ambient UoW at the vector search boundary.
+        _knowledgeIndex.SearchAsync(
+                Arg.Any<VectorSearchRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uowManager.Current.ShouldBeNull();
+                return (IReadOnlyList<VectorSearchResult>)new[] { CreateVectorResult(candidate.Id, 0.9) };
+            });
+
+        // Assert NO ambient UoW at the LLM evaluation boundary.
+        _inferenceAgent.EvaluateAsync(
+                Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uowManager.Current.ShouldBeNull();
+                return new RelationInferenceResult
+                {
+                    IsRelated = true, Confidence = 0.85, Description = "match"
+                };
+            });
+
+        var created = await _service.DiscoverAsync(source.Id);
+
+        created.Count.ShouldBe(1);
+        // Sanity: all three external boundaries were actually hit (the assertion ran).
+        await _embeddingGenerator.Received(1).GenerateAsync(
+            Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions>(), Arg.Any<CancellationToken>());
+        await _knowledgeIndex.Received(1).SearchAsync(Arg.Any<VectorSearchRequest>(), Arg.Any<CancellationToken>());
+        await _inferenceAgent.Received(1).EvaluateAsync(
+            Arg.Any<DocumentSnapshot>(), Arg.Any<DocumentSnapshot>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task DiscoverAsync_Should_Skip_Candidate_With_No_Markdown()
     {
         var source = CreateDocument(markdown: "合同内容");


### PR DESCRIPTION
Replaces #120 (closed when its base was deleted on #125 merge). Identical content, rebased onto main; includes the post-review hardening commit (PromptBoundary wrap, TenantId via DocumentSnapshot, UoW null assertion test). MAF workflow review on the original returned PASS.