### PR TITLE
fix(documents): server-side upload size + content-type validation (#221)

### DIFF
--- a/angular/packages/paperbase/documents/src/lib/documents/document-list/document-list.component.html
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-list/document-list.component.html
@@ -32,7 +32,7 @@
         <label class="btn btn-outline-primary mb-0" [class.disabled]="isBulkUploading()">
           <i class="fas fa-upload me-1"></i>
           {{ isBulkUploading() ? ('AbpUi::Loading' | abpLocalization) : ('::Document:BulkUpload' | abpLocalization) }}
-          <input type="file" multiple accept=".pdf,.png,.jpg,.jpeg" class="d-none"
+          <input type="file" multiple [attr.accept]="acceptAttribute" class="d-none"
                  (change)="onBulkFileChange($event)" [disabled]="isBulkUploading()">
         </label>
         <button class="btn btn-primary" (click)="uploadNew()">

--- a/angular/packages/paperbase/documents/src/lib/documents/document-list/document-list.component.ts
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-list/document-list.component.ts
@@ -12,7 +12,7 @@ import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { LocalizationPipe, PermissionService } from '@abp/ng.core';
+import { LocalizationPipe, LocalizationService, PermissionService } from '@abp/ng.core';
 import type { PagedResultDto } from '@abp/ng.core';
 import { ConfirmationService, ToasterService } from '@abp/ng.theme.shared';
 import { Confirmation } from '@abp/ng.theme.shared';
@@ -31,6 +31,11 @@ import {
   PAPERBASE_PERMISSIONS,
 } from '@dignite/paperbase';
 import { formatExtractedFieldValue } from '../../shared/format-field-value';
+import {
+  MAX_UPLOAD_FILE_BYTES,
+  UPLOAD_ACCEPT_ATTRIBUTE,
+  isAllowedUpload,
+} from '../upload-constraints';
 import { from, of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 
@@ -61,6 +66,7 @@ export class DocumentListComponent implements OnInit {
   private readonly confirmation = inject(ConfirmationService);
   private readonly toaster = inject(ToasterService);
   private readonly permissionService = inject(PermissionService);
+  private readonly localization = inject(LocalizationService);
   private readonly destroyRef = inject(DestroyRef);
 
   // Shared with the detail view so multi-value (#212) / object cells render consistently.
@@ -83,6 +89,9 @@ export class DocumentListComponent implements OnInit {
   isLoading = signal(true);
   isBulkUploading = signal(false);
   bulkUploadResults = signal<UploadResult[]>([]);
+
+  // Picker `accept` filter, derived from the shared whitelist (mirrors backend, #221).
+  readonly acceptAttribute = UPLOAD_ACCEPT_ATTRIBUTE;
 
   reviewStatusFilter = signal<DocumentReviewStatus | undefined>(undefined);
   typeFilter = signal<string>('');
@@ -246,10 +255,39 @@ export class DocumentListComponent implements OnInit {
     if (!input.files?.length) return;
     const files = Array.from(input.files);
 
-    this.isBulkUploading.set(true);
-    this.bulkUploadResults.set([]);
+    // Mirror the backend fail-closed gate (#221): pre-filter MIME + extension + size so
+    // invalid files get instant feedback instead of a round-trip rejection. The backend
+    // remains the authoritative gate; this only spares the obvious cases.
+    const valid: File[] = [];
+    const rejected: UploadResult[] = [];
+    for (const f of files) {
+      if (!isAllowedUpload(f)) {
+        rejected.push({
+          fileName: f.name,
+          succeeded: false,
+          errorMessage: this.localization.instant('::Document:UnsupportedFileType'),
+        });
+      } else if (f.size > MAX_UPLOAD_FILE_BYTES) {
+        rejected.push({
+          fileName: f.name,
+          succeeded: false,
+          errorMessage: this.localization.instant('::Document:FileTooLarge'),
+        });
+      } else {
+        valid.push(f);
+      }
+    }
 
-    from(files)
+    if (valid.length === 0) {
+      this.bulkUploadResults.set(rejected);
+      input.value = '';
+      return;
+    }
+
+    this.isBulkUploading.set(true);
+    this.bulkUploadResults.set(rejected);
+
+    from(valid)
       .pipe(
         mergeMap(
           file =>

--- a/angular/packages/paperbase/documents/src/lib/documents/document-upload/document-upload.component.html
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-upload/document-upload.component.html
@@ -80,7 +80,7 @@
                   {{ '::Document:BrowseFiles' | abpLocalization }}
                   <input
                     type="file"
-                    accept="image/*,application/pdf"
+                    [attr.accept]="acceptAttribute"
                     multiple
                     class="d-none"
                     (change)="onFileSelected($event)"

--- a/angular/packages/paperbase/documents/src/lib/documents/document-upload/document-upload.component.ts
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-upload/document-upload.component.ts
@@ -8,6 +8,11 @@ import { ToasterService } from '@abp/ng.theme.shared';
 import { CabinetDto, CabinetService, DocumentService, PAPERBASE_PERMISSIONS } from '@dignite/paperbase';
 import { from, of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
+import {
+  MAX_UPLOAD_FILE_BYTES,
+  UPLOAD_ACCEPT_ATTRIBUTE,
+  isAllowedUpload,
+} from '../upload-constraints';
 
 // Limits the number of concurrent /api/documents/upload requests to avoid
 // exhausting the browser's per-origin connection pool and overloading the
@@ -42,6 +47,9 @@ export class DocumentUploadComponent implements OnInit {
   );
   cabinets = signal<CabinetDto[]>([]);
   selectedCabinetId = signal<string>('');
+
+  // Picker `accept` filter, derived from the shared whitelist (mirrors backend, #221).
+  readonly acceptAttribute = UPLOAD_ACCEPT_ATTRIBUTE;
 
   isDragOver = signal(false);
   isUploading = signal(false);
@@ -91,15 +99,13 @@ export class DocumentUploadComponent implements OnInit {
   }
 
   private uploadFiles(files: File[]): void {
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'application/pdf'];
-    const maxSizeBytes = 20 * 1024 * 1024;
-
+    // Mirror the backend fail-closed gate (#221): MIME + extension whitelist, then size.
     const valid = files.filter(f => {
-      if (!allowedTypes.includes(f.type)) {
+      if (!isAllowedUpload(f)) {
         this.toaster.error('::Document:UnsupportedFileType', '::Error');
         return false;
       }
-      if (f.size > maxSizeBytes) {
+      if (f.size > MAX_UPLOAD_FILE_BYTES) {
         this.toaster.error('::Document:FileTooLarge', '::Error');
         return false;
       }

--- a/angular/packages/paperbase/documents/src/lib/documents/upload-constraints.ts
+++ b/angular/packages/paperbase/documents/src/lib/documents/upload-constraints.ts
@@ -1,0 +1,46 @@
+// Client-side upload constraints — MUST mirror the backend DocumentConsts
+// (core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentConsts.cs:
+//  MaxUploadFileBytes / AllowedUploadContentTypes / AllowedUploadExtensions, #221).
+// These are a UX nicety (instant feedback + file-picker filtering); the backend
+// is the authoritative fail-closed gate. If the backend defaults change, change
+// these to match — single source of truth on the Angular side lives here.
+
+/** Maximum upload size in bytes (20 MiB). Mirrors DocumentConsts.MaxUploadFileBytes. */
+export const MAX_UPLOAD_FILE_BYTES = 20 * 1024 * 1024;
+
+/** Allowed MIME types. Mirrors DocumentConsts.AllowedUploadContentTypes. */
+export const ALLOWED_UPLOAD_CONTENT_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+] as const;
+
+/** Allowed file extensions (lowercase, leading dot). Mirrors DocumentConsts.AllowedUploadExtensions. */
+export const ALLOWED_UPLOAD_EXTENSIONS = [
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.pdf',
+] as const;
+
+/**
+ * Value for a file input's `accept` attribute, derived from the whitelists so the
+ * native picker filters to exactly the allowed set (no `image/*` over-reach).
+ */
+export const UPLOAD_ACCEPT_ATTRIBUTE = [
+  ...ALLOWED_UPLOAD_CONTENT_TYPES,
+  ...ALLOWED_UPLOAD_EXTENSIONS,
+].join(',');
+
+/** True when both the MIME type and the extension are in their respective whitelists (mirrors the backend dual check). */
+export function isAllowedUpload(file: File): boolean {
+  const typeOk = (ALLOWED_UPLOAD_CONTENT_TYPES as readonly string[]).includes(file.type);
+  const dot = file.name.lastIndexOf('.');
+  const ext = dot >= 0 ? file.name.slice(dot).toLowerCase() : '';
+  const extOk = (ALLOWED_UPLOAD_EXTENSIONS as readonly string[]).includes(ext);
+  return typeOk && extOk;
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/DocumentAppService.cs
@@ -202,14 +202,43 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
         var contentType = input.File.ContentType ?? "application/octet-stream";
         var extension = Path.GetExtension(fileName);
 
-        await using var source = input.File.GetStream();
-        using var buffer = new MemoryStream();
-        await source.CopyToAsync(buffer);
-        var bytes = buffer.ToArray();
+        // fail-closed 文件校验（#221）：content-type + 扩展名双重白名单。任意类型都会落 blob 并触发
+        // 文本提取 / 分类 job，浪费算力且行为不确定——故不在通道允许集内立即 loud fail，不落 blob、不入队。
+        // content-type 客户端可伪造，扩展名又决定 blob 后缀 + DefaultTextExtractor dispatch，故二者都校验。
+        if (string.IsNullOrEmpty(extension) ||
+            !DocumentConsts.AllowedUploadExtensions.Contains(extension) ||
+            !DocumentConsts.AllowedUploadContentTypes.Contains(contentType))
+        {
+            throw new BusinessException(PaperbaseErrorCodes.Document.UnsupportedFileType)
+                .WithData("FileName", fileName)
+                .WithData("ContentType", contentType);
+        }
+
+        // 客户端声明的长度先做廉价拒绝（不可信，攻击者可少报或不报）——真正的边界是下方流式拷贝按
+        // 实际字节数施加的硬上限，超限即刻中止，不把超大 body 全量缓冲进内存。
+        if (input.File.ContentLength is > 0 and var declared && declared > DocumentConsts.MaxUploadFileBytes)
+        {
+            throw new BusinessException(PaperbaseErrorCodes.Document.FileTooLarge)
+                .WithData("FileName", fileName)
+                .WithData("MaxBytes", DocumentConsts.MaxUploadFileBytes);
+        }
+
+        // 在独立 using 作用域内缓冲：拿到 bytes 后立即释放 buffer，使 SaveAsync 期间只驻留 bytes（1×），
+        // 消除此前 buffer + bytes 同时驻留的 ~2× 内存放大（#221 复审补充 1）。哈希需全量字节，无法完全流式。
+        byte[] bytes;
+        await using (var source = input.File.GetStream())
+        using (var buffer = new MemoryStream())
+        {
+            await CopyWithLimitAsync(source, buffer, DocumentConsts.MaxUploadFileBytes, fileName);
+            bytes = buffer.ToArray();
+        }
         var fileSize = bytes.LongLength;
 
         var contentHash = ContentHasher.Sha256Hex(bytes);
 
+        // 内容哈希去重是 check-then-act（ContentHash 仅非唯一索引）。两个并发的同文件上传可能双双通过检查 →
+        // 产生重复 Document。本期有意接受该 race（#221 复审补充 2）：概率低、危害低（最多一份重复，可后续删），
+        // 而给 ContentHash 加唯一索引会把 race 失败方变成一次 500——通道层不为低概率重复付这个代价。
         var existing = await _documentRepository.FindByContentHashAsync(contentHash);
         if (existing != null)
         {
@@ -258,6 +287,30 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
         await _pipelineJobScheduler.QueueAsync(document, PaperbasePipelines.TextExtraction);
 
         return await MapToDtoAsync(document);
+    }
+
+    /// <summary>
+    /// 把 <paramref name="source"/> 拷贝进 <paramref name="destination"/>，按实际读取字节数施加硬上限（#221）。
+    /// 一旦累计超过 <paramref name="maxBytes"/> 立即抛 <c>Document.FileTooLarge</c>——不依赖客户端声明的
+    /// ContentLength（可伪造），也不把超大 body 全量缓冲进内存。
+    /// </summary>
+    protected static async Task CopyWithLimitAsync(Stream source, Stream destination, long maxBytes, string fileName)
+    {
+        var rented = new byte[81920];
+        long total = 0;
+        int read;
+        while ((read = await source.ReadAsync(rented)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                throw new BusinessException(PaperbaseErrorCodes.Document.FileTooLarge)
+                    .WithData("FileName", fileName)
+                    .WithData("MaxBytes", maxBytes);
+            }
+
+            await destination.WriteAsync(rented.AsMemory(0, read));
+        }
     }
 
     public virtual async Task<IRemoteStreamContent> GetBlobAsync(Guid id)

--- a/core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentConsts.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentConsts.cs
@@ -1,9 +1,42 @@
+using System;
+using System.Collections.Generic;
+
 namespace Dignite.Paperbase.Documents;
 
 public static class DocumentConsts
 {
     public static int MaxTitleLength { get; set; } = 256;
     public static int MaxClassificationReasonLength { get; set; } = 2048;
+
+    /// <summary>
+    /// 上传文件大小硬上限（字节，默认 20 MiB，#221）。fail-closed 安全门：
+    /// 超限 → loud <c>BusinessException</c>（<c>Document.FileTooLarge</c>），不落 blob、不触发任何 pipeline。
+    /// 与前端 document-upload 组件的 20 MB 客户端校验对齐（前端是体验，服务端是边界）。
+    /// static mutable——host 可按部署算力 / OCR provider 在启动期上调（与 <see cref="MaxNativePayloadArchiveBytes"/> 同例）。
+    /// 上调时需同步上调 host 的 Kestrel <c>MaxRequestBodySize</c> / <c>FormOptions.MultipartBodyLengthLimit</c>。
+    /// </summary>
+    public static long MaxUploadFileBytes { get; set; } = 20L * 1024 * 1024;
+
+    /// <summary>
+    /// 允许上传的 content-type 白名单（不区分大小写，#221）。fail-closed 安全门：
+    /// 不在白名单 → loud <c>BusinessException</c>（<c>Document.UnsupportedFileType</c>），不落 blob、不触发 pipeline。
+    /// 默认与前端 document-upload 组件 + "SupportedFormats" 文案对齐（图片 + PDF）。
+    /// static mutable——host 若启用 MarkItDown 数字版文档（Word / HTML / CSV 等）按需扩充，并同步 <see cref="AllowedUploadExtensions"/>。
+    /// </summary>
+    public static ISet<string> AllowedUploadContentTypes { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg", "image/png", "image/gif", "image/webp", "application/pdf"
+    };
+
+    /// <summary>
+    /// 允许上传的文件扩展名白名单（含前导点，不区分大小写，#221）。与 <see cref="AllowedUploadContentTypes"/> 双重校验：
+    /// content-type 客户端可伪造，而扩展名决定 blobName 后缀 + <c>DefaultTextExtractor</c> 的 dispatch
+    /// （图片走 OCR / 其他走 Markdown），故二者都要 fail-closed 校验。默认集合与白名单 content-type 对应。
+    /// </summary>
+    public static ISet<string> AllowedUploadExtensions { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ".jpg", ".jpeg", ".png", ".gif", ".webp", ".pdf"
+    };
 
     /// <summary>OCR / 抽取阶段检测到的语言 tag（ISO 639-1 或 IETF）。</summary>
     public static int MaxLanguageLength { get; set; } = 16;

--- a/core/src/Dignite.Paperbase.Domain.Shared/Localization/Paperbase/en.json
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Localization/Paperbase/en.json
@@ -222,6 +222,8 @@
     "Paperbase:MarkdownIsImmutable": "Extracted markdown has already been set and cannot be changed.",
     "Paperbase:DocumentDuplicate": "This file has already been uploaded ({FileName}).",
     "Paperbase:DocumentInRecycleBin": "This file already exists in the recycle bin ({FileName}).",
+    "Paperbase:DocumentFileTooLarge": "File '{FileName}' exceeds the maximum allowed size of {MaxBytes} bytes.",
+    "Paperbase:DocumentUnsupportedFileType": "File '{FileName}' has an unsupported type ('{ContentType}'). Please upload a supported image or PDF.",
     "Paperbase:UnknownPipelineCode": "Pipeline '{PipelineCode}' is not retryable.",
     "Paperbase:PipelineNeverRan": "Pipeline '{PipelineCode}' has not started yet.",
     "Paperbase:PipelineRetryInProgress": "Pipeline '{PipelineCode}' already has an attempt in progress.",

--- a/core/src/Dignite.Paperbase.Domain.Shared/Localization/Paperbase/zh-Hans.json
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Localization/Paperbase/zh-Hans.json
@@ -22,6 +22,8 @@
     "Document:ContinueToDocuments": "继续查看文档",
     "Paperbase:DocumentDuplicate": "该文件已经上传过 ({FileName})。",
     "Paperbase:DocumentInRecycleBin": "该文件已在回收站中 ({FileName})。",
+    "Paperbase:DocumentFileTooLarge": "文件 '{FileName}' 超过了允许的最大大小 {MaxBytes} 字节。",
+    "Paperbase:DocumentUnsupportedFileType": "文件 '{FileName}' 的类型 ('{ContentType}') 不受支持。请上传受支持的图片或 PDF。",
     "Paperbase:UnknownPipelineCode": "流水线 '{PipelineCode}' 不支持重试。",
     "Paperbase:PipelineNeverRan": "流水线 '{PipelineCode}' 尚未运行。",
     "Paperbase:PipelineRetryInProgress": "流水线 '{PipelineCode}' 已有进行中的尝试。",

--- a/core/src/Dignite.Paperbase.Domain.Shared/PaperbaseErrorCodes.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/PaperbaseErrorCodes.cs
@@ -16,6 +16,9 @@ public static class PaperbaseErrorCodes
         public const string Duplicate = "Paperbase:DocumentDuplicate";
         public const string InRecycleBin = "Paperbase:DocumentInRecycleBin";
         public const string NotClassified = "Paperbase:DocumentNotClassified";
+        // #221：上传 fail-closed 校验失败码（大小超限 / content-type + 扩展名不在白名单）。
+        public const string FileTooLarge = "Paperbase:DocumentFileTooLarge";
+        public const string UnsupportedFileType = "Paperbase:DocumentUnsupportedFileType";
     }
 
     public static class DocumentType

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -197,6 +197,84 @@ public class DocumentAppService_Delete_Tests
         exception.Code.ShouldBe(PaperbaseErrorCodes.Cabinet.InvalidId);
     }
 
+    [Fact]
+    public async Task UploadAsync_Throws_UnsupportedFileType_When_ContentType_Not_Allowed()
+    {
+        // #221：扩展名合法但 content-type 不在白名单 → fail-closed，不落 blob、不入队。
+        var input = CreateUploadInput([1, 2, 3], fileName: "A.pdf", contentType: "application/zip");
+
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.UploadAsync(input));
+
+        exception.Code.ShouldBe(PaperbaseErrorCodes.Document.UnsupportedFileType);
+        await _documentRepository.DidNotReceive().InsertAsync(
+            Arg.Any<Document>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await _blobContainer.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadAsync_Throws_UnsupportedFileType_When_Extension_Not_Allowed()
+    {
+        // #221：content-type 合法但扩展名不在白名单（决定 blob 后缀 + DefaultTextExtractor dispatch）→ fail-closed。
+        var input = CreateUploadInput([1, 2, 3], fileName: "A.exe", contentType: "application/pdf");
+
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.UploadAsync(input));
+
+        exception.Code.ShouldBe(PaperbaseErrorCodes.Document.UnsupportedFileType);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Throws_FileTooLarge_When_Declared_ContentLength_Exceeds_Limit()
+    {
+        // #221：客户端声明的 ContentLength 超限 → 廉价快速拒绝（不读流）。
+        var input = new UploadDocumentInput
+        {
+            File = new RemoteStreamContent(
+                new MemoryStream([1, 2, 3]),
+                "A.pdf",
+                "application/pdf",
+                readOnlyLength: DocumentConsts.MaxUploadFileBytes + 1,
+                disposeStream: true)
+        };
+
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.UploadAsync(input));
+
+        exception.Code.ShouldBe(PaperbaseErrorCodes.Document.FileTooLarge);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Throws_FileTooLarge_When_Streamed_Bytes_Exceed_Limit_Despite_Underreported_Length()
+    {
+        // #221：声明的 ContentLength 少报（不可信），但流式拷贝按实际字节数施加的硬上限仍兜住——
+        // 不依赖客户端声明，也不把超大 body 全量缓冲。临时下调 static 上限（finally 复原，类内串行执行）。
+        var original = DocumentConsts.MaxUploadFileBytes;
+        try
+        {
+            DocumentConsts.MaxUploadFileBytes = 4;
+            var input = new UploadDocumentInput
+            {
+                File = new RemoteStreamContent(
+                    new MemoryStream(new byte[10]),
+                    "A.pdf",
+                    "application/pdf",
+                    readOnlyLength: 3, // 少报，绕过廉价 ContentLength 检查
+                    disposeStream: true)
+            };
+
+            var exception = await Should.ThrowAsync<BusinessException>(async () =>
+                await _appService.UploadAsync(input));
+
+            exception.Code.ShouldBe(PaperbaseErrorCodes.Document.FileTooLarge);
+        }
+        finally
+        {
+            DocumentConsts.MaxUploadFileBytes = original;
+        }
+    }
+
     private static Document CreateDocument()
     {
         return new Document(
@@ -228,14 +306,15 @@ public class DocumentAppService_Delete_Tests
                 originalFileName: "test.pdf"));
     }
 
-    private static UploadDocumentInput CreateUploadInput(byte[] bytes)
+    private static UploadDocumentInput CreateUploadInput(
+        byte[] bytes, string fileName = "A.pdf", string contentType = "application/pdf")
     {
         return new UploadDocumentInput
         {
             File = new RemoteStreamContent(
                 new MemoryStream(bytes),
-                "A.pdf",
-                "application/pdf",
+                fileName,
+                contentType,
                 disposeStream: true)
         };
     }

--- a/host/src/PaperbaseHostModule.cs
+++ b/host/src/PaperbaseHostModule.cs
@@ -1,4 +1,5 @@
 using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.Documents;
 using Dignite.Paperbase.Host.Data;
 using Dignite.Paperbase.EntityFrameworkCore;
 using Dignite.Paperbase.Host.HealthChecks;
@@ -16,6 +17,8 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.OpenApi;
@@ -209,6 +212,26 @@ public class PaperbaseHostModule : AbpModule
         ConfigureDistributedEventBus();
         ConfigureAI(context, configuration);
         ConfigureOpenTelemetry(context, configuration);
+        ConfigureRequestLimits(context);
+    }
+
+    // #221：上传请求体上限作为 Kestrel / Form 层 backstop。真正的 fail-closed 友好错误在
+    // DocumentAppService.UploadAsync（按 DocumentConsts.MaxUploadFileBytes 校验后抛 BusinessException）；
+    // 此处留一段 multipart 信封余量（+1 MiB），使正常的最大尺寸文件不会在到达应用层前被 413 截断，
+    // 同时把 ASP.NET Core 默认的隐式 ~28.6 MB（Kestrel）/ 128 MB（Form）上限收敛为显式、可审计的边界。
+    private static void ConfigureRequestLimits(ServiceConfigurationContext context)
+    {
+        var bodyLimit = DocumentConsts.MaxUploadFileBytes + 1024 * 1024;
+
+        context.Services.Configure<KestrelServerOptions>(options =>
+        {
+            options.Limits.MaxRequestBodySize = bodyLimit;
+        });
+
+        context.Services.Configure<FormOptions>(options =>
+        {
+            options.MultipartBodyLengthLimit = bodyLimit;
+        });
     }
 
     // 启用 ABP transactional outbox + inbox（issue #188）：


### PR DESCRIPTION
Closes #221.

## Problem
`DocumentAppService.UploadAsync` had **no** application-level file-size cap and **no** content-type whitelist. Any type/size could land in blob storage and trigger text-extraction/classification jobs (DoS/OOM + non-intended types entering the pipeline). The request body size also relied on the implicit ASP.NET Core default (~28.6 MB Kestrel), i.e. an unauditable boundary.

The **Angular** client also had the upload whitelist duplicated and drifting from what the backend would accept (details below).

## Backend changes
**Fail-closed validation (`UploadAsync`)**
- Content-type **+ extension** dual whitelist — both must be allowed, else a loud `BusinessException` before any blob write / job queue. Extension is checked separately because content-type is client-spoofable and the extension drives the blob suffix + `DefaultTextExtractor` dispatch.
- Size: cheap early reject on the client-declared `ContentLength`, plus an authoritative **streaming hard-cap** (`CopyWithLimitAsync`) that counts actual bytes — an under-reported `ContentLength` can't slip a huge body through or buffer it.

**Robustness items the issue asked to evaluate**
- **Memory amplification (~2×)** → fixed: the buffer `MemoryStream` is scoped and released right after `ToArray()`, so only `bytes` (1×) is resident during `SaveAsync`.
- **Dedup race** → **accepted, no unique index** (documented inline). Low probability/harm; a unique index would turn the race loser into a 500.

**Constants / errors / host**
- `DocumentConsts.MaxUploadFileBytes` (20 MiB) + `AllowedUploadContentTypes` / `AllowedUploadExtensions` as host-overridable static-mutables (precedent: `MaxNativePayloadArchiveBytes`). Defaults aligned with the Angular whitelist (JPEG/PNG/GIF/WebP/PDF) — a host that wants MarkItDown digital-office formats widens both sets at startup.
- `PaperbaseErrorCodes.Document.FileTooLarge` / `UnsupportedFileType` + `en` / `zh-Hans` localization.
- Host backstop: explicit Kestrel `MaxRequestBodySize` + `FormOptions.MultipartBodyLengthLimit` (+1 MiB envelope margin) so the app-layer check stays the authoritative, friendly error.

## Frontend changes (Angular)
The client had the whitelist duplicated and drifting:
- `document-upload` validated **MIME only** (no extension), and its desktop picker used `accept="image/*,application/pdf"` — over-broad (offered tiff/bmp/svg the backend rejects).
- `document-list` bulk upload had **no client validation at all** and a narrow `accept=".pdf,.png,.jpg,.jpeg"` — missing `.gif`/`.webp` that the backend allows.

Now centralized in `upload-constraints.ts` (single source of truth, mirrors `DocumentConsts`):
- `MAX_UPLOAD_FILE_BYTES`, `ALLOWED_UPLOAD_CONTENT_TYPES`, `ALLOWED_UPLOAD_EXTENSIONS`, derived `UPLOAD_ACCEPT_ATTRIBUTE`, and `isAllowedUpload()` (dual MIME + extension check).
- Both pickers' `accept` derive from the shared whitelist (exact allowed set).
- Both upload paths validate MIME + extension + size; bulk upload pre-filters with localized per-file messages instead of a server round-trip.
- Camera-capture input keeps `accept="image/*"` (camera UX); the runtime `isAllowedUpload` filter still enforces the whitelist.

Client validation stays a UX nicety; the backend remains the authoritative fail-closed gate. A comment marks the file as the single source to keep in sync with `DocumentConsts.cs`.

## Tests / build
- 4 new backend tests (content-type reject, extension reject, declared-length reject, streamed-cap-defeats-underreported-length). Full Application suite: **167/167 passing**. Application + host build clean.
- Angular: `nx build paperbase` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)