### PR TITLE
refactor(domain): make extraction metadata value objects inherit ValueObject (#218)

### DIFF
--- a/core/src/Dignite.Paperbase.Domain/Documents/DocumentTextExtractionMetadata.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/DocumentTextExtractionMetadata.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using Volo.Abp.Domain.Values;
+
 namespace Dignite.Paperbase.Documents;
 
 /// <summary>
@@ -14,7 +17,7 @@ namespace Dignite.Paperbase.Documents;
 /// get-only 属性 + 唯一带参构造让 System.Text.Json 反序列化复用同一构造（参数名匹配属性名），套路同 <c>ExportColumn</c>。
 /// </para>
 /// </summary>
-public class DocumentTextExtractionMetadata
+public class DocumentTextExtractionMetadata : ValueObject
 {
     /// <summary>
     /// 胜出 provider 的家族 / 名称（如 <c>PaddleOCR</c> / <c>AzureDocumentIntelligence</c> / <c>ElBruno.MarkItDotNet</c>）；未知时 null。
@@ -36,5 +39,26 @@ public class DocumentTextExtractionMetadata
     {
         ProviderName = providerName;
         NativePayloadManifest = nativePayloadManifest;
+    }
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        // ABP 的 ValueEquals 用 SequenceEqual + 默认比较器，对 atomic 走 object.Equals——嵌套 ValueObject
+        // 不会递归 ValueEquals（默认比较器退化为引用相等）。故这里把 NativePayloadManifest 的各原子值<b>展平</b>
+        // 进父序列，让父级 ValueEquals 真正结构化深比较；可空成员统一取空串/0 占位避免 null atomic + 区分
+        // "manifest 缺席" 与 "manifest 各字段恰为默认值"（前缀 NULL sentinel）。
+        yield return ProviderName ?? string.Empty;
+
+        if (NativePayloadManifest is null)
+        {
+            yield return "\0null-manifest";
+            yield break;
+        }
+
+        yield return NativePayloadManifest.BlobName;
+        yield return NativePayloadManifest.ContentType;
+        yield return NativePayloadManifest.SizeBytes;
+        yield return NativePayloadManifest.Sha256;
+        yield return NativePayloadManifest.SchemaName;
     }
 }

--- a/core/src/Dignite.Paperbase.Domain/Documents/NativePayloadManifest.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/NativePayloadManifest.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Volo.Abp;
+using Volo.Abp.Domain.Values;
 
 namespace Dignite.Paperbase.Documents;
 
@@ -11,7 +13,7 @@ namespace Dignite.Paperbase.Documents;
 /// <b>无</b> archive 时 <see cref="DocumentTextExtractionMetadata.NativePayloadManifest"/> 整体为 <c>null</c>（不构造空壳）。
 /// </para>
 /// </summary>
-public class NativePayloadManifest
+public class NativePayloadManifest : ValueObject
 {
     /// <summary>
     /// 归档 blob 的稳定 per-document key（<c>extraction-native/{documentId}</c>，重提取覆盖）。
@@ -38,5 +40,14 @@ public class NativePayloadManifest
         SizeBytes = sizeBytes;
         Sha256 = Check.NotNullOrWhiteSpace(sha256, nameof(sha256));
         SchemaName = Check.NotNullOrWhiteSpace(schemaName, nameof(schemaName));
+    }
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        yield return BlobName;
+        yield return ContentType;
+        yield return SizeBytes;
+        yield return Sha256;
+        yield return SchemaName;
     }
 }

--- a/core/test/Dignite.Paperbase.Domain.Tests/Documents/DocumentTextExtractionMetadataTests.cs
+++ b/core/test/Dignite.Paperbase.Domain.Tests/Documents/DocumentTextExtractionMetadataTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// #218：<see cref="DocumentTextExtractionMetadata"/> / <see cref="NativePayloadManifest"/> 继承
+/// ABP <c>ValueObject</c> 后获得结构化相等性（经 <c>ValueEquals</c> 暴露——ABP 10.x 的 ValueObject 不覆写
+/// <c>Equals</c>/<c>GetHashCode</c>/<c>==</c>，结构化比较是 opt-in 的 <c>ValueEquals</c>），且不破坏
+/// System.Text.Json 序列化往返（套路同 ExportColumn）。纯单元测试，无需 ABP host。
+/// </summary>
+public class DocumentTextExtractionMetadataTests
+{
+    private static NativePayloadManifest CreateManifest() =>
+        new("extraction-native/doc-1", "application/json", 1234, "abc123", "PaddleOCR/PP-StructureV3");
+
+    [Fact]
+    public void Manifest_With_Same_Values_Should_Be_ValueEqual()
+    {
+        CreateManifest().ValueEquals(CreateManifest()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Manifest_With_Different_Values_Should_Not_Be_ValueEqual()
+    {
+        var other = new NativePayloadManifest(
+            "extraction-native/doc-1", "application/json", 1234, "DIFFERENT", "PaddleOCR/PP-StructureV3");
+        CreateManifest().ValueEquals(other).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Metadata_With_Same_Values_Including_Nested_Manifest_Should_Be_ValueEqual()
+    {
+        var a = new DocumentTextExtractionMetadata("PaddleOCR", CreateManifest());
+        var b = new DocumentTextExtractionMetadata("PaddleOCR", CreateManifest());
+
+        a.ValueEquals(b).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Metadata_With_Null_Members_Should_Be_ValueEqual_And_Differ_From_Populated()
+    {
+        var emptyA = new DocumentTextExtractionMetadata(null, null);
+        var emptyB = new DocumentTextExtractionMetadata(null, null);
+
+        emptyA.ValueEquals(emptyB).ShouldBeTrue();
+        emptyA.ValueEquals(new DocumentTextExtractionMetadata("PaddleOCR", null)).ShouldBeFalse();
+        emptyA.ValueEquals(new DocumentTextExtractionMetadata(null, CreateManifest())).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Json_Roundtrip_Should_Preserve_Value_Equality()
+    {
+        var original = new DocumentTextExtractionMetadata("PaddleOCR", CreateManifest());
+
+        var json = JsonSerializer.Serialize(original);
+        var roundtripped = JsonSerializer.Deserialize<DocumentTextExtractionMetadata>(json);
+
+        roundtripped.ShouldNotBeNull();
+        roundtripped!.ValueEquals(original).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Closes #218

## Background

A code review found that `DocumentTextExtractionMetadata` and `NativePayloadManifest` are semantically value objects (immutable, no identity, equality by content), but did not inherit ABP's `ValueObject` — whereas `FileOrigin` in the same project already inherits it correctly. This PR brings both into alignment with `FileOrigin`.

## Changes

- `DocumentTextExtractionMetadata` / `NativePayloadManifest` inherit `Volo.Abp.Domain.Values.ValueObject` and implement `GetAtomicValues()`
- Add `DocumentTextExtractionMetadataTests` (5 pure unit tests, no ABP host required)

## Key implementation notes

ABP 10.x `ValueObject` does **not** override `Equals` / `GetHashCode` / `==` — structural comparison is opt-in via `ValueEquals(obj)`, which internally uses `SequenceEqual` + default comparer and does **not** recurse into nested `ValueObject`s. Therefore:

- Tests assert structural equality via `ValueEquals(...)` (not `ShouldBe` / `GetHashCode`)
- The parent `DocumentTextExtractionMetadata.GetAtomicValues()` **flattens** the atomic values of the nested `NativePayloadManifest` into its own sequence (directly yielding a nested ValueObject degrades to reference equality), and uses a `\0null-manifest` sentinel to distinguish "manifest absent" from "manifest with all fields at default values", achieving true deep comparison

## Verification

- `dotnet test` — 5/5 pass (including nested manifest deep comparison, null member distinction, System.Text.Json serialization round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)