### PR TITLE
docs: refresh chat docs for anchor model + SSE streaming + GroundingSource

### DIFF
--- a/docs/ai-provider.md
+++ b/docs/ai-provider.md
@@ -185,7 +185,7 @@ context.Services.AddOpenTelemetry()
 | Source / Meter | Emitted by | What it covers |
 | --- | --- | --- |
 | `Experimental.Microsoft.Extensions.AI` (Activity + Meter) | `OpenTelemetryChatClient` | OTel GenAI semantic conventions: `chat {model}` / `execute_tool {name}` spans, `gen_ai.client.operation.duration` (s), `gen_ai.client.token.usage`, streaming `time_to_first_chunk` / `time_per_output_chunk` |
-| `Dignite.Paperbase.DocumentChat` (Meter) | `DocumentChatTelemetryRecorder` | Project-specific deltas only: `paperbase.document_chat.turn.degraded` counter (the "honest signal" — model declined to invoke search OR retrieval failed) and `paperbase.document_chat.tool.result.size` histogram. **Does not duplicate** the gen_ai.* signals above. |
+| `Dignite.Paperbase.DocumentChat` (Meter) | `DocumentChatTelemetryRecorder` | Project-specific deltas only: `paperbase.document_chat.turn.degraded` counter (the "honest signal" — model invoked **no tool at all**, equivalent to `GroundingSource == None`) and `paperbase.document_chat.tool.result.size` histogram. The full per-turn / per-tool dimensions (`GroundingSource`, `ToolCallSummary`, `ToolCallDepth`, `CitationsTrimmed`, `AnchorResolutionFailed`) are attached to `AbpAuditLogs.ExtraProperties` rather than emitted as metric tags — see [document-chat.md → Observability](document-chat.md#observability). **Does not duplicate** the gen_ai.* signals above. |
 
 Business-domain audit (tenant / user / conversation / document) goes to
 `AbpAuditLogs.Comments` + `ExtraProperties` (`DocumentChatTelemetryRecorder`

--- a/docs/document-chat-client.md
+++ b/docs/document-chat-client.md
@@ -24,17 +24,19 @@ Content-Type: application/json
 
 {
   "title": "Q4 Contract Review",
-  "documentTypeCode": "Contract"
+  "documentId": "d9e8f7a6-1234-5678-9abc-def012345678"
 }
 ```
 
-`documentId` and `documentTypeCode` are mutually exclusive. Omit both for a global (all-documents) conversation scope.
+Both `title` and `documentId` are optional. `documentId` is the **anchor** — the document the user opened when starting the chat. The server hints the anchor's `id` + `documentTypeCode` to the model each turn, but **does not constrain retrieval** to it. The model is free to search across other documents and types. Omit `documentId` for a chat that starts with no anchor.
+
+> Removed since 2026-05: `documentTypeCode`, `topK`, and `minScore` are no longer accepted on create. Per-turn retrieval defaults come from server-side `PaperbaseAIBehavior` (see [document-chat.md → Configuration](document-chat.md#configuration)) and the model decides per call whether to override them via the `search_paperbase_documents` tool parameters.
 
 ```bash
 curl -X POST https://localhost:44393/api/paperbase/document-chat/conversations \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"title":"Q4 Contract Review","documentTypeCode":"Contract"}'
+  -d '{"title":"Q4 Contract Review","documentId":"d9e8f7a6-1234-5678-9abc-def012345678"}'
 ```
 
 **Expected response — 200 OK**
@@ -44,10 +46,7 @@ curl -X POST https://localhost:44393/api/paperbase/document-chat/conversations \
   "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "tenantId": null,
   "title": "Q4 Contract Review",
-  "documentId": null,
-  "documentTypeCode": "Contract",
-  "topK": null,
-  "minScore": null,
+  "documentId": "d9e8f7a6-1234-5678-9abc-def012345678",
   "creationTime": "2026-04-30T09:12:00Z"
 }
 ```
@@ -55,9 +54,7 @@ curl -X POST https://localhost:44393/api/paperbase/document-chat/conversations \
 | Field | Meaning |
 |---|---|
 | `id` | Use as `conversationId` in subsequent calls |
-| `documentTypeCode` | RAG retrieval is scoped to documents of this type |
-| `documentId` | If set, retrieval is limited to a single document |
-| `topK` / `minScore` | `null` means "use server-side [`PaperbaseKnowledgeIndex`](knowledge-index.md#provider-neutral-defaults) defaults" |
+| `documentId` | Anchor document. Hinted to the model as soft context; **not** a retrieval scope. May be `null`. |
 
 ---
 
@@ -124,26 +121,118 @@ curl -X POST \
       "sourceName": "Document d9e8f7a6-... (chunk #12)"
     }
   ],
-  "isDegraded": false
+  "isDegraded": false,
+  "groundingSource": 1
 }
 ```
 
 | Field | Meaning |
 |---|---|
 | `answer` | The model's response for this turn |
-| `citations` | RAG retrieval results that grounded the answer; empty if none |
+| `citations` | RAG retrieval results that grounded the answer; empty if the model used only structured tools or no tools at all |
 | `citations[].documentId` | Source document to load before showing the Markdown source pane |
 | `citations[].pageNumber` | Compatibility/metadata field only. Do not use it to choose a PDF viewer or drive citation navigation |
 | `citations[].chunkIndex` | Knowledge-index chunk ordinal for display/debug context |
 | `citations[].snippet` | Truncated text chunk (≤ 200 graphemes). This is the primary client-side highlight key |
 | `citations[].sourceName` | Human-readable source label for display |
-| `isDegraded` | `true` if retrieval was unavailable and the answer used context-only fallback |
+| `isDegraded` | `true` when `groundingSource == None`, i.e. the model produced an answer without invoking any tool. **Not** an infrastructure-failure signal on its own. |
+| `groundingSource` | `0` = `None`, `1` = `Vector`, `2` = `Structured`, `3` = `Mixed`. See [document-chat.md → Grounding source and degraded answers](document-chat.md#grounding-source-and-degraded-answers) for the full classification rule. |
 
 For clickable citation behavior, see [document-chat.md → Citation-to-source navigation](document-chat.md#citation-to-source-navigation). In short: open `documentId`, render `Document.Markdown`, highlight `snippet` when possible, and treat `chunkIndex` as context only.
 
 ---
 
-## 3. Retry Logic (409 Conflict)
+## 3. Stream a Message (Server-Sent Events)
+
+**POST** `/conversations/{conversationId}/messages/stream`
+
+The streaming endpoint returns Server-Sent Events (`Content-Type: text/event-stream`) and emits incremental deltas as the model produces them: text tokens, tool-call start/finish events, and a terminal `Done` (or `Error`) event. Use it when you want a Claude-Code-style "live activity" UI rather than a single buffered answer.
+
+The request body, idempotency contract, and 409 retry semantics are identical to the buffered endpoint in section 2 — the same `clientTurnId` is honoured. The server persists at the same boundary; if the client drops mid-stream, the abort cancels the underlying request and **no partial answer is committed**.
+
+```http
+POST /api/paperbase/document-chat/conversations/3fa85f64-…/messages/stream
+Authorization: Bearer {token}
+Content-Type: application/json
+Accept: text/event-stream
+
+{
+  "message": "What are the payment terms in this contract?",
+  "clientTurnId": "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+}
+```
+
+### Delta schema
+
+Each SSE event carries one JSON object on a single `data:` line. The discriminator is `kind`:
+
+| `kind` (numeric) | Name | Description |
+|---|---|---|
+| `0` | `PartialText` | Incremental text token. Concatenate `text` onto the assistant bubble. |
+| `1` | `Done` | Terminal success. Carries the final `citations`, `userMessageId`, `assistantMessageId`, `isDegraded`, `groundingSource`. |
+| `2` | `Error` | Terminal failure. Carries `errorMessage`. The stream closes after this event. |
+| `3` | `ToolCallStarted` | A tool invocation began. Carries `toolName`, `toolCallId`, `progressDescription`. |
+| `4` | `ToolCallCompleted` | The tool with this `toolCallId` finished. Carries `elapsedMs` and `toolCallSucceeded`. |
+
+```ts
+// Discriminated-union shape (see angular/packages/paperbase/src/lib/proxy/documents/chat/models.ts)
+interface ChatTurnDeltaDto {
+  kind: 0 | 1 | 2 | 3 | 4;
+  // PartialText
+  text?: string;
+  // Done
+  citations?: ChatCitationDto[];
+  userMessageId?: string;
+  assistantMessageId?: string;
+  isDegraded?: boolean;
+  groundingSource?: 0 | 1 | 2 | 3;
+  // Error
+  errorMessage?: string;
+  // ToolCallStarted / ToolCallCompleted
+  toolName?: string;
+  toolCallId?: string;
+  // ToolCallStarted only — sanitised, user-facing label produced by the tool's
+  // progress describer. Never raw model arguments.
+  progressDescription?: string;
+  // ToolCallCompleted only
+  elapsedMs?: number;
+  toolCallSucceeded?: boolean;
+}
+```
+
+### Example wire trace
+
+```
+data: {"kind":3,"toolName":"search_paperbase_documents","toolCallId":"call_01","progressDescription":"正在按问题语义检索文档…"}
+
+data: {"kind":4,"toolName":"search_paperbase_documents","toolCallId":"call_01","elapsedMs":342,"toolCallSucceeded":true}
+
+data: {"kind":0,"text":"Payment is due within 30"}
+
+data: {"kind":0,"text":" days of invoice date per clause 5.2."}
+
+data: {"kind":1,"userMessageId":"a1b2c3d4-…001","assistantMessageId":"a1b2c3d4-…002","citations":[…],"isDegraded":false,"groundingSource":1}
+```
+
+### Consumer guarantees
+
+- **Tool-call correlation** — `ToolCallStarted` and `ToolCallCompleted` are correlated by `toolCallId`. The server emits started events as the model fires them and completed events as each finishes; the model can fan out tools in parallel, so completed events do not necessarily arrive in started-event order.
+- **`progressDescription` is always sanitised** — every tool registered through `IDocumentChatToolFactory.Create(..., progressDescriber)` produces a static or structurally-derived label (e.g. `"正在按甲方筛选合同…"`). It **never echoes raw user input or raw model arguments**, so it is safe to render directly in the UI before any per-tool authorization check has fired.
+- **`Done` is the only signal that text is complete** — earlier `PartialText` events have no terminator. Wait for `kind == 1` before clearing any "thinking…" state.
+- **`Error` (`kind == 2`) is terminal** — the server closes the stream after emitting it. Treat as the stream-equivalent of a non-200 response on the buffered endpoint.
+- **JSON casing** — payloads are camelCase (`JsonSerializerDefaults.Web`), matching the rest of the proxy types.
+
+### Why not `EventSource`?
+
+`EventSource` is GET-only and cannot set `Authorization` headers without polyfills. Consume the stream with `fetch` + `ReadableStream` + `AbortController` (see `angular/packages/paperbase/src/lib/proxy/http-api/documents/document-chat.service.ts → sendMessageStream` for a reference Angular implementation that exposes the deltas as an RxJS `Observable<ChatTurnDeltaDto>`).
+
+### Cancellation
+
+Aborting the underlying `fetch` (e.g. user navigates away, switches conversation) cancels the server-side `OperationCanceledException` path, which discards the in-flight assistant message instead of persisting a half-formed answer. The user message is also **not** persisted in this case — re-sending with the same `clientTurnId` will re-run the model, not return a cached partial.
+
+---
+
+## 4. Retry Logic (409 Conflict)
 
 A 409 response means a concurrent turn is already being committed on the same
 conversation (optimistic-concurrency stamp mismatch). The correct response is:
@@ -215,9 +304,12 @@ called twice for the same turn.
   "assistantMessageId": "a1b2c3d4-0000-0000-0000-000000000002",
   "answer": "Payment is due within 30 days of invoice date per clause 5.2.",
   "citations": [],
-  "isDegraded": false
+  "isDegraded": false,
+  "groundingSource": 1
 }
 ```
 
 The `userMessageId` and `assistantMessageId` are the original persisted turn IDs.
 They do not change when the same `clientTurnId` is replayed.
+
+`groundingSource` on a replay is a **best-effort approximation** — the per-turn audit scope is gone by the time the replay runs, and `ChatMessage` does not persist the original classification. The replay reconstructs it from the persisted `IsDegraded` flag and citation count: degraded ⇒ `None`; otherwise citations ⇒ `Vector`, no citations ⇒ `Structured`. `Mixed` and `Vector` are indistinguishable on replay. Do not rely on `groundingSource` for branching logic on idempotent retries — use the live response instead.

--- a/docs/document-chat.md
+++ b/docs/document-chat.md
@@ -6,10 +6,11 @@ This page covers the chat as a *feature* — what it does, how to tune it, and w
 
 ## What it can do
 
-- **Conversation-scoped retrieval.** A conversation can be unscoped (search across all the user's documents), scoped to a `documentTypeCode` (e.g. only contracts), or scoped to a single `documentId`.
-- **Citations.** Every answer carries the chunk(s) that grounded it. The agent prompt enforces `[chunk N]` citations and the result is post-processed into a structured `citations` array (document id, chunk index, snippet, source name).
-- **Tool calling.** Business modules contribute structured query tools through `IDocumentChatToolContributor`. Example: a `ContractChatToolContributor` can let the model call `search_contracts` to filter by counterparty or amount, alongside the built-in `search_paperbase_documents` semantic-search tool. Each tool runs **fail-closed**: explicit permission check + explicit tenant predicate + result-row cap inside the tool body. See [`.claude/rules/doc-chat-anti-patterns.md`](../.claude/rules/doc-chat-anti-patterns.md) for the contract.
-- **Idempotent turns.** The client generates a `clientTurnId` per turn; replays with the same id never re-invoke the model.
+- **Anchor-driven, not scope-locked.** A conversation may carry a `documentId` — the document the user opened when starting the chat. This is treated as a **soft anchor** in the system prompt (`id` + `documentTypeCode` only — never the title), not a retrieval constraint. The model is free to (and encouraged to) search across other documents and types, follow `DocumentRelation` edges, and reconcile across the corpus. A conversation without `documentId` behaves the same way, just without the anchor hint.
+- **Citations.** Every answer carries the chunk(s) that grounded it. The agent prompt enforces `[chunk N]` citations and the result is post-processed into a structured `citations` array (document id, chunk index, snippet, source name). Citations from multiple `search_paperbase_documents` invocations within one turn are **appended and de-duplicated** — never overwritten — and capped at `MaxCapturedCitations`.
+- **Tool calling.** The agent always sees the same flat toolset (built-in tools + every business module's contributor tools). See the [Tools](#tools) section below for the catalog and the fail-closed contract every tool follows.
+- **Streaming.** The HTTP API exposes both a buffered `POST .../messages` and a Server-Sent-Events `POST .../messages/stream` endpoint. The streaming endpoint emits `PartialText`, `ToolCallStarted`, `ToolCallCompleted`, and a terminal `Done` (or `Error`) delta — see [client guide → Streaming](document-chat-client.md#3-stream-a-message-server-sent-events) for the protocol.
+- **Idempotent turns.** The client generates a `clientTurnId` per turn; replays with the same id never re-invoke the model. Idempotency applies to both the buffered and streaming endpoints.
 - **Optional LLM rerank.** Off by default. When enabled, retrieval recall is expanded `RecallExpandFactor`× and the chat model rescues the most relevant `TopK` before the answer prompt.
 
 ## Permissions
@@ -31,19 +32,78 @@ Chat-related knobs live in `PaperbaseAIBehavior` alongside the other Application
 "PaperbaseAIBehavior": {
   "EnableLlmRerank": false,
   "RecallExpandFactor": 4,
-  "DocumentChatMinScore": 0.45
+  "DocumentChatTopK": 5,
+  "DocumentChatMinScore": 0.45,
+  "MaxCapturedCitations": 50,
+  "MaxToolsPerTurn": 0
 }
 ```
 
 | Key | Default | Description |
 | --- | --- | --- |
 | `EnableLlmRerank` | `false` | When enabled, document chat retrieves an expanded candidate set, asks the chat model to rerank chunks by question relevance, and injects only the final `TopK` into the answer prompt. Off by default to conserve tokens; enable when retrieval quality is the bottleneck (often in mixed-language corpora). |
-| `RecallExpandFactor` | `4` | Multiplier applied to the conversation's `topK` (or `PaperbaseKnowledgeIndex:DefaultTopK`) before LLM rerank. With the defaults `topK=5` × `4` = 20 candidates rescored. |
-| `DocumentChatMinScore` | `0.45` | Default normalized cosine threshold for document chat RAG searches when the conversation has no explicit `minScore`. This is intentionally lower than `PaperbaseKnowledgeIndex:MinScore` to improve recall for cross-language questions and proper-noun lookups. Set to `null` to fall back to the knowledge-index default. |
+| `RecallExpandFactor` | `4` | Multiplier applied to `DocumentChatTopK` (or `PaperbaseKnowledgeIndex:DefaultTopK`) before LLM rerank. With the defaults `topK=5` × `4` = 20 candidates rescored. |
+| `DocumentChatTopK` | `5` | Default top-K passed to `search_paperbase_documents` when the model does not specify it. The model can override per call (e.g. raise to 10–15 for cross-document reconciliation). |
+| `DocumentChatMinScore` | `0.45` | Default normalized cosine threshold for document chat RAG searches when the model does not specify `minScore`. Intentionally lower than `PaperbaseKnowledgeIndex:MinScore` to improve recall for cross-language questions and proper-noun lookups. |
+| `MaxCapturedCitations` | `50` | Hard upper bound on the number of distinct citations a single turn may accumulate across all `search_paperbase_documents` calls. When the cap is hit, additional results are dropped and `CitationsTrimmed = true` is recorded on the audit row. Defends against prompt-injection-driven citation bombs. |
+| `MaxToolsPerTurn` | `0` (unlimited) | Soft cap on the number of contributor tools exposed to the agent per turn. `0` means no cap. When the cap is exceeded, the dispatcher prefers tools whose contributor `DocumentTypeCode` matches the conversation anchor and trims the rest, recording `ToolsTrimmed = true`. Leave at `0` until business modules genuinely outgrow the model's tool-list comprehension. |
 
-Document chat uses a single MAF tool-calling path: the agent exposes `search_paperbase_documents` (RAG) plus any business-module contributor tools, with `ChatToolMode.Auto` so the model picks when (and with what query / `documentIds`) to invoke them. There is no operator switch for "always retrieve before answering" — see *When the answer is degraded* below for the honest-signal contract that replaced it.
+The agent uses `ChatToolMode.Auto` — the model picks when (and with what `documentIds` / `documentTypeCode` / `topK` / `minScore`) to invoke each tool. There is no operator switch for "always retrieve before answering" — see *When the answer is degraded* below for the honest-signal contract that replaced it.
+
+`IDocumentChatToolContributor.DocumentTypeCode` is **informational** — it is *not* a filter. Every contributor's tools are exposed on every turn regardless of conversation anchor. The field is used only as a tie-breaker hint for `MaxToolsPerTurn` trimming and to help reviewers understand intent. Do not rely on it for authorization (do that inside each tool body — see *Adding a tool contributor* below).
 
 The hard cap on tool-call rounds within a single turn is configured at host wiring time via `PaperbaseAI:MaxToolIterations` (default `10`); see [ai-provider.md → Provider wiring](ai-provider.md#provider-wiring-paperbaseai). For prompt language behavior, see [ai-provider.md → Cross-cutting LLM behavior](ai-provider.md#cross-cutting-llm-behavior-paperbaseaibehavior). For retrieval `topK` / `minScore` defaults, see [knowledge-index.md](knowledge-index.md). For BM25-augmented hybrid retrieval, see [hybrid-search.md](hybrid-search.md).
+
+## Tools
+
+The agent's toolset is the union of the built-in tools below plus every `IDocumentChatToolContributor`-registered tool. The model picks when, in what order, and with what arguments to invoke each — there is no scripted workflow.
+
+### Built-in tools
+
+| Tool | What it does | Notes |
+|---|---|---|
+| `search_paperbase_documents` | Semantic vector search over the user's documents. The model supplies a natural-language `query`; optional `documentIds[]`, `documentTypeCode`, `topK`, `minScore` parameters let it drill in after a structured-tool round. | Tenant-scoped at the binding layer (`_tenantId` is captured in the closure, not derived from `DataFilter`). Defaults from `PaperbaseAIBehavior:DocumentChatTopK` / `:DocumentChatMinScore`. Citations from all calls in one turn are appended + deduplicated up to `MaxCapturedCitations`. |
+| `get_document_relations` | Bidirectional lookup over the `DocumentRelation` aggregate — returns documents linked to a given `documentId` (manual + AI-discovered edges). Ordered by source (`Manual` first) then by `Confidence` desc, capped at 20 per call. | Requires `Paperbase.Documents.Default` (re-asserted inside the tool body). Powers cross-document reasoning chains like contract → matching invoices. See [relation-discovery.md](relation-discovery.md) for how the underlying graph is populated. |
+
+### Contributor tools
+
+Every business module that wants to expose structured queries to the agent ships an `IDocumentChatToolContributor` (registered as `ITransientDependency`). Reference: `modules/contracts/src/Dignite.Paperbase.Contracts.Application/Chat/ContractChatToolContributor.cs` contributes:
+
+- `search_contracts` — list contracts by counterparty / number / status
+- `get_contract_detail` — fetch a single contract's structured fields
+- `get_contract_aggregate` — sum amounts across a filtered contract set
+
+See [Adding a tool contributor](#adding-a-tool-contributor-business-modules) for the contract every new contributor must follow.
+
+### The fail-closed contract
+
+Every tool — built-in or contributor — must satisfy the same three rules inside its method body, because the LLM (not the HTTP authorization filter) decides when to call it. HTTP-level `[Authorize]` on the AppService does **not** cover these calls.
+
+1. **Explicit permission check** via `IAuthorizationService.CheckAsync(...)`. The Chat permission alone is insufficient — each tool re-asserts the feature permission relevant to its data.
+2. **Explicit tenant predicate** in the query (`Where(x => x.TenantId == _tenantId)`). Do not rely on ABP's ambient `DataFilter` — any code path that disables it would silently leak across tenants.
+3. **Hard `Take(N)` row cap** to defend against prompt-injection-driven recall bombs.
+
+Reverse examples and the rationale: [`.claude/rules/doc-chat-anti-patterns.md`](../.claude/rules/doc-chat-anti-patterns.md), reverse examples C and D.
+
+### Tool-call progress description
+
+The streaming endpoint emits a `ToolCallStarted` delta when the model fires a tool. The user-facing label on that delta comes from the optional `progressDescriber` parameter on `IDocumentChatToolFactory.Create(..., progressDescriber)`:
+
+```csharp
+yield return toolFactory.Create(
+    ctx,
+    binding.SearchAsync,
+    name: "search_contracts",
+    description: "Search contracts by counterparty…",
+    progressDescriber: args =>
+    {
+        if (args.TryGetValue("partyName", out _)) return "正在按甲方筛选合同…";
+        if (args.TryGetValue("contractNumber", out _)) return "正在按合同编号查找合同…";
+        return "正在检索合同…";
+    });
+```
+
+The describer is **structural only** — it inspects which arguments the model supplied but **must never echo their values**. Echoing raw arguments would leak data before any per-tool permission check has fired (see [`.claude/rules/doc-chat-anti-patterns.md`](../.claude/rules/doc-chat-anti-patterns.md) reverse example C #4). Tools that omit `progressDescriber` get a generic fallback (`"正在执行 {toolName}…"`).
 
 ## Citation-to-source navigation
 
@@ -79,16 +139,46 @@ The original file is still available through the document detail experience, but
 
 Do not add `preferredView` to server DTOs. There is only one citation source view today: Markdown. If exact positioning becomes necessary later, prefer adding Markdown offsets or persisted source ranges after measuring snippet-match failures in production data.
 
-## When the answer is degraded
+## Grounding source and degraded answers
 
-`ChatTurnResultDto.IsDegraded = true` flags answers that ran without retrieval grounding. Two cases produce it:
+Every turn carries a `groundingSource` enum on `ChatTurnResultDto` describing what kind of evidence the answer rests on:
+
+| `groundingSource` | Meaning | `isDegraded` |
+|---|---|---|
+| `None` (0) | The model produced an answer **without invoking any tool** — no search, no contributor tool. Falls back to conversation history and the model's parametric knowledge. | `true` |
+| `Vector` (1) | The model invoked `search_paperbase_documents` (and/or other vector-backed retrieval) at least once. Retrieved chunks are reflected in `citations`. | `false` |
+| `Structured` (2) | The model invoked only structured/contributor tools (`search_contracts`, `get_contract_aggregate`, `get_document_relations`, …). The answer is grounded in business data, often without text citations. | `false` |
+| `Mixed` (3) | The model invoked both vector search and structured tools in the same turn. | `false` |
+
+`isDegraded` is therefore equivalent to `groundingSource == None`. The classification is performed by inspecting the turn's tool-call audit trail in `DocumentChatTelemetryRecorder` — there is no separate flag the model can lie about.
 
 | Cause | What happened | What to do |
 |---|---|---|
-| Knowledge index unavailable | `IDocumentKnowledgeIndex.SearchAsync` threw — Qdrant down, network fault, etc. | Treat as a transient infrastructure incident. The model still produced an answer using only conversation history. |
-| Model declined to invoke `search_paperbase_documents` | The model judged the question answerable without retrieval (greetings, follow-up clarifications, contributor-tool answers that don't need RAG). | Accept it: citations reflect what the model *actually used*; an empty list with `IsDegraded = true` is the honest signal. If a class of questions is consistently answered without search where you want it grounded, tighten the QA system prompt in `DefaultPromptProvider` rather than forcing pre-injection. |
+| Knowledge index unavailable | `IDocumentKnowledgeIndex.SearchAsync` threw — Qdrant down, network fault, etc. The model may still call other tools or fall back to history. | Treat as a transient infrastructure incident. If the model still called structured tools, the turn is `Structured`, not `None`. |
+| Model declined to invoke any tool | The model judged the question answerable without retrieval (greetings, follow-up clarifications). | Accept it: an empty `citations` array with `groundingSource = None` and `isDegraded = true` is the honest signal. If a class of questions is consistently answered without tool calls where you want them grounded, tighten the QA system prompt in `DefaultPromptProvider` rather than forcing pre-injection. |
 
-`isDegraded` is surfaced to the API client so UIs can show a "no sources used" banner.
+`isDegraded` and `groundingSource` are both surfaced on the API response so the UI can show a "no sources used" banner or a "answered from contract data" badge.
+
+## Observability
+
+Beyond the OpenTelemetry signals from `Microsoft.Extensions.AI` (see [ai-provider.md → OpenTelemetry signals](ai-provider.md#opentelemetry-signals)), each turn enriches the ABP audit row through `DocumentChatTelemetryRecorder`. Two structured payloads are attached to `AbpAuditLogs.ExtraProperties`:
+
+| Property key | Shape | Meaning |
+| --- | --- | --- |
+| `DocumentChat.Turn` | `DocumentChatTurnAuditEntry` (single object) | One per turn. Carries `ConversationId`, `Streaming`, `CitationCount`, `IsDegraded`, `ElapsedMs`, `Outcome`, plus the dimensions in the table below. |
+| `DocumentChat.ToolCalls` | `IReadOnlyList<DocumentChatToolAuditEntry>` | One entry per tool invocation, in call order. Carries `ToolName`, `ArgumentsSummary` (sanitised — never raw user input), `ResultSizeBytes`, `ElapsedMs`, `Outcome`, `ExceptionType`. |
+
+Notable fields on `DocumentChat.Turn`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `GroundingSource` | enum | `None` / `Vector` / `Structured` / `Mixed` — derived by `ClassifyGrounding` from the per-tool entries, not a flag the model can set |
+| `ToolCallDepth` | `int` | Total tool invocations in this turn (sum of `ToolCallSummary` values; includes failed invocations because they reflect actual model behaviour) |
+| `ToolCallSummary` | `Dictionary<string,int>` | Per-tool invocation count, e.g. `{ "search_paperbase_documents": 2, "get_contract_detail": 1 }` |
+| `CitationsTrimmed` | `bool` | `true` if `MaxCapturedCitations` was hit and additional vector-search hits were dropped |
+| `AnchorResolutionFailed` | `bool` | `true` if the conversation has a `documentId` but the per-turn anchor lookup degraded (document deleted, tenant mismatch, or caller lost `Documents.Default`). The turn proceeds **without** the anchor hint — never throws 404. |
+
+These dimensions are what drives the upgrade decision in the future: if production telemetry shows `ToolCallDepth > 8` for ≥ 20% of turns, that is the trigger to evaluate planner sub-agents (Magentic Orchestration). Until then, the single `ChatClientAgent` + flat tool list is intentionally kept simple — see [`.claude/rules/doc-chat-anti-patterns.md`](../.claude/rules/doc-chat-anti-patterns.md) reverse example D for the rationale against premature `AsAIFunction()` sub-agents.
 
 ## Adding a tool contributor (business modules)
 


### PR DESCRIPTION
## Summary

Catches the public-facing chat docs up to four merged Slices that landed without doc updates of their own. No code changes — `docs/` only.

| Slice | What it changed | What this PR documents |
|---|---|---|
| #100 | DocumentId became a soft anchor (id + typeCode hint, never Title); DocumentTypeCode/TopK/MinScore dropped from the conversation; per-turn anchor re-assertion may degrade silently | new \`## Tools\` section, anchor semantics, removed-fields callout in client guide |
| #99  | Citations append + dedup + cap; IsDegraded ≡ \`GroundingSource == None\` | new \`## Grounding source and degraded answers\` section + updated client response shape with \`groundingSource\` |
| #98  | Per-turn audit dimensions (\`GroundingSource\`, \`ToolCallSummary\`, \`ToolCallDepth\`, \`CitationsTrimmed\`, \`AnchorResolutionFailed\`) on \`AbpAuditLogs.ExtraProperties\` | new \`## Observability\` section + corrected \`turn.degraded\` definition in ai-provider.md |
| #116 / #129 / #130 | SSE streaming endpoint + \`ChatTurnDelta\` wire format + sanitised \`progressDescriber\` contract | new section 3 in client guide; \`### Tool-call progress description\` in document-chat.md |

Also fixes a dangling anchor: \`relation-discovery.md\` was linking \`document-chat.md#tools\`, which didn't exist as a heading until this PR.

## Files

- \`docs/document-chat.md\` — anchor model, new config keys (\`DocumentChatTopK\`, \`MaxCapturedCitations\`, \`MaxToolsPerTurn\`), \`## Tools\` catalog, \`GroundingSource\` semantics, \`## Observability\`
- \`docs/document-chat-client.md\` — Create input/response trimmed to current shape; new \`## 3. Stream a Message (Server-Sent Events)\` section with delta schema + wire trace + cancellation semantics; \`groundingSource\` in response and replay
- \`docs/ai-provider.md\` — corrected \`turn.degraded\` description; pointer to \`document-chat.md#observability\` for the full audit dimensions

## Verification

- All in-page anchors (\`#tools\`, \`#observability\`, \`#grounding-source-and-degraded-answers\`, \`#3-stream-a-message-server-sent-events\`) resolve to real headings — verified via \`grep '^##'\`.
- Code claims spot-checked against \`DocumentChatTelemetryRecorder\`, \`DocumentChatAppService.FillStreamingChannelAsync\`, \`DocumentChatController.SseSerializerOptions\`, and \`DocumentSearchCapture.Append\`.
- Replay-\`groundingSource\` doc note matches the "best-effort approximation" comment in \`BuildTurnResultFromPersisted\`.

## Test plan
- [ ] Render the three updated docs on GitHub and click the new anchors
- [ ] Confirm \`relation-discovery.md\` → \`document-chat.md#tools\` no longer 404s in-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)