### PR TITLE
fix(efcore): narrow HardDeleteAsync to disable only ISoftDelete (#220)

### DIFF
--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -66,11 +66,17 @@ public class EfCoreDocumentRepository
 
     public virtual async Task HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        var dbContext = await GetDbContextAsync();
-        await dbContext.Set<Document>()
-            .IgnoreQueryFilters()
-            .Where(d => d.Id == id)
-            .ExecuteDeleteAsync(GetCancellationToken(cancellationToken));
+        // 只穿透软删（物理删已软删的行），保留 IMultiTenant 租户边界——绝不 IgnoreQueryFilters()
+        // （会连同 IMultiTenant 一起关掉，使无应用层租户校验的未来调用方跨租户硬删，#220）。
+        // ExecuteDeleteAsync 依赖 DB 级 ON DELETE CASCADE（DocumentExtractedField / DocumentPipelineRun
+        // 两个 child FK 均 OnDelete(Cascade)），收窄过滤器不影响级联。
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            var dbContext = await GetDbContextAsync();
+            await dbContext.Set<Document>()
+                .Where(d => d.Id == id)
+                .ExecuteDeleteAsync(GetCancellationToken(cancellationToken));
+        }
     }
 
     public virtual async Task<List<Guid>> GetFieldMatchedIdsAsync(


### PR DESCRIPTION
Closes #220

## Problem

`EfCoreDocumentRepository.HardDeleteAsync` calls `IgnoreQueryFilters()` before `ExecuteDeleteAsync`, which **simultaneously** disables both the `ISoftDelete` and `IMultiTenant` global query filters. The method only needs to bypass soft-delete (to physically delete a soft-deleted row), but incidentally punches through the tenant boundary as well.

## Whether this is currently exploitable

**Not an active vulnerability; defense-in-depth**: the sole caller, `DocumentAppService.PermanentDeleteAsync`, calls `GetAsync(id)` within a scope that only `DataFilter.Disable<ISoftDelete>()` (`IMultiTenant` still active) before calling `HardDeleteAsync(id)` — a cross-tenant id would throw `EntityNotFoundException` first. The risk is that any future caller that does not include this application-layer tenant check would be able to physically delete records across tenants; the repository method should not assume its callers have already performed tenant validation.

## Fix

Narrow the filter scope to soft-delete only, preserving the tenant filter (consistent with the existing pattern of `FindByContentHashAsync` in the same file):

```csharp
using (DataFilter.Disable<ISoftDelete>())
{
    var dbContext = await GetDbContextAsync();
    await dbContext.Set<Document>()
        .Where(d => d.Id == id)          // IMultiTenant still applied automatically
        .ExecuteDeleteAsync(...);
}
```

## Verification

- EFCore project `dotnet build` passes (0 warnings, 0 errors)
- `ExecuteDeleteAsync` relies on DB-level `ON DELETE CASCADE` (`DocumentExtractedField` / `DocumentPipelineRun` child FKs both use `OnDelete(Cascade)`); narrowing the filter scope does not affect cascading deletes

🤖 Generated with [Claude Code](https://claude.com/claude-code)