### PR TITLE
refactor(documents): L2 tenant via Document.TenantId, not ICurrentTenant (#121)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService.cs
@@ -8,7 +8,6 @@ using Volo.Abp;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Services;
 using Volo.Abp.Guids;
-using Volo.Abp.MultiTenancy;
 
 namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 
@@ -46,16 +45,20 @@ public class RelationDiscoveryService : DomainService
 
     private readonly IEnumerable<IDocumentIdentifierProvider> _providers;
     private readonly IDocumentRelationRepository _relationRepository;
-    private readonly ICurrentTenant _currentTenant;
+    private readonly IDocumentRepository _documentRepository;
 
+    // No ICurrentTenant injection (Issue #121): tenant flows through Document.TenantId
+    // (loaded from the source document at the start of DiscoverAsync). Background jobs may
+    // run without an ambient ICurrentTenant restored — explicit Document-derived tenant is
+    // Hangfire-safe and matches L3's strategy in SemanticRelationDiscoveryService.
     public RelationDiscoveryService(
         IEnumerable<IDocumentIdentifierProvider> providers,
         IDocumentRelationRepository relationRepository,
-        ICurrentTenant currentTenant)
+        IDocumentRepository documentRepository)
     {
         _providers = providers;
         _relationRepository = relationRepository;
-        _currentTenant = currentTenant;
+        _documentRepository = documentRepository;
     }
 
     /// <summary>
@@ -70,6 +73,18 @@ public class RelationDiscoveryService : DomainService
         {
             throw new ArgumentException("Source document id required.", nameof(sourceDocumentId));
         }
+
+        // Phase 0: load source to capture authoritative TenantId (Issue #121).
+        // Document hard-deleted between event publish and L2 execution → drop silently.
+        var source = await _documentRepository.FindAsync(sourceDocumentId, cancellationToken: cancellationToken);
+        if (source == null)
+        {
+            Logger.LogInformation(
+                "L2 RelationDiscovery: document {DocumentId} no longer exists; skipping",
+                sourceDocumentId);
+            return Array.Empty<DocumentRelation>();
+        }
+        var sourceTenantId = source.TenantId;
 
         // Phase 1: collect all identifiers held by source document across all providers.
         var sourceIdentifiers = await CollectSourceIdentifiersAsync(sourceDocumentId, cancellationToken);
@@ -102,9 +117,12 @@ public class RelationDiscoveryService : DomainService
             if (alreadyLinked.Contains(peer.PeerDocumentId)) continue;
 
             var description = $"Identifier match: {peer.IdentifierType} = {peer.IdentifierValue}";
+            // TenantId from source.TenantId (Hangfire-safe, Issue #121). Source and peers
+            // must be in the same tenant: providers query through ABP's IMultiTenant filter
+            // which scopes by ambient or by source — peers never cross tenant by design.
             var relation = new DocumentRelation(
                 GuidGenerator.Create(),
-                _currentTenant.Id,
+                sourceTenantId,
                 sourceDocumentId: sourceDocumentId,
                 targetDocumentId: peer.PeerDocumentId,
                 description: description,

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -30,10 +30,11 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
         // Replace RelationDiscoveryService entirely — this test only verifies the JOB's
         // PipelineRun lifecycle wiring, not the discovery logic (covered separately by
         // RelationDiscoveryService_Tests).
+        // Issue #121: L2 ctor now takes IDocumentRepository instead of ICurrentTenant.
         context.Services.AddSingleton(Substitute.For<RelationDiscoveryService>(
             Array.Empty<IDocumentIdentifierProvider>(),
             Substitute.For<IDocumentRelationRepository>(),
-            Substitute.For<ICurrentTenant>()));
+            Substitute.For<IDocumentRepository>()));
 
         // Same treatment for L3 — substitute so this test stays focused on the job's lifecycle
         // and L2 → L3 fallback chaining; L3's own logic is covered by SemanticRelationDiscoveryService_Tests.

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryService_Tests.cs
@@ -22,6 +22,10 @@ public class RelationDiscoveryServiceTestModule : AbpModule
         // so we verify the entity it constructed without exercising EF.
         context.Services.AddSingleton(Substitute.For<IDocumentRelationRepository>());
 
+        // Issue #121: L2 now loads source Document for tenant id (Hangfire-safe). Mock the
+        // document repository; tests configure FindAsync per-case via SetupSource.
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+
         // Two providers wired into DI — singletons so the test class instance and the service's
         // injected IEnumerable resolve to the SAME fake instances (otherwise transient resolution
         // gives the service a different enumeration than what the test mutates → state silently lost).
@@ -39,6 +43,7 @@ public class RelationDiscoveryService_Tests
 {
     private readonly RelationDiscoveryService _service;
     private readonly IDocumentRelationRepository _relationRepository;
+    private readonly IDocumentRepository _documentRepository;
     private readonly FakeContractProvider _contractProvider;
     private readonly FakeInvoiceProvider _invoiceProvider;
 
@@ -46,10 +51,45 @@ public class RelationDiscoveryService_Tests
     {
         _service = GetRequiredService<RelationDiscoveryService>();
         _relationRepository = GetRequiredService<IDocumentRelationRepository>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
         // Resolve the singletons by their concrete type — same instances as those enumerated
         // through IEnumerable<IDocumentIdentifierProvider> by the service.
         _contractProvider = GetRequiredService<FakeContractProvider>();
         _invoiceProvider = GetRequiredService<FakeInvoiceProvider>();
+
+        // Default: any document id resolves to a tenantless Document. Tests that exercise
+        // tenant-stamping or "doc not found" override this via SetupSource / SetupSourceMissing.
+        _documentRepository
+            .FindAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => CreateDocumentWithId((Guid)callInfo[0], tenantId: null));
+    }
+
+    // ── Issue #121 helper: wire FindAsync(documentId) → Document with optional tenant ──
+    private void SetupSource(Guid documentId, Guid? tenantId = null)
+    {
+        var doc = CreateDocumentWithId(documentId, tenantId);
+        _documentRepository.FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(doc);
+    }
+
+    private void SetupSourceMissing(Guid documentId)
+    {
+        _documentRepository.FindAsync(documentId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Document?)null);
+    }
+
+    private static Document CreateDocumentWithId(Guid id, Guid? tenantId)
+    {
+        return new Document(
+            id, tenantId,
+            $"blobs/{Guid.NewGuid():N}.pdf",
+            SourceType.Digital,
+            new FileOrigin(
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
     }
 
     [Fact]
@@ -70,6 +110,80 @@ public class RelationDiscoveryService_Tests
     {
         await Should.ThrowAsync<ArgumentException>(async () =>
             await _service.DiscoverAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Drop_Silently_When_Source_Document_Hard_Deleted()
+    {
+        // Issue #121: source loaded for tenant resolution. If document was hard-deleted between
+        // event publish and L2 execution → drop without throwing (matches handler / job pattern).
+        var sourceDocId = Guid.NewGuid();
+        SetupSourceMissing(sourceDocId);
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.ShouldBeEmpty();
+        // Providers must not be queried — short-circuit on document-not-found is the cheapest path.
+        _contractProvider.FindCalls.ShouldBeEmpty();
+        _invoiceProvider.FindCalls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Stamp_New_Relation_With_Source_Document_TenantId()
+    {
+        // Issue #121: TenantId on the new DocumentRelation must come from Document.TenantId,
+        // NOT from ambient ICurrentTenant (Hangfire-safe). Test asserts a non-null source
+        // tenant ID propagates correctly without ICurrentTenant.Change(...).
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+        var sourceTenantId = Guid.NewGuid();
+
+        SetupSource(sourceDocId, tenantId: sourceTenantId);
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-TENANT")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-TENANT")] = new[] { peerDocId };
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        var created = await _service.DiscoverAsync(sourceDocId);
+
+        created.Count.ShouldBe(1);
+        created.Single().TenantId.ShouldBe(sourceTenantId);
+    }
+
+    [Fact]
+    public async Task DiscoverAsync_Should_Run_Provider_Calls_Without_Ambient_UoW()
+    {
+        // .claude/rules/background-jobs.md § Tests: regression guard at the provider call boundary.
+        // L2 itself only does DB queries, but providers are pluggable (third-party modules may
+        // do HTTP / cache / LLM in future iterations) — we must not open an ambient UoW around them.
+        // OnGetIdentifiersInvoked / OnFindDocumentsInvoked callbacks fire INSIDE provider methods,
+        // so the assertion captures UoW state at exactly the boundary the rule cares about.
+        var uowManager = GetRequiredService<Volo.Abp.Uow.IUnitOfWorkManager>();
+        var sourceDocId = Guid.NewGuid();
+        var peerDocId = Guid.NewGuid();
+
+        var getIdentifiersUowState = (object?)"unset";
+        var findDocumentsUowState = (object?)"unset";
+
+        _contractProvider.OnGetIdentifiersInvoked = () => getIdentifiersUowState = uowManager.Current;
+        _contractProvider.OnFindDocumentsInvoked = () => findDocumentsUowState = uowManager.Current;
+
+        _contractProvider.Identifiers[sourceDocId] = new[]
+        {
+            new DocumentIdentifierEntry(DocumentIdentifierTypes.ContractNumber, "HT-UOW-CHECK")
+        };
+        _invoiceProvider.Lookup[(DocumentIdentifierTypes.ContractNumber, "HT-UOW-CHECK")] = new[] { peerDocId };
+        _relationRepository.GetListByDocumentIdAsync(sourceDocId, Arg.Any<CancellationToken>())
+            .Returns(new List<DocumentRelation>());
+
+        await _service.DiscoverAsync(sourceDocId);
+
+        getIdentifiersUowState.ShouldBeNull("provider GetIdentifiersAsync ran with ambient UoW");
+        findDocumentsUowState.ShouldBeNull("provider FindDocumentsAsync ran with ambient UoW");
     }
 
     [Fact]
@@ -300,9 +414,13 @@ internal sealed class FakeContractProvider : IDocumentIdentifierProvider
     // Failure-injection knobs used by provider-isolation tests.
     public HashSet<Guid> GetIdentifiersThrowsFor { get; } = new();
     public HashSet<(string Type, string Value)> FindDocumentsThrowsFor { get; } = new();
+    // Inspection hook used by UoW-null-assertion tests; runs at the provider call boundary.
+    public Action? OnGetIdentifiersInvoked { get; set; }
+    public Action? OnFindDocumentsInvoked { get; set; }
 
     public Task<IReadOnlyList<DocumentIdentifierEntry>> GetIdentifiersAsync(Guid documentId, CancellationToken cancellationToken = default)
     {
+        OnGetIdentifiersInvoked?.Invoke();
         if (GetIdentifiersThrowsFor.Contains(documentId))
             throw new InvalidOperationException("Simulated provider failure (GetIdentifiersAsync)");
         return Task.FromResult(Identifiers.TryGetValue(documentId, out var v) ? v : (IReadOnlyList<DocumentIdentifierEntry>)Array.Empty<DocumentIdentifierEntry>());
@@ -310,6 +428,7 @@ internal sealed class FakeContractProvider : IDocumentIdentifierProvider
 
     public Task<IReadOnlyList<Guid>> FindDocumentsAsync(string identifierType, string identifierValue, CancellationToken cancellationToken = default)
     {
+        OnFindDocumentsInvoked?.Invoke();
         FindCalls.Add((identifierType, identifierValue));
         if (FindDocumentsThrowsFor.Contains((identifierType, identifierValue)))
             throw new InvalidOperationException("Simulated provider failure (FindDocumentsAsync)");


### PR DESCRIPTION
Replaces #122 (closed when its base was deleted on #126 merge). Identical content, rebased onto main.