### PR TITLE
fix(docker): remove stale COPY of removed modules/ directory

### DIFF
--- a/host/Dockerfile
+++ b/host/Dockerfile
@@ -17,7 +17,6 @@ WORKDIR /src
 # loops, so the lost cache cost is negligible.
 COPY common.props Directory.Packages.props Dignite.Paperbase.slnx ./
 COPY core/ core/
-COPY modules/ modules/
 COPY host/ host/
 
 RUN dotnet restore "host/src/Dignite.Paperbase.Host.csproj"


### PR DESCRIPTION
Removes the stale `COPY modules/ modules/` from `host/Dockerfile`. The `modules/` directory was moved out of Paperbase scope (CLAUDE.md — downstream business consumers live in their own repos) and no longer exists in the repo, so the push-to-main **Build Docker image** CI step failed with `"/modules": not found`, leaving `main` CI red since #247.

The failure was masked on PRs because that step runs only on push (`if: github.event_name == ''push''` in ci.yml), never on pull requests — so PR checks were always green while `main` stayed red.

**Verified locally** with the exact CI command (`docker build -f host/Dockerfile .`): restore → build → publish all succeed and the image exports cleanly (`Build succeeded. / 0 Error(s)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)