### PR TITLE
test(documents): stub GetCountAsync to match UploadAsync fail-fast (#241)

### DIFF
--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -52,12 +52,9 @@ public class DocumentAppService_Delete_Tests
         _cabinetRepository = GetRequiredService<ICabinetRepository>();
 
         // UploadAsync 的前置 fail-fast 检查（当前层至少有一个 DocumentType）—— 测试默认走"已配置"路径，
-        // 让重复 / 回收站检查能跑到。专门测试"未配置 → NoDocumentTypesConfigured"应在另外的 fact 里覆盖空 list。
-        _documentTypeRepository.GetListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Returns(new System.Collections.Generic.List<DocumentType>
-            {
-                new(Guid.NewGuid(), null, "host.general", "General", 0.7, 0)
-            });
+        // 让 cabinet / 文件校验 / 重复 / 回收站检查能跑到。fail-fast 走 GetCountAsync()（#241，非 GetListAsync）；
+        // 专门测试"未配置 → NoDocumentTypesConfigured"在对应 fact 里把 count 覆盖为 0。
+        _documentTypeRepository.GetCountAsync(Arg.Any<CancellationToken>()).Returns(1L);
     }
 
     [Fact]
@@ -118,8 +115,7 @@ public class DocumentAppService_Delete_Tests
     {
         // 覆盖 fail-fast：删除 Host 启动期 seed 后，新部署 / 新租户首次上传必须先建至少一个 DocumentType。
         // 不做这个检查的话，文档会上传成功 → 分类候选集为空 → 永远卡 PendingReview。
-        _documentTypeRepository.GetListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Returns(new System.Collections.Generic.List<DocumentType>());
+        _documentTypeRepository.GetCountAsync(Arg.Any<CancellationToken>()).Returns(0L);
 
         var exception = await Should.ThrowAsync<BusinessException>(async () =>
         {


### PR DESCRIPTION
Fixes the 8 baseline-red `UploadAsync_*` tests in `DocumentAppService_Delete_Tests`.

## Root cause
`72a79df` changed `UploadAsync`'s fail-fast to `_documentTypeRepository.GetCountAsync() > 0`, but the test still stubbed `GetListAsync`. The NSubstitute mock's un-stubbed `GetCountAsync()` returned the default `0`, so every upload test tripped `NoDocumentTypesConfigured` before its intended assertion. The dedicated `NoneConfigured` test, in turn, passed only by accident of that same default.

## Fix (test-only)
Stub the method the code actually calls: `GetCountAsync → 1` in the constructor, `→ 0` in the `NoneConfigured` test. Dead `GetListAsync` stubs dropped. No production change.

## Verification
`Application.Tests` now **174/174** green (was 166 passed / 8 failed).

Closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
