### PR TITLE
ci(angular): run unit tests on plain Vitest (jsdom), enable in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: npx nx run-many -t lint
         working-directory: angular
 
-      # Test step intentionally disabled — no *.spec.ts / *.test.ts files exist in the
-      # workspace yet, so vitest fails with "No tests found" before any rule runs.
-      # Re-enable when the first Angular spec lands.
+      # Unit tests run on plain Vitest (jsdom) via vitest.config.mts, not the
+      # `@angular/build:unit-test` builder — see vitest.setup.ts for the rationale.
+      - name: Unit tests
+        run: npx vitest run
+        working-directory: angular

--- a/angular/package.json
+++ b/angular/package.json
@@ -11,10 +11,11 @@
     "build": "nx run-many -t build",
     "build:paperbase": "nx build paperbase",
     "build:host": "nx build host",
-    "test": "nx run-many -t test",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "nx run-many -t lint",
     "affected:build": "nx affected -t build",
-    "affected:test": "nx affected -t test"
+    "affected:test": "vitest run"
   },
   "dependencies": {
     "@abp/ng.account": "~10.2.0",

--- a/angular/packages/paperbase/src/lib/proxy/documents/document-review-status.enum.spec.ts
+++ b/angular/packages/paperbase/src/lib/proxy/documents/document-review-status.enum.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DocumentReviewStatus,
+  documentReviewStatusOptions,
+} from './document-review-status.enum';
+
+describe('DocumentReviewStatus (smoke)', () => {
+  it('exposes the expected numeric values', () => {
+    expect(DocumentReviewStatus.None).toBe(0);
+    expect(DocumentReviewStatus.PendingReview).toBe(10);
+    expect(DocumentReviewStatus.Reviewed).toBe(20);
+  });
+
+  it('maps every member to an option entry', () => {
+    expect(documentReviewStatusOptions).toHaveLength(3);
+  });
+});

--- a/angular/vitest.config.mts
+++ b/angular/vitest.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['packages/**/*.spec.ts', 'apps/**/*.spec.ts'],
+    // Skip the broken `@angular/build:unit-test` (vitest) builder; see vitest.setup.ts.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.angular/**'],
+  },
+});

--- a/angular/vitest.setup.ts
+++ b/angular/vitest.setup.ts
@@ -1,0 +1,15 @@
+// Angular unit tests run on plain Vitest (jsdom) instead of the `@angular/build:unit-test`
+// builder, whose browser-mode detection is defeated by devkit materializing the unset
+// `browsers` option to `[]` (it checks `=== undefined`). Partial-compiled Angular/ABP
+// libraries are JIT-linked at runtime via `@angular/compiler` here — no Angular Linker needed.
+import '@angular/compiler';
+import 'zone.js';
+import 'zone.js/testing';
+
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
+
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());


### PR DESCRIPTION
## Background

Unit tests in `angular/` via `nx test` / `@angular/build:unit-test` builder **cannot run**, due to an upstream toolchain bug unrelated to project code:

- When nx invokes the builder via `@angular-devkit/architect`, devkit's `addUndefinedDefaults` materializes unset array option `browsers` as `[]`.
- The builder only falls back to jsdom/node when `browsers === undefined` — the empty array `[]` bypasses the short-circuit and is treated as "browser mode requested", producing `requires either "playwright" or "webdriverio"`.
- Installing playwright does not help: `browsers: []` enters a zero-browser-instance path. The root cause is `[]` itself (the builder should check `browsers?.length`).

This is the actual reason the test step in `ci.yml` was previously commented out.

## Changes

Bypass the broken builder; run tests with bare Vitest (jsdom):

- **`angular/vitest.config.mts`** — jsdom environment, `globals`, `setupFiles`, `include: packages/** + apps/**`
- **`angular/vitest.setup.ts`** — imports `@angular/compiler` (JIT-links partial-compiled Angular/ABP libraries, no Angular Linker required) + `zone.js` + `zone.js/testing`, and initializes TestBed with Angular 21's `platformBrowserTesting`
- **smoke spec** (`document-review-status.enum.spec.ts`, 2 cases) as the first test seed
- **`package.json`** — `test` → `vitest run`, adds `test:watch`, `affected:test` → `vitest run`
- **`ci.yml`** — replaces the disabled test step with a real `npx vitest run`

> Note: the `nx test paperbase` builder path still triggers the upstream `browsers=[]` bug and is not changed by this PR; the canonical test command is now `npm test`.

## Local verification

| Step | Result |
|------|--------|
| `npm test` (vitest run) | ✅ 2 passed |
| `nx lint paperbase` | ✅ All files pass |
| `nx build paperbase --configuration production` | ✅ Built (ng-packagr automatically excludes `.spec.ts`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)