### PR TITLE
fix(angular): clear three template eslint errors from #129/#133

### DIFF
--- a/angular/packages/paperbase/chat/src/lib/chat-panel.component.html
+++ b/angular/packages/paperbase/chat/src/lib/chat-panel.component.html
@@ -197,7 +197,7 @@
                       <i class="fas fa-times-circle me-2 text-danger"></i>
                     }
                     <span class="tool-event-description">{{ ev.description }}</span>
-                    @if (ev.elapsedMs != null) {
+                    @if (ev.elapsedMs !== null && ev.elapsedMs !== undefined) {
                       <span class="tool-event-elapsed">{{ ev.elapsedMs | number:'1.0-0' }}ms</span>
                     }
                   </div>

--- a/angular/packages/paperbase/documents/src/lib/document-relation-graph/document-relation-graph.component.html
+++ b/angular/packages/paperbase/documents/src/lib/document-relation-graph/document-relation-graph.component.html
@@ -8,17 +8,18 @@
     <div class="d-flex align-items-center gap-2 flex-wrap">
       <!-- Depth selector -->
       <div class="btn-group btn-group-sm" role="group">
-        <button
-          *ngFor="let d of [1, 2, 3]"
-          type="button"
-          class="btn"
-          [class.btn-primary]="depth() === d"
-          [class.btn-outline-secondary]="depth() !== d"
-          (click)="setDepth(d)"
-          [disabled]="isLoading()"
-        >
-          {{ d }} {{ '::Document:RelationGraph:Hop' | abpLocalization }}
-        </button>
+        @for (d of [1, 2, 3]; track d) {
+          <button
+            type="button"
+            class="btn"
+            [class.btn-primary]="depth() === d"
+            [class.btn-outline-secondary]="depth() !== d"
+            (click)="setDepth(d)"
+            [disabled]="isLoading()"
+          >
+            {{ d }} {{ '::Document:RelationGraph:Hop' | abpLocalization }}
+          </button>
+        }
       </div>
 
       <!-- Show AiSuggested toggle -->
@@ -149,7 +150,7 @@
               <span class="badge bg-warning text-dark ms-1">
                 <i class="fas fa-robot me-1"></i>{{ '::Document:RelationSource:AI' | abpLocalization }}
               </span>
-              @if (e.confidence != null && e.confidence > 0) {
+              @if (e.confidence !== null && e.confidence !== undefined && e.confidence > 0) {
                 <span class="text-muted ms-2">{{ (e.confidence * 100).toFixed(0) }}%</span>
               }
             } @else if (e.source === RelationSource.Manual) {


### PR DESCRIPTION
After PR #134 (chat SSE FE) merged, the \`build-angular\` job went red on \`main\` with three template lint errors — one carried in from #129 (this PR's chat-panel work), two from the parallel #133 RelationDiscovery viewer landing in the same window. All three are local template-syntax modernisations; no behavior change.

| File | Line | Rule | Fix |
|---|---|---|---|
| \`chat-panel.component.html\` | 200 | \`@angular-eslint/template/eqeqeq\` | \`ev.elapsedMs != null\` → \`!== null && !== undefined\` |
| \`document-relation-graph.component.html\` | 12 | \`@angular-eslint/template/prefer-control-flow\` | \`*ngFor="let d of [1,2,3]"\` → \`@for (d of [1,2,3]; track d)\` |
| \`document-relation-graph.component.html\` | 152 | \`@angular-eslint/template/eqeqeq\` | \`e.confidence != null\` → \`!== null && !== undefined\` |

## Test plan

- [x] \`npx nx lint paperbase\`: passes locally (\`All files pass linting.\`) — note: I also ran \`npm install\` to pull in \`@typescript-eslint/utils\` so the lint actually runs on a fresh checkout; same gap PR #108 already fixed in CI
- [ ] CI \`build-angular\` (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)