### PR TITLE
chore(extraction): log field-extraction input size at debug level

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
@@ -57,6 +57,14 @@ public class FieldExtractionWorkflow : ITransientDependency
             return new Dictionary<string, JsonElement?>();
         }
 
+        // 可观测性：移除截断后字段抽取喂全文，这里记录输入规模（字符数 + 字段数）。补偿原"截断 warning"
+        // 消失留下的盲区——当超大文档撞 provider 上下文窗口（抛 provider 异常）时，紧邻的这条日志给出
+        // "是不是文档太大"的本地线索。Debug 级：逐文档调用不污染正常日志；真实 token 用量另由 OTel 的
+        // gen_ai.* span 记录。
+        _logger.LogDebug(
+            "Field extraction over {CharCount} characters across {FieldCount} fields (full document, no truncation).",
+            markdown.Length, fields.Count);
+
         // 字段抽取喂入**完整 Markdown**，绝不截断：类型绑定字段（合同金额 / 发票号 / 到期日等）
         // 可能出现在文档任何位置，按字符数截断尾部会静默漏抽关键字段。这与分类路径有意分化——
         // DocumentClassificationWorkflow 只需文档前段语义即可判型，故按 MaxTextLengthPerExtraction 截断；


### PR DESCRIPTION
Follow-up to #247. After removing truncation from field extraction, the only local signal about input size was lost — when an oversized document hits a provider context window limit, the failure manifests only as a provider exception with no adjacent clue about "was the document too large?".

## Changes

Add a single `LogDebug` call at the top of `FieldExtractionWorkflow.ExtractAsync` (immediately before the LLM call), logging the Markdown character count and field count:

```
Field extraction over {CharCount} characters across {FieldCount} fields (full document, no truncation).
```

- **Debug level**: called per document, does not pollute normal logs; enable Debug to see it when troubleshooting, and it sits right next to the potentially-throwing provider call, providing size context on failure.
- Actual token usage is still recorded by the chat client's OpenTelemetry `gen_ai.*` span — this log is a supplementary local signal.
- **Classification path intentionally not touched**: it still truncates and already has a truncation warning; no observability gap there.

## Verification

- Build: 0 errors, 0 warnings
- `FieldExtraction*` tests 17/17 passed (the new log runs through `NullLogger` in tests, no behavior change, so no test updates required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)