### PR TITLE
fix(field-extraction): harden system prompt for flattened tables

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
@@ -110,9 +110,12 @@ public class FieldExtractionWorkflow : ITransientDependency
         "DateTime as an offset-free ISO-8601 \"YYYY-MM-DDThh:mm:ss\" JSON string (local wall-clock time, no timezone offset or trailing Z); " +
         "Boolean as JSON true or false; " +
         "Text as the original text. " +
-        "When a field cannot be confidently extracted or normalized to its declared type, set its value to null. " +
+        "When a value cannot be normalized to its declared data type, set that field to null. " +
         "A field whose schema type is array accepts multiple values: return a JSON array of strings (each a distinct value found in the document), or an empty array when none apply. " +
-        "The input document is provided as Markdown — treat headings, tables, and lists as semantic structure signals.";
+        "The document is Markdown produced by automated extraction (digital parsing or OCR), so its layout is best-effort and table grids are frequently flattened into plain lines: " +
+        "a line of column labels followed by one or more lines of space- or tab-separated values is still a table — read each such line as a row and align its cells to the column labels from left to right. " +
+        "Use headings, tables, and lists as structure signals, but never require Markdown table syntax: extract tabular values even when the pipes and separators have been stripped during extraction. " +
+        "Set a field to null only when its information is genuinely absent from the document — not merely because the text is unformatted, split across lines, or lacks table syntax.";
 
     private static string BuildSchemaUserMessage(IReadOnlyList<FieldExtractionDescriptor> fields)
     {


### PR DESCRIPTION
## What
Harden the field-extraction system prompt so the LLM extracts tabular data even when text extraction flattens a table grid into space/tab-separated lines (no Markdown `|` pipes).

## Why
On a real invoice (digital PDF → MarkItDown → flat text), the field-extraction model returned a field's configured sentinel (`明細なし`) for a line-item field, treating "no Markdown table syntax" as "no data". The data was present as plain text; the model just bailed.

## Change
- `FieldExtractionWorkflow.SystemInstructions`: tell the model extraction flattens tables; a header line + aligned space/tab-separated value lines is still a table (read each as a row, align cells to labels); null a field only when info is genuinely absent — not merely unformatted. Compile-time constant (security rule); **no contract / DTO / schema change**.

## Verification
- `FieldExtractionWorkflow_Tests`: 8/8 green.
- E2E against the host's DeepSeek-V3 on the real invoice: the *decisive* fix for that specific document was the admin-configured field prompt (user data, not in this PR). This system-prompt change is the **general-purpose floor** — it makes every field extraction cope with flattened tables, including fields with simple or empty prompts.

Prompt wording fix, no boundary/contract change → per repo convention no separate design Issue needed. Related but separate scope: #259 (vision-LLM OCR for photo/receipt inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)