### PR TITLE
feat(chat): consume SSE on the FE; render tool-call progress cards (#116 FE half)

### DIFF
--- a/angular/packages/paperbase/chat/src/lib/chat-panel.component.html
+++ b/angular/packages/paperbase/chat/src/lib/chat-panel.component.html
@@ -171,6 +171,40 @@
 
         @for (item of messages(); track item.id) {
           <div class="message-row" [class.user]="item.role === ChatMessageRole.User">
+            <!--
+              Issue #116: render in-flight tool calls ABOVE the answer bubble so
+              users see "the agent is doing something" the moment a tool fires.
+              Pending entries show a spinner; success/failure entries collapse
+              to a check / cross + duration (sourced from the backend, not the
+              browser, because the backend already has a stopwatch). The
+              `description` text is whatever the tool's progressDescriber
+              returned — never raw model arguments (Issue #130 pre-authz leak).
+            -->
+            @if (item.toolEvents && item.toolEvents.length > 0) {
+              <div class="tool-events">
+                @for (ev of item.toolEvents; track ev.toolCallId) {
+                  <div
+                    class="tool-event"
+                    [class.tool-event-pending]="ev.status === 'pending'"
+                    [class.tool-event-success]="ev.status === 'success'"
+                    [class.tool-event-failure]="ev.status === 'failure'"
+                  >
+                    @if (ev.status === 'pending') {
+                      <span class="spinner-border spinner-border-sm me-2"></span>
+                    } @else if (ev.status === 'success') {
+                      <i class="fas fa-check-circle me-2 text-success"></i>
+                    } @else {
+                      <i class="fas fa-times-circle me-2 text-danger"></i>
+                    }
+                    <span class="tool-event-description">{{ ev.description }}</span>
+                    @if (ev.elapsedMs != null) {
+                      <span class="tool-event-elapsed">{{ ev.elapsedMs | number:'1.0-0' }}ms</span>
+                    }
+                  </div>
+                }
+              </div>
+            }
+
             <div
               class="message-bubble"
               [class.assistant]="item.role === ChatMessageRole.Assistant"

--- a/angular/packages/paperbase/chat/src/lib/chat-panel.component.scss
+++ b/angular/packages/paperbase/chat/src/lib/chat-panel.component.scss
@@ -151,6 +151,57 @@
   margin-top: 0.3rem;
 }
 
+// Issue #116: in-flight tool-call cards rendered above the assistant bubble.
+// Visually distinct from the answer text (subtle border + smaller font) so they
+// read as "system activity" rather than "the assistant said this".
+.tool-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.45rem;
+}
+
+.tool-event {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #e9ecef;
+  border-left-width: 3px;
+  border-radius: 4px;
+  background: #fafbfc;
+  font-size: 0.82rem;
+  color: #495057;
+
+  .tool-event-description {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tool-event-elapsed {
+    font-variant-numeric: tabular-nums;
+    color: #868e96;
+    font-size: 0.75rem;
+    margin-left: auto;
+  }
+}
+
+.tool-event-pending {
+  border-left-color: #0d6efd;
+}
+
+.tool-event-success {
+  border-left-color: #198754;
+}
+
+.tool-event-failure {
+  border-left-color: #dc3545;
+  background: #fff5f5;
+  color: #842029;
+}
+
 .citation {
   border-left-width: 3px !important;
 }

--- a/angular/packages/paperbase/chat/src/lib/chat-panel.component.ts
+++ b/angular/packages/paperbase/chat/src/lib/chat-panel.component.ts
@@ -25,6 +25,8 @@ import {
   ChatConversationDto,
   ChatConversationListItemDto,
   ChatMessageDto,
+  ChatTurnDeltaDto,
+  ChatTurnDeltaKind,
   CreateChatConversationInput,
   DocumentDto,
   DocumentChatService,
@@ -40,6 +42,22 @@ interface ChatMessageView {
   isDegraded?: boolean;
   isPending?: boolean;
   isError?: boolean;
+  // Issue #116: per-message ordered list of tool-call events the agent fired
+  // while producing this assistant turn. Populated only on streaming send;
+  // sync replay (idempotent path) and historical message load leave it empty.
+  toolEvents?: ToolCallEventView[];
+}
+
+// Issue #116: UI projection of ToolCallStarted/Completed pairs. Started events
+// open the entry; the matching Completed flips state to success/failure and
+// fills elapsedMs. Order is the order events arrive on the SSE channel — that
+// matches the order the LLM invoked the tools, which is what users want to read.
+interface ToolCallEventView {
+  toolCallId: string;
+  toolName: string;
+  description: string;
+  status: 'pending' | 'success' | 'failure';
+  elapsedMs?: number;
 }
 
 interface SelectedCitation {
@@ -328,6 +346,21 @@ export class ChatPanelComponent implements OnInit, OnChanges, AfterViewChecked {
       });
   }
 
+  /**
+   * Issue #116: streams the turn so the user sees tool-call progress + text
+   * deltas in real time instead of staring at a `Thinking…` spinner during the
+   * 5–10s the multi-step tool reasoning takes. Internally consumes SSE via
+   * {@link DocumentChatService.sendMessageStream}.
+   *
+   * Lifecycle of the pending assistant message:
+   *  - On send: insert a row with `isPending=true`, empty content, empty toolEvents
+   *  - On `ToolCallStarted`: append an entry to that row's `toolEvents` (status=pending)
+   *  - On `ToolCallCompleted`: flip the matching entry's status (success/failure) +
+   *    fill elapsedMs (matched by toolCallId so out-of-order completions still bind)
+   *  - On `PartialText`: clear `isPending` (we have content now) + append text
+   *  - On `Done`: replace pending id with assistant id, set citations + isDegraded
+   *  - On `Error`: flip to error state
+   */
   private sendToConversation(conversation: ChatConversationDto, text: string): void {
     if (!conversation.id) return;
 
@@ -348,30 +381,16 @@ export class ChatPanelComponent implements OnInit, OnChanges, AfterViewChecked {
         content: '',
         citations: [],
         isPending: true,
+        toolEvents: [],
       },
     ]);
 
     this.isSending.set(true);
     this.chatService
-      .sendMessage(conversation.id, { message: text, clientTurnId })
+      .sendMessageStream(conversation.id, { message: text, clientTurnId })
       .pipe(finalize(() => this.isSending.set(false)))
       .subscribe({
-        next: result => {
-          this.messages.update(items =>
-            items.map(item =>
-              item.id === pendingAssistantId
-                ? {
-                    id: result.assistantMessageId ?? pendingAssistantId,
-                    role: ChatMessageRole.Assistant,
-                    content: result.answer ?? '',
-                    citations: result.citations ?? [],
-                    isDegraded: result.isDegraded,
-                  }
-                : item
-            )
-          );
-          this.loadConversations();
-        },
+        next: delta => this.applyDelta(pendingAssistantId, delta),
         error: () => {
           this.messages.update(items =>
             items.map(item =>
@@ -387,7 +406,80 @@ export class ChatPanelComponent implements OnInit, OnChanges, AfterViewChecked {
           );
           this.toaster.error('::DocumentChat:SendFailed', '::Error');
         },
+        complete: () => this.loadConversations(),
       });
+  }
+
+  /**
+   * Mutates the pending assistant row in place based on a single SSE delta.
+   * Kept alongside {@link sendToConversation} so the streaming wiring stays
+   * grokkable — the kind/branch table here is the spec for the FE half of
+   * `ChatTurnDeltaKind`.
+   */
+  private applyDelta(pendingAssistantId: string, delta: ChatTurnDeltaDto): void {
+    this.messages.update(items =>
+      items.map(item => {
+        if (item.id !== pendingAssistantId) return item;
+
+        switch (delta.kind) {
+          case ChatTurnDeltaKind.ToolCallStarted: {
+            // Defensive: ignore events with no callId — the matching Completed
+            // would be unbindable, leaving a hung "pending" card.
+            if (!delta.toolCallId || !delta.toolName) return item;
+            const events = [...(item.toolEvents ?? [])];
+            events.push({
+              toolCallId: delta.toolCallId,
+              toolName: delta.toolName,
+              description: delta.progressDescription ?? `正在执行 ${delta.toolName}…`,
+              status: 'pending',
+            });
+            return { ...item, toolEvents: events };
+          }
+          case ChatTurnDeltaKind.ToolCallCompleted: {
+            if (!delta.toolCallId) return item;
+            const events = (item.toolEvents ?? []).map(ev =>
+              ev.toolCallId === delta.toolCallId
+                ? {
+                    ...ev,
+                    status: delta.toolCallSucceeded === false ? 'failure' as const : 'success' as const,
+                    elapsedMs: delta.elapsedMs,
+                  }
+                : ev
+            );
+            return { ...item, toolEvents: events };
+          }
+          case ChatTurnDeltaKind.PartialText: {
+            return {
+              ...item,
+              // First text chunk implicitly clears the spinner. If the model
+              // answers without invoking any tool, this is the first thing the
+              // user sees on screen.
+              isPending: false,
+              content: item.content + (delta.text ?? ''),
+            };
+          }
+          case ChatTurnDeltaKind.Done: {
+            return {
+              ...item,
+              id: delta.assistantMessageId ?? item.id,
+              isPending: false,
+              citations: delta.citations ?? [],
+              isDegraded: delta.isDegraded,
+            };
+          }
+          case ChatTurnDeltaKind.Error: {
+            return {
+              ...item,
+              isPending: false,
+              isError: true,
+              content: delta.errorMessage ?? 'DocumentChat:SendFailed',
+            };
+          }
+          default:
+            return item;
+        }
+      })
+    );
   }
 
   private toMessageView(message: ChatMessageDto): ChatMessageView {

--- a/angular/packages/paperbase/src/lib/proxy/documents/chat/models.ts
+++ b/angular/packages/paperbase/src/lib/proxy/documents/chat/models.ts
@@ -40,6 +40,55 @@ export interface ChatTurnResultDto {
   answer?: string;
   citations?: ChatCitationDto[];
   isDegraded?: boolean;
+  // Issue #99: surfaces grounding source so the UI can distinguish "answered
+  // via vector search" / "answered via structured tools" / mixed / none.
+  groundingSource?: GroundingSource;
+}
+
+// Issue #99 / #100: categorises which kinds of tools the model invoked in a turn.
+// Numeric values must match the .NET enum order in
+// core/src/Dignite.Paperbase.Application.Contracts/Chat/GroundingSource.cs.
+export enum GroundingSource {
+  None = 0,
+  Vector = 1,
+  Structured = 2,
+  Mixed = 3,
+}
+
+// Issue #116: SSE delta event shape streamed from the
+// `POST /api/paperbase/document-chat/conversations/{id}/messages/stream` endpoint.
+// Numeric `kind` values must match the .NET enum order in
+// core/src/Dignite.Paperbase.Application.Contracts/Chat/ChatTurnDeltaKind.cs.
+export enum ChatTurnDeltaKind {
+  PartialText = 0,
+  Done = 1,
+  Error = 2,
+  ToolCallStarted = 3,
+  ToolCallCompleted = 4,
+}
+
+export interface ChatTurnDeltaDto {
+  kind: ChatTurnDeltaKind;
+  // PartialText
+  text?: string;
+  // Done
+  citations?: ChatCitationDto[];
+  userMessageId?: string;
+  assistantMessageId?: string;
+  isDegraded?: boolean;
+  groundingSource?: GroundingSource;
+  // Error
+  errorMessage?: string;
+  // ToolCallStarted / ToolCallCompleted (Issue #116)
+  toolName?: string;
+  toolCallId?: string;
+  // ToolCallStarted only — sanitised, user-facing label produced by the tool
+  // contributor's progress describer (see `.claude/rules/doc-chat-anti-patterns.md`
+  // reverse example C #4 / Issue #130: never echoes raw model arguments).
+  progressDescription?: string;
+  // ToolCallCompleted only
+  elapsedMs?: number;
+  toolCallSucceeded?: boolean;
 }
 
 export interface CreateChatConversationInput {

--- a/angular/packages/paperbase/src/lib/proxy/http-api/documents/document-chat.service.ts
+++ b/angular/packages/paperbase/src/lib/proxy/http-api/documents/document-chat.service.ts
@@ -1,13 +1,30 @@
-import { RestService, Rest } from '@abp/ng.core';
+import { AuthService, EnvironmentService, RestService, Rest } from '@abp/ng.core';
 import type { PagedResultDto } from '@abp/ng.core';
 import { Injectable, inject } from '@angular/core';
-import type { ChatConversationDto, ChatConversationListItemDto, ChatMessageDto, ChatTurnResultDto, CreateChatConversationInput, GetChatConversationListInput, GetChatMessageListInput, SendChatMessageInput } from '../../documents/chat/models';
+import { Observable } from 'rxjs';
+import type {
+  ChatConversationDto,
+  ChatConversationListItemDto,
+  ChatMessageDto,
+  ChatTurnDeltaDto,
+  ChatTurnResultDto,
+  CreateChatConversationInput,
+  GetChatConversationListInput,
+  GetChatMessageListInput,
+  SendChatMessageInput,
+} from '../../documents/chat/models';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DocumentChatService {
   private restService = inject(RestService);
+  // Issue #116 FE half: streaming is hand-rolled (fetch + ReadableStream) because
+  // ABP's RestService is request/response shaped. EnvironmentService gives us the
+  // API base URL the rest of the proxy uses; AuthService gives us the same bearer
+  // token RestService would attach.
+  private environmentService = inject(EnvironmentService);
+  private authService = inject(AuthService);
   apiName = 'Default';
 
 
@@ -61,4 +78,96 @@ export class DocumentChatService {
       body: input,
     },
     { apiName: this.apiName,...config });
+
+  /**
+   * Issue #116: streams the per-turn deltas (PartialText + ToolCallStarted /
+   * ToolCallCompleted + Done / Error) from the SSE endpoint at
+   * `POST /api/paperbase/document-chat/conversations/{id}/messages/stream`.
+   *
+   * Why fetch + ReadableStream instead of `EventSource`:
+   * - `EventSource` is GET-only; the backend takes the message body as POST
+   * - `EventSource` cannot set `Authorization` headers without browser polyfills
+   *
+   * The Observable's teardown aborts the fetch, so unsubscribing mid-turn (e.g.
+   * the user navigates away) cancels the underlying HTTP request and the backend
+   * sees `OperationCanceledException` — which `FillStreamingChannelAsync` already
+   * handles by discarding the partial answer instead of persisting it.
+   */
+  sendMessageStream(conversationId: string, input: SendChatMessageInput): Observable<ChatTurnDeltaDto> {
+    return new Observable<ChatTurnDeltaDto>(subscriber => {
+      const controller = new AbortController();
+      const baseUrl = this.environmentService.getApiUrl('default');
+      const url = `${baseUrl}/api/paperbase/document-chat/conversations/${conversationId}/messages/stream`;
+      const token = this.authService.getAccessToken();
+
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(input),
+        signal: controller.signal,
+      })
+        .then(async response => {
+          if (!response.ok || !response.body) {
+            subscriber.error(new Error(`SSE stream failed (HTTP ${response.status})`));
+            return;
+          }
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          try {
+            while (true) {
+              const { value, done } = await reader.read();
+              if (done) break;
+              buffer += decoder.decode(value, { stream: true });
+
+              // SSE events are separated by `\n\n`. Within an event, lines
+              // starting with `data: ` carry the JSON payload (possibly across
+              // multiple lines per the spec — concatenated with `\n`).
+              let separatorIdx: number;
+              while ((separatorIdx = buffer.indexOf('\n\n')) >= 0) {
+                const rawEvent = buffer.slice(0, separatorIdx);
+                buffer = buffer.slice(separatorIdx + 2);
+
+                const dataPayload = rawEvent
+                  .split('\n')
+                  .filter(line => line.startsWith('data:'))
+                  .map(line => line.replace(/^data:\s?/, ''))
+                  .join('\n');
+
+                if (!dataPayload) continue;
+
+                try {
+                  subscriber.next(JSON.parse(dataPayload) as ChatTurnDeltaDto);
+                } catch (parseErr) {
+                  subscriber.error(parseErr);
+                  return;
+                }
+              }
+            }
+            subscriber.complete();
+          } catch (err) {
+            // AbortController-driven cancellation surfaces as DOMException 'AbortError'
+            // — that is normal teardown, not a stream failure.
+            if (controller.signal.aborted) {
+              subscriber.complete();
+            } else {
+              subscriber.error(err);
+            }
+          }
+        })
+        .catch(err => {
+          if (!controller.signal.aborted) {
+            subscriber.error(err);
+          }
+        });
+
+      return () => controller.abort();
+    });
+  }
 }

--- a/core/src/Dignite.Paperbase.HttpApi/Chat/DocumentChatController.cs
+++ b/core/src/Dignite.Paperbase.HttpApi/Chat/DocumentChatController.cs
@@ -15,6 +15,16 @@ namespace Dignite.Paperbase.HttpApi.Chat;
 [Route("api/paperbase/document-chat")]
 public class DocumentChatController : PaperbaseController, IDocumentChatAppService
 {
+    // Issue #116 FE half: the SSE handler below bypasses ABP's MVC pipeline (it
+    // writes the response stream directly), so it never picks up ABP's per-request
+    // JSON options. Default System.Text.Json serializes PascalCase property names,
+    // which would force the Angular consumer to special-case Kind/ToolName/... vs
+    // the camelCase the rest of the proxy types use. JsonSerializerDefaults.Web
+    // gives camelCase + the same enum-as-number convention every other endpoint
+    // in this controller already speaks.
+    private static readonly JsonSerializerOptions SseSerializerOptions =
+        new(JsonSerializerDefaults.Web);
+
     private readonly IDocumentChatAppService _documentChatAppService;
 
     public DocumentChatController(IDocumentChatAppService documentChatAppService)
@@ -77,7 +87,7 @@ public class DocumentChatController : PaperbaseController, IDocumentChatAppServi
         await foreach (var delta in _documentChatAppService.SendMessageStreamingAsync(
             conversationId, input, cancellationToken))
         {
-            var json = JsonSerializer.Serialize(delta);
+            var json = JsonSerializer.Serialize(delta, SseSerializerOptions);
             await Response.WriteAsync($"data: {json}\n\n", cancellationToken);
             await Response.Body.FlushAsync(cancellationToken);
         }


### PR DESCRIPTION
Closes #116 (FE half — backend half landed in #129; security follow-up in #132).

## What lands here

The Angular chat-panel was still calling the **sync** `sendMessage` endpoint while the backend already streamed `ToolCallStarted` / `ToolCallCompleted` events from #129. Result: the user kept staring at a `Thinking…` spinner for the full 5–10s of multi-tool reasoning, even though the agent was demonstrably doing work the whole time.

This PR closes the loop. The FE now consumes the SSE stream and renders per-tool progress cards above the assistant bubble in real time.

## Backend (1 line + comment)

`DocumentChatController`'s SSE handler bypasses ABP's MVC pipeline (writes the response stream directly), so it never picked up ABP's per-request JSON options — default `System.Text.Json` was emitting **PascalCase** property names. Switching to `JsonSerializerDefaults.Web` (one `JsonSerializerOptions` instance, reused) gets us camelCase + the same enum-as-number convention every other endpoint already speaks. No FE branch needed for the field-name skew.

## FE proxy (`models.ts`)

Adds the three new types the streaming consumer needs:

- `ChatTurnDeltaKind` enum — `PartialText / Done / Error / ToolCallStarted / ToolCallCompleted`, numeric values match the .NET enum order
- `ChatTurnDeltaDto` interface — every field nullable; populated only on its matching kind
- `GroundingSource` enum — also extends `ChatTurnResultDto` for the sync path that #99 already added on the backend

> Note: this file still has stale `documentTypeCode` / `topK` / `minScore` fields on `ChatConversationDto` / `CreateChatConversationInput` from before #100. That's a separate proxy-regen housekeeping pass and out of scope here — the existing FE code uses optional access so they fall through harmlessly.

## FE service (`document-chat.service.ts`)

New `sendMessageStream(conversationId, input): Observable<ChatTurnDeltaDto>`. Hand-rolled SSE consumer (`fetch` + `ReadableStream`) because:

- `EventSource` is GET-only; the backend takes the message body as POST
- `EventSource` cannot set `Authorization` headers without browser polyfills

Token + base URL come from `AuthService.getAccessToken()` and `EnvironmentService.getApiUrl('default')` — same plumbing `RestService` would attach for the sync path.

The Observable's teardown calls `AbortController.abort()`, so unsubscribing mid-turn (user navigates away, conversation switched, etc.) cancels the underlying HTTP request. The backend's `FillStreamingChannelAsync` already handles `OperationCanceledException` by discarding the partial answer instead of persisting it — this PR makes that path actually reachable from the UI.

## FE chat-panel (component + html + scss)

- `ChatMessageView` gains `toolEvents: ToolCallEventView[]` (per-message ordered list of started/completed pairs)
- `sendToConversation` switched from `sendMessage` → `sendMessageStream`
- New `applyDelta(...)` reducer handles all five `Kind` branches; correlates `ToolCallStarted` ↔ `ToolCallCompleted` by `toolCallId` so out-of-order completions still bind correctly
- Defensive: `ToolCallStarted` with no `toolCallId` / `toolName` is dropped (would leave a hung pending card otherwise)
- First `PartialText` implicitly clears `isPending` (the spinner)
- `Error` event flips to `isError` + uses backend's safe `errorMessage`

Template renders `toolEvents` **above** the message bubble so the user sees "the agent is doing something" the moment a tool fires:

| Status | Visual |
|---|---|
| `pending` | spinner + description |
| `success` | `✓` icon + description + elapsed ms (from backend stopwatch, not browser) |
| `failure` | `✕` icon + description, distinct red background |

Description text is whatever the tool's `progressDescriber` returned. Issue #130 already locked this down: never echoes raw model arguments.

## What we did NOT do (intentional out-of-scope)

- **No frontend tests added.** The Angular workspace currently has no test setup for the chat package; bootstrapping that is its own task.
- **The 4.51 kB component-style budget warning** is a known existing pattern (`home.component.scss` is also over). Build passes; not a blocker.
- **Idempotent replay path** (sync `sendMessage` → `BuildTurnResultFromPersisted`) still works for retries — we kept the sync proxy method unchanged so any future retry UI can use it.
- **Stale `documentTypeCode` / `topK` / `minScore` proxy fields** from before #100 — separate housekeeping.

## Test plan

- [x] `dotnet build core/src/Dignite.Paperbase.HttpApi`: 0 errors
- [x] `npx nx build paperbase`: succeeds, all secondary entry-points (incl. `chat`) built
- [x] `npx nx build host`: succeeds end-to-end (`Application bundle generation complete`); only the pre-existing SCSS budget warning
- [x] Manual mental walk-through: `Started → Started → Completed → Completed → PartialText × N → Done` arrives in order, `applyDelta` reducer handles each branch, abort on unsubscribe cancels the fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)