### PR TITLE
feat(documents): structured telemetry for L2/L3 RelationDiscovery (#123)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/DocumentRelationAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/DocumentRelationAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 using Dignite.Paperbase.Permissions;
 using Microsoft.AspNetCore.Authorization;
 using Volo.Abp.Application.Dtos;
@@ -16,13 +17,16 @@ public class DocumentRelationAppService : PaperbaseAppService, IDocumentRelation
 
     private readonly IDocumentRepository _documentRepository;
     private readonly IDocumentRelationRepository _relationRepository;
+    private readonly RelationDiscoveryTelemetryRecorder _telemetry;
 
     public DocumentRelationAppService(
         IDocumentRepository documentRepository,
-        IDocumentRelationRepository relationRepository)
+        IDocumentRelationRepository relationRepository,
+        RelationDiscoveryTelemetryRecorder telemetry)
     {
         _documentRepository = documentRepository;
         _relationRepository = relationRepository;
+        _telemetry = telemetry;
     }
 
     public virtual async Task<ListResultDto<DocumentRelationDto>> GetListAsync(Guid documentId)
@@ -127,15 +131,31 @@ public class DocumentRelationAppService : PaperbaseAppService, IDocumentRelation
     [Authorize(PaperbasePermissions.DocumentRelations.Delete)]
     public virtual async Task DeleteAsync(Guid id)
     {
+        // Issue #123: capture pre-delete source/confidence so the funnel metric reflects the
+        // ORIGINAL relation kind (a deleted AiSuggested = "user rejected the suggestion";
+        // a deleted Manual = "user undid their own confirmation" — different signals).
+        var existing = await _relationRepository.FindAsync(id);
         await _relationRepository.DeleteAsync(id);
+
+        if (existing != null)
+        {
+            _telemetry.RecordSuggestionRejected(existing.Source, existing.Confidence);
+        }
     }
 
     [Authorize(PaperbasePermissions.DocumentRelations.ConfirmRelation)]
     public virtual async Task<DocumentRelationDto> ConfirmAsync(Guid id)
     {
         var relation = await _relationRepository.GetAsync(id);
+        // Issue #123: capture pre-confirm source/confidence; relation.Confirm() flips both fields
+        // (Source → Manual, Confidence → null), so the metric needs to be tagged BEFORE the flip.
+        var originalSource = relation.Source;
+        var originalConfidence = relation.Confidence;
+
         relation.Confirm();
         await _relationRepository.UpdateAsync(relation);
+
+        _telemetry.RecordSuggestionConfirmed(originalSource, originalConfidence);
         return ObjectMapper.Map<DocumentRelation, DocumentRelationDto>(relation);
     }
 

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Documents;
 using Microsoft.Extensions.Logging;
@@ -38,6 +39,7 @@ public class RelationDiscoveryBackgroundJob
     private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
     private readonly RelationDiscoveryService _discoveryService;
     private readonly SemanticRelationDiscoveryService _semanticDiscoveryService;
+    private readonly RelationDiscoveryTelemetryRecorder _telemetry;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
 
     public RelationDiscoveryBackgroundJob(
@@ -46,6 +48,7 @@ public class RelationDiscoveryBackgroundJob
         DocumentPipelineRunAccessor pipelineRunAccessor,
         RelationDiscoveryService discoveryService,
         SemanticRelationDiscoveryService semanticDiscoveryService,
+        RelationDiscoveryTelemetryRecorder telemetry,
         IUnitOfWorkManager unitOfWorkManager)
     {
         _documentRepository = documentRepository;
@@ -53,21 +56,32 @@ public class RelationDiscoveryBackgroundJob
         _pipelineRunAccessor = pipelineRunAccessor;
         _discoveryService = discoveryService;
         _semanticDiscoveryService = semanticDiscoveryService;
+        _telemetry = telemetry;
         _unitOfWorkManager = unitOfWorkManager;
     }
 
     public override async Task ExecuteAsync(RelationDiscoveryJobArgs args)
     {
+        var totalStopwatch = Stopwatch.StartNew();
+
         var workItem = await BeginRunAsync(args);
         if (workItem == null)
         {
+            // Document hard-deleted; no PipelineRun to mark, but still record run metric for ops.
+            totalStopwatch.Stop();
+            _telemetry.RecordRun(new RelationDiscoveryRunMetrics
+            {
+                DocumentId = args.DocumentId,
+                Result = RelationDiscoveryRunResult.DocumentMissing,
+                TotalDurationMs = totalStopwatch.Elapsed.TotalMilliseconds
+            });
             return;
         }
 
-        int createdCount;
+        DiscoveryOutcome outcome;
         try
         {
-            createdCount = await DiscoverAsync(workItem.DocumentId);
+            outcome = await DiscoverAsync(workItem.DocumentId);
         }
         catch (Exception ex)
         {
@@ -75,10 +89,30 @@ public class RelationDiscoveryBackgroundJob
                 "L2 RelationDiscovery failed for document {DocumentId}. PipelineRun marked failed; document lifecycle unchanged (non-key pipeline).",
                 workItem.DocumentId);
             await FailRunAsync(workItem.DocumentId, workItem.RunId, ex.Message);
+            totalStopwatch.Stop();
+            _telemetry.RecordRun(new RelationDiscoveryRunMetrics
+            {
+                DocumentId = workItem.DocumentId,
+                Result = RelationDiscoveryRunResult.Failed,
+                FailureReason = ex.GetType().Name,
+                TotalDurationMs = totalStopwatch.Elapsed.TotalMilliseconds
+            });
             return;
         }
 
-        await CompleteRunAsync(workItem.DocumentId, workItem.RunId, createdCount);
+        await CompleteRunAsync(workItem.DocumentId, workItem.RunId, outcome.TotalCreated);
+        totalStopwatch.Stop();
+        _telemetry.RecordRun(new RelationDiscoveryRunMetrics
+        {
+            DocumentId = workItem.DocumentId,
+            Result = RelationDiscoveryRunResult.Succeeded,
+            L2CreatedCount = outcome.L2Created,
+            L3Invoked = outcome.L3Invoked,
+            L3CreatedCount = outcome.L3Invoked ? outcome.L3Created : null,
+            L2DurationMs = outcome.L2DurationMs,
+            L3DurationMs = outcome.L3Invoked ? outcome.L3DurationMs : null,
+            TotalDurationMs = totalStopwatch.Elapsed.TotalMilliseconds
+        });
     }
 
     protected virtual async Task<DiscoveryWorkItem?> BeginRunAsync(RelationDiscoveryJobArgs args)
@@ -106,31 +140,50 @@ public class RelationDiscoveryBackgroundJob
         return new DiscoveryWorkItem(run.Id, document.Id);
     }
 
-    protected virtual async Task<int> DiscoverAsync(Guid documentId)
+    protected virtual async Task<DiscoveryOutcome> DiscoverAsync(Guid documentId)
     {
         // L2: structured fan-out across business-module providers. Cheap (DB queries only).
         // L2 writes commit in a dedicated UoW (autoSave: false on inserts ⇒ uow.CompleteAsync()).
         int l2Count;
+        var l2Stopwatch = Stopwatch.StartNew();
         using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
         {
             var created = await _discoveryService.DiscoverAsync(documentId);
             await uow.CompleteAsync();
             l2Count = created.Count;
         }
+        l2Stopwatch.Stop();
 
         if (l2Count > 0)
         {
             // L2 found structured matches — that's strong signal; don't run L3 (expensive LLM)
             // on top. L3 is the fallback for "structured matching found nothing".
-            return l2Count;
+            return new DiscoveryOutcome(l2Count, false, 0, l2Stopwatch.Elapsed.TotalMilliseconds, 0);
         }
 
         // L3 fallback: vector recall + LLM evaluation. Disabled by default (operator opt-in).
         // NOT wrapped in an outer UoW: SemanticRelationDiscoveryService uses autoSave: true on
         // each relation insert (per-call implicit UoW), so LLM calls between candidates run with
         // no ambient UoW — satisfies the "no DB connection during external work" rule.
+        var l3Stopwatch = Stopwatch.StartNew();
         var l3Created = await _semanticDiscoveryService.DiscoverAsync(documentId);
-        return l3Created.Count;
+        l3Stopwatch.Stop();
+        return new DiscoveryOutcome(
+            L2Created: 0,
+            L3Invoked: true,
+            L3Created: l3Created.Count,
+            L2DurationMs: l2Stopwatch.Elapsed.TotalMilliseconds,
+            L3DurationMs: l3Stopwatch.Elapsed.TotalMilliseconds);
+    }
+
+    protected sealed record DiscoveryOutcome(
+        int L2Created,
+        bool L3Invoked,
+        int L3Created,
+        double L2DurationMs,
+        double L3DurationMs)
+    {
+        public int TotalCreated => L2Created + L3Created;
     }
 
     protected virtual async Task CompleteRunAsync(Guid documentId, Guid runId, int createdCount)

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryTelemetryRecorder.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/RelationDiscoveryTelemetryRecorder.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Issue #123: structured telemetry for L2/L3 RelationDiscovery — counters / histograms exported via
+/// <see cref="System.Diagnostics.Metrics"/> and a paired structured log line per metric event.
+///
+/// <para>
+/// <strong>Why a project-specific recorder vs ABP audit log</strong>: BackgroundJob runs are not in
+/// HTTP context and have no audit scope by default; we need metrics, not audit rows. The
+/// log lines are kept (not replaced) to preserve developer-grade observability.
+/// </para>
+///
+/// <para>
+/// <strong>Tag policy</strong>: tags are low-cardinality enums or buckets. <c>tenant_id</c> is
+/// intentionally NOT a tag (would cause cardinality explosion in multi-tenant deployments
+/// and isn't needed for ops dashboards — per-tenant drill-down via traces / logs instead).
+/// </para>
+/// </summary>
+public class RelationDiscoveryTelemetryRecorder : ISingletonDependency
+{
+    public const string MeterName = "Dignite.Paperbase.Documents.RelationDiscovery";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> RunsTotal = Meter.CreateCounter<long>(
+        "paperbase.relation_discovery.runs.total",
+        description: "RelationDiscovery background job executions, by result (succeeded / failed / document_missing).");
+
+    private static readonly Histogram<long> L2Created = Meter.CreateHistogram<long>(
+        "paperbase.relation_discovery.l2.created",
+        description: "AiSuggested DocumentRelations created by L2 (structured fan-out) per run.");
+
+    private static readonly Counter<long> L3Invoked = Meter.CreateCounter<long>(
+        "paperbase.relation_discovery.l3.invoked",
+        description: "Times L3 (semantic + LLM fallback) was invoked because L2 found zero peers.");
+
+    private static readonly Counter<long> L3LlmCalls = Meter.CreateCounter<long>(
+        "paperbase.relation_discovery.l3.llm_calls",
+        description: "Per-candidate LLM evaluations by L3, by result (confirmed / rejected / error).");
+
+    private static readonly Histogram<long> L3Created = Meter.CreateHistogram<long>(
+        "paperbase.relation_discovery.l3.created",
+        description: "AiSuggested DocumentRelations created by L3 per run (only when L3 invoked).");
+
+    private static readonly Histogram<double> RunDuration = Meter.CreateHistogram<double>(
+        "paperbase.relation_discovery.duration",
+        unit: "ms",
+        description: "Wall-clock duration per RelationDiscovery layer (l2 / l3 / total).");
+
+    /// <summary>
+    /// AiSuggested → Manual conversions. The ONLY ground-truth signal for L2/L3 quality —
+    /// the model's self-reported <see cref="DocumentRelation.Confidence"/> is not ground truth.
+    /// </summary>
+    private static readonly Counter<long> SuggestionConfirmed = Meter.CreateCounter<long>(
+        "paperbase.relation.suggestion.confirmed",
+        description: "User accepted an AiSuggested DocumentRelation (Confirm). Tags: source, confidence_bucket.");
+
+    /// <summary>
+    /// AiSuggested deletions. Paired with <see cref="SuggestionConfirmed"/> for the accept-rate funnel:
+    /// <c>accept_rate = confirmed / (confirmed + rejected)</c>.
+    /// </summary>
+    private static readonly Counter<long> SuggestionRejected = Meter.CreateCounter<long>(
+        "paperbase.relation.suggestion.rejected",
+        description: "User deleted an AiSuggested DocumentRelation (Delete). Tags: source, confidence_bucket.");
+
+    private readonly ILogger<RelationDiscoveryTelemetryRecorder> _logger;
+
+    public RelationDiscoveryTelemetryRecorder(ILogger<RelationDiscoveryTelemetryRecorder> logger)
+    {
+        _logger = logger;
+    }
+
+    public virtual void RecordRun(RelationDiscoveryRunMetrics metrics)
+    {
+        RunsTotal.Add(1, new KeyValuePair<string, object?>("result", metrics.Result.ToString()));
+
+        if (metrics.L2CreatedCount.HasValue)
+        {
+            L2Created.Record(metrics.L2CreatedCount.Value);
+        }
+
+        if (metrics.L3Invoked)
+        {
+            L3Invoked.Add(1);
+            if (metrics.L3CreatedCount.HasValue)
+            {
+                L3Created.Record(metrics.L3CreatedCount.Value);
+            }
+        }
+
+        if (metrics.L2DurationMs.HasValue)
+        {
+            RunDuration.Record(metrics.L2DurationMs.Value, new KeyValuePair<string, object?>("layer", "l2"));
+        }
+        if (metrics.L3DurationMs.HasValue)
+        {
+            RunDuration.Record(metrics.L3DurationMs.Value, new KeyValuePair<string, object?>("layer", "l3"));
+        }
+        if (metrics.TotalDurationMs.HasValue)
+        {
+            RunDuration.Record(metrics.TotalDurationMs.Value, new KeyValuePair<string, object?>("layer", "total"));
+        }
+
+        if (metrics.Result == RelationDiscoveryRunResult.Succeeded)
+        {
+            _logger.LogInformation(
+                "RelationDiscovery run succeeded. DocumentId={DocumentId} L2Created={L2Created} L3Invoked={L3Invoked} L3Created={L3Created} L2Ms={L2Ms} L3Ms={L3Ms} TotalMs={TotalMs}",
+                metrics.DocumentId,
+                metrics.L2CreatedCount,
+                metrics.L3Invoked,
+                metrics.L3CreatedCount,
+                metrics.L2DurationMs,
+                metrics.L3DurationMs,
+                metrics.TotalDurationMs);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "RelationDiscovery run did not complete normally. DocumentId={DocumentId} Result={Result} FailureReason={FailureReason} TotalMs={TotalMs}",
+                metrics.DocumentId,
+                metrics.Result,
+                metrics.FailureReason,
+                metrics.TotalDurationMs);
+        }
+    }
+
+    public virtual void RecordL3LlmCall(RelationDiscoveryL3CallResult result)
+    {
+        L3LlmCalls.Add(1, new KeyValuePair<string, object?>("result", result.ToString()));
+    }
+
+    public virtual void RecordSuggestionConfirmed(RelationSource originalSource, double? confidence)
+    {
+        SuggestionConfirmed.Add(1,
+            new KeyValuePair<string, object?>("source", originalSource.ToString()),
+            new KeyValuePair<string, object?>("confidence_bucket", BucketConfidence(confidence)));
+    }
+
+    public virtual void RecordSuggestionRejected(RelationSource originalSource, double? confidence)
+    {
+        SuggestionRejected.Add(1,
+            new KeyValuePair<string, object?>("source", originalSource.ToString()),
+            new KeyValuePair<string, object?>("confidence_bucket", BucketConfidence(confidence)));
+    }
+
+    /// <summary>
+    /// Bucket continuous confidence into 4 fixed buckets aligned with
+    /// <see cref="Ai.PaperbaseAIBehaviorOptions.SemanticRelationDiscoveryConfidenceThreshold"/> = 0.7
+    /// (anything below threshold should never reach storage, so &lt;0.7 is a "shouldn't happen" signal).
+    /// </summary>
+    protected virtual string BucketConfidence(double? confidence)
+    {
+        if (!confidence.HasValue) return "(none)";   // Manual relations have null confidence
+        if (confidence.Value < 0.7) return "<0.7";
+        if (confidence.Value < 0.8) return "0.7-0.8";
+        if (confidence.Value < 0.9) return "0.8-0.9";
+        return "0.9+";
+    }
+}
+
+/// <summary>Per-run metrics emitted by <see cref="RelationDiscoveryBackgroundJob"/> at completion.</summary>
+public sealed record RelationDiscoveryRunMetrics
+{
+    public required Guid DocumentId { get; init; }
+    public required RelationDiscoveryRunResult Result { get; init; }
+
+    /// <summary>Number of AiSuggested relations L2 created (null = L2 didn't run, e.g. document missing).</summary>
+    public int? L2CreatedCount { get; init; }
+
+    /// <summary>True when L2 returned 0 and L3 was invoked.</summary>
+    public bool L3Invoked { get; init; }
+
+    /// <summary>Number of AiSuggested relations L3 created (null = L3 didn't run).</summary>
+    public int? L3CreatedCount { get; init; }
+
+    public double? L2DurationMs { get; init; }
+    public double? L3DurationMs { get; init; }
+    public double? TotalDurationMs { get; init; }
+
+    /// <summary>Set when <see cref="Result"/> is <see cref="RelationDiscoveryRunResult.Failed"/>.</summary>
+    public string? FailureReason { get; init; }
+}
+
+public enum RelationDiscoveryRunResult
+{
+    Succeeded = 0,
+    Failed = 1,
+    DocumentMissing = 2
+}
+
+/// <summary>Per-candidate LLM evaluation result inside L3.</summary>
+public enum RelationDiscoveryL3CallResult
+{
+    /// <summary>LLM returned <c>IsRelated=true</c> with confidence ≥ threshold; relation created.</summary>
+    Confirmed = 0,
+
+    /// <summary>LLM returned <c>IsRelated=false</c> OR confidence below threshold; no relation created.</summary>
+    Rejected = 1,
+
+    /// <summary>LLM call threw — candidate dropped, others continue (per-candidate isolation).</summary>
+    Error = 2
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/RelationDiscovery/SemanticRelationDiscoveryService.cs
@@ -50,6 +50,7 @@ public class SemanticRelationDiscoveryService : DomainService
     private readonly IDocumentKnowledgeIndex _knowledgeIndex;
     private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
     private readonly RelationInferenceAgent _inferenceAgent;
+    private readonly RelationDiscoveryTelemetryRecorder _telemetry;
     private readonly PaperbaseAIBehaviorOptions _aiOptions;
 
     // No ICurrentTenant injection: tenant flows through DocumentSnapshot.TenantId, sourced from
@@ -60,6 +61,7 @@ public class SemanticRelationDiscoveryService : DomainService
         IDocumentKnowledgeIndex knowledgeIndex,
         IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
         RelationInferenceAgent inferenceAgent,
+        RelationDiscoveryTelemetryRecorder telemetry,
         IOptions<PaperbaseAIBehaviorOptions> aiOptions)
     {
         _documentRepository = documentRepository;
@@ -67,6 +69,7 @@ public class SemanticRelationDiscoveryService : DomainService
         _knowledgeIndex = knowledgeIndex;
         _embeddingGenerator = embeddingGenerator;
         _inferenceAgent = inferenceAgent;
+        _telemetry = telemetry;
         _aiOptions = aiOptions.Value;
     }
 
@@ -211,11 +214,13 @@ public class SemanticRelationDiscoveryService : DomainService
             Logger.LogError(ex,
                 "L3 SemanticRelationDiscovery: LLM evaluation failed for ({Source}, {Candidate}); skipping pair",
                 sourceDocumentId, candidateId);
+            _telemetry.RecordL3LlmCall(RelationDiscoveryL3CallResult.Error);
             return null;
         }
 
         if (!inference.IsRelated || inference.Confidence < _aiOptions.SemanticRelationDiscoveryConfidenceThreshold)
         {
+            _telemetry.RecordL3LlmCall(RelationDiscoveryL3CallResult.Rejected);
             return null;
         }
 
@@ -241,6 +246,7 @@ public class SemanticRelationDiscoveryService : DomainService
         // Per-insert auto-save uses an implicit per-call UoW; LLM calls between candidates
         // happen with NO ambient UoW, satisfying the rule.
         await _relationRepository.InsertAsync(relation, autoSave: true, ct);
+        _telemetry.RecordL3LlmCall(RelationDiscoveryL3CallResult.Confirmed);
         return relation;
     }
 

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryBackgroundJob_Tests.cs
@@ -10,6 +10,7 @@ using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
 using Dignite.Paperbase.KnowledgeIndex;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
@@ -46,6 +47,7 @@ public class RelationDiscoveryBackgroundJobTestModule : AbpModule
             Substitute.For<RelationInferenceAgent>(
                 Substitute.For<IChatClient>(),
                 Options.Create(new PaperbaseAIBehaviorOptions())),
+            new RelationDiscoveryTelemetryRecorder(NullLogger<RelationDiscoveryTelemetryRecorder>.Instance),
             Options.Create(new PaperbaseAIBehaviorOptions())));
     }
 }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryTelemetryRecorder_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/RelationDiscovery/RelationDiscoveryTelemetryRecorder_Tests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents.Pipelines.RelationDiscovery;
+
+/// <summary>
+/// Direct tests against <see cref="RelationDiscoveryTelemetryRecorder"/> using a
+/// <see cref="MeterListener"/> to capture emitted measurements. Meter is process-wide
+/// (singleton), so listener filters by instrument name to avoid noise from other tests.
+/// </summary>
+public class RelationDiscoveryTelemetryRecorder_Tests
+{
+    private readonly RelationDiscoveryTelemetryRecorder _recorder = new(NullLogger<RelationDiscoveryTelemetryRecorder>.Instance);
+
+    [Fact]
+    public void RecordRun_Should_Emit_Counter_With_Result_Tag()
+    {
+        using var capture = new MeterCapture("paperbase.relation_discovery.runs.total");
+
+        _recorder.RecordRun(new RelationDiscoveryRunMetrics
+        {
+            DocumentId = Guid.NewGuid(),
+            Result = RelationDiscoveryRunResult.Succeeded,
+            L2CreatedCount = 0,
+            TotalDurationMs = 12.5
+        });
+
+        capture.Measurements.Count.ShouldBe(1);
+        capture.Measurements[0].Value.ShouldBe(1L);
+        capture.Measurements[0].Tags["result"].ShouldBe("Succeeded");
+    }
+
+    [Fact]
+    public void RecordRun_Should_Record_L2_Created_Histogram_When_Set()
+    {
+        using var capture = new MeterCapture("paperbase.relation_discovery.l2.created");
+
+        _recorder.RecordRun(new RelationDiscoveryRunMetrics
+        {
+            DocumentId = Guid.NewGuid(),
+            Result = RelationDiscoveryRunResult.Succeeded,
+            L2CreatedCount = 3
+        });
+
+        capture.Measurements.Count.ShouldBe(1);
+        capture.Measurements[0].Value.ShouldBe(3L);
+    }
+
+    [Fact]
+    public void RecordRun_Should_Skip_L3_Histogram_When_L3_Not_Invoked()
+    {
+        using var l3InvokedCapture = new MeterCapture("paperbase.relation_discovery.l3.invoked");
+        using var l3CreatedCapture = new MeterCapture("paperbase.relation_discovery.l3.created");
+
+        _recorder.RecordRun(new RelationDiscoveryRunMetrics
+        {
+            DocumentId = Guid.NewGuid(),
+            Result = RelationDiscoveryRunResult.Succeeded,
+            L2CreatedCount = 1,
+            L3Invoked = false
+        });
+
+        l3InvokedCapture.Measurements.ShouldBeEmpty();
+        l3CreatedCapture.Measurements.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RecordRun_Should_Emit_L3_Counter_And_Histogram_When_L3_Invoked()
+    {
+        using var l3InvokedCapture = new MeterCapture("paperbase.relation_discovery.l3.invoked");
+        using var l3CreatedCapture = new MeterCapture("paperbase.relation_discovery.l3.created");
+
+        _recorder.RecordRun(new RelationDiscoveryRunMetrics
+        {
+            DocumentId = Guid.NewGuid(),
+            Result = RelationDiscoveryRunResult.Succeeded,
+            L2CreatedCount = 0,
+            L3Invoked = true,
+            L3CreatedCount = 2
+        });
+
+        l3InvokedCapture.Measurements.Count.ShouldBe(1);
+        l3InvokedCapture.Measurements[0].Value.ShouldBe(1L);
+        l3CreatedCapture.Measurements.Count.ShouldBe(1);
+        l3CreatedCapture.Measurements[0].Value.ShouldBe(2L);
+    }
+
+    [Fact]
+    public void RecordRun_Should_Emit_Duration_Histogram_With_Layer_Tags()
+    {
+        using var capture = new MeterCapture("paperbase.relation_discovery.duration");
+
+        _recorder.RecordRun(new RelationDiscoveryRunMetrics
+        {
+            DocumentId = Guid.NewGuid(),
+            Result = RelationDiscoveryRunResult.Succeeded,
+            L2DurationMs = 5.0,
+            L3DurationMs = 1500.0,
+            TotalDurationMs = 1505.0,
+            L3Invoked = true
+        });
+
+        capture.Measurements.Count.ShouldBe(3);
+        capture.Measurements.ShouldContain(m => (string)m.Tags["layer"] == "l2" && Math.Abs(m.ValueAsDouble - 5.0) < 0.01);
+        capture.Measurements.ShouldContain(m => (string)m.Tags["layer"] == "l3" && Math.Abs(m.ValueAsDouble - 1500.0) < 0.01);
+        capture.Measurements.ShouldContain(m => (string)m.Tags["layer"] == "total" && Math.Abs(m.ValueAsDouble - 1505.0) < 0.01);
+    }
+
+    [Fact]
+    public void RecordL3LlmCall_Should_Tag_With_Result()
+    {
+        using var capture = new MeterCapture("paperbase.relation_discovery.l3.llm_calls");
+
+        _recorder.RecordL3LlmCall(RelationDiscoveryL3CallResult.Confirmed);
+        _recorder.RecordL3LlmCall(RelationDiscoveryL3CallResult.Rejected);
+        _recorder.RecordL3LlmCall(RelationDiscoveryL3CallResult.Error);
+
+        capture.Measurements.Count.ShouldBe(3);
+        capture.Measurements.Select(m => (string)m.Tags["result"])
+            .ShouldBe(new[] { "Confirmed", "Rejected", "Error" });
+    }
+
+    [Theory]
+    [InlineData(null, "(none)")]
+    [InlineData(0.5, "<0.7")]
+    [InlineData(0.7, "0.7-0.8")]
+    [InlineData(0.79, "0.7-0.8")]
+    [InlineData(0.8, "0.8-0.9")]
+    [InlineData(0.89, "0.8-0.9")]
+    [InlineData(0.9, "0.9+")]
+    [InlineData(0.95, "0.9+")]
+    [InlineData(1.0, "0.9+")]
+    public void RecordSuggestionConfirmed_Should_Bucket_Confidence(double? confidence, string expectedBucket)
+    {
+        using var capture = new MeterCapture("paperbase.relation.suggestion.confirmed");
+
+        _recorder.RecordSuggestionConfirmed(RelationSource.AiSuggested, confidence);
+
+        capture.Measurements.Count.ShouldBe(1);
+        capture.Measurements[0].Tags["confidence_bucket"].ShouldBe(expectedBucket);
+        capture.Measurements[0].Tags["source"].ShouldBe("AiSuggested");
+    }
+
+    [Fact]
+    public void RecordSuggestionRejected_Should_Tag_Source_And_Confidence_Bucket()
+    {
+        using var capture = new MeterCapture("paperbase.relation.suggestion.rejected");
+
+        _recorder.RecordSuggestionRejected(RelationSource.AiSuggested, 0.85);
+
+        capture.Measurements.Count.ShouldBe(1);
+        capture.Measurements[0].Tags["source"].ShouldBe("AiSuggested");
+        capture.Measurements[0].Tags["confidence_bucket"].ShouldBe("0.8-0.9");
+    }
+
+    [Fact]
+    public void RecordSuggestionConfirmed_Should_Handle_Null_Confidence_For_Manual_Source()
+    {
+        // Manual relations carry null Confidence by domain invariant. Recorder must accept this.
+        using var capture = new MeterCapture("paperbase.relation.suggestion.confirmed");
+
+        _recorder.RecordSuggestionConfirmed(RelationSource.Manual, confidence: null);
+
+        capture.Measurements.Count.ShouldBe(1);
+        capture.Measurements[0].Tags["source"].ShouldBe("Manual");
+        capture.Measurements[0].Tags["confidence_bucket"].ShouldBe("(none)");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Disposable scope that captures all measurements emitted to a single instrument
+    /// on the RelationDiscovery meter. Filters by instrument name so other tests'
+    /// emissions on the same meter don't pollute results.
+    /// </summary>
+    private sealed class MeterCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        public List<CapturedMeasurement> Measurements { get; } = new();
+
+        public MeterCapture(string instrumentName)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == RelationDiscoveryTelemetryRecorder.MeterName
+                        && instrument.Name == instrumentName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((inst, value, tags, state) =>
+                Measurements.Add(new CapturedMeasurement(value, value, ToDictionary(tags))));
+            _listener.SetMeasurementEventCallback<double>((inst, value, tags, state) =>
+                Measurements.Add(new CapturedMeasurement((long)value, value, ToDictionary(tags))));
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+
+        private static IReadOnlyDictionary<string, object?> ToDictionary(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            foreach (var kv in tags)
+            {
+                dict[kv.Key] = kv.Value;
+            }
+            return dict;
+        }
+    }
+
+    private sealed record CapturedMeasurement(long Value, double ValueAsDouble, IReadOnlyDictionary<string, object?> Tags);
+}


### PR DESCRIPTION
Replaces #124 (closed when its base was deleted on #127 merge). Identical content, rebased onto main.