### PR TITLE
refactor(ai-workflow): truncation logging + drop dead title language param (#226)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Ai/DefaultPromptProvider.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/DefaultPromptProvider.cs
@@ -4,7 +4,7 @@ namespace Dignite.Paperbase.Ai;
 
 /// <summary>
 /// 内置 <see cref="IPromptProvider"/> 实现。
-/// 按 <paramref name="language"/> 参数将语言指令嵌入系统提示词；
+/// 分类提示词按 language 参数将语言指令嵌入系统提示词；标题提示词跟随文档语言、不接受 language；
 /// 返回的 <see cref="PromptTemplate.SystemInstructions"/> 不含 PromptBoundary 规则，
 /// 由各 Workflow 在使用前追加。
 /// </summary>
@@ -20,7 +20,7 @@ public class DefaultPromptProvider : IPromptProvider, ITransientDependency
         $"Respond in: {language}."
     );
 
-    public virtual PromptTemplate GetTitleGenerationPrompt(string language) => new(
+    public virtual PromptTemplate GetTitleGenerationPrompt() => new(
         "You generate concise document titles. " +
         "Given a document in Markdown format, return one short descriptive title only — " +
         "the kind that appears in a file browser or search result. " +

--- a/core/src/Dignite.Paperbase.Application/Ai/IPromptProvider.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/IPromptProvider.cs
@@ -9,5 +9,10 @@ public interface IPromptProvider
 {
     PromptTemplate GetClassificationPrompt(string language);
 
-    PromptTemplate GetTitleGenerationPrompt(string language);
+    /// <summary>
+    /// 标题生成提示词。<b>不</b>接受 language 参数——标题策略是「跟随文档语言」
+    /// （prompt 内置 "Respond in the same language as the document."），
+    /// 不受 <c>PaperbaseAIBehaviorOptions.DefaultLanguage</c> 影响。
+    /// </summary>
+    PromptTemplate GetTitleGenerationPrompt();
 }

--- a/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
@@ -23,7 +23,15 @@ public class PaperbaseAIBehaviorOptions
     public int MaxTextLengthPerExtraction { get; set; } = 8000;
 
     /// <summary>
-    /// AI 交互默认语言（影响系统提示词语言）。
+    /// AI 交互默认语言。<b>仅作用于分类路径</b>（DocumentClassificationWorkflow，强制分类
+    /// 输出/reason 用此语言）。其余 LLM 路径按各自设计的语言策略，<b>不</b>消费此选项：
+    /// <list type="bullet">
+    ///   <item>分类：强制此语言（DefaultLanguage）</item>
+    ///   <item>标题：跟随文档语言（prompt 内置 "respond in the same language as the document"）</item>
+    ///   <item>字段值：保留文档原文</item>
+    ///   <item>Slug：强制英译（URL 友好）</item>
+    /// </list>
+    /// 这套「按路径分化」是预期设计，不是 bug——新增 LLM 路径前先确认其语言策略归属。
     /// </summary>
     public string DefaultLanguage { get; set; } = "ja";
 

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
@@ -61,9 +61,16 @@ public class FieldExtractionWorkflow : ITransientDependency
             return new Dictionary<string, JsonElement?>();
         }
 
-        var truncated = markdown.Length > _behaviorOptions.MaxTextLengthPerExtraction
-            ? markdown[.._behaviorOptions.MaxTextLengthPerExtraction]
-            : markdown;
+        var truncated = markdown;
+        if (markdown.Length > _behaviorOptions.MaxTextLengthPerExtraction)
+        {
+            // 截断会丢弃文档尾部，关键字段（合同金额 / 发票号等）若位于尾部将被静默漏抽——
+            // 运营侧需要在 telemetry 看到字段抽取截断率（与分类路径 DocumentClassificationWorkflow 对齐）。
+            _logger.LogWarning(
+                "Field extraction input truncated from {OriginalLength} to {TruncatedLength} characters; fields beyond the cutoff will be missed.",
+                markdown.Length, _behaviorOptions.MaxTextLengthPerExtraction);
+            truncated = markdown[.._behaviorOptions.MaxTextLengthPerExtraction];
+        }
 
         // system role 保持**编译期常量** —— 防 prompt injection（CLAUDE.md "## 安全约定 / Description / Instructions 编译期常量"）。
         // 字段 schema（含租户用户输入的 f.Name / f.Prompt）放进 user role 第一条 message，

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -235,7 +235,8 @@ public class DocumentTextExtractionBackgroundJob
                 ? markdown[.._behaviorOptions.MaxTitleGenerationMarkdownLength]
                 : markdown;
 
-            var template = _promptProvider.GetTitleGenerationPrompt(_behaviorOptions.DefaultLanguage);
+            // 标题策略：跟随文档语言（prompt 内置），不消费 DefaultLanguage —— 故无参调用。
+            var template = _promptProvider.GetTitleGenerationPrompt();
             var messages = new List<ChatMessage>
             {
                 new(ChatRole.System, template.SystemInstructions + "\n\n" + PromptBoundary.BoundaryRule),


### PR DESCRIPTION
Implements the confirmed, low-risk polish items (①②③) from #226; ④ deferred to the host deployment side.

## Changes

### ① Field extraction truncation warning
`FieldExtractionWorkflow` silently truncates when Markdown exceeds `MaxTextLengthPerExtraction` (default 8000) → add `LogWarning`, aligning with the classification path (`DocumentClassificationWorkflow`). Without this, critical fields in contracts/invoices that appear after character 8000 are silently dropped, with no truncation rate visible in telemetry.

### ② Remove dead title-generation language parameter
`IPromptProvider.GetTitleGenerationPrompt(string language)`'s `language` argument was never consumed — the title prompt is hardcoded to "respond in the same language as the document", which overrides the argument. Remove the parameter to eliminate ambiguity (the title strategy is intentionally "follow the document's language"). Updated implementation and all call sites.

### ③ Document language strategy
Add comments to `PaperbaseAIBehaviorOptions.DefaultLanguage` documenting the language strategy for each LLM path (classification forced / title follows document / field values preserve original / slug forced to English), marking these as intentional design. **`ja` default value not changed** — the core default is consistent with the host `appsettings.json` and is an intentional choice.

### ④ Cost knobs — deferred
Prompt caching / reasoning effort / relaxing `MaxTextLengthPerExtraction` all belong at the host `ConfigureAI` layer and involve cost/quality trade-offs; left to deployment-side evaluation, out of scope for the channel core.

## Boundary
All changes are host-layer / observability polish; **no channel boundary is touched** (exit contract / field architecture / Markdown-first / security rules unchanged).

## Verification
`Application` + `Application.Tests` projects: 0 warnings, 0 errors.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)