### PR TITLE
fix(extraction): full Markdown for field extraction + surrogate-safe classification truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,14 @@ Paperbase 通过四种出口给下游消费方：
 | `FieldsExtractedEto` | 字段抽取完成（载荷单段 `FieldCount`；按 `Document.TenantId` 决定本文档跑哪层 schema，单桶持久化） | 否 |
 | `DocumentReadyEto` | **全流水线完成 + 拿到已确认类型（分类置信度达标或人工确认）** | **是** |
 
+**回收站 / 生命周期事件**（与多阶段管线正交，不受 Ready 闸门约束；下游据此把派生数据归档或物理删除）：
+
+| 生命周期事件 | 触发时机 |
+|------------|---------|
+| `DocumentDeletedEto` | 文档软删除（进回收站）——下游应把派生数据置为可恢复的归档状态 |
+| `DocumentRestoredEto` | 文档从回收站恢复——下游应解除归档 |
+| `DocumentPermanentlyDeletedEto` | 文档永久删除（含原文件 / 归档 blob）——下游应物理删除派生数据 |
+
 **载荷设计**：事件载荷一律薄（ID + 关键元数据），下游通过 REST/MCP 回拉详细数据。
 
 **Ready 闸门（分类置信度 + 人工审核）**：

--- a/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
@@ -18,7 +18,9 @@ public class PaperbaseAIBehaviorOptions
     public int MaxDocumentTypesInClassificationPrompt { get; set; } = 50;
 
     /// <summary>
-    /// 结构化提取单次调用最大文本长度，超出时截断。
+    /// 分类提示词中文档 Markdown 的最大字符数，超出时按 UTF-16 码元截断前部（不切断代理对）。
+    /// <b>仅作用于分类路径</b>（<c>DocumentClassificationWorkflow</c>）——字段抽取（<c>FieldExtractionWorkflow</c>）
+    /// 有意喂入<b>完整</b> Markdown 不截断，因为类型绑定字段可能出现在文档任何位置，尾部截断会静默漏抽。
     /// </summary>
     public int MaxTextLengthPerExtraction { get; set; } = 8000;
 

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/Classification/DocumentClassificationWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/Classification/DocumentClassificationWorkflow.cs
@@ -58,6 +58,7 @@ public class DocumentClassificationWorkflow : ITransientDependency
         }
 
         // 候选集排序与数量上限由调用方（DocumentClassificationBackgroundJob）决定。
+        // 分类只需文档前段语义即可判型，故按 MaxTextLengthPerExtraction 截断前部（与字段抽取喂全文有意分化）。
         var truncatedText = markdown;
         if (markdown.Length > _options.MaxTextLengthPerExtraction)
         {
@@ -65,7 +66,7 @@ public class DocumentClassificationWorkflow : ITransientDependency
             Logger.LogWarning(
                 "Classification input truncated from {OriginalLength} to {TruncatedLength} characters; key fields beyond the cutoff will be missed.",
                 markdown.Length, _options.MaxTextLengthPerExtraction);
-            truncatedText = markdown[.._options.MaxTextLengthPerExtraction];
+            truncatedText = TruncateAtCharBoundary(markdown, _options.MaxTextLengthPerExtraction);
         }
 
         // 字段架构 v2：DocumentType.DisplayName 是 DB-resolved string，
@@ -190,6 +191,20 @@ public class DocumentClassificationWorkflow : ITransientDependency
         if (value < 0d) return 0d;
         if (value > 1d) return 1d;
         return value;
+    }
+
+    // 按 UTF-16 码元上限截断，但不切断代理对：末位若是高位代理（其低位已被切掉），一并丢弃，
+    // 避免半个码点在 UTF-8 编码送 LLM 时退化成 U+FFFD。截断点已在被丢弃的文档尾部，多退一个 char 无影响。
+    // internal 便于 Application.Tests 直接验证边界逻辑（与上面置信度 helper 同源）。
+    internal static string TruncateAtCharBoundary(string text, int maxChars)
+    {
+        if (maxChars <= 0)
+            return string.Empty;
+        if (text.Length <= maxChars)
+            return text;
+
+        var end = char.IsHighSurrogate(text[maxChars - 1]) ? maxChars - 1 : maxChars;
+        return text[..end];
     }
 
     private sealed class ClassificationResponse

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
@@ -10,7 +10,6 @@ using Dignite.Paperbase.Ai;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 
 namespace Dignite.Paperbase.Documents.Pipelines.FieldExtraction;
@@ -35,16 +34,13 @@ namespace Dignite.Paperbase.Documents.Pipelines.FieldExtraction;
 public class FieldExtractionWorkflow : ITransientDependency
 {
     private readonly IChatClient _chatClient;
-    private readonly PaperbaseAIBehaviorOptions _behaviorOptions;
     private readonly ILogger<FieldExtractionWorkflow> _logger;
 
     public FieldExtractionWorkflow(
         [FromKeyedServices(PaperbaseAIConsts.StructuredChatClientKey)] IChatClient chatClient,
-        IOptions<PaperbaseAIBehaviorOptions> behaviorOptions,
         ILogger<FieldExtractionWorkflow> logger)
     {
         _chatClient = chatClient;
-        _behaviorOptions = behaviorOptions.Value;
         _logger = logger;
     }
 
@@ -61,17 +57,12 @@ public class FieldExtractionWorkflow : ITransientDependency
             return new Dictionary<string, JsonElement?>();
         }
 
-        var truncated = markdown;
-        if (markdown.Length > _behaviorOptions.MaxTextLengthPerExtraction)
-        {
-            // 截断会丢弃文档尾部，关键字段（合同金额 / 发票号等）若位于尾部将被静默漏抽——
-            // 运营侧需要在 telemetry 看到字段抽取截断率（与分类路径 DocumentClassificationWorkflow 对齐）。
-            _logger.LogWarning(
-                "Field extraction input truncated from {OriginalLength} to {TruncatedLength} characters; fields beyond the cutoff will be missed.",
-                markdown.Length, _behaviorOptions.MaxTextLengthPerExtraction);
-            truncated = markdown[.._behaviorOptions.MaxTextLengthPerExtraction];
-        }
-
+        // 字段抽取喂入**完整 Markdown**，绝不截断：类型绑定字段（合同金额 / 发票号 / 到期日等）
+        // 可能出现在文档任何位置，按字符数截断尾部会静默漏抽关键字段。这与分类路径有意分化——
+        // DocumentClassificationWorkflow 只需文档前段语义即可判型，故按 MaxTextLengthPerExtraction 截断；
+        // 字段抽取需要全文覆盖。超大文档的 token 成本 / 上下文窗口由 host 选用的模型 + provider 负责，
+        // 通道层不预截（预截只会把"漏抽"伪装成"抽取成功"，比直接的 provider 报错更难排查）。
+        //
         // system role 保持**编译期常量** —— 防 prompt injection（CLAUDE.md "## 安全约定 / Description / Instructions 编译期常量"）。
         // 字段 schema（含租户用户输入的 f.Name / f.Prompt）放进 user role 第一条 message，
         // 让模型把"指令"与"用户数据"分开看待——配合 PromptBoundary.WrapField + BoundaryRule。
@@ -82,7 +73,7 @@ public class FieldExtractionWorkflow : ITransientDependency
         {
             new(ChatRole.System, SystemInstructions + "\n\n" + PromptBoundary.BoundaryRule),
             new(ChatRole.User, schemaMessage),
-            new(ChatRole.User, PromptBoundary.WrapDocument(truncated))
+            new(ChatRole.User, PromptBoundary.WrapDocument(markdown))
         };
 
         var options = new ChatOptions

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationTruncationTests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationTruncationTests.cs
@@ -1,0 +1,58 @@
+using Dignite.Paperbase.Documents.Pipelines.Classification;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// 回归保护：<see cref="DocumentClassificationWorkflow.TruncateAtCharBoundary"/> 不切断代理对。
+///
+/// 背景：分类按 MaxTextLengthPerExtraction（UTF-16 码元）截断文档前部喂 LLM。朴素的
+/// <c>markdown[..N]</c> 会在 N 落在代理对中间时留下半个码点——UTF-8 编码送 LLM 时退化成 U+FFFD。
+/// 截断点位于被丢弃的尾部，故末位若是高位代理则一并丢弃即可（多退一个 char 无影响）。
+/// </summary>
+public class DocumentClassificationTruncationTests
+{
+    [Fact]
+    public void Returns_Text_Unchanged_When_Within_Limit()
+    {
+        DocumentClassificationWorkflow.TruncateAtCharBoundary("hello", 10).ShouldBe("hello");
+        DocumentClassificationWorkflow.TruncateAtCharBoundary("hello", 5).ShouldBe("hello");
+    }
+
+    [Fact]
+    public void Truncates_Plain_Text_At_Char_Limit()
+    {
+        DocumentClassificationWorkflow.TruncateAtCharBoundary("abcdef", 3).ShouldBe("abc");
+    }
+
+    [Fact]
+    public void Does_Not_Split_A_Surrogate_Pair_At_The_Cut()
+    {
+        // "A" + 😀 (U+1F600，一个代理对 = 2 个 UTF-16 码元) + "B"。
+        // 在 maxChars=2 处截断会落在代理对中间——应丢弃整个高位代理，得到 "A"（长度 1），不留半个码点。
+        var text = "A\U0001F600B";
+        var result = DocumentClassificationWorkflow.TruncateAtCharBoundary(text, 2);
+
+        result.ShouldBe("A");
+        result.Length.ShouldBe(1);
+        char.IsHighSurrogate(result[^1]).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Keeps_A_Whole_Surrogate_Pair_When_It_Fits()
+    {
+        // maxChars=3 容纳 "A" + 完整代理对 → 原样保留（长度 3）。
+        var text = "A\U0001F600B";
+        var result = DocumentClassificationWorkflow.TruncateAtCharBoundary(text, 3);
+
+        result.ShouldBe("A\U0001F600");
+        result.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Returns_Empty_For_Non_Positive_Limit()
+    {
+        DocumentClassificationWorkflow.TruncateAtCharBoundary("abc", 0).ShouldBe(string.Empty);
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionEventHandler_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionEventHandler_Tests.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Paperbase.Abstractions.Documents;
-using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Documents;
 using Dignite.Paperbase.Documents.DocumentTypes;
 using Dignite.Paperbase.Documents.Fields;
@@ -15,7 +14,6 @@ using Dignite.Paperbase.Documents.Pipelines.FieldExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.EventBus.Distributed;
@@ -38,7 +36,6 @@ public class FieldExtractionEventHandlerTestModule : AbpModule
         // 测试 case 内对 virtual ExtractAsync 设 Returns/Throws。
         var workflow = Substitute.ForPartsOf<FieldExtractionWorkflow>(
             Substitute.For<IChatClient>(),
-            Options.Create(new PaperbaseAIBehaviorOptions()),
             NullLogger<FieldExtractionWorkflow>.Instance);
         context.Services.AddSingleton(workflow);
     }

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow_Tests.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Documents.Pipelines.FieldExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -32,7 +30,6 @@ public class FieldExtractionWorkflow_Tests
 
         return new FieldExtractionWorkflow(
             chatClient,
-            Options.Create(new PaperbaseAIBehaviorOptions()),
             NullLogger<FieldExtractionWorkflow>.Instance);
     }
 


### PR DESCRIPTION
Wrap-up changes after first-principles review before real-world testing (only items approved by the owner; no new issues opened).

## Changes

**1. Feed full Markdown to field extraction (no more truncation)** — `FieldExtractionWorkflow`
Type-bound fields (contract amount / invoice number / expiry date…) can appear anywhere in a document; truncating the tail by character count **silently drops fields**. `ExtractAsync` now passes the full Markdown to the LLM; the removed `IOptions<PaperbaseAIBehaviorOptions>` injection is no longer used. Token cost / context-window management for very large documents is left to the model + provider configured in the host — the channel layer does not pre-truncate (pre-truncation just disguises "missed field" as "success").

**2. Classification truncation made surrogate-safe** — `DocumentClassificationWorkflow`
Classification still truncates at `MaxTextLengthPerExtraction` (type detection only needs the leading portion of the document), but the naive `markdown[..N]` is replaced with `TruncateAtCharBoundary`: if the last character is a high surrogate (with its low surrogate cut off), it is discarded as well, preventing a half code point from degrading to U+FFFD when UTF-8 encoded before sending to the LLM. Added unit tests for this helper.

**3. `MaxTextLengthPerExtraction` comment updated** — now applies only to the classification path (field extraction no longer consumes it).

**4. Documentation update** — `CLAUDE.md` exit-event contract table updated to include recycle-bin / lifecycle ETOs (`DocumentDeletedEto` / `DocumentRestoredEto` / `DocumentPermanentlyDeletedEto`), annotated as orthogonal to the multi-stage pipeline and not subject to the Ready gate.

## Verification

- Full solution build: **0 errors** (0 warnings in changed files)
- `Application.Tests` full run: **179/179 passed** (including 5 new truncation tests + 9 fixed `FieldExtractionEventHandler` tests)
- Code review (`maf-workflow-reviewer`) verified all `llm-call-anti-patterns.md` security rules are compliant (compile-time constant instructions / complete `PromptBoundary` wrapping / no `AIContextProviders`), and caught a sibling test constructor I missed in the initial version (`ForPartsOf` old 3-arg → runtime `MissingMethodException`), now fixed
- Note: the sandbox inotify instance limit (128) causes the full parallel integration test suite to occasionally crash at ABP host bootstrap; running with `DOTNET_USE_POLLING_FILE_WATCHER=true` passes all green, confirmed unrelated to this change

## Intentionally **not** changed during review (retained per owner decision)

- SlugSuggestion (LLM slug suggestion) — Japanese→English translation is only feasible with LLM; valuable for MCP naming
- Cabinet — a user-facing manual organization dimension; not needed in ETO/MCP
- `IsMultiTenant=false` — intentional design
- `Document.Restore()` domain method — discovered that directly touching the soft-delete field is the consistent existing pattern across 3 aggregates; changing only `Document` would create inconsistency, so reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)