### PR TITLE
fix(documents): record Rejected review status, reconcile reject lifecycle (#237)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/DocumentAppService.cs
@@ -600,19 +600,11 @@ public class DocumentAppService : PaperbaseAppService, IDocumentAppService
         if (input.CabinetId.HasValue)
             query = query.Where(x => x.CabinetId == input.CabinetId.Value);
 
+        // 按人工审核状态过滤。被拒绝的文档现在落 ReviewStatus=Rejected（#237）——既天然不出现在
+        // PendingReview 队列，也可被调用方显式按 Rejected 查询；不再需要旧的"PendingReview 额外排除
+        // LifecycleStatus=Failed"特例（那是 reject 文档曾停在 PendingReview 时的补丁）。
         if (input.ReviewStatus.HasValue)
-        {
             query = query.Where(d => d.ReviewStatus == input.ReviewStatus.Value);
-
-            // PendingReview 队列默认只展示仍需处理的文档。RejectReview 会保留
-            // ReviewStatus=PendingReview 作为审计信号，但 lifecycle 已是 Failed；
-            // 若调用方确实要查失败审核记录，可显式传 LifecycleStatus=Failed。
-            if (input.ReviewStatus.Value == DocumentReviewStatus.PendingReview &&
-                !input.LifecycleStatus.HasValue)
-            {
-                query = query.Where(d => d.LifecycleStatus != DocumentLifecycleStatus.Failed);
-            }
-        }
 
         return query;
     }

--- a/core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentReviewStatus.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentReviewStatus.cs
@@ -9,5 +9,8 @@ public enum DocumentReviewStatus
     PendingReview = 10,
 
     /// <summary>已由人工确认文档类型</summary>
-    Reviewed = 20
+    Reviewed = 20,
+
+    /// <summary>操作员拒绝审核（#237）。可恢复信号：后续 Reclassify 会把状态转回 <see cref="Reviewed"/>。</summary>
+    Rejected = 30
 }

--- a/core/src/Dignite.Paperbase.Domain/Documents/Document.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/Document.cs
@@ -46,6 +46,7 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// <summary>
     /// 人工审核状态。
     /// 分类置信度不足或无法产出有效类型时自动置为 PendingReview；人工确认后置为 Reviewed；
+    /// 操作员拒绝时置为 Rejected（#237，可恢复——后续 Reclassify 会转回 Reviewed）；
     /// 新一轮自动分类成功时重置为 None。
     /// </summary>
     public virtual DocumentReviewStatus ReviewStatus { get; private set; }
@@ -254,22 +255,37 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     }
 
     /// <summary>
-    /// 操作员拒绝审核——文档落到 Failed 生命周期状态；ReviewStatus 保留以便审计。
-    /// 拒绝是"当前数字化结果不可用 / 无法归类"的终态结论：保留原文件、Markdown、OCR confidence 和拒绝原因，
-    /// 不在同一 Document 上做源文件替换或重跑；需要重试由操作员重新上传。
+    /// 操作员拒绝审核——把 <see cref="ReviewStatus"/> 置为 <see cref="DocumentReviewStatus.Rejected"/>（拒绝的权威信号），
+    /// 并把 <see cref="LifecycleStatus"/> 落到 Failed 作为"宏观不可用"外观。保留原文件、Markdown、confidence 和拒绝原因。
+    /// <para>
+    /// <b>拒绝可恢复，不是终态</b>（#237）：本方法只记录"操作员此刻拒绝"这一事实，不封死文档。操作员后续可对
+    /// 同一文档 Reclassify 指派类型——届时 <see cref="ConfirmClassification"/> 把 ReviewStatus 转回 Reviewed、
+    /// 流水线派生回 Ready、<c>DocumentReadyEto</c> 重新发布；下游按 ETO 的 <c>EventTime</c> 单调幂等吸收重发
+    /// （见 CLAUDE.md 投递语义）。"曾被拒绝 → 已复审"的轨迹由 ABP 实体审计日志承载，不在聚合根上建吸收态 / Reopen 状态机。
+    /// </para>
     /// <para>
     /// <b>lifecycle 派生规则的合法例外</b>：通常 <see cref="LifecycleStatus"/> 由
-    /// <see cref="DocumentPipelineRunManager"/> 从 pipeline run 状态派生（见类首注释 line 32-35），
-    /// 此处直接 <see cref="TransitionLifecycle"/> 到 Failed 是 review 终态语义的合法越权：
-    /// 拒绝即终态，无需等待 pipeline run 推进。
+    /// <see cref="DocumentPipelineRunManager"/> 从 pipeline run 状态派生，此处直接 <see cref="TransitionLifecycle"/>
+    /// 到 Failed 是人工审核轴的合法越权。迁移后 Failed 不再语义重载——它统一表示"宏观不可用"，<b>原因</b>由细分字段
+    /// 正交说明（pipeline run = 技术失败；<see cref="ReviewStatus"/> = Rejected = 操作员拒绝）。
     /// </para>
     /// </summary>
     public void RejectReview(string? reason = null)
     {
         ClassificationReason = TruncateReason(reason) ?? ClassificationReason;
+        ReviewStatus = DocumentReviewStatus.Rejected;
         TransitionLifecycle(DocumentLifecycleStatus.Failed);
     }
 
+    /// <summary>
+    /// 迁移 <see cref="LifecycleStatus"/> 并发 <see cref="DocumentLifecycleStatusChangedEvent"/>（仅在状态实变时）。
+    /// <para>
+    /// <b>无合法转移矩阵是有意的</b>（#237 Finding B）：除 <c>old == new</c> 短路外，任意 <c>(old, new)</c> 跳转都允许，
+    /// 包括 <c>Failed → Ready</c>（拒绝后 Reclassify 复活）与 <c>Ready → Processing → Ready</c>（已就绪文档手动重跑流水线）。
+    /// 二者都会重新派生 Ready 并重发 <c>DocumentReadyEto</c>——通道层不拦，由下游按 ETO 的 <c>EventTime</c> 单调幂等吸收
+    /// （CLAUDE.md 投递语义）。在网关聚合根上不引入硬状态机，是"通道保持简单、幂等交给下游"的有意取舍。
+    /// </para>
+    /// </summary>
     internal void TransitionLifecycle(DocumentLifecycleStatus newStatus)
     {
         if (LifecycleStatus == newStatus)

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Review_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Review_Tests.cs
@@ -44,7 +44,7 @@ public class DocumentAppServiceReviewTestModule : AbpModule
 }
 
 /// <summary>
-/// <see cref="DocumentAppService.RejectReviewAsync"/> 行为 + PendingReview 列表过滤测试。
+/// <see cref="DocumentAppService.RejectReviewAsync"/> 行为（#237：落 ReviewStatus=Rejected，可恢复）+ 审核列表过滤测试。
 /// <para>
 /// #196 砍掉 OCR 置信度门槛后，进 PendingReview 的唯一来源是分类低置信度 / 无合适类型
 /// （<see cref="DocumentPipelineRunManager.CompleteClassificationWithLowConfidenceAsync"/>）；
@@ -74,14 +74,16 @@ public class DocumentAppService_Review_Tests
         await _appService.RejectReviewAsync(doc.Id, new RejectReviewInput { Reason = "scan unusable" });
 
         doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.Failed);
+        doc.ReviewStatus.ShouldBe(DocumentReviewStatus.Rejected);
         doc.ClassificationReason.ShouldBe("scan unusable");
     }
 
     [Fact]
-    public async Task PendingReview_Filter_Excludes_Failed_Rejections_By_Default()
+    public async Task PendingReview_Filter_Excludes_Rejected_Documents_By_Default()
     {
         var activePending = await CreatePendingReviewDocumentAsync("needs review");
 
+        // 被拒绝的文档落 ReviewStatus=Rejected（#237），自然不匹配 PendingReview 过滤。
         var rejected = await CreatePendingReviewDocumentAsync("low confidence");
         rejected.RejectReview("scan unusable");
 
@@ -95,18 +97,16 @@ public class DocumentAppService_Review_Tests
     }
 
     [Fact]
-    public async Task PendingReview_Filter_Allows_Failed_Rejections_When_Lifecycle_Is_Explicit()
+    public async Task RejectedDocuments_Are_Queryable_By_Rejected_ReviewStatus()
     {
+        // #237：拒绝可恢复 + 留痕——reject 把 ReviewStatus 落到 Rejected（权威信号），
+        // 操作员 / 下游据此显式查询被拒文档；LifecycleStatus 仍是 Failed 的"宏观不可用"外观。
         var rejected = await CreatePendingReviewDocumentAsync("low confidence");
         rejected.RejectReview("scan unusable");
 
         var result = ApplyFilterForTest(
                 new[] { rejected }.AsQueryable(),
-                new GetDocumentListInput
-                {
-                    ReviewStatus = DocumentReviewStatus.PendingReview,
-                    LifecycleStatus = DocumentLifecycleStatus.Failed
-                })
+                new GetDocumentListInput { ReviewStatus = DocumentReviewStatus.Rejected })
             .ToList();
 
         result.ShouldContain(rejected);


### PR DESCRIPTION
## What & why

`Document.RejectReview` documented itself as "terminal", but `Reclassify` could silently revive a rejected document back to `Ready` and re-emit `DocumentReadyEto` — with nothing recording that an operator had rejected it (#237).

**Root cause:** `LifecycleStatus.Failed` was overloaded for two unrelated things — technical failure (pipeline retry exhausted) and operator rejection — and `DeriveLifecycle` only sees pipeline-run state, so it can't tell them apart.

## Approach (decision recorded on #237: reject is recoverable + leaves a trace)

- **Add `DocumentReviewStatus.Rejected`.** `RejectReview` now sets it, keeping `TransitionLifecycle(Failed)` only as the "macro-unavailable" surface. `Failed` is no longer overloaded — cause is told orthogonally (pipeline run = technical failure; `ReviewStatus = Rejected` = operator reject).
- **Stays recoverable.** `Reclassify` still revives via `ConfirmClassification` (`Rejected → Reviewed`). `Ready` may be re-derived and `DocumentReadyEto` re-emitted; downstream dedupes by `EventTime` (CLAUDE.md delivery semantics). The "was rejected → reviewed" trail lives in ABP entity audit history — no absorbing state / Reopen machine.
- **Drop the obsolete queue special-case.** The old "PendingReview queue excludes `Failed`" filter is gone: rejected docs carry `ReviewStatus=Rejected`, so they are naturally excluded from the PendingReview queue and queryable by `Rejected`.
- **Document `TransitionLifecycle`'s intentionally matrix-free design** (Finding B): re-derivation is absorbed downstream, not gated in the channel.

## Out-of-band contract impact

- REST `DocumentDto` / list `ReviewStatus` gains the `Rejected` value + filter option.
- MCP and event ETOs unchanged.
- No schema migration (enum value only); historical `(Failed, PendingReview)` rows are **not** backfilled.

## Tests

- `DocumentAppService_Review_Tests`: 3 cases synced to the new semantics (reject → `Rejected`; PendingReview queue excludes rejected; rejected queryable by `Rejected`).
- Domain.Tests 114/114 green; host full-chain build clean.
- Note: 8 pre-existing `UploadAsync_*` failures in Application.Tests are **unrelated** (baseline-red, `NoDocumentTypesConfigured` seed issue) — verified via `git stash`.

Closes #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
