### PR TITLE
refactor(pipelines): #216 follow-up cleanups (#1/#2/#6)

### DIFF
--- a/.claude/rules/background-jobs.md
+++ b/.claude/rules/background-jobs.md
@@ -36,10 +36,12 @@ This avoids holding database connections, locks, or transactions while external 
 
 `DocumentPipelineRun` 本身就是 `AggregateRoot<Guid>`，通过 `IDocumentPipelineRunRepository` 直接操作，**不再经 `Document` 聚合根**。后台作业（`DocumentTextExtractionBackgroundJob` / `DocumentClassificationBackgroundJob`）三阶段 UoW 的 BeginRun / CompleteRun / FailRun 都按这个模式：
 
-- 用 `_documentRepository.GetAsync(id, includeDetails: false)` 加载 Document（**不再** `GetWithPipelineRunsAsync`）
-- 用 `_runRepository.FindAsync(runId)` 加载具体的 run（**不再** `document.GetRun(runId)`）
+- 用 `DocumentRepository.GetAsync(id, includeDetails: false)` 加载 Document（**不再** `GetWithPipelineRunsAsync`）
+- 用 `RunRepository.FindAsync(runId)` 加载具体的 run（**不再** `document.GetRun(runId)`）
 - 通过 `DocumentPipelineRunManager` 修改 run 状态（manager 内部 `_runRepo.UpdateAsync` 显式持久化）
 - 同 UoW commit 时 Document 主行 UPDATE + PipelineRun 行 UPDATE / INSERT 一并 flush
+
+CompleteRun / FailRun 阶段共享的「加载 Document + 按 runId 定位 run（找不到则 fallback 重建）」前导，以及两类作业完全一致的失败收尾，收敛在基类 `DocumentPipelineBackgroundJobBase<TArgs>`（`LoadDocumentAndRunAsync` / `FailRunAsync`，#216 follow-up #2）；两个作业各自只实现差异化的 Begin / Complete 主体。
 
 **这是该实体的唯一例外**——其他流水线相关 child 实体（如未来的 ChunkBlock）仍按"通过聚合根访问"的标准模式管理。具体决策详见 Issue #216。
 

--- a/core/src/Dignite.Paperbase.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/DocumentAppService.cs
@@ -23,7 +23,6 @@ namespace Dignite.Paperbase.Documents;
 public class DocumentAppService : PaperbaseAppService, IDocumentAppService
 {
     private readonly IDocumentRepository _documentRepository;
-    private readonly IDocumentPipelineRunRepository _runRepository;
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
     private readonly ICabinetRepository _cabinetRepository;
@@ -34,7 +33,6 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
 
     public DocumentAppService(
         IDocumentRepository documentRepository,
-        IDocumentPipelineRunRepository runRepository,
         IDocumentTypeRepository documentTypeRepository,
         IFieldDefinitionRepository fieldDefinitionRepository,
         ICabinetRepository cabinetRepository,
@@ -44,7 +42,6 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
         IDistributedEventBus distributedEventBus)
     {
         _documentRepository = documentRepository;
-        _runRepository = runRepository;
         _documentTypeRepository = documentTypeRepository;
         _fieldDefinitionRepository = fieldDefinitionRepository;
         _cabinetRepository = cabinetRepository;
@@ -385,8 +382,9 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
         }
 
         // 只需文档主行（IsDeleted / FileOrigin）+ 最近一次该 pipeline 的 run（判可重试）；不碰字段值。
-        // 租户隔离由 ambient IMultiTenant 过滤器施加，GetAsync / runRepo 查询对跨租户 / 不存在 id 行为一致。
-        // #216：PipelineRun 独立聚合根后改走 runRepo.FindLatestByDocumentAndCodeAsync。
+        // 租户隔离由 ambient IMultiTenant 过滤器施加，GetAsync 对跨租户 / 不存在 id 抛 EntityNotFound。
+        // #216 follow-up：retry 状态机判定下沉到 DocumentPipelineRunManager.EnsureRetryableAsync，
+        // AppService 不再直接依赖 IDocumentPipelineRunRepository。
         var document = await _documentRepository.GetAsync(id, includeDetails: false);
 
         if (document.IsDeleted)
@@ -395,25 +393,7 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
                 .WithData("FileName", document.FileOrigin.BlobName);
         }
 
-        var latestRun = await _runRepository.FindLatestByDocumentAndCodeAsync(id, input.PipelineCode);
-        if (latestRun == null)
-        {
-            throw new BusinessException(PaperbaseErrorCodes.Pipeline.NeverRan)
-                .WithData("PipelineCode", input.PipelineCode);
-        }
-
-        switch (latestRun.Status)
-        {
-            case PipelineRunStatus.Pending:
-            case PipelineRunStatus.Running:
-                throw new BusinessException(PaperbaseErrorCodes.Pipeline.RetryInProgress)
-                    .WithData("PipelineCode", input.PipelineCode);
-            case PipelineRunStatus.Succeeded:
-            case PipelineRunStatus.Skipped:
-                throw new BusinessException(PaperbaseErrorCodes.Pipeline.NotRetryable)
-                    .WithData("PipelineCode", input.PipelineCode)
-                    .WithData("Status", latestRun.Status.ToString());
-        }
+        var latestRun = await _pipelineRunManager.EnsureRetryableAsync(id, input.PipelineCode);
 
         Logger.LogInformation(
             "RetryPipelineAsync user={UserId} tenant={TenantId} doc={DocumentId} pipeline={PipelineCode} previousAttempt={Attempt}",

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
@@ -18,44 +18,35 @@ namespace Dignite.Paperbase.Documents.Pipelines.Classification;
 
 [BackgroundJobName("Paperbase.DocumentClassification")]
 public class DocumentClassificationBackgroundJob
-    : AsyncBackgroundJob<DocumentClassificationJobArgs>, ITransientDependency
+    : DocumentPipelineBackgroundJobBase<DocumentClassificationJobArgs>, ITransientDependency
 {
-    private readonly IDocumentRepository _documentRepository;
-    private readonly IDocumentPipelineRunRepository _runRepository;
     private readonly IDocumentTypeRepository _documentTypeRepository;
-    private readonly DocumentPipelineRunManager _pipelineRunManager;
-    private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
     private readonly DocumentClassificationWorkflow _workflow;
     private readonly IDistributedEventBus _distributedEventBus;
     private readonly IClock _clock;
     private readonly PaperbaseAIBehaviorOptions _aiOptions;
     private readonly ICurrentTenant _currentTenant;
-    private readonly IUnitOfWorkManager _unitOfWorkManager;
 
     public DocumentClassificationBackgroundJob(
         IDocumentRepository documentRepository,
         IDocumentPipelineRunRepository runRepository,
-        IDocumentTypeRepository documentTypeRepository,
         DocumentPipelineRunManager pipelineRunManager,
         DocumentPipelineRunAccessor pipelineRunAccessor,
+        IUnitOfWorkManager unitOfWorkManager,
+        IDocumentTypeRepository documentTypeRepository,
         DocumentClassificationWorkflow workflow,
         IDistributedEventBus distributedEventBus,
         IClock clock,
         IOptions<PaperbaseAIBehaviorOptions> aiOptions,
-        ICurrentTenant currentTenant,
-        IUnitOfWorkManager unitOfWorkManager)
+        ICurrentTenant currentTenant)
+        : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
-        _documentRepository = documentRepository;
-        _runRepository = runRepository;
         _documentTypeRepository = documentTypeRepository;
-        _pipelineRunManager = pipelineRunManager;
-        _pipelineRunAccessor = pipelineRunAccessor;
         _workflow = workflow;
         _distributedEventBus = distributedEventBus;
         _clock = clock;
         _aiOptions = aiOptions.Value;
         _currentTenant = currentTenant;
-        _unitOfWorkManager = unitOfWorkManager;
     }
 
     public override async Task ExecuteAsync(DocumentClassificationJobArgs args)
@@ -69,16 +60,16 @@ public class DocumentClassificationBackgroundJob
         }
         catch (Exception ex)
         {
-            await FailRunAsync(workItem.DocumentId, workItem.RunId, ex.Message);
+            await FailRunAsync(workItem.DocumentId, workItem.RunId, ex.Message, PaperbasePipelines.Classification);
             throw;
         }
     }
 
     private async Task<ClassificationWorkItem> BeginRunAsync(DocumentClassificationJobArgs args)
     {
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        using var uow = UnitOfWorkManager.Begin(requiresNew: true);
 
-        var document = await _documentRepository.GetAsync(args.DocumentId, includeDetails: false);
+        var document = await DocumentRepository.GetAsync(args.DocumentId, includeDetails: false);
 
         // 候选集组装：按 Document.TenantId 匹配单层文档类型，不跨层 union；按 Priority DESC + 截断。
         List<DocumentType> candidates;
@@ -92,9 +83,9 @@ public class DocumentClassificationBackgroundJob
                 .ToList();
         }
 
-        var run = await _pipelineRunAccessor.BeginOrStartAsync(
+        var run = await PipelineRunAccessor.BeginOrStartAsync(
             document, args.PipelineRunId, PaperbasePipelines.Classification);
-        await _documentRepository.UpdateAsync(document, autoSave: true);
+        await DocumentRepository.UpdateAsync(document, autoSave: true);
 
         await uow.CompleteAsync();
 
@@ -131,30 +122,13 @@ public class DocumentClassificationBackgroundJob
         ClassificationWorkItem workItem,
         DocumentClassificationOutcome outcome)
     {
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        using var uow = UnitOfWorkManager.Begin(requiresNew: true);
 
-        var document = await _documentRepository.GetAsync(workItem.DocumentId, includeDetails: false);
-        var run = await _runRepository.FindAsync(workItem.RunId)
-            ?? await _pipelineRunAccessor.BeginOrStartAsync(
-                document, workItem.RunId, PaperbasePipelines.Classification);
+        var (document, run) = await LoadDocumentAndRunAsync(
+            workItem.DocumentId, workItem.RunId, PaperbasePipelines.Classification);
 
         await ApplyClassificationResultAsync(document, run, outcome);
-        await _documentRepository.UpdateAsync(document, autoSave: true);
-
-        await uow.CompleteAsync();
-    }
-
-    private async Task FailRunAsync(Guid documentId, Guid runId, string errorMessage)
-    {
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
-
-        var document = await _documentRepository.GetAsync(documentId, includeDetails: false);
-        var run = await _runRepository.FindAsync(runId)
-            ?? await _pipelineRunAccessor.BeginOrStartAsync(
-                document, runId, PaperbasePipelines.Classification);
-
-        await _pipelineRunManager.FailAsync(document, run, errorMessage);
-        await _documentRepository.UpdateAsync(document, autoSave: true);
+        await DocumentRepository.UpdateAsync(document, autoSave: true);
 
         await uow.CompleteAsync();
     }
@@ -179,7 +153,7 @@ public class DocumentClassificationBackgroundJob
 
         if (typeDef != null && outcome.ConfidenceScore >= typeDef.ConfidenceThreshold)
         {
-            await _pipelineRunManager.CompleteClassificationAsync(
+            await PipelineRunManager.CompleteClassificationAsync(
                 document, run, typeDef, outcome.ConfidenceScore);
 
             await _distributedEventBus.PublishAsync(
@@ -195,7 +169,7 @@ public class DocumentClassificationBackgroundJob
             return;
         }
 
-        await _pipelineRunManager.CompleteClassificationWithLowConfidenceAsync(
+        await PipelineRunManager.CompleteClassificationWithLowConfidenceAsync(
             document, run, outcome.Reason, outcome.Candidates);
     }
 

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/DocumentPipelineBackgroundJobBase.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/DocumentPipelineBackgroundJobBase.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.Uow;
+
+namespace Dignite.Paperbase.Documents.Pipelines;
+
+/// <summary>
+/// 文档流水线后台作业（文本提取 / 分类）的共享骨架（#216 follow-up #2）。封装两类作业重复的
+/// Complete/Fail 阶段前导——短 UoW 内重载 Document + 定位 PipelineRun（按 runId fallback 重建），
+/// 以及两侧完全一致的失败收尾。Begin 阶段各作业逻辑不同（候选集组装 / blob 读取），不在基类。
+/// <para>
+/// 三阶段短 UoW 纪律见 <c>.claude/rules/background-jobs.md</c>：Begin / Complete / Fail 各自独立 UoW，
+/// 外部慢工作（OCR / LLM / blob IO）在任何 UoW 之外执行。<see cref="DocumentPipelineRun"/> 自 #216 起是
+/// 独立聚合根，经 <see cref="IDocumentPipelineRunRepository"/> 直接读写，不再走 <see cref="Document"/> 聚合。
+/// </para>
+/// </summary>
+public abstract class DocumentPipelineBackgroundJobBase<TArgs> : AsyncBackgroundJob<TArgs>
+{
+    protected IDocumentRepository DocumentRepository { get; }
+    protected IDocumentPipelineRunRepository RunRepository { get; }
+    protected DocumentPipelineRunManager PipelineRunManager { get; }
+    protected DocumentPipelineRunAccessor PipelineRunAccessor { get; }
+    protected IUnitOfWorkManager UnitOfWorkManager { get; }
+
+    protected DocumentPipelineBackgroundJobBase(
+        IDocumentRepository documentRepository,
+        IDocumentPipelineRunRepository runRepository,
+        DocumentPipelineRunManager pipelineRunManager,
+        DocumentPipelineRunAccessor pipelineRunAccessor,
+        IUnitOfWorkManager unitOfWorkManager)
+    {
+        DocumentRepository = documentRepository;
+        RunRepository = runRepository;
+        PipelineRunManager = pipelineRunManager;
+        PipelineRunAccessor = pipelineRunAccessor;
+        UnitOfWorkManager = unitOfWorkManager;
+    }
+
+    /// <summary>
+    /// Complete / Fail 阶段共享加载：取 Document（不 eager-load runs），按 <paramref name="runId"/> 定位本作业
+    /// 的 run，找不到则经 <see cref="DocumentPipelineRunAccessor.BeginOrStartAsync"/> 按该 runId fallback 重建。
+    /// 调用方负责在自己的短 UoW 内调用并提交。
+    /// </summary>
+    protected virtual async Task<(Document Document, DocumentPipelineRun Run)> LoadDocumentAndRunAsync(
+        Guid documentId,
+        Guid runId,
+        string pipelineCode)
+    {
+        var document = await DocumentRepository.GetAsync(documentId, includeDetails: false);
+        var run = await RunRepository.FindAsync(runId)
+            ?? await PipelineRunAccessor.BeginOrStartAsync(document, runId, pipelineCode);
+        return (document, run);
+    }
+
+    /// <summary>
+    /// 失败收尾：独立短 UoW 内重载 Document + run，标记 run 失败（Manager 内部据此派生 LifecycleStatus），
+    /// 持久化 Document 主行并提交。两类作业的失败路径完全一致（仅 <paramref name="pipelineCode"/> 不同），
+    /// 故上提至基类。调用方在 catch 中调用后通常 re-throw 以触发 ABP 后台作业重试。
+    /// </summary>
+    protected virtual async Task FailRunAsync(
+        Guid documentId,
+        Guid runId,
+        string errorMessage,
+        string pipelineCode)
+    {
+        using var uow = UnitOfWorkManager.Begin(requiresNew: true);
+
+        var (document, run) = await LoadDocumentAndRunAsync(documentId, runId, pipelineCode);
+        await PipelineRunManager.FailAsync(document, run, errorMessage);
+        await DocumentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+    }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -22,16 +22,11 @@ namespace Dignite.Paperbase.Documents.Pipelines.TextExtraction;
 
 [BackgroundJobName("Paperbase.DocumentTextExtraction")]
 public class DocumentTextExtractionBackgroundJob
-    : AsyncBackgroundJob<DocumentTextExtractionJobArgs>, ITransientDependency
+    : DocumentPipelineBackgroundJobBase<DocumentTextExtractionJobArgs>, ITransientDependency
 {
-    private readonly IDocumentRepository _documentRepository;
-    private readonly IDocumentPipelineRunRepository _runRepository;
-    private readonly DocumentPipelineRunManager _pipelineRunManager;
-    private readonly DocumentPipelineRunAccessor _pipelineRunAccessor;
     private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
     private readonly ITextExtractor _textExtractor;
     private readonly IBlobContainer<PaperbaseDocumentContainer> _blobContainer;
-    private readonly IUnitOfWorkManager _unitOfWorkManager;
     private readonly IDistributedEventBus _distributedEventBus;
     private readonly IClock _clock;
     /// <summary>
@@ -49,24 +44,20 @@ public class DocumentTextExtractionBackgroundJob
         IDocumentPipelineRunRepository runRepository,
         DocumentPipelineRunManager pipelineRunManager,
         DocumentPipelineRunAccessor pipelineRunAccessor,
+        IUnitOfWorkManager unitOfWorkManager,
         DocumentPipelineJobScheduler pipelineJobScheduler,
         ITextExtractor textExtractor,
         IBlobContainer<PaperbaseDocumentContainer> blobContainer,
-        IUnitOfWorkManager unitOfWorkManager,
         IDistributedEventBus distributedEventBus,
         IClock clock,
         [FromKeyedServices(PaperbaseAIConsts.TitleGeneratorChatClientKey)] IChatClient titleGeneratorChatClient,
         IPromptProvider promptProvider,
         IOptions<PaperbaseAIBehaviorOptions> behaviorOptions)
+        : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
-        _documentRepository = documentRepository;
-        _runRepository = runRepository;
-        _pipelineRunManager = pipelineRunManager;
-        _pipelineRunAccessor = pipelineRunAccessor;
         _pipelineJobScheduler = pipelineJobScheduler;
         _textExtractor = textExtractor;
         _blobContainer = blobContainer;
-        _unitOfWorkManager = unitOfWorkManager;
         _distributedEventBus = distributedEventBus;
         _clock = clock;
         _titleGeneratorChatClient = titleGeneratorChatClient;
@@ -103,19 +94,19 @@ public class DocumentTextExtractionBackgroundJob
         }
         catch (Exception ex)
         {
-            await FailRunAsync(args.DocumentId, workItem.RunId, ex.Message);
+            await FailRunAsync(args.DocumentId, workItem.RunId, ex.Message, PaperbasePipelines.TextExtraction);
             throw;
         }
     }
 
     private async Task<TextExtractionWorkItem> BeginRunAsync(DocumentTextExtractionJobArgs args)
     {
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        using var uow = UnitOfWorkManager.Begin(requiresNew: true);
 
-        var document = await _documentRepository.GetAsync(args.DocumentId, includeDetails: false);
-        var run = await _pipelineRunAccessor.BeginOrStartAsync(
+        var document = await DocumentRepository.GetAsync(args.DocumentId, includeDetails: false);
+        var run = await PipelineRunAccessor.BeginOrStartAsync(
             document, args.PipelineRunId, PaperbasePipelines.TextExtraction);
-        await _documentRepository.UpdateAsync(document, autoSave: true);
+        await DocumentRepository.UpdateAsync(document, autoSave: true);
 
         await uow.CompleteAsync();
 
@@ -133,14 +124,12 @@ public class DocumentTextExtractionBackgroundJob
         string? title,
         DocumentTextExtractionMetadata extractionMetadata)
     {
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        using var uow = UnitOfWorkManager.Begin(requiresNew: true);
 
-        var document = await _documentRepository.GetAsync(documentId, includeDetails: false);
-        var run = await _runRepository.FindAsync(runId)
-            ?? await _pipelineRunAccessor.BeginOrStartAsync(
-                document, runId, PaperbasePipelines.TextExtraction);
+        var (document, run) = await LoadDocumentAndRunAsync(
+            documentId, runId, PaperbasePipelines.TextExtraction);
 
-        await _pipelineRunManager.CompleteTextExtractionAsync(
+        await PipelineRunManager.CompleteTextExtractionAsync(
             document, run, result.Markdown, title,
             language: result.DetectedLanguage,
             extractionMetadata: extractionMetadata);
@@ -280,21 +269,6 @@ public class DocumentTextExtractionBackgroundJob
         return trimmed.Length <= DocumentConsts.MaxTitleLength
             ? trimmed
             : trimmed[..DocumentConsts.MaxTitleLength];
-    }
-
-    private async Task FailRunAsync(Guid documentId, Guid runId, string errorMessage)
-    {
-        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
-
-        var document = await _documentRepository.GetAsync(documentId, includeDetails: false);
-        var run = await _runRepository.FindAsync(runId)
-            ?? await _pipelineRunAccessor.BeginOrStartAsync(
-                document, runId, PaperbasePipelines.TextExtraction);
-
-        await _pipelineRunManager.FailAsync(document, run, errorMessage);
-        await _documentRepository.UpdateAsync(document, autoSave: true);
-
-        await uow.CompleteAsync();
     }
 
     private sealed record TextExtractionWorkItem(

--- a/core/src/Dignite.Paperbase.Domain/Dignite.Paperbase.Domain.csproj
+++ b/core/src/Dignite.Paperbase.Domain/Dignite.Paperbase.Domain.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Volo.Abp.Ddd.Domain" />
     <ProjectReference Include="..\Dignite.Paperbase.Abstractions\Dignite.Paperbase.Abstractions.csproj" />
     <ProjectReference Include="..\Dignite.Paperbase.Domain.Shared\Dignite.Paperbase.Domain.Shared.csproj" />
+    <!-- EFCore.Tests 需直接构造 DocumentPipelineRun（internal 构造器）以验证仓储对未 flush run 的可见性语义（#216 follow-up #1）。 -->
+    <InternalsVisibleTo Include="Dignite.Paperbase.EntityFrameworkCore.Tests" />
   </ItemGroup>
 
 </Project>

--- a/core/src/Dignite.Paperbase.Domain/Documents/Pipelines/DocumentPipelineRunManager.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/Pipelines/DocumentPipelineRunManager.cs
@@ -23,9 +23,9 @@ namespace Dignite.Paperbase.Documents.Pipelines;
 /// </para>
 /// <para>
 /// #216 起 <see cref="DocumentPipelineRun"/> 是独立聚合根：状态流转通过 <see cref="IDocumentPipelineRunRepository"/>
-/// 持久化；<see cref="DeriveLifecycleAsync"/> 查仓储算最新 run，但 <b>EF Core 默认 LINQ 查 DB</b>，看不到
-/// 本 UoW 内尚未 flush 的 Insert/Modify——故每次 Manager 方法都把"刚改动的 run 实例"以 <c>runJustChanged</c>
-/// 参数传入，在 DeriveLifecycleAsync 内 in-memory override DB 结果，确保派生用的是 post-change 视图。
+/// 持久化；<see cref="DeriveLifecycleAsync"/> 查仓储算最新 run。EF Core 默认 LINQ 查 DB 看不到本 UoW 内尚未
+/// flush 的 Insert/Modify，故 <see cref="IDocumentPipelineRunRepository.GetLatestRunsByCodesAsync"/> 在仓储内
+/// 合并 change-tracker 的 Local entries 补上 post-change 视图——派生逻辑因此无需调用方传入"刚改动的 run"。
 /// </para>
 /// <para>
 /// <b>AttemptNumber 并发安全</b>（#216 D2）：拆分前 Document 主行 UPDATE 提供隐式行级锁；拆分后无此互斥。
@@ -84,7 +84,7 @@ public class DocumentPipelineRunManager : DomainService
                 // autoSave:true → 触发本 UoW 立即 SaveChanges，撞键当场抛 DbUpdateException 而非延后到外层 commit。
                 // 同 UoW / 同事务：成功的 INSERT 仍由外层 UoW commit 才真正可见给其他事务；失败 / 外层回滚一并撤销。
                 await _runRepo.InsertAsync(run, autoSave: true);
-                await DeriveLifecycleAsync(document, runJustChanged: run);
+                await DeriveLifecycleAsync(document);
                 return run;
             }
             catch (Exception ex) when (IsAttemptNumberUniqueViolation(ex)
@@ -248,6 +248,41 @@ public class DocumentPipelineRunManager : DomainService
     }
 
     /// <summary>
+    /// 取该 pipeline 最近一次 run 并校验其可重试性——仅 <see cref="PipelineRunStatus.Failed"/> 可重试。
+    /// 不存在任何 run → <c>Pipeline.NeverRan</c>；Pending/Running → <c>Pipeline.RetryInProgress</c>（并发护栏）；
+    /// Succeeded/Skipped → <c>Pipeline.NotRetryable</c>。校验通过返回该 failed run，调用方据其
+    /// <see cref="DocumentPipelineRun.AttemptNumber"/> 记审计日志后再 <see cref="QueueAsync"/> 触发重试。
+    /// <para>
+    /// retry 状态机判定是 run 聚合的 domain 关注点，集中在 manager（已持有 <see cref="IDocumentPipelineRunRepository"/>），
+    /// 让 AppService 不直接查 run 仓储（#216 follow-up #6）。PipelineCode 合法性是输入层校验，留在调用方。
+    /// </para>
+    /// </summary>
+    public virtual async Task<DocumentPipelineRun> EnsureRetryableAsync(Guid documentId, string pipelineCode)
+    {
+        var latestRun = await _runRepo.FindLatestByDocumentAndCodeAsync(documentId, pipelineCode);
+        if (latestRun == null)
+        {
+            throw new BusinessException(PaperbaseErrorCodes.Pipeline.NeverRan)
+                .WithData("PipelineCode", pipelineCode);
+        }
+
+        switch (latestRun.Status)
+        {
+            case PipelineRunStatus.Pending:
+            case PipelineRunStatus.Running:
+                throw new BusinessException(PaperbaseErrorCodes.Pipeline.RetryInProgress)
+                    .WithData("PipelineCode", pipelineCode);
+            case PipelineRunStatus.Succeeded:
+            case PipelineRunStatus.Skipped:
+                throw new BusinessException(PaperbaseErrorCodes.Pipeline.NotRetryable)
+                    .WithData("PipelineCode", pipelineCode)
+                    .WithData("Status", latestRun.Status.ToString());
+        }
+
+        return latestRun;
+    }
+
+    /// <summary>
     /// Shared tail of every state transition: persist the run via repo, optionally fire the run-completed
     /// LocalEvent, then re-derive Document.LifecycleStatus. BeginAsync skips the event (run is just starting,
     /// not completing); Complete/Fail/Skip all publish it.
@@ -264,33 +299,21 @@ public class DocumentPipelineRunManager : DomainService
             run.PublishRunCompletedEvent();
         }
 
-        await DeriveLifecycleAsync(document, runJustChanged: run);
+        await DeriveLifecycleAsync(document);
     }
 
     /// <summary>
     /// 根据所有关键流水线的最新 Run 派生 Document.LifecycleStatus。
     /// <para>
-    /// <paramref name="runJustChanged"/>：本次 Manager 调用刚 Insert/Update 的 run。EF Core 默认 LINQ 查 DB，
-    /// 看不到本 UoW 内尚未 flush 的更改——故把内存 run 实例显式 in-memory override 进结果集，
-    /// 确保派生用的是 post-change 视图。
+    /// 最新 run 由 <see cref="IDocumentPipelineRunRepository.GetLatestRunsByCodesAsync"/> 提供，该仓储已
+    /// 合并本 UoW 内尚未 flush 的 change-tracker 实体（EFCore 实现 peek Local entries；in-memory fake 因
+    /// 持有 run 引用天然可见）。故此处直接消费仓储结果即是 post-change 视图，无需调用方再传入"刚改动的 run"。
     /// </para>
     /// </summary>
-    protected virtual async Task DeriveLifecycleAsync(
-        Document document,
-        DocumentPipelineRun? runJustChanged = null)
+    protected virtual async Task DeriveLifecycleAsync(Document document)
     {
         var latestRuns = await _runRepo.GetLatestRunsByCodesAsync(
             document.Id, PaperbasePipelines.KeyPipelines);
-
-        // In-memory override：刚改动的 run 比 DB 读到的更新；按 AttemptNumber 比较接管同一 PipelineCode。
-        if (runJustChanged != null && PaperbasePipelines.KeyPipelines.Contains(runJustChanged.PipelineCode))
-        {
-            if (!latestRuns.TryGetValue(runJustChanged.PipelineCode, out var existing)
-                || runJustChanged.AttemptNumber >= existing.AttemptNumber)
-            {
-                latestRuns[runJustChanged.PipelineCode] = runJustChanged;
-            }
-        }
 
         var derivedStatus = DocumentLifecycleStatus.Processing;
         var allSucceeded = true;

--- a/core/src/Dignite.Paperbase.Domain/Documents/Pipelines/IDocumentPipelineRunRepository.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/Pipelines/IDocumentPipelineRunRepository.cs
@@ -30,6 +30,11 @@ public interface IDocumentPipelineRunRepository : IRepository<DocumentPipelineRu
     /// 字典 key = PipelineCode（仅返回有数据的 code）。
     /// 用于：<see cref="DocumentPipelineRunManager.DeriveLifecycleAsync"/> 算 <see cref="Document.LifecycleStatus"/>
     /// （避免 N 次 round-trip）。
+    /// <para>
+    /// <b>契约语义</b>：结果必须反映本 UoW 内尚未 flush 的修改（DeriveLifecycle 紧跟 Manager 的
+    /// <c>UpdateAsync(run, autoSave:false)</c> / Insert 调用）。EFCore 实现合并 change-tracker 的 Local entries；
+    /// in-memory fake 因直接持有 run 引用天然满足。实现方不得只返回"已落库"的陈旧视图。
+    /// </para>
     /// </summary>
     Task<Dictionary<string, DocumentPipelineRun>> GetLatestRunsByCodesAsync(
         Guid documentId,

--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/Documents/Pipelines/EfCoreDocumentPipelineRunRepository.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/Documents/Pipelines/EfCoreDocumentPipelineRunRepository.cs
@@ -47,19 +47,50 @@ public class EfCoreDocumentPipelineRunRepository
             return new Dictionary<string, DocumentPipelineRun>();
         }
 
-        var dbSet = await GetDbSetAsync();
+        var dbContext = await GetDbContextAsync();
 
         // 按 PipelineCode 取最大 AttemptNumber 的 run。EF Core 8+ 把
         // GroupBy(...).Select(g => g.OrderByDescending(...).First()) 翻译为 SQL Server ROW_NUMBER() OVER
         // (PARTITION BY PipelineCode ORDER BY AttemptNumber DESC) WHERE rn = 1，
         // 只回传"每 code 一行"——不靠"少量行 + 内存 GroupBy"的假设。
-        var latest = await dbSet
+        var latest = await dbContext.Set<DocumentPipelineRun>()
             .Where(r => r.DocumentId == documentId && pipelineCodes.Contains(r.PipelineCode))
             .GroupBy(r => r.PipelineCode)
             .Select(g => g.OrderByDescending(r => r.AttemptNumber).First())
             .ToListAsync(GetCancellationToken(cancellationToken));
 
-        return latest.ToDictionary(r => r.PipelineCode);
+        var result = latest.ToDictionary(r => r.PipelineCode);
+
+        // 合并本 UoW 内尚未 flush 的 change-tracker 实体。DeriveLifecycle 紧跟 Manager 的
+        // UpdateAsync(run)（autoSave:false）/ Insert 调用——run 的 post-change 状态此刻可能只在
+        // tracker、DB 仍是旧值（或新 run 尚未落库）。上面的 GroupBy 在 DB 端按已持久化的 AttemptNumber
+        // 选行，看不到这些未 flush 修改。显式合并 Added/Modified 的 Local entries（取每个 PipelineCode
+        // 下 AttemptNumber 最大者），把"看到未 flush 视图"的责任收敛在 Infrastructure 层——Domain 的
+        // DeriveLifecycleAsync 因此不再需要调用方传入"刚改动的 run"（#216 follow-up #1）。
+        foreach (var entry in dbContext.ChangeTracker.Entries<DocumentPipelineRun>())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            var run = entry.Entity;
+            if (run.DocumentId != documentId || !pipelineCodes.Contains(run.PipelineCode))
+            {
+                continue;
+            }
+
+            // unique 索引 (DocumentId, PipelineCode, AttemptNumber) 保证同三元组至多一行：>= 的"相等"分支
+            // 正常态下只会用 tracker 的 Modified 实体覆盖 identity-map 下的同一对象引用（幂等无副作用）；
+            // 真正需要接管的新 run 走 Added 且 AttemptNumber 必然更大。与被删除的旧 in-memory override 语义逐字一致。
+            if (!result.TryGetValue(run.PipelineCode, out var existing)
+                || run.AttemptNumber >= existing.AttemptNumber)
+            {
+                result[run.PipelineCode] = run;
+            }
+        }
+
+        return result;
     }
 
     public virtual async Task<List<DocumentPipelineRun>> GetListByDocumentAsync(

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Review_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Review_Tests.cs
@@ -148,12 +148,12 @@ public class DocumentAppService_Review_Tests
 
     private IQueryable<Document> ApplyFilterForTest(IQueryable<Document> query, GetDocumentListInput input)
     {
-        // #216：DocumentPipelineRunManager 与 DocumentAppService 都新增了 IDocumentPipelineRunRepository 依赖；
-        // 本测试只反射调 ApplyFilter（纯 LINQ 函数，不触发 manager / repo 实际调用），传 Substitute 即可。
+        // #216：DocumentPipelineRunManager 依赖 IDocumentPipelineRunRepository（AppService 自 follow-up #6 起
+        // 不再直接依赖——retry 状态机判定下沉到 manager.EnsureRetryableAsync）；本测试只反射调 ApplyFilter
+        // （纯 LINQ 函数，不触发 manager / repo 实际调用），传 Substitute 即可。
         var runRepoSubstitute = Substitute.For<Pipelines.IDocumentPipelineRunRepository>();
         var service = new DocumentAppService(
             Substitute.For<IDocumentRepository>(),
-            runRepoSubstitute,
             Substitute.For<IDocumentTypeRepository>(),
             Substitute.For<IFieldDefinitionRepository>(),
             Substitute.For<ICabinetRepository>(),

--- a/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineRunAggregatePersistence_Tests.cs
+++ b/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineRunAggregatePersistence_Tests.cs
@@ -56,6 +56,40 @@ public class DocumentPipelineRunAggregatePersistence_Tests
         });
     }
 
+    [Fact]
+    public async Task GetLatestRunsByCodes_Surfaces_Unflushed_Run_In_Same_Uow()
+    {
+        var documentId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _documentRepository.InsertAsync(CreateDocument(documentId), autoSave: true);
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // 同一 UoW 内 Insert 一个 run 但 autoSave:false——故意不 flush。DB 端 GroupBy 查询查不到这条未落库的行
+            // （DB 里根本没有它），EF identity map 也无从物化它。唯有 GetLatestRunsByCodesAsync 合并 change-tracker
+            // 的 Added entries 才能感知它。给 #216 follow-up #1 的 ChangeTracker 合并上锁：删掉仓储里那段合并
+            // foreach，本测试即红（DeriveLifecycle 会回退到看不见同 UoW 内未 flush run 的 stale-view bug）。
+            var run = new DocumentPipelineRun(
+                _guidGenerator.Create(),
+                documentId,
+                tenantId: null,
+                PaperbasePipelines.Classification,
+                attemptNumber: 1);
+            await _runRepository.InsertAsync(run, autoSave: false);
+
+            var latest = await _runRepository.GetLatestRunsByCodesAsync(
+                documentId,
+                new[] { PaperbasePipelines.Classification });
+
+            latest.ShouldContainKey(PaperbasePipelines.Classification);
+            latest[PaperbasePipelines.Classification].Id.ShouldBe(run.Id);
+            latest[PaperbasePipelines.Classification].Status.ShouldBe(PipelineRunStatus.Pending);
+        });
+    }
+
     private static Document CreateDocument(Guid id)
     {
         return new Document(


### PR DESCRIPTION
Implements the remaining actionable portion of the #216 follow-up cleanups (6 items recorded during code-review + Codex review).

## Implemented (#1 / #2 / #6)

### #1 — Eliminate EF change-tracker semantic leak from `DeriveLifecycleAsync`
The `runJustChanged` override parameter was a leakage of EF persistence details into the Domain API (every Manager call site had to pass it mechanically). Changed to:
- `EfCoreDocumentPipelineRunRepository.GetLatestRunsByCodesAsync` merges Added/Modified entities from `ChangeTracker` after the DB GroupBy query — the responsibility of "reflecting unflushed UoW modifications" is pushed down to Infrastructure
- `DocumentPipelineRunManager.DeriveLifecycleAsync(document)` returns to a clean signature
- `IDocumentPipelineRunRepository` promotes this semantic to the interface contract (the in-memory fake satisfies it naturally by holding run references)
- New EFCore integration test: insert an Added-not-yet-flushed run, assert it is visible after merging — regression lock (removing the merge foreach turns it red; requires `InternalsVisibleTo` to construct a run)

### #2 — Deduplicate background job Complete/Fail preamble
Introduce `DocumentPipelineBackgroundJobBase<TArgs>`, encapsulating the `LoadDocumentAndRunAsync` + `FailRunAsync` duplication common to both job types; differentiated logic (candidate set assembly / blob read / title generation / native-payload archiving) stays in subclasses.

### #6 — Free `DocumentAppService` from `IDocumentPipelineRunRepository`
Push retry state-machine validation down to `DocumentPipelineRunManager.EnsureRetryableAsync` (reuses the manager's existing run repo, zero new dependencies); AppService constructor parameters 9→8. Retry execution ordering contract (UnknownCode before GetAsync, IsDeleted before run-state check) preserved.

## Decided not to implement (#4 / #5)
- **#4 (skip `DeriveLifecycle` DB read in `QueueAsync`)**: original suggestion was "not a bottleneck, leave status quo". `GetLatestRunsByCodesAsync` is a sub-ms PK/index query; conditional short-circuiting carries a correctness risk of missing `Failed` state from other pipelines. Pre-optimization + risk > benefit.
- **#5 (pull back Markdown in `RetryPipelineAsync`)**: retry is a low-frequency manual operation; the Markdown waste only manifests in the rare intersection of large document + retry. Adding a projection method for a hypothetical scenario is pre-optimization; the original note already said "leave for watch".

(#3 AttemptNumber retry was implemented in the original #216 PR.)

## Verification
- `dotnet build` 0 errors
- `dotnet test` **329 all green** (Mcp 10 / Domain 109 / Application 163 / EFCore 47)
- `abp-architecture-reviewer`: no critical / major issues; all three change groups clean

Addresses #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)