### PR TITLE
fix(documents): detail page 404 via missing DocumentPipelineRunController + NG8107 cleanup

### DIFF
--- a/angular/packages/paperbase/documents/src/lib/documents/document-detail/document-detail.component.html
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-detail/document-detail.component.html
@@ -10,8 +10,8 @@
       {{ '::Document:Detail' | abpLocalization }}
     </h5>
     @if (document()) {
-      <span class="ms-2 fw-semibold text-truncate" style="max-width: 480px;" [title]="document()!.title || document()!.fileOrigin?.originalFileName">
-        {{ document()!.title || document()!.fileOrigin?.originalFileName }}
+      <span class="ms-2 fw-semibold text-truncate" style="max-width: 480px;" [title]="document()!.title || document()!.fileOrigin.originalFileName">
+        {{ document()!.title || document()!.fileOrigin.originalFileName }}
       </span>
       <span [class]="getDocumentStatusBadgeClass(document()!)" class="ms-2">
         @if (isProcessing()) {
@@ -78,14 +78,14 @@
               <img
                 [src]="blobUrl()"
                 (error)="onImageError()"
-                alt="{{ document()!.fileOrigin?.originalFileName }}"
+                alt="{{ document()!.fileOrigin.originalFileName }}"
                 class="img-fluid preview-image"
                 style="max-height: 600px; object-fit: contain;"
               />
             } @else if (!isImage()) {
               <div class="text-center text-muted py-4">
                 <i class="fas fa-file-pdf fa-4x text-danger mb-3 d-block"></i>
-                <p>{{ document()!.fileOrigin?.originalFileName }}</p>
+                <p>{{ document()!.fileOrigin.originalFileName }}</p>
                 <button
                   class="btn btn-outline-primary btn-sm"
                   (click)="openFile()"
@@ -108,9 +108,9 @@
           </div>
           <div class="card-footer text-muted small">
             <i class="fas fa-file me-1"></i>
-            {{ document()!.fileOrigin?.originalFileName }}
+            {{ document()!.fileOrigin.originalFileName }}
             &nbsp;·&nbsp;
-            {{ document()!.fileOrigin?.contentType }}
+            {{ document()!.fileOrigin.contentType }}
           </div>
         </div>
       </div>
@@ -160,7 +160,7 @@
                 }
 
                 <dt class="col-sm-5 text-muted">{{ '::Document:UploadedBy' | abpLocalization }}</dt>
-                <dd class="col-sm-7">{{ document()!.fileOrigin?.uploadedByUserName }}</dd>
+                <dd class="col-sm-7">{{ document()!.fileOrigin.uploadedByUserName }}</dd>
 
                 <dt class="col-sm-5 text-muted">{{ '::Document:UploadedAt' | abpLocalization }}</dt>
                 <dd class="col-sm-7">{{ document()!.creationTime | date:'yyyy-MM-dd HH:mm' }}</dd>

--- a/angular/packages/paperbase/documents/src/lib/documents/document-list/document-list.component.html
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-list/document-list.component.html
@@ -161,7 +161,7 @@
                 </td>
                 <td>
                   <span class="fw-semibold">
-                    {{ doc.title || doc.fileOrigin?.originalFileName }}
+                    {{ doc.title || doc.fileOrigin.originalFileName }}
                   </span>
                 </td>
                 <td>
@@ -193,7 +193,7 @@
                     {{ getDocumentStatusLabel(doc) | abpLocalization }}
                   </span>
                 </td>
-                <td class="text-muted small">{{ formatFileSize(doc.fileOrigin?.fileSize ?? 0) }}</td>
+                <td class="text-muted small">{{ formatFileSize(doc.fileOrigin.fileSize ?? 0) }}</td>
                 <td class="text-muted small">{{ doc.creationTime | date:'yyyy-MM-dd HH:mm' }}</td>
                 <td class="d-flex gap-1">
                   @if (needsConfirmation(doc) && canConfirm) {
@@ -266,7 +266,7 @@
         </div>
         <div class="modal-body">
           <p class="text-muted small mb-3">
-            {{ doc.title || doc.fileOrigin?.originalFileName }}
+            {{ doc.title || doc.fileOrigin.originalFileName }}
           </p>
           <label class="form-label fw-semibold">{{ '::Document:SelectDocumentType' | abpLocalization }}</label>
           <select

--- a/angular/packages/paperbase/documents/src/lib/documents/document-recycle-bin/document-recycle-bin.component.html
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-recycle-bin/document-recycle-bin.component.html
@@ -59,7 +59,7 @@
                 </td>
                 <td>
                   <span class="text-muted">
-                    {{ doc.title || doc.fileOrigin?.originalFileName }}
+                    {{ doc.title || doc.fileOrigin.originalFileName }}
                   </span>
                 </td>
                 <td>
@@ -69,7 +69,7 @@
                     <span class="text-muted">—</span>
                   }
                 </td>
-                <td class="text-muted small">{{ formatFileSize(doc.fileOrigin?.fileSize ?? 0) }}</td>
+                <td class="text-muted small">{{ formatFileSize(doc.fileOrigin.fileSize ?? 0) }}</td>
                 <td class="text-muted small">
                   @if (doc.deletionTime) {
                     {{ doc.deletionTime | date:'yyyy-MM-dd HH:mm' }}

--- a/angular/packages/paperbase/documents/src/lib/documents/document-review-queue/document-review-queue.component.html
+++ b/angular/packages/paperbase/documents/src/lib/documents/document-review-queue/document-review-queue.component.html
@@ -62,7 +62,7 @@
                 </td>
                 <td>
                   <span class="fw-semibold">
-                    {{ doc.title || doc.fileOrigin?.originalFileName }}
+                    {{ doc.title || doc.fileOrigin.originalFileName }}
                   </span>
                 </td>
                 <td>
@@ -153,7 +153,7 @@
         </div>
         <div class="modal-body">
           <p class="text-muted small mb-3">
-            {{ doc.title || doc.fileOrigin?.originalFileName }}
+            {{ doc.title || doc.fileOrigin.originalFileName }}
           </p>
           <label class="form-label fw-semibold">{{ '::Document:SelectDocumentType' | abpLocalization }}</label>
           <select
@@ -202,7 +202,7 @@
         </div>
         <div class="modal-body">
           <p class="text-muted small mb-3">
-            {{ doc.title || doc.fileOrigin?.originalFileName }}
+            {{ doc.title || doc.fileOrigin.originalFileName }}
           </p>
           <label class="form-label fw-semibold">{{ '::Document:Review:RejectReason' | abpLocalization }}</label>
           <textarea

--- a/core/src/Dignite.Paperbase.HttpApi/Documents/Pipelines/DocumentPipelineRunController.cs
+++ b/core/src/Dignite.Paperbase.HttpApi/Documents/Pipelines/DocumentPipelineRunController.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Documents.Pipelines;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dignite.Paperbase.HttpApi.Documents.Pipelines;
+
+// #216 把 PipelineRun 拆为独立聚合根并新增 IDocumentPipelineRunAppService，但当时漏了这个手写 controller。
+// host Auto API 只覆盖 PaperbaseHostModule.Assembly（见 PaperbaseHostModule.ConfigureAutoApiControllers），
+// Application assembly 的 AppService 全靠 HttpApi 显式 controller 暴露——缺这层转发，前端调
+// /api/paperbase/document-pipeline-runs 会落到无匹配路由的 404（null body），拖垮文档详情页的 forkJoin。
+[Area("paperbase")]
+[Route("api/paperbase/document-pipeline-runs")]
+public class DocumentPipelineRunController : PaperbaseController, IDocumentPipelineRunAppService
+{
+    private readonly IDocumentPipelineRunAppService _documentPipelineRunAppService;
+
+    public DocumentPipelineRunController(IDocumentPipelineRunAppService documentPipelineRunAppService)
+    {
+        _documentPipelineRunAppService = documentPipelineRunAppService;
+    }
+
+    // GET /api/paperbase/document-pipeline-runs?documentId=...
+    // 单个 Guid 简单参数在 GET 下默认从 query string 绑定，与前端 proxy（params: { documentId }）对齐。
+    [HttpGet]
+    public virtual Task<List<DocumentPipelineRunDto>> GetListAsync(Guid documentId)
+    {
+        return _documentPipelineRunAppService.GetListAsync(documentId);
+    }
+}


### PR DESCRIPTION
## Detail page inaccessible (404 for all documents)

**Root cause:** #216 split PipelineRun into a standalone aggregate root and added `IDocumentPipelineRunAppService` along with a frontend proxy (`/api/paperbase/document-pipeline-runs`), but omitted the corresponding hand-written `DocumentPipelineRunController`. This project's Auto API only covers the host assembly; Application-layer AppServices are all exposed via explicit HttpApi controllers. Without this forwarding layer, frontend calls to that URL hit an unmatched route returning `404 null null`, breaking the `forkJoin([get, getListByDocument])` on the document detail page and making **all document detail pages inaccessible** (the list page does not call this endpoint and was unaffected).

Log evidence (two requests on the detail page):
- `GET .../document-pipeline-runs?documentId=... → 404 null null` (routing-layer not found, not ABP EntityNotFound)
- `GET .../documents/{id} → 499` (forkJoin cancelled by the above error)

**Fix:** add `DocumentPipelineRunController` following the same pattern as the existing 6 controllers, exposing `GET /api/paperbase/document-pipeline-runs?documentId=...`. No frontend proxy or migration changes needed.

## NG8107 template cleanup

`DocumentDto` / `DocumentListItemDto`'s `fileOrigin` is a non-nullable `FileOriginDto` (corresponding to a backend owned entity that is never null at runtime); the `?.` optional-chaining operators in templates are redundant and strictTemplates reports NG8107. Remove 15 redundant `?.` occurrences across 4 component templates (detail/list/review-queue/recycle-bin) (`title` remains nullable; `||` fallbacks are preserved).

## Verification
- Backend `dotnet build` HttpApi passes
- Frontend `nx build paperbase` passes, NG8107 count zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)