### PR TITLE
ci: bump actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Background

CI runs were reporting deprecation warnings: the wrapper scripts for `actions/checkout@v4` and `actions/setup-node@v4` run on Node.js 20, and GitHub will enforce an upgrade to Node 24 on runners starting **2026-06-16**.

## Changes

Bump both actions to v5 (wrapper script runtime → Node 24).

**Pure CI-runner layer change, unrelated to ABP/Angular:**
- `node-version: '22'` (the Node version actually used to build/test Angular) **unchanged**
- `setup-dotnet@v4` **not touched** (not in the Node 20 deprecation scope)
- v5 is backward-compatible with inputs such as `node-version` / `cache`; no API changes

Sole effect: eliminates deprecation warnings and prevents CI failures after 6-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)