### PR TITLE
feat(ocr): thread CancellationToken through IOcrProvider.RecognizeAsync (#238)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -15,6 +15,7 @@ using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Threading;
 using Volo.Abp.Timing;
 using Volo.Abp.Uow;
 
@@ -38,6 +39,9 @@ public class DocumentTextExtractionBackgroundJob
     private readonly IChatClient _titleGeneratorChatClient;
     private readonly IPromptProvider _promptProvider;
     private readonly PaperbaseAIBehaviorOptions _behaviorOptions;
+    // ABP 后台作业执行器（BackgroundJobExecuter）在调用 ExecuteAsync 前用 ICancellationTokenProvider.Use(...)
+    // 把作业执行上下文的取消令牌（默认 worker 来源是 host 停机令牌）压入 ambient，外部慢工作据此可取消。
+    private readonly ICancellationTokenProvider _cancellationTokenProvider;
 
     public DocumentTextExtractionBackgroundJob(
         IDocumentRepository documentRepository,
@@ -52,7 +56,8 @@ public class DocumentTextExtractionBackgroundJob
         IClock clock,
         [FromKeyedServices(PaperbaseAIConsts.TitleGeneratorChatClientKey)] IChatClient titleGeneratorChatClient,
         IPromptProvider promptProvider,
-        IOptions<PaperbaseAIBehaviorOptions> behaviorOptions)
+        IOptions<PaperbaseAIBehaviorOptions> behaviorOptions,
+        ICancellationTokenProvider cancellationTokenProvider)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _pipelineJobScheduler = pipelineJobScheduler;
@@ -63,6 +68,7 @@ public class DocumentTextExtractionBackgroundJob
         _titleGeneratorChatClient = titleGeneratorChatClient;
         _promptProvider = promptProvider;
         _behaviorOptions = behaviorOptions.Value;
+        _cancellationTokenProvider = cancellationTokenProvider;
     }
 
     public override async Task ExecuteAsync(DocumentTextExtractionJobArgs args)
@@ -82,7 +88,7 @@ public class DocumentTextExtractionBackgroundJob
                 LanguageHints = { "ja", "en" }
             };
 
-            var result = await _textExtractor.ExtractAsync(blobStream, ctx);
+            var result = await _textExtractor.ExtractAsync(blobStream, ctx, _cancellationTokenProvider.Token);
 
             var title = await TryGenerateTitleAsync(result.Markdown)
                 ?? MarkdownTitleExtractor.ExtractTitle(result.Markdown)

--- a/core/src/Dignite.Paperbase.Ocr.AzureDocumentIntelligence/AzureDocumentIntelligenceOcrProvider.cs
+++ b/core/src/Dignite.Paperbase.Ocr.AzureDocumentIntelligence/AzureDocumentIntelligenceOcrProvider.cs
@@ -25,9 +25,12 @@ public class AzureDocumentIntelligenceOcrProvider : IOcrProvider, ITransientDepe
         _options = options.Value;
     }
 
-    public virtual async Task<OcrResult> RecognizeAsync(Stream fileStream, OcrOptions options)
+    public virtual async Task<OcrResult> RecognizeAsync(
+        Stream fileStream,
+        OcrOptions options,
+        CancellationToken cancellationToken = default)
     {
-        var (analyzeResult, rawResponse) = await AnalyzeAsync(fileStream, ModelId, cancellationToken: default);
+        var (analyzeResult, rawResponse) = await AnalyzeAsync(fileStream, ModelId, cancellationToken);
 
         var markdown = BuildMarkdown(analyzeResult);
 

--- a/core/src/Dignite.Paperbase.Ocr.PaddleOcr/PaddleOcrProvider.cs
+++ b/core/src/Dignite.Paperbase.Ocr.PaddleOcr/PaddleOcrProvider.cs
@@ -27,7 +27,10 @@ public class PaddleOcrProvider : IOcrProvider, ITransientDependency
         _httpClientFactory = httpClientFactory;
     }
 
-    public virtual async Task<OcrResult> RecognizeAsync(Stream fileStream, OcrOptions options)
+    public virtual async Task<OcrResult> RecognizeAsync(
+        Stream fileStream,
+        OcrOptions options,
+        CancellationToken cancellationToken = default)
     {
         var modelName = _options.ModelName;
         var rawJson = await SendAsync(
@@ -35,7 +38,7 @@ public class PaddleOcrProvider : IOcrProvider, ITransientDependency
             options.LanguageHints,
             options.ContentType,
             modelName,
-            cancellationToken: default);
+            cancellationToken);
 
         var result = JsonSerializer.Deserialize<PaddleOcrResponse>(rawJson)
             ?? throw new InvalidOperationException("PaddleOCR server returned an empty response.");

--- a/core/src/Dignite.Paperbase.Ocr/IOcrProvider.cs
+++ b/core/src/Dignite.Paperbase.Ocr/IOcrProvider.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Dignite.Paperbase.Ocr;
@@ -31,5 +32,10 @@ namespace Dignite.Paperbase.Ocr;
 /// </remarks>
 public interface IOcrProvider
 {
-    Task<OcrResult> RecognizeAsync(Stream fileStream, OcrOptions options);
+    /// <param name="cancellationToken">
+    /// 文本提取后台作业经 ABP 后台作业取消令牌（host 关闭 / 作业取消）一路传入。
+    /// OCR 调用通常是长耗时外部 HTTP（本地 sidecar / 云 LRO 轮询），实现方<b>必须</b>把它
+    /// 透传给底层 HTTP / SDK 调用，以便作业 / host 关闭时能及时中止。
+    /// </param>
+    Task<OcrResult> RecognizeAsync(Stream fileStream, OcrOptions options, CancellationToken cancellationToken = default);
 }

--- a/core/src/Dignite.Paperbase.TextExtraction/DefaultTextExtractor.cs
+++ b/core/src/Dignite.Paperbase.TextExtraction/DefaultTextExtractor.cs
@@ -93,7 +93,7 @@ public class DefaultTextExtractor : ITextExtractor, ITransientDependency
             {
                 ContentType = ctx.ContentType ?? string.Empty,
                 LanguageHints = languageHints
-            });
+            }, cancellationToken);
 
             Logger.LogDebug("OCR completed using {Provider}.", result.ProviderName ?? _ocrProvider.GetType().Name);
 

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DefaultTextExtractor_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DefaultTextExtractor_Tests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Abstractions.TextExtraction;
 using Dignite.Paperbase.Ocr;
@@ -47,7 +48,8 @@ public class DefaultTextExtractor_Tests : AbpIntegratedTest<DefaultTextExtractor
             Arg.Is<OcrOptions>(o =>
                 o.ContentType == "image/jpeg" &&
                 o.LanguageHints.Contains("ja") &&
-                o.LanguageHints.Contains("en")));
+                o.LanguageHints.Contains("en")),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -106,7 +108,7 @@ public class DefaultTextExtractor_Tests : AbpIntegratedTest<DefaultTextExtractor
     [Fact]
     public async Task Should_Not_Retry_Ocr_For_Image()
     {
-        _ocrProvider.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>())
+        _ocrProvider.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
             .Returns(new OcrResult
             {
                 Markdown = "| A | B |\n|---|---|\n| kept | table |"
@@ -126,7 +128,8 @@ public class DefaultTextExtractor_Tests : AbpIntegratedTest<DefaultTextExtractor
         // orchestrator 不做 OCR 重试——provider 只调用一次。
         await _ocrProvider.Received(1).RecognizeAsync(
             Arg.Any<Stream>(),
-            Arg.Any<OcrOptions>());
+            Arg.Any<OcrOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     // === #210 provenance：ProviderName 传播 + NativePayload 扁平字段映射 ===
@@ -187,7 +190,7 @@ public class DefaultTextExtractor_Tests : AbpIntegratedTest<DefaultTextExtractor
             // OCR provider 负责选择部署配置中的模型并输出 Markdown；orchestrator 不做 profile 重试。
             // 带扁平 NativePayload 字段 + provider 身份，覆盖 #210 provenance 组装（编排层透传 + 映射 NativePayload）。
             var fakeOcr = Substitute.For<IOcrProvider>();
-            fakeOcr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>())
+            fakeOcr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
                 .Returns(new OcrResult
                 {
                     Markdown = "fake ocr markdown",


### PR DESCRIPTION
Closes #238.

## Problem
`IOcrProvider.RecognizeAsync(Stream, OcrOptions)` does not accept a `CancellationToken`, making OCR the only uncancellable segment in the text-extraction chain:
- `PaddleOcrProvider` / `AzureDocumentIntelligenceOcrProvider` can only call the underlying long-running external HTTP with `cancellationToken: default` (PaddleOCR sidecar timeout 600s; Azure DI LRO polling)
- `DefaultTextExtractor.ExtractByOcrAsync` cannot forward its already-available token downstream

The Markdown leg honors the token end-to-end; the OCR leg breaks the chain at the contract boundary.

## Changes
- **`IOcrProvider.RecognizeAsync`** adds `CancellationToken cancellationToken = default` (OCR provider contract change — per CLAUDE.md handling rule #3, issue #238 was opened before touching the code)
- **PaddleOcr / AzureDocumentIntelligence** both providers forward the token, removing the hard-coded `cancellationToken: default`
- **`DefaultTextExtractor.ExtractByOcrAsync`** forwards its existing `cancellationToken` to `RecognizeAsync`, bringing the OCR leg to token parity with the Markdown leg
- **`DocumentTextExtractionBackgroundJob`** injects `ICancellationTokenProvider` and passes the job execution context cancellation token to `ExtractAsync`
- **`DefaultTextExtractor_Tests`** NSubstitute matchers updated to include `Arg.Any<CancellationToken>()`

## Design notes
ABP's `BackgroundJobExecuter` calls `ICancellationTokenProvider.Use(context.CancellationToken)` before invoking `ExecuteAsync`, pushing the token into the ambient; in the default worker the source is the host shutdown token — so `_cancellationTokenProvider.Token` is a real, actionable cancellation signal, fulfilling the issue's intent of "cancellable at job / host shutdown".

## Verification
- `Dignite.Paperbase.Application` / both OCR provider projects build successfully
- `DefaultTextExtractor_Tests` 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)