### PR TITLE
fix(ci): drop build step for removed contracts nx project (#202)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,6 @@ jobs:
         run: npx nx build paperbase --configuration production
         working-directory: angular
 
-      - name: Build contracts library
-        run: npx nx build contracts --configuration production
-        working-directory: angular
-
       - name: Build host application
         run: npx nx build host --configuration production
         working-directory: angular


### PR DESCRIPTION
## Summary
Drop the `build-angular` "Build contracts library" step. The `contracts` nx project was removed in 9f7f71c (Angular cleanup); the workspace now has only `paperbase` and `host`. The stale step failed on every PR — including backend-only ones — masking real Angular build regressions.

## Verification
- `angular/` nx projects confirmed: only `paperbase` + `host` (no `contracts`).
- Remaining steps (`paperbase` build, `host` build, lint) unchanged.

Closes #202