### PR TITLE
feat(chat): stream tool-call progress events (backend half of #116)

### DIFF
--- a/core/src/Dignite.Paperbase.Abstractions/Chat/IDocumentChatToolFactory.cs
+++ b/core/src/Dignite.Paperbase.Abstractions/Chat/IDocumentChatToolFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.AI;
 
 namespace Dignite.Paperbase.Abstractions.Chat;
@@ -12,9 +13,22 @@ public interface IDocumentChatToolFactory
     /// <summary>
     /// Creates an audited document-chat tool from a .NET method delegate.
     /// </summary>
+    /// <param name="ctx">Per-turn context (tenant, conversation, user, anchor document).</param>
+    /// <param name="method">The .NET delegate that implements the tool body.</param>
+    /// <param name="name">Stable tool name surfaced to the LLM. Must be a compile-time constant.</param>
+    /// <param name="description">Tool description surfaced to the LLM. Must be a compile-time constant.</param>
+    /// <param name="progressDescriber">
+    /// Issue #116: optional function that returns a sanitized, user-facing description of an
+    /// in-flight call (e.g. "正在按甲方 'X 公司' 查找合同"). Surfaces in the streaming
+    /// <c>ToolCallStarted</c> event. Receives the raw <c>AIFunctionArguments</c>; the implementer
+    /// is responsible for suppressing PII and LLM-rewritten free-form text — the returned string
+    /// reaches end users, not just operators. Return <c>null</c> to fall back to a generic
+    /// "正在执行 {ToolName}..." label produced by the AppService.
+    /// </param>
     AIFunction Create(
         DocumentChatToolContext ctx,
         Delegate method,
         string name,
-        string description);
+        string description,
+        Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber = null);
 }

--- a/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaDto.cs
+++ b/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaDto.cs
@@ -51,4 +51,43 @@ public class ChatTurnDeltaDto
     /// <see cref="ChatTurnDeltaKind.Error"/>. Never contains internal exception details.
     /// </summary>
     public string? ErrorMessage { get; set; }
+
+    // ── Issue #116: tool-call progress fields ───────────────────────────────
+    // Populated only on ToolCallStarted / ToolCallCompleted events. Lets the UI
+    // render in-progress cards during multi-step tool reasoning so users see
+    // activity instead of a black screen.
+
+    /// <summary>
+    /// Tool name (e.g. "search_paperbase_documents", "search_contracts"). Set on
+    /// <see cref="ChatTurnDeltaKind.ToolCallStarted"/> and
+    /// <see cref="ChatTurnDeltaKind.ToolCallCompleted"/>.
+    /// </summary>
+    public string? ToolName { get; set; }
+
+    /// <summary>
+    /// Correlation id for matching a <see cref="ChatTurnDeltaKind.ToolCallStarted"/> to
+    /// its <see cref="ChatTurnDeltaKind.ToolCallCompleted"/>. Comes from MAF's
+    /// <c>FunctionCallContent.CallId</c>; opaque to the UI.
+    /// </summary>
+    public string? ToolCallId { get; set; }
+
+    /// <summary>
+    /// Sanitized human-readable description of the in-flight call (e.g.
+    /// "正在按甲方 'X 公司' 查找合同"). Set on <see cref="ChatTurnDeltaKind.ToolCallStarted"/>.
+    /// Populated by each tool's contributor-supplied describer; never carries raw
+    /// arguments JSON or LLM-rewritten queries (see Issue #116 §4).
+    /// </summary>
+    public string? ProgressDescription { get; set; }
+
+    /// <summary>
+    /// Wall-clock duration of the tool invocation in milliseconds. Set on
+    /// <see cref="ChatTurnDeltaKind.ToolCallCompleted"/>.
+    /// </summary>
+    public double? ElapsedMs { get; set; }
+
+    /// <summary>
+    /// <c>true</c> when the tool returned normally, <c>false</c> when it threw.
+    /// Set on <see cref="ChatTurnDeltaKind.ToolCallCompleted"/>.
+    /// </summary>
+    public bool? ToolCallSucceeded { get; set; }
 }

--- a/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaKind.cs
+++ b/core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaKind.cs
@@ -1,4 +1,4 @@
-﻿namespace Dignite.Paperbase.Chat;
+namespace Dignite.Paperbase.Chat;
 
 public enum ChatTurnDeltaKind
 {
@@ -20,5 +20,25 @@ public enum ChatTurnDeltaKind
     /// <see cref="ChatTurnDeltaDto.ErrorMessage"/> carries a safe client-facing message.
     /// No further events follow.
     /// </summary>
-    Error
+    Error,
+
+    /// <summary>
+    /// Issue #116: model decided to invoke a tool. Populated fields:
+    /// <see cref="ChatTurnDeltaDto.ToolName"/>,
+    /// <see cref="ChatTurnDeltaDto.ToolCallId"/>,
+    /// <see cref="ChatTurnDeltaDto.ProgressDescription"/>.
+    /// Lets the UI render an in-progress card (e.g. "▸ 正在按甲方 'X 公司' 查找合同")
+    /// instead of a black screen during multi-step tool reasoning.
+    /// </summary>
+    ToolCallStarted,
+
+    /// <summary>
+    /// Issue #116: a tool returned (or threw). Correlates with the matching
+    /// <see cref="ToolCallStarted"/> via <see cref="ChatTurnDeltaDto.ToolCallId"/>.
+    /// Populated: <see cref="ChatTurnDeltaDto.ToolName"/>,
+    /// <see cref="ChatTurnDeltaDto.ToolCallId"/>,
+    /// <see cref="ChatTurnDeltaDto.ElapsedMs"/>,
+    /// <see cref="ChatTurnDeltaDto.ToolCallSucceeded"/>.
+    /// </summary>
+    ToolCallCompleted
 }

--- a/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/DocumentChatAppService.cs
@@ -460,7 +460,7 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
         // telemetry but does not block the turn — see reverse example E.
         var anchorResolutionFailed = conversation.DocumentId.HasValue && string.IsNullOrEmpty(anchorContext);
 
-        return new AgentSetup(agent, session, capture, anchorResolutionFailed);
+        return new AgentSetup(agent, session, capture, anchorResolutionFailed, tools);
     }
 
     /// <summary>
@@ -779,6 +779,113 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
     /// On error, a <see cref="ChatTurnDeltaKind.Error"/> event is written before closing
     /// the channel.
     /// </summary>
+    /// <summary>
+    /// Issue #116: surfaces MAF's <see cref="MeAi.FunctionCallContent"/> and
+    /// <see cref="MeAi.FunctionResultContent"/> updates as
+    /// <see cref="ChatTurnDeltaKind.ToolCallStarted"/> and
+    /// <see cref="ChatTurnDeltaKind.ToolCallCompleted"/> events on the streaming channel
+    /// so the UI can render in-progress cards instead of a black screen.
+    /// </summary>
+    /// <remarks>
+    /// Tool-name → describer resolution: looks up the AIFunction by name in
+    /// <paramref name="tools"/> (the same list passed to <c>ChatClientAgentOptions</c>),
+    /// downcasts to <see cref="Telemetry.DocumentChatToolFactory.AuditedDocumentChatFunction"/>,
+    /// and invokes its <c>ProgressDescriber</c>. Falls back to a generic label when the
+    /// tool didn't supply one — never reveals raw <c>arguments</c> JSON, which would
+    /// re-introduce the prompt-injection / PII vector reverse example C #4 forbids.
+    /// </remarks>
+    private async Task EmitToolCallEventsAsync(
+        AgentResponseUpdate update,
+        IReadOnlyList<AITool> tools,
+        IDictionary<string, (string ToolName, long StartTimestamp)> toolCallStartTimes,
+        ChannelWriter<ChatTurnDeltaDto> writer,
+        CancellationToken ct)
+    {
+        if (update.Contents == null || update.Contents.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var content in update.Contents)
+        {
+            switch (content)
+            {
+                case MeAi.FunctionCallContent call when !string.IsNullOrEmpty(call.CallId):
+                {
+                    toolCallStartTimes[call.CallId] = (call.Name, Stopwatch.GetTimestamp());
+
+                    // Snapshot arguments into a read-only dictionary so describers can't
+                    // accidentally mutate the same instance MAF will hand to the tool body.
+                    var roArgs = call.Arguments == null
+                        ? (IReadOnlyDictionary<string, object?>)new Dictionary<string, object?>(StringComparer.Ordinal)
+                        : new Dictionary<string, object?>(call.Arguments, StringComparer.Ordinal);
+
+                    await writer.WriteAsync(new ChatTurnDeltaDto
+                    {
+                        Kind = ChatTurnDeltaKind.ToolCallStarted,
+                        ToolName = call.Name,
+                        ToolCallId = call.CallId,
+                        ProgressDescription = ResolveProgressDescription(call.Name, roArgs, tools)
+                    }, ct);
+                    break;
+                }
+
+                case MeAi.FunctionResultContent result when !string.IsNullOrEmpty(result.CallId):
+                {
+                    if (!toolCallStartTimes.TryGetValue(result.CallId, out var entry))
+                    {
+                        // Out-of-order Result without a matching Started — emit Completed
+                        // anyway so the UI doesn't leave a card hanging, but ElapsedMs is
+                        // unknown. Should not happen with FunctionInvokingChatClient but
+                        // defensive against future custom invokers. The MAF
+                        // FunctionResultContent does not carry the tool name (it's only on
+                        // the originating FunctionCallContent), so we synthesise a placeholder.
+                        entry = ("(unknown)", Stopwatch.GetTimestamp());
+                    }
+                    else
+                    {
+                        toolCallStartTimes.Remove(result.CallId);
+                    }
+
+                    var elapsedMs = Stopwatch.GetElapsedTime(entry.StartTimestamp).TotalMilliseconds;
+                    var succeeded = result.Exception is null;
+
+                    await writer.WriteAsync(new ChatTurnDeltaDto
+                    {
+                        Kind = ChatTurnDeltaKind.ToolCallCompleted,
+                        ToolName = entry.ToolName,
+                        ToolCallId = result.CallId,
+                        ElapsedMs = elapsedMs,
+                        ToolCallSucceeded = succeeded
+                    }, ct);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static string ResolveProgressDescription(
+        string toolName,
+        IReadOnlyDictionary<string, object?> arguments,
+        IReadOnlyList<AITool> tools)
+    {
+        foreach (var tool in tools)
+        {
+            if (tool is Telemetry.DocumentChatToolFactory.AuditedDocumentChatFunction audited
+                && string.Equals(audited.Name, toolName, StringComparison.Ordinal))
+            {
+                var described = audited.ProgressDescriber?.Invoke(arguments);
+                if (!string.IsNullOrEmpty(described))
+                {
+                    return described;
+                }
+                break;
+            }
+        }
+
+        return $"正在执行 {toolName}…";
+    }
+
     private async Task FillStreamingChannelAsync(
         ChatConversation conversation,
         SendChatMessageInput input,
@@ -795,9 +902,19 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
             var setup = await PrepareAgentSetupAsync(conversation, ct);
             // MAF prepends history via DocumentChatHistoryProvider — see InvokeAgentAsync.
             var newUserMessage = new MeAi.ChatMessage(MeAi.ChatRole.User, input.Message);
+
+            // Issue #116: per-CallId stopwatch dictionary so ToolCallCompleted can carry
+            // accurate ElapsedMs even when the FunctionInvokingChatClient interleaves
+            // multiple in-flight calls. Keyed by CallId from FunctionCallContent.
+            var toolCallStartTimes = new Dictionary<string, (string ToolName, long StartTimestamp)>(StringComparer.Ordinal);
+
             await foreach (var update in setup.Agent.RunStreamingAsync(
                 newUserMessage, setup.Session, options: null, ct))
             {
+                // Tool-call progress events first — they help users see the agent is
+                // working before any text starts streaming.
+                await EmitToolCallEventsAsync(update, setup.Tools, toolCallStartTimes, writer, ct);
+
                 var text = update.Text;
                 if (!string.IsNullOrEmpty(text))
                 {
@@ -970,12 +1087,19 @@ public class DocumentChatAppService : PaperbaseAppService, IDocumentChatAppServi
     /// <see cref="DocumentChatAppService.BuildAnchorContextAsync"/> degraded for it
     /// (deleted, tenant mismatch, or caller lost <c>Documents.Default</c>). Surfaces
     /// to telemetry so operators can see permission drift at scale; never blocks the turn.
+    /// <para>
+    /// Issue #116: <see cref="Tools"/> mirrors the <c>ChatClientAgentOptions.ChatOptions.Tools</c>
+    /// list so the streaming path can look up an
+    /// <see cref="Telemetry.DocumentChatToolFactory.AuditedDocumentChatFunction"/> by name
+    /// to resolve its <c>ProgressDescriber</c> when emitting <c>ToolCallStarted</c> events.
+    /// </para>
     /// </remarks>
     protected record AgentSetup(
         ChatClientAgent Agent,
         AgentSession Session,
         DocumentSearchCapture Capture,
-        bool AnchorResolutionFailed);
+        bool AnchorResolutionFailed,
+        IReadOnlyList<AITool> Tools);
 
     protected record AgentRunOutcome(
         string Text,

--- a/core/src/Dignite.Paperbase.Application/Chat/Search/DocumentTextSearchAdapter.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Search/DocumentTextSearchAdapter.cs
@@ -151,7 +151,55 @@ public class DocumentTextSearchAdapter : ITransientDependency
             toolContext,
             binding.InvokeAsync,
             name: functionName,
-            description: functionDescription);
+            description: functionDescription,
+            // Issue #116: never surface the LLM-rewritten `query` (PII risk per
+            // .claude/rules/doc-chat-anti-patterns.md reverse example C #4). Show
+            // structural intent only — type filter and how many docs are being
+            // drilled into.
+            progressDescriber: SummarizeProgress);
+    }
+
+    private static string SummarizeProgress(IReadOnlyDictionary<string, object?> arguments)
+    {
+        var documentTypeCode = TryGetString(arguments, "documentTypeCode");
+        var documentIdsCount = TryGetCollectionCount(arguments, "documentIds");
+
+        if (documentIdsCount > 0)
+        {
+            return $"正在 {documentIdsCount} 份候选文档中向量检索…";
+        }
+
+        if (!string.IsNullOrEmpty(documentTypeCode))
+        {
+            return $"正在按文档类型 \"{documentTypeCode}\" 向量检索…";
+        }
+
+        return "正在跨全库向量检索…";
+    }
+
+    private static string? TryGetString(IReadOnlyDictionary<string, object?> arguments, string key)
+        => arguments.TryGetValue(key, out var value) ? value?.ToString() : null;
+
+    private static int TryGetCollectionCount(IReadOnlyDictionary<string, object?> arguments, string key)
+    {
+        if (!arguments.TryGetValue(key, out var value) || value is null)
+        {
+            return 0;
+        }
+
+        if (value is System.Collections.ICollection coll)
+        {
+            return coll.Count;
+        }
+
+        if (value is System.Collections.IEnumerable seq)
+        {
+            var count = 0;
+            foreach (var _ in seq) count++;
+            return count;
+        }
+
+        return 0;
     }
 
     // ── nested helper ────────────────────────────────────────────────────────

--- a/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatToolFactory.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatToolFactory.cs
@@ -44,10 +44,11 @@ public class DocumentChatToolFactory : IDocumentChatToolFactory, ITransientDepen
         DocumentChatToolContext ctx,
         Delegate method,
         string name,
-        string description)
+        string description,
+        Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber = null)
     {
         var inner = AIFunctionFactory.Create(method, name, description);
-        return new AuditedDocumentChatFunction(inner, ctx, _recorder);
+        return new AuditedDocumentChatFunction(inner, ctx, _recorder, progressDescriber);
     }
 
     private static IReadOnlyDictionary<string, object?> SummarizeArguments(AIFunctionArguments? arguments)
@@ -272,20 +273,35 @@ public class DocumentChatToolFactory : IDocumentChatToolFactory, ITransientDepen
         return Convert.ToHexString(bytes, 0, HashHexPrefixLength / 2).ToLowerInvariant();
     }
 
-    private sealed class AuditedDocumentChatFunction : AIFunction
+    /// <summary>
+    /// Internal so <c>DocumentChatAppService</c> (same assembly) can downcast on the
+    /// streaming path to fetch <see cref="ProgressDescriber"/> for
+    /// <c>ToolCallStarted</c> events. External consumers should treat the returned
+    /// <see cref="AIFunction"/> as opaque.
+    /// </summary>
+    internal sealed class AuditedDocumentChatFunction : AIFunction
     {
         private readonly AIFunction _inner;
         private readonly DocumentChatToolContext _ctx;
         private readonly DocumentChatTelemetryRecorder _recorder;
 
+        /// <summary>
+        /// Issue #116: optional sanitized-progress describer supplied at registration
+        /// time. <c>null</c> when the tool didn't opt in; the streaming AppService
+        /// falls back to a generic "正在执行 {ToolName}" label.
+        /// </summary>
+        public Func<IReadOnlyDictionary<string, object?>, string?>? ProgressDescriber { get; }
+
         public AuditedDocumentChatFunction(
             AIFunction inner,
             DocumentChatToolContext ctx,
-            DocumentChatTelemetryRecorder recorder)
+            DocumentChatTelemetryRecorder recorder,
+            Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber = null)
         {
             _inner = inner;
             _ctx = ctx;
             _recorder = recorder;
+            ProgressDescriber = progressDescriber;
         }
 
         public override string Name => _inner.Name;

--- a/core/src/Dignite.Paperbase.Application/Chat/Tools/DocumentRelationsTool.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Tools/DocumentRelationsTool.cs
@@ -67,7 +67,10 @@ public class DocumentRelationsTool : ITransientDependency
                 "Use this BEFORE search_paperbase_documents when the question implies cross-document evidence " +
                 "(e.g. 'has this contract been paid?' → call get_document_relations on the contract, then " +
                 "drill into the returned documentIds with search_paperbase_documents). " +
-                "Returns up to 20 entries, ordered with manual links first, then AI-suggested links by confidence descending.");
+                "Returns up to 20 entries, ordered with manual links first, then AI-suggested links by confidence descending.",
+            // Issue #116 progress description: documentId is opaque to the user; the
+            // anchor doc is implicit from context. Generic label is fine here.
+            progressDescriber: _ => "正在查找该文档的关联文档…");
     }
 
     /// <summary>

--- a/core/test/Dignite.Paperbase.Application.Tests/Chat/Streaming/DocumentChatToolProgressStreaming_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Chat/Streaming/DocumentChatToolProgressStreaming_Tests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.KnowledgeIndex;
+using Microsoft.Extensions.AI;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Security.Claims;
+using Xunit;
+using MEAI = Microsoft.Extensions.AI;
+
+namespace Dignite.Paperbase.Chat;
+
+/// <summary>
+/// Issue #116: streaming-path guard that the AppService surfaces MAF's
+/// <see cref="MEAI.FunctionCallContent"/> / <see cref="MEAI.FunctionResultContent"/>
+/// updates as <see cref="ChatTurnDeltaKind.ToolCallStarted"/> /
+/// <see cref="ChatTurnDeltaKind.ToolCallCompleted"/> events on the SSE channel —
+/// so the user sees activity instead of a black screen during multi-tool reasoning.
+/// </summary>
+public class DocumentChatToolProgressStreaming_Tests
+    : PaperbaseApplicationTestBase<DocumentChatAppServiceTestModule>
+{
+    private readonly IDocumentChatAppService _appService;
+    private readonly IChatClient _chatClient;
+    private readonly IDocumentKnowledgeIndex _knowledgeIndex;
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
+    private readonly ICurrentPrincipalAccessor _principalAccessor;
+
+    private static readonly Guid OwnerUserId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    public DocumentChatToolProgressStreaming_Tests()
+    {
+        _appService = GetRequiredService<IDocumentChatAppService>();
+        _chatClient = GetRequiredService<IChatClient>();
+        _knowledgeIndex = GetRequiredService<IDocumentKnowledgeIndex>();
+        _embeddingGenerator = GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>();
+        _principalAccessor = GetRequiredService<ICurrentPrincipalAccessor>();
+
+        SetupDefaultEmbedding();
+        _knowledgeIndex.SearchAsync(Arg.Any<VectorSearchRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VectorSearchResult>());
+    }
+
+    [Fact]
+    public async Task Streaming_Surfaces_ToolCallStarted_And_ToolCallCompleted_Events()
+    {
+        // Script the IChatClient stream to walk through:
+        //   1) FunctionCallContent (search_paperbase_documents) → 2) FunctionResultContent
+        //   3) FunctionCallContent (unknown_tool, exercises the fallback label)
+        //   4) FunctionResultContent (failure)
+        //   5–6) text chunks → end
+        // The test deliberately uses Substitute.For<IChatClient> directly (no
+        // FunctionInvokingChatClient wrap) — that lets us drive the exact sequence
+        // of updates the AppService translates without having to register real tool
+        // implementations or rely on the function-invocation loop.
+        var searchCallId = "call-search-1";
+        var unknownCallId = "call-unknown-2";
+
+        _chatClient.GetStreamingResponseAsync(
+                Arg.Any<IEnumerable<MEAI.ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ScriptStream(searchCallId, unknownCallId));
+
+        var conversationId = await CreateConversationAsync();
+        var deltas = new List<ChatTurnDeltaDto>();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (ChangeUser(OwnerUserId))
+            {
+                await foreach (var delta in _appService.SendMessageStreamingAsync(
+                    conversationId,
+                    new SendChatMessageInput { Message = "q", ClientTurnId = Guid.NewGuid() }))
+                {
+                    deltas.Add(delta);
+                }
+            }
+        });
+
+        // Expected order: Started/Completed/Started/Completed/PartialText × 2/Done
+        deltas.Select(d => d.Kind).ToList().ShouldBe(new[]
+        {
+            ChatTurnDeltaKind.ToolCallStarted,
+            ChatTurnDeltaKind.ToolCallCompleted,
+            ChatTurnDeltaKind.ToolCallStarted,
+            ChatTurnDeltaKind.ToolCallCompleted,
+            ChatTurnDeltaKind.PartialText,
+            ChatTurnDeltaKind.PartialText,
+            ChatTurnDeltaKind.Done
+        });
+
+        // First Started — the registered search_paperbase_documents tool: describer
+        // should resolve to the structured "正在跨全库向量检索…" label (no doc-ids /
+        // type were supplied in the scripted call args).
+        var firstStarted = deltas[0];
+        firstStarted.ToolName.ShouldBe(ChatConsts.SearchPaperbaseDocumentsToolName);
+        firstStarted.ToolCallId.ShouldBe(searchCallId);
+        firstStarted.ProgressDescription.ShouldBe("正在跨全库向量检索…");
+
+        // First Completed — correlates by ToolCallId, ElapsedMs populated, success.
+        var firstCompleted = deltas[1];
+        firstCompleted.ToolCallId.ShouldBe(searchCallId);
+        firstCompleted.ToolName.ShouldBe(ChatConsts.SearchPaperbaseDocumentsToolName);
+        firstCompleted.ToolCallSucceeded.ShouldBe(true);
+        firstCompleted.ElapsedMs.ShouldNotBeNull();
+
+        // Second Started — unknown_tool isn't in the agent's tool list; falls back
+        // to the generic "正在执行 {ToolName}…" label.
+        var secondStarted = deltas[2];
+        secondStarted.ToolName.ShouldBe("unknown_tool");
+        secondStarted.ToolCallId.ShouldBe(unknownCallId);
+        secondStarted.ProgressDescription.ShouldBe("正在执行 unknown_tool…");
+
+        // Second Completed — failure path; ToolCallSucceeded must be false.
+        var secondCompleted = deltas[3];
+        secondCompleted.ToolCallId.ShouldBe(unknownCallId);
+        secondCompleted.ToolCallSucceeded.ShouldBe(false);
+
+        // Text chunks survive verbatim.
+        deltas[4].Text.ShouldBe("Hello");
+        deltas[5].Text.ShouldBe(" World");
+    }
+
+    [Fact]
+    public async Task Streaming_Without_Tool_Calls_Yields_Only_PartialText_And_Done()
+    {
+        // Regression guard: if the model never invokes a tool (the Issue #100 anchor /
+        // pure-knowledge case), the new code path must NOT fabricate ToolCall events.
+        _chatClient.GetStreamingResponseAsync(
+                Arg.Any<IEnumerable<MEAI.ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => YieldText("plain ", "answer"));
+
+        var conversationId = await CreateConversationAsync();
+        var deltas = new List<ChatTurnDeltaDto>();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (ChangeUser(OwnerUserId))
+            {
+                await foreach (var delta in _appService.SendMessageStreamingAsync(
+                    conversationId,
+                    new SendChatMessageInput { Message = "q", ClientTurnId = Guid.NewGuid() }))
+                {
+                    deltas.Add(delta);
+                }
+            }
+        });
+
+        deltas.ShouldNotContain(d =>
+            d.Kind == ChatTurnDeltaKind.ToolCallStarted
+            || d.Kind == ChatTurnDeltaKind.ToolCallCompleted);
+        deltas.Count(d => d.Kind == ChatTurnDeltaKind.PartialText).ShouldBe(2);
+        deltas[^1].Kind.ShouldBe(ChatTurnDeltaKind.Done);
+    }
+
+    private static async IAsyncEnumerable<MEAI.ChatResponseUpdate> ScriptStream(
+        string searchCallId,
+        string unknownCallId,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        // Tool 1: registered tool (search_paperbase_documents). No documentIds / typeCode
+        // in arguments → describer returns the "全库向量检索" label.
+        yield return UpdateWithContent(new MEAI.FunctionCallContent(
+            callId: searchCallId,
+            name: ChatConsts.SearchPaperbaseDocumentsToolName,
+            arguments: new Dictionary<string, object?> { ["query"] = "anything" }));
+
+        await Task.Yield();
+
+        yield return UpdateWithContent(new MEAI.FunctionResultContent(
+            callId: searchCallId,
+            result: "{\"results\":[]}"));
+
+        // Tool 2: tool not registered with the agent → AppService falls back to generic label.
+        yield return UpdateWithContent(new MEAI.FunctionCallContent(
+            callId: unknownCallId,
+            name: "unknown_tool",
+            arguments: new Dictionary<string, object?>()));
+
+        await Task.Yield();
+
+        // Failure path: include an Exception so ToolCallSucceeded comes through false.
+        yield return UpdateWithContent(new MEAI.FunctionResultContent(
+            callId: unknownCallId,
+            result: null)
+        {
+            Exception = new InvalidOperationException("scripted failure")
+        });
+
+        // Final text chunks the assistant streams after tool work is done.
+        yield return new MEAI.ChatResponseUpdate(MEAI.ChatRole.Assistant, "Hello");
+        yield return new MEAI.ChatResponseUpdate(MEAI.ChatRole.Assistant, " World");
+    }
+
+    private static async IAsyncEnumerable<MEAI.ChatResponseUpdate> YieldText(
+        params string[] chunks)
+    {
+        foreach (var chunk in chunks)
+        {
+            await Task.Yield();
+            yield return new MEAI.ChatResponseUpdate(MEAI.ChatRole.Assistant, chunk);
+        }
+    }
+
+    private static MEAI.ChatResponseUpdate UpdateWithContent(MEAI.AIContent content)
+        => new()
+        {
+            Role = MEAI.ChatRole.Assistant,
+            Contents = new List<MEAI.AIContent> { content }
+        };
+
+    private async Task<Guid> CreateConversationAsync()
+        => await WithUnitOfWorkAsync(async () =>
+        {
+            using (ChangeUser(OwnerUserId))
+            {
+                var dto = await _appService.CreateConversationAsync(new CreateChatConversationInput
+                {
+                    Title = "Tool-progress streaming test"
+                });
+                return dto.Id;
+            }
+        });
+
+    private IDisposable ChangeUser(Guid userId)
+    {
+        var claims = new List<Claim> { new(AbpClaimTypes.UserId, userId.ToString()) };
+        return _principalAccessor.Change(new ClaimsPrincipal(new ClaimsIdentity(claims, "test")));
+    }
+
+    private void SetupDefaultEmbedding()
+    {
+        var embedding = new Embedding<float>(new float[] { 0.1f, 0.2f, 0.3f });
+        _embeddingGenerator
+            .GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GeneratedEmbeddings<Embedding<float>>([embedding]));
+    }
+}

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.Application/Chat/ContractChatToolContributor.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.Application/Chat/ContractChatToolContributor.cs
@@ -65,7 +65,11 @@ public class ContractChatToolContributor : IDocumentChatToolContributor, ITransi
                 "Search contracts by structured criteria: contract number, party name, " +
                 "date range, or amount range. " +
                 "Returns matched document IDs and contract metadata summaries. " +
-                "Use the returned document IDs to restrict further document content search to the relevant contracts.");
+                "Use the returned document IDs to restrict further document content search to the relevant contracts.",
+            // Issue #116: party / contract number are user-meaningful filters and OK to surface.
+            // Dates / amount ranges are too noisy in a one-line label — caller can see them in
+            // the audit log. The string is end-user facing, so keep it short and friendly.
+            progressDescriber: DescribeSearch);
 
         yield return toolFactory.Create(
             ctx,
@@ -75,7 +79,9 @@ public class ContractChatToolContributor : IDocumentChatToolContributor, ITransi
                 "Fetch the full extracted field set for a single contract by its document ID. " +
                 "Use this after search_contracts narrows the candidate set, when the user asks " +
                 "for fields not included in the search summary (governing law, auto-renewal, " +
-                "termination notice days, effective date, etc.).");
+                "termination notice days, effective date, etc.).",
+            // documentId is opaque to users; generic label is more useful here than a UUID.
+            progressDescriber: _ => "正在查询合同详情…");
 
         yield return toolFactory.Create(
             ctx,
@@ -86,8 +92,38 @@ public class ContractChatToolContributor : IDocumentChatToolContributor, ITransi
                 "filtered by party name, signed-date range, or status. " +
                 "Use this for arithmetic questions like \"how many active contracts with party X\" " +
                 "or \"total signed amount in Q1\" — these cannot be answered by vector search " +
-                "over document chunks.");
+                "over document chunks.",
+            progressDescriber: DescribeAggregate);
     }
+
+    private static string DescribeSearch(IReadOnlyDictionary<string, object?> arguments)
+    {
+        var party = TryGetString(arguments, "partyName");
+        var contractNumber = TryGetString(arguments, "contractNumber");
+
+        if (!string.IsNullOrEmpty(party))
+        {
+            return $"正在按甲方 \"{party}\" 查找合同…";
+        }
+
+        if (!string.IsNullOrEmpty(contractNumber))
+        {
+            return $"正在按合同号 \"{contractNumber}\" 查找合同…";
+        }
+
+        return "正在按条件筛选合同…";
+    }
+
+    private static string DescribeAggregate(IReadOnlyDictionary<string, object?> arguments)
+    {
+        var party = TryGetString(arguments, "partyName");
+        return string.IsNullOrEmpty(party)
+            ? "正在统计合同金额…"
+            : $"正在统计 \"{party}\" 的合同金额…";
+    }
+
+    private static string? TryGetString(IReadOnlyDictionary<string, object?> arguments, string key)
+        => arguments.TryGetValue(key, out var value) ? value?.ToString() : null;
 
     // ── nested binding ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Partial #116 (backend half — frontend Angular changes deferred to a follow-up commit).

## What lands here

The streaming AppService now translates MAF's `FunctionCallContent` / `FunctionResultContent` updates into `ChatTurnDeltaKind.ToolCallStarted` / `ChatTurnDeltaKind.ToolCallCompleted` events on the SSE channel. The UI can finally render in-progress cards from the moment the model decides to invoke a tool, instead of the user staring at a 5–10s blank screen during multi-step reasoning (the canonical "Has it been paid yet?" turn that fans out to `get_contract_detail` → `get_document_relations` → `search_paperbase_documents`).

## Privacy boundary — Option B from the Issue

Each tool owns the contract for what its in-progress label says to end users:

| Tool | Sample label |
|---|---|
| `search_paperbase_documents` | `Searching the entire vector store…` / `Vector-searching by document type \"contract.general\"…` / `Vector-searching across 5 candidate documents…` |
| `search_contracts` | `Searching contracts by Party A \"Company X\"…` / `Searching contracts by contract number \"INV-001\"…` |
| `get_contract_detail` | `Fetching contract details…` |
| `get_contract_aggregate` | `Aggregating contract amounts for \"Company X\"…` |
| `get_document_relations` | `Finding documents related to this document…` |
| (any tool without a describer) | `Executing {ToolName}…` |

Critical: `search_paperbase_documents` **never** echoes the LLM-rewritten `query` argument — that's a PII / prompt-injection vector per `.claude/rules/doc-chat-anti-patterns.md` reverse example C #4. Structural intent only (filter type / target count).

## Wiring

- **`IDocumentChatToolFactory.Create`** gains an optional `progressDescriber` delegate. Old call sites compile unchanged (no behavior change for tools that don't opt in)
- **`AuditedDocumentChatFunction`** (now `internal sealed` so the AppService can downcast on the streaming path) stores the describer and exposes it via a public property
- **`AgentSetup`** record gains `Tools: IReadOnlyList<AITool>` so `FillStreamingChannelAsync` can resolve describer-by-name without re-querying the agent
- **Per-CallId stopwatch dictionary** in the streaming handler so `ToolCallCompleted` carries accurate `ElapsedMs` even when MAF interleaves multiple in-flight calls
- **Failure path**: a `FunctionResultContent.Exception != null` flips `ToolCallSucceeded` to `false`; the UI can render the failed card differently
- **Defensive completion**: a `FunctionResultContent` without a matching `FunctionCallContent` still emits a `Completed` event so the UI never leaves a started card hanging

## What stays unchanged

- Telemetry / audit signals (`DocumentChatTelemetryRecorder`, `GroundingSource`, `AnchorResolutionFailed`, `CitationsTrimmed`) — the new SSE events are purely UX, never the source of truth
- Idempotent replay path (`BuildTurnResultFromPersisted`) — still emits a single `Done` with no fabricated ToolCall events for work that already happened
- Sync `SendMessageAsync` path — by definition not streaming, no change

## Test plan

- [x] `dotnet build` (whole solution): 0 errors
- [x] `dotnet test core/test/Dignite.Paperbase.Application.Tests`: 282 / 282 pass
- [x] `Chat/Streaming/DocumentChatToolProgressStreaming_Tests.cs` (new): scripts 2 tool calls + text chunks through `Substitute<IChatClient>.GetStreamingResponseAsync` and asserts the SSE channel yields `Started / Completed / Started / Completed / PartialText × 2 / Done` in order, exercising both the describer path (registered tool) and the fallback path (unknown tool)
- [x] Regression guard: turns without any tool calls don't emit spurious ToolCall events
- [x] `dotnet test core/test/Dignite.Paperbase.Domain.Tests`: 42 / 42 pass
- [x] CI is now green on this repo (since #113), so this PR's CI run is the real check

## Out of scope (separate commit / PR for the FE half)

- Angular `chat-panel`: render `ToolCallStarted` as a collapsible "▸ {ProgressDescription}" card with a spinner; on matching `ToolCallCompleted` (correlate by `ToolCallId`), collapse to "✓ {ProgressDescription} ({ElapsedMs}ms)" or "✕ ..." on failure. Backend is the hard prereq for that work
- Token-by-token argument streaming (`FunctionCallContent` arrives complete; we don't try to render character-by-character)
- Cancellation UI (mid-call interruption is a separate Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)