### PR TITLE
fix(chat): post-review fixes for #129 — pre-authz arg leak + binary-breaking factory (#130)

### DIFF
--- a/core/src/Dignite.Paperbase.Abstractions/Chat/IDocumentChatToolFactory.cs
+++ b/core/src/Dignite.Paperbase.Abstractions/Chat/IDocumentChatToolFactory.cs
@@ -13,22 +13,40 @@ public interface IDocumentChatToolFactory
     /// <summary>
     /// Creates an audited document-chat tool from a .NET method delegate.
     /// </summary>
-    /// <param name="ctx">Per-turn context (tenant, conversation, user, anchor document).</param>
-    /// <param name="method">The .NET delegate that implements the tool body.</param>
-    /// <param name="name">Stable tool name surfaced to the LLM. Must be a compile-time constant.</param>
-    /// <param name="description">Tool description surfaced to the LLM. Must be a compile-time constant.</param>
-    /// <param name="progressDescriber">
-    /// Issue #116: optional function that returns a sanitized, user-facing description of an
-    /// in-flight call (e.g. "正在按甲方 'X 公司' 查找合同"). Surfaces in the streaming
-    /// <c>ToolCallStarted</c> event. Receives the raw <c>AIFunctionArguments</c>; the implementer
-    /// is responsible for suppressing PII and LLM-rewritten free-form text — the returned string
-    /// reaches end users, not just operators. Return <c>null</c> to fall back to a generic
-    /// "正在执行 {ToolName}..." label produced by the AppService.
-    /// </param>
+    AIFunction Create(
+        DocumentChatToolContext ctx,
+        Delegate method,
+        string name,
+        string description);
+
+    /// <summary>
+    /// Issue #116: opt-in overload that lets the caller supply a sanitized,
+    /// user-facing description of an in-flight call (e.g. <c>"正在按文档类型 'X' 向量检索…"</c>).
+    /// Surfaces in the streaming <c>ToolCallStarted</c> event.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default implementation forwards to the four-arg
+    /// <see cref="Create(DocumentChatToolContext, Delegate, string, string)"/>
+    /// and discards the describer — preserving binary compatibility with external
+    /// implementers compiled against the pre-Issue-#116 interface (Issue #130
+    /// post-mortem: PR #129 originally mutated the existing signature, which
+    /// breaks pre-built modules loaded against an upgraded core package).
+    /// First-party <c>DocumentChatToolFactory</c> overrides this overload to
+    /// actually route the describer into the audit wrapper.
+    /// </para>
+    /// <para>
+    /// SECURITY: <paramref name="progressDescriber"/> output reaches end users
+    /// via SSE BEFORE the tool body runs. It MUST NOT echo raw model arguments
+    /// — see <c>.claude/rules/doc-chat-anti-patterns.md</c> reverse example C #4
+    /// and the Issue #130 post-mortem.
+    /// </para>
+    /// </remarks>
     AIFunction Create(
         DocumentChatToolContext ctx,
         Delegate method,
         string name,
         string description,
-        Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber = null);
+        Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber)
+        => Create(ctx, method, name, description);
 }

--- a/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatToolFactory.cs
+++ b/core/src/Dignite.Paperbase.Application/Chat/Telemetry/DocumentChatToolFactory.cs
@@ -40,12 +40,23 @@ public class DocumentChatToolFactory : IDocumentChatToolFactory, ITransientDepen
         _recorder = recorder;
     }
 
+    // Issue #130: split into two overloads (mirroring the interface) so external
+    // implementers compiled against the pre-#129 interface still bind. The 4-arg
+    // is the original required member; the 5-arg is the opt-in describer-aware
+    // overload introduced for #116.
+    public virtual AIFunction Create(
+        DocumentChatToolContext ctx,
+        Delegate method,
+        string name,
+        string description)
+        => Create(ctx, method, name, description, progressDescriber: null);
+
     public virtual AIFunction Create(
         DocumentChatToolContext ctx,
         Delegate method,
         string name,
         string description,
-        Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber = null)
+        Func<IReadOnlyDictionary<string, object?>, string?>? progressDescriber)
     {
         var inner = AIFunctionFactory.Create(method, name, description);
         return new AuditedDocumentChatFunction(inner, ctx, _recorder, progressDescriber);

--- a/modules/contracts/src/Dignite.Paperbase.Contracts.Application/Chat/ContractChatToolContributor.cs
+++ b/modules/contracts/src/Dignite.Paperbase.Contracts.Application/Chat/ContractChatToolContributor.cs
@@ -96,31 +96,37 @@ public class ContractChatToolContributor : IDocumentChatToolContributor, ITransi
             progressDescriber: DescribeAggregate);
     }
 
+    // Issue #130 (Codex review of #129): the previous implementations echoed raw
+    // model-controlled `partyName` / `contractNumber` values into user-facing SSE
+    // text. ToolCallStarted is emitted BEFORE the tool body's
+    // ContractsPermissions.Contracts.Default check runs, so a user without that
+    // permission could still observe contract-specific reflected text — and a
+    // prompt-injected / hallucinated value would round-trip back to the UI.
+    //
+    // Until we add a separate post-authorization event type that's safe to
+    // populate from real arguments, pre-execution descriptions stay generic and
+    // never reflect anything from `arguments`. Filter shape (which field the
+    // model chose) is also model-controlled but carries no value content.
     private static string DescribeSearch(IReadOnlyDictionary<string, object?> arguments)
     {
-        var party = TryGetString(arguments, "partyName");
-        var contractNumber = TryGetString(arguments, "contractNumber");
+        var hasParty = !string.IsNullOrEmpty(TryGetString(arguments, "partyName"));
+        var hasContractNumber = !string.IsNullOrEmpty(TryGetString(arguments, "contractNumber"));
 
-        if (!string.IsNullOrEmpty(party))
+        if (hasParty)
         {
-            return $"正在按甲方 \"{party}\" 查找合同…";
+            return "正在按甲方筛选合同…";
         }
 
-        if (!string.IsNullOrEmpty(contractNumber))
+        if (hasContractNumber)
         {
-            return $"正在按合同号 \"{contractNumber}\" 查找合同…";
+            return "正在按合同号查找合同…";
         }
 
         return "正在按条件筛选合同…";
     }
 
     private static string DescribeAggregate(IReadOnlyDictionary<string, object?> arguments)
-    {
-        var party = TryGetString(arguments, "partyName");
-        return string.IsNullOrEmpty(party)
-            ? "正在统计合同金额…"
-            : $"正在统计 \"{party}\" 的合同金额…";
-    }
+        => "正在统计合同金额…";
 
     private static string? TryGetString(IReadOnlyDictionary<string, object?> arguments, string key)
         => arguments.TryGetValue(key, out var value) ? value?.ToString() : null;


### PR DESCRIPTION
Closes #130. Two needs-attention findings from [Codex adversarial review of #129](https://github.com/dignite-projects/dignite-paperbase/pull/129).

## Finding 1 (security-touching) — pre-authorization argument leak

`ContractChatToolContributor.DescribeSearch` / `DescribeAggregate` interpolated raw model-controlled `partyName` / `contractNumber` into the user-facing SSE text. `EmitToolCallEventsAsync` writes the rendered description to the channel **the moment a `FunctionCallContent` arrives** — well before the tool body's `ContractsPermissions.Contracts.Default` check. Three concrete consequences:

- A user holding `Documents.Chat.SendMessage` but lacking `Contracts.Default` received contract-specific reflected text before the tool failed closed
- Whatever the LLM (or a prompt-injecting input) put into `partyName` / `contractNumber` round-tripped to the UI
- The existing per-tool authorization gate ended up only blocking the actual DB query, not the side channel via the progress label

**Fix**: drop raw-argument echo from pre-execution descriptions for module tools. Until/unless we add a separate post-authorization event type, contract progress labels stay generic (`Filtering contracts by Party A…` / `Aggregating contract amounts…`). Filter shape (which field the model chose) survives — also model-controlled but carries no value content. `search_paperbase_documents`'s describer is unaffected; it already echoed structural intent only.

## Finding 2 (compat) — binary-breaking interface signature change

PR #129 added `progressDescriber` (default `null`) directly to the existing `IDocumentChatToolFactory.Create`. Source-compatible for in-tree callers but **binary-incompatible** for any external module compiled against the pre-#129 interface. Optional-parameter defaults bake into the call site at compile time, so a pre-#129 module's compiled assembly references the 4-arg signature and would fail to bind / DI-resolve against an upgraded core package without recompile.

`Dignite.Paperbase.Abstractions` is intended for downstream module consumption per [CLAUDE.md](CLAUDE.md), so mutating the interface signature in place was the wrong shape.

**Fix**: restore the original 4-arg method and add the describer-aware overload via a [C# default interface method](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods) that forwards to the 4-arg for external implementers. First-party `DocumentChatToolFactory` overrides both: 4-arg delegates to 5-arg with `null` describer; 5-arg does the actual work. External modules compiled against the pre-#129 interface continue to load and DI-resolve without changes; their tools just don't get progress descriptions, which is the safe default.

## Test plan

- [x] `dotnet build` (whole solution): 0 errors, 12 pre-existing warnings unrelated
- [x] `dotnet test core/test/Dignite.Paperbase.Application.Tests`: 282 / 282 pass
- [x] `dotnet test core/test/Dignite.Paperbase.Domain.Tests`: 42 / 42 pass
- [x] The streaming progress test from #129 still passes — it asserts on `search_paperbase_documents`'s describer (unchanged in this PR) and the unknown-tool fallback path; it never asserted on the contract describers, so the labels going generic doesn't regress test coverage
- [ ] CI check (will run on push)

## Acceptance (matches Issue #130)

- [x] `DescribeSearch` / `DescribeAggregate` no longer echo `partyName` / `contractNumber` (or any other model-controlled string) in pre-execution `ToolCallStarted` events
- [x] `IDocumentChatToolFactory.Create(4-arg)` signature restored to the pre-#129 form
- [x] All `Application.Tests` pass
- [x] Manual mental check: a user without `ContractsPermissions.Contracts.Default` no longer sees contract-specific reflected progress text — they see a generic `Filtering contracts by Party A…` before the tool fails closed (acceptable: the SYSTEM has the capability is fine to disclose; what shouldn't leak is the data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)