### PR TITLE
refactor(fields): rename DocumentExtractedField.StringValue column to TextValue

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/Exports/ExportProjection.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Exports/ExportProjection.cs
@@ -30,7 +30,7 @@ internal sealed class ExtractedFieldProjection
     /// 与 REST/MCP 出口的 Order-0 标量渲染一致、且确定（不依赖 DB 未指定的行返回顺序）。完整多值 join 留作后续增量。</summary>
     public int Order { get; init; }
 
-    public string? StringValue { get; init; }
+    public string? TextValue { get; init; }
     public string? LongTextValue { get; init; }
     public bool? BooleanValue { get; init; }
     public decimal? NumberValue { get; init; }

--- a/core/src/Dignite.Paperbase.Application/Documents/Exports/ExportTemplateAppService.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Exports/ExportTemplateAppService.cs
@@ -140,7 +140,7 @@ public class ExportTemplateAppService : PaperbaseAppService, IExportTemplateAppS
                         {
                             FieldDefinitionId = f.FieldDefinitionId,
                             Order = f.Order,
-                            StringValue = f.StringValue,
+                            TextValue = f.TextValue,
                             LongTextValue = f.LongTextValue,
                             BooleanValue = f.BooleanValue,
                             NumberValue = f.NumberValue,
@@ -284,7 +284,7 @@ public class ExportTemplateAppService : PaperbaseAppService, IExportTemplateAppS
     // ApplyFieldValueFilter 一致（绝不静默吐空单元格：新增枚举值漏改本处应在测试 / 运行期响亮报错，而非无声错导）。
     private static string? FieldValueToString(ExtractedFieldProjection f, FieldDataType dataType) => dataType switch
     {
-        FieldDataType.Text => f.StringValue,
+        FieldDataType.Text => f.TextValue,
         FieldDataType.LongText => f.LongTextValue,
         // Number 以最小形渲染（"0.######"）：整数 1000 → "1000"，小数 10.50 → "10.5"——不带 decimal(38,6) 的 6 位尾零。
         FieldDataType.Number => f.NumberValue?.ToString("0.######", CultureInfo.InvariantCulture),

--- a/core/src/Dignite.Paperbase.Application/Documents/Fields/ExtractedFieldValueValidator.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Fields/ExtractedFieldValueValidator.cs
@@ -21,7 +21,7 @@ namespace Dignite.Paperbase.Documents.Fields;
 /// <para>
 /// 严格语义（不做强制转换）：声明类型即承诺值可表达为该 JSON 类型。数字字段须为 JSON number、
 /// 布尔字段须为 JSON true/false、日期字段须为 ISO-8601 字符串。要存自由文本有两个档位：
-/// <see cref="FieldDataType.Text"/>（结构化短值，长度须 ≤ <see cref="DocumentExtractedFieldConsts.MaxStringValueLength"/>，
+/// <see cref="FieldDataType.Text"/>（结构化短值，长度须 ≤ <see cref="DocumentExtractedFieldConsts.MaxTextValueLength"/>，
 /// 与持久化列长同源、入复合索引、可等值查询，#209）或 <see cref="FieldDataType.LongText"/>
 /// （长内容如摘要 / 描述，长度须 ≤ <see cref="DocumentExtractedFieldConsts.MaxLongTextValueLength"/>，落 nvarchar(max) 列、不索引不可查询）。
 /// 真正的全文载荷仍归 Document.Markdown，不在类型绑定字段承载。
@@ -69,7 +69,7 @@ internal static class ExtractedFieldValueValidator
         return dataType switch
         {
             FieldDataType.Text => value.ValueKind == JsonValueKind.String &&
-                                    (value.GetString() ?? string.Empty).Length <= DocumentExtractedFieldConsts.MaxStringValueLength,
+                                    (value.GetString() ?? string.Empty).Length <= DocumentExtractedFieldConsts.MaxTextValueLength,
             FieldDataType.LongText => value.ValueKind == JsonValueKind.String &&
                                       (value.GetString() ?? string.Empty).Length <= DocumentExtractedFieldConsts.MaxLongTextValueLength,
             FieldDataType.Number => value.ValueKind == JsonValueKind.Number && value.TryGetDecimal(out _),

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
@@ -173,7 +173,7 @@ public class FieldExtractionWorkflow : ITransientDependency
                 ["items"] = new JsonObject
                 {
                     ["type"] = "string",
-                    ["maxLength"] = DocumentExtractedFieldConsts.MaxStringValueLength
+                    ["maxLength"] = DocumentExtractedFieldConsts.MaxTextValueLength
                 },
                 ["description"] = "A JSON array of short structured string values, or null/empty array when absent."
             };
@@ -187,7 +187,7 @@ public class FieldExtractionWorkflow : ITransientDependency
         switch (dataType)
         {
             case FieldDataType.Text:
-                schema["maxLength"] = DocumentExtractedFieldConsts.MaxStringValueLength;
+                schema["maxLength"] = DocumentExtractedFieldConsts.MaxTextValueLength;
                 schema["description"] = "A short structured string value, or null when absent.";
                 break;
             case FieldDataType.LongText:

--- a/core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentExtractedFieldConsts.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Documents/DocumentExtractedFieldConsts.cs
@@ -5,22 +5,22 @@ public static class DocumentExtractedFieldConsts
     /// <summary>
     /// 类型绑定字段 <c>Text</c> 值的最大长度。
     /// <para>
-    /// 同时是 DB 列长度（<c>StringValue nvarchar(256)</c>）与 App 层校验上限（<c>ExtractedFieldValueValidator</c>）——
+    /// 同时是 DB 列长度（<c>TextValue nvarchar(256)</c>）与 App 层校验上限（<c>ExtractedFieldValueValidator</c>）——
     /// 二者必须一致：校验放过的值都要存得下。改动此值需重新生成 EF migration。
     /// </para>
     /// <para>
-    /// 限长（而非 <c>nvarchar(max)</c>）让 <c>StringValue</c> 能进 <c>(TenantId, FieldDefinitionId, StringValue,
+    /// 限长（而非 <c>nvarchar(max)</c>）让 <c>TextValue</c> 能进 <c>(TenantId, FieldDefinitionId, TextValue,
     /// DocumentId)</c> 复合索引键，文本字段等值查询走纯 index seek（#209）。类型绑定 文本字段是从 Markdown
     /// 抽取的结构化短值（姓名 / 编号 / 币种 / 案由等），不承载长文本（长文本归 <c>Document.Markdown</c>），故 256
     /// 是充裕上限；且 256×2 bytes + 三个 Guid（48 bytes）= 560 bytes，安全落在 SQL Server 非聚集索引键 1700 bytes 上限内。
     /// </para>
     /// </summary>
-    public static int MaxStringValueLength { get; set; } = 256;
+    public static int MaxTextValueLength { get; set; } = 256;
 
     /// <summary>
     /// 类型绑定字段 <c>LongText</c> 值的最大长度（App 层校验上限 + LLM schema 软提示）。
     /// <para>
-    /// 与 <see cref="MaxStringValueLength"/> 的 256 不同源：<c>LongText</c> 落独立的 <c>LongTextValue nvarchar(max)</c> 列，
+    /// 与 <see cref="MaxTextValueLength"/> 的 256 不同源：<c>LongText</c> 落独立的 <c>LongTextValue nvarchar(max)</c> 列，
     /// <b>不进任何索引、不可作查询条件</b>（DB 列本身不限长）。此上限是<b>反滥用护栏</b>——防恶意 / 失控文档诱导 LLM
     /// 对长文本字段吐出超大字符串，灌爆 prompt 往返与 DB 行。8000 字符（约数千汉字）从容覆盖摘要 / 描述 / 风险提示等
     /// 长内容抽取场景；真正的全文载荷归 <c>Document.Markdown</c>，不在类型绑定字段承载。改动此值无需重建索引（列不限长），

--- a/core/src/Dignite.Paperbase.Domain.Shared/Documents/Fields/FieldDataType.cs
+++ b/core/src/Dignite.Paperbase.Domain.Shared/Documents/Fields/FieldDataType.cs
@@ -12,8 +12,8 @@ namespace Dignite.Paperbase.Documents.Fields;
 /// <para>
 /// <see cref="Text"/> 与 <see cref="LongText"/> 刻意分开，二者是"短结构化值 vs 长内容"两种用途：
 /// <list type="bullet">
-///   <item><see cref="Text"/>：结构化短值（姓名 / 编号 / 币种 / 案由等），限长 256（<c>DocumentExtractedFieldConsts.MaxStringValueLength</c>），
-///   落 <c>StringValue</c> 列、进复合索引键，支持等值查询 + 多值（#209 / #212）。</item>
+///   <item><see cref="Text"/>：结构化短值（姓名 / 编号 / 币种 / 案由等），限长 256（<c>DocumentExtractedFieldConsts.MaxTextValueLength</c>），
+///   落 <c>TextValue</c> 列、进复合索引键，支持等值查询 + 多值（#209 / #212）。</item>
 ///   <item><see cref="LongText"/>：长内容（摘要 / 描述 / 风险提示等，由租户用 B 机制自配字段抽取），落独立的
 ///   <c>LongTextValue</c> 列（<c>nvarchar(max)</c>），<b>不进任何索引、不可作查询条件、不支持多值</b>——
 ///   纯存储载荷，出口 DTO 照常渲染为字符串。注意这是 B 机制下用户自配的<b>类型绑定字段</b>，

--- a/core/src/Dignite.Paperbase.Domain/Documents/DocumentExtractedField.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/DocumentExtractedField.cs
@@ -16,7 +16,7 @@ namespace Dignite.Paperbase.Documents;
 /// 不再冗余字段名 / TypeCode 字符串；<see cref="FieldDefinition.Name"/> rename 不级联本表。<see cref="Order"/> 是值在
 /// 多值集合内的 0-based 位序：单值字段恒为 0（同文档同字段唯一）；多值文本字段（<c>AllowMultiple</c>）一字段多行、Order 递增。
 /// 整组重建 / 操作员手改走 reconcile（按 <c>(FieldDefinitionId, Order)</c> 原地更新），不留重复行。值按写入时的 <c>FieldDataType</c> 落到对应类型化列
-/// （<see cref="StringValue"/> / <see cref="NumberValue"/> / …）——类型由所引用的 <see cref="FieldDefinition"/> 决定、<b>不在本行持久化</b>（#208），
+/// （<see cref="TextValue"/> / <see cref="NumberValue"/> / …）——类型由所引用的 <see cref="FieldDefinition"/> 决定、<b>不在本行持久化</b>（#208），
 /// 让 <c>GetFieldMatchedIdsAsync</c> 用普通列比较（等值 + 范围）跨任意关系型数据库可移植——不再依赖 SQL Server <c>JSON_VALUE</c> / <c>TRY_CONVERT</c> 方言。
 /// </para>
 /// <para>
@@ -50,14 +50,14 @@ public class DocumentExtractedField : Entity, IMultiTenant
 
     // 类型化值列——按字段类型取用其一，其余为 null（类型由 FieldDefinition 决定、不在本行持久化，#208）。
     // 普通列即可建 B-tree 索引、支持等值 + 范围。Number（整数与小数统一）落 NumberValue。
-    public virtual string? StringValue { get; private set; }
+    public virtual string? TextValue { get; private set; }
     public virtual bool? BooleanValue { get; private set; }
     public virtual decimal? NumberValue { get; private set; }
     public virtual DateOnly? DateValue { get; private set; }
     public virtual DateTime? DateTimeValue { get; private set; }
 
     // LongText 落独立的 nvarchar(max) 列——长内容载荷（摘要 / 描述等），不进任何索引、不可作查询条件、不支持多值。
-    // 与 StringValue（限长 256、入复合索引、可等值查询）刻意分列：长文本进不了索引键，强塞 StringValue 会废掉 #209 的 index seek。
+    // 与 TextValue（限长 256、入复合索引、可等值查询）刻意分列：长文本进不了索引键，强塞 TextValue 会废掉 #209 的 index seek。
     public virtual string? LongTextValue { get; private set; }
 
     protected DocumentExtractedField()
@@ -80,7 +80,7 @@ public class DocumentExtractedField : Entity, IMultiTenant
     /// </summary>
     internal void SetValue(DocumentFieldValue value)
     {
-        StringValue = null;
+        TextValue = null;
         BooleanValue = null;
         NumberValue = null;
         DateValue = null;
@@ -91,7 +91,7 @@ public class DocumentExtractedField : Entity, IMultiTenant
         switch (value.DataType)
         {
             case FieldDataType.Text:
-                StringValue = element.GetString();
+                TextValue = element.GetString();
                 break;
             case FieldDataType.LongText:
                 LongTextValue = element.GetString();
@@ -120,7 +120,7 @@ public class DocumentExtractedField : Entity, IMultiTenant
     /// </summary>
     public JsonElement ToJsonElement(FieldDataType dataType) => dataType switch
     {
-        FieldDataType.Text => JsonSerializer.SerializeToElement(StringValue),
+        FieldDataType.Text => JsonSerializer.SerializeToElement(TextValue),
         FieldDataType.LongText => JsonSerializer.SerializeToElement(LongTextValue),
         FieldDataType.Number => JsonSerializer.SerializeToElement(NumberValue),
         FieldDataType.Boolean => JsonSerializer.SerializeToElement(BooleanValue),

--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -160,9 +160,9 @@ public class EfCoreDocumentRepository
                 {
                     throw RangeNotSupported(name, fieldQuery.FieldDataType);
                 }
-                var stringValue = fieldQuery.FieldValue!;
+                var textValue = fieldQuery.FieldValue!;
                 return query.Where(d => d.ExtractedFieldValues
-                    .Any(f => f.FieldDefinitionId == fieldDefinitionId && f.StringValue == stringValue));
+                    .Any(f => f.FieldDefinitionId == fieldDefinitionId && f.TextValue == textValue));
 
             case FieldDataType.LongText:
                 // 长文本字段落 nvarchar(max) 列、不进索引——红线：永不作查询条件（等值 / 区间 / LIKE 全禁）。

--- a/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Paperbase.EntityFrameworkCore/EntityFrameworkCore/PaperbaseDbContextModelCreatingExtensions.cs
@@ -137,10 +137,10 @@ public static class PaperbaseDbContextModelCreatingExtensions
             b.HasKey(x => new { x.DocumentId, x.FieldDefinitionId, x.Order });
 
             // 字段类型不在本行持久化（#208）：由所引用 FieldDefinition.DataType 决定，读 / 导出路径已 load 该实体。
-            // StringValue 限长 nvarchar(256)（#209）：类型绑定 文本字段是从 Markdown 抽取的结构化短值（姓名 / 编号 /
+            // TextValue 限长 nvarchar(256)（#209）：类型绑定 文本字段是从 Markdown 抽取的结构化短值（姓名 / 编号 /
             // 币种 / 案由等），不承载长文本（长文本归 Document.Markdown）——限长换来它能进复合索引键，等值查询走 index seek。
-            // 校验上限同源 DocumentExtractedFieldConsts.MaxStringValueLength（ExtractedFieldValueValidator 一并卡住）。
-            b.Property(x => x.StringValue).HasMaxLength(DocumentExtractedFieldConsts.MaxStringValueLength);
+            // 校验上限同源 DocumentExtractedFieldConsts.MaxTextValueLength（ExtractedFieldValueValidator 一并卡住）。
+            b.Property(x => x.TextValue).HasMaxLength(DocumentExtractedFieldConsts.MaxTextValueLength);
 
             // LongTextValue 不限长（不调 HasMaxLength → provider 映射为 nvarchar(max) 等大文本类型，跨库可移植）：
             // 长内容载荷（摘要 / 描述等）。刻意不进下方任何复合索引、也无单列索引——长文本既进不了索引键，也无等值 / 区间查询语义
@@ -163,7 +163,7 @@ public static class PaperbaseDbContextModelCreatingExtensions
             // (FieldDefinitionId, typedValue) EXISTS。下列 (TenantId, FieldDefinitionId, <typedValue>, DocumentId) 复合索引
             // 支撑 文本等值 + Number / 日期字段的等值 + 范围（文本限长 256 后可进索引键，#209）。Boolean 不单建索引——
             // 基数仅 2，selectivity 太低，靠 (TenantId, FieldDefinitionId) 前缀分组 + 与其他字段 AND 收窄即可。
-            b.HasIndex(x => new { x.TenantId, x.FieldDefinitionId, x.StringValue, x.DocumentId });
+            b.HasIndex(x => new { x.TenantId, x.FieldDefinitionId, x.TextValue, x.DocumentId });
             b.HasIndex(x => new { x.TenantId, x.FieldDefinitionId, x.NumberValue, x.DocumentId });
             b.HasIndex(x => new { x.TenantId, x.FieldDefinitionId, x.DateValue, x.DocumentId });
             b.HasIndex(x => new { x.TenantId, x.FieldDefinitionId, x.DateTimeValue, x.DocumentId });

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_ExtractedFields_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/DocumentAppService_ExtractedFields_Tests.cs
@@ -186,7 +186,7 @@ public class DocumentAppService_ExtractedFields_Tests
 
         // 数组 → 3 行，按 Order 还原。
         doc.ExtractedFieldValues.Count.ShouldBe(3);
-        doc.ExtractedFieldValues.OrderBy(f => f.Order).Select(f => f.StringValue)
+        doc.ExtractedFieldValues.OrderBy(f => f.Order).Select(f => f.TextValue)
             .ShouldBe(new[] { "urgent", "legal", "2026" });
 
         // FieldsExtractedEto.FieldCount 是逻辑字段数（1），非展开行数（3）。

--- a/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositorySearch_Tests.cs
+++ b/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositorySearch_Tests.cs
@@ -442,7 +442,7 @@ public class EfCoreDocumentRepositorySearch_Tests : PaperbaseEntityFrameworkCore
             // 3 行持久化，按 Order 还原。
             var doc = await _documentRepository.GetAsync(id, includeDetails: true);
             doc.ExtractedFieldValues.Count.ShouldBe(3);
-            doc.ExtractedFieldValues.OrderBy(f => f.Order).Select(f => f.StringValue)
+            doc.ExtractedFieldValues.OrderBy(f => f.Order).Select(f => f.TextValue)
                 .ShouldBe(new[] { "urgent", "legal", "2026" });
 
             // 按任一值命中（.Any 跨多行；查询路径对多值天然兼容，无需改动）。
@@ -495,7 +495,7 @@ public class EfCoreDocumentRepositorySearch_Tests : PaperbaseEntityFrameworkCore
         await WithUnitOfWorkAsync(async () =>
         {
             var reloaded = await _documentRepository.GetAsync(id, includeDetails: true);
-            reloaded.ExtractedFieldValues.OrderBy(f => f.Order).Select(f => f.StringValue)
+            reloaded.ExtractedFieldValues.OrderBy(f => f.Order).Select(f => f.TextValue)
                 .ShouldBe(new[] { "x", "y" });
 
             // 被删除的 Order 2 旧值（"c"）查不到。

--- a/host/src/Migrations/20260604024159_Rename_StringValue_To_TextValue.Designer.cs
+++ b/host/src/Migrations/20260604024159_Rename_StringValue_To_TextValue.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.Paperbase.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.Paperbase.Host.Migrations
 {
     [DbContext(typeof(PaperbaseHostDbContext))]
-    partial class PaperbaseHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604024159_Rename_StringValue_To_TextValue")]
+    partial class Rename_StringValue_To_TextValue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260604024159_Rename_StringValue_To_TextValue.cs
+++ b/host/src/Migrations/20260604024159_Rename_StringValue_To_TextValue.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.Paperbase.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Rename_StringValue_To_TextValue : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "StringValue",
+                table: "PaperbaseDocumentExtractedFields",
+                newName: "TextValue");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_PaperbaseDocumentExtractedFields_TenantId_FieldDefinitionId_StringValue_DocumentId",
+                table: "PaperbaseDocumentExtractedFields",
+                newName: "IX_PaperbaseDocumentExtractedFields_TenantId_FieldDefinitionId_TextValue_DocumentId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "TextValue",
+                table: "PaperbaseDocumentExtractedFields",
+                newName: "StringValue");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_PaperbaseDocumentExtractedFields_TenantId_FieldDefinitionId_TextValue_DocumentId",
+                table: "PaperbaseDocumentExtractedFields",
+                newName: "IX_PaperbaseDocumentExtractedFields_TenantId_FieldDefinitionId_StringValue_DocumentId");
+        }
+    }
+}


### PR DESCRIPTION
Follows up on #251 / 357d4d1 (`FieldDataType.String` → `Text`) with a **column name consistency wrap-up**: the enum value is now `Text`, but the column carrying it was still named `StringValue`.

## Changes (backend only)
- **Entity / persistence layer**: `DocumentExtractedField.StringValue` → `TextValue` (property / `SetValue` / `ToJsonElement` / EF mapping / composite index)
- **Queries / export / validation**: `EfCoreDocumentRepository` queries, `ExportProjection` / `ExportTemplateAppService` projections, `ExtractedFieldValueValidator`, `FieldExtractionWorkflow` extraction schema
- **Constants**: `MaxStringValueLength` → `MaxTextValueLength`
- Exit contract untouched: `ExtractedFields` dictionary keys are field names, not column names; zero frontend references

## Migration
Column rename requires a migration. `20260604024159_Rename_StringValue_To_TextValue`: `RenameColumn` + `RenameIndex` (SQL `sp_rename`, **preserves data + index, rollback-safe** — not drop+add). Needs to be applied to `Paperbase-Dev` after merge.

## Verification
- Compilation passes (core CSC, zero errors)
- Persistence tests **25/25 passing**
- Migration is a safe rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)