### PR TITLE
feat(cabinet): AI fallback cabinet selection when upload leaves cabinet empty (manual-first, #265)

### DIFF
--- a/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
+++ b/core/src/Dignite.Paperbase.Application/Ai/PaperbaseAIBehaviorOptions.cs
@@ -42,4 +42,17 @@ public class PaperbaseAIBehaviorOptions
     /// 超出时截断尾部（文档开头通常已包含标题、摘要等关键信息）。
     /// </summary>
     public int MaxTitleGenerationMarkdownLength { get; set; } = 4000;
+
+    /// <summary>
+    /// 「留空 AI 兜底选柜」（#265）提示词中最多包含的候选文件柜数量，超出时截断。
+    /// 镜像 <see cref="MaxDocumentTypesInClassificationPrompt"/>——柜选择与分类同属「从受限候选集挑一个」。
+    /// </summary>
+    public int MaxCabinetsInSuggestionPrompt { get; set; } = 50;
+
+    /// <summary>
+    /// 「留空 AI 兜底选柜」（#265）的弃选阈值：LLM 置信度低于此值时<b>不</b>写入 CabinetId，文档保持「未归类」。
+    /// 柜是人工组织维度，宁可留空交由操作员后续改派（#257），也不强塞一个把握不大的柜。
+    /// 文档 Markdown 截断复用 <see cref="MaxTextLengthPerExtraction"/>（选柜与分类一样只需文档前段语义）。
+    /// </summary>
+    public double MinCabinetSuggestionConfidence { get; set; } = 0.6;
 }

--- a/core/src/Dignite.Paperbase.Application/Documents/Cabinets/CabinetSuggestionWorkflow.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Cabinets/CabinetSuggestionWorkflow.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Paperbase.Documents.Cabinets;
+
+/// <summary>
+/// 「留空 AI 兜底选柜」Workflow（#265，MAF ChatClientAgent + 结构化输出）。
+/// <para>
+/// 放在 <c>Documents/Cabinets/</c> 而非 <c>Pipelines/</c>——文件柜是<b>人工组织维度，正交于内容 pipeline</b>（#194）。
+/// 本 workflow 是上传后<b>一次性独立</b>的兜底步骤，<b>不</b>是分类 / 字段抽取 pipeline 的阶段：它<b>只</b>在
+/// 文档<b>未</b>归类（操作员上传时留空）时由 <c>DocumentCabinetSuggestionBackgroundJob</c> 调用一次，
+/// 从当前层的文件柜里挑一个最贴合的，或在没有清晰匹配时弃选（保持「未归类」）。
+/// </para>
+/// <para>
+/// 结构镜像 <see cref="Pipelines.Classification.DocumentClassificationWorkflow"/>（同 keyed structured client、
+/// PromptBoundary 包裹、前段截断、结构化输出），但更轻——无 PipelineRun、无出口事件、无置信度归一化分支
+/// （柜选择只需「编号 + 置信度」）。安全约定逐条对齐 <c>.claude/rules/llm-call-anti-patterns.md</c>：
+/// 柜名是用户控制文本 → <see cref="PromptBoundary.WrapField"/>；markdown → <see cref="PromptBoundary.WrapDocument"/>；
+/// system prompt 是编译期 <c>const</c>；不信任 LLM 输出（编号越界 / 非法 → 弃选）。
+/// </para>
+/// </summary>
+public class CabinetSuggestionWorkflow : ITransientDependency
+{
+    /// <summary>
+    /// 与分类同走 <see cref="PaperbaseAIConsts.StructuredChatClientKey"/> keyed client
+    /// （structured-output、tool-free、prompt-unique）——host 可把它指向更小 / 更便宜的模型。
+    /// </summary>
+    private readonly IChatClient _chatClient;
+    private readonly PaperbaseAIBehaviorOptions _options;
+
+    public ILogger<CabinetSuggestionWorkflow> Logger { get; set; }
+        = NullLogger<CabinetSuggestionWorkflow>.Instance;
+
+    public CabinetSuggestionWorkflow(
+        [FromKeyedServices(PaperbaseAIConsts.StructuredChatClientKey)] IChatClient chatClient,
+        IOptions<PaperbaseAIBehaviorOptions> options)
+    {
+        _chatClient = chatClient;
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// 编译期常量 system instructions（防 prompt injection，<b>不</b>拼接任何运行时字符串）。
+    /// 让 LLM 从编号候选里选一个，或在没有清晰匹配时返回 <c>null</c>（宁缺毋滥）。
+    /// </summary>
+    private const string SystemPrompt =
+        "You help organize an uploaded document into the best-matching filing cabinet. " +
+        "Cabinets are a human organizational dimension (e.g. by department, project, or batch) and are " +
+        "independent of the document's content type. You are given a numbered list of the available " +
+        "cabinets and the beginning of the document (as Markdown). " +
+        "Pick the single cabinet whose name best fits the document, and report your confidence (0.0 to 1.0). " +
+        "If no cabinet clearly fits, return null for cabinetIndex with a low confidence — it is better to " +
+        "leave the document uncategorized than to file it into a poorly matching cabinet. " +
+        "Return JSON only: {\"cabinetIndex\": <1-based number or null>, \"confidence\": <0.0-1.0>}.";
+
+    /// <summary>
+    /// 从候选柜列表中为 <paramref name="markdown"/> 挑一个柜。返回 <see cref="CabinetSuggestionOutcome"/>
+    /// （<see cref="CabinetSuggestionOutcome.CabinetId"/> 为 <c>null</c> 表示弃选 / 无法识别 / 编号越界）。
+    /// 置信度阈值由调用方（<c>DocumentCabinetSuggestionBackgroundJob</c>）按
+    /// <see cref="PaperbaseAIBehaviorOptions.MinCabinetSuggestionConfidence"/> 施加——本方法只解析 + 映射，不做阈值裁决。
+    /// </summary>
+    public virtual async Task<CabinetSuggestionOutcome> RunAsync(
+        IReadOnlyList<Cabinet> candidates,
+        string markdown,
+        CancellationToken cancellationToken = default)
+    {
+        if (candidates == null || candidates.Count == 0)
+        {
+            return CabinetSuggestionOutcome.None;
+        }
+
+        // 选柜只需文档前段语义即可判断归属，故按 MaxTextLengthPerExtraction 截断前部（与分类同策略）。
+        var truncatedText = markdown;
+        if (markdown.Length > _options.MaxTextLengthPerExtraction)
+        {
+            // 截断率是有价值的运营信号（与 DocumentClassificationWorkflow 同精神记一条 warning）。
+            Logger.LogWarning(
+                "Cabinet suggestion input truncated from {OriginalLength} to {TruncatedLength} characters.",
+                markdown.Length, _options.MaxTextLengthPerExtraction);
+            truncatedText = TruncateAtCharBoundary(markdown, _options.MaxTextLengthPerExtraction);
+        }
+
+        // 候选集以 1-based 编号喂入——用编号而非 Guid / Name 回显：避免 LLM 复制 GUID 出错，
+        // 且天然抗注入（只能在预载候选集内选）。柜名是用户控制文本，必须 PromptBoundary.WrapField 包裹。
+        var numbered = string.Join(
+            "\n",
+            candidates.Select((c, i) => $"{i + 1}. {PromptBoundary.WrapField(c.Name)}"));
+
+        var userMessage = $$"""
+                ## Available Cabinets
+                {{numbered}}
+
+                ## Document Markdown (first {{_options.MaxTextLengthPerExtraction}} characters)
+                {{PromptBoundary.WrapDocument(truncatedText)}}
+                """;
+
+        AIAgent agent = new ChatClientAgent(
+            _chatClient,
+            new ChatClientAgentOptions
+            {
+                Name = "PaperbaseCabinetSuggester",
+                ChatOptions = new ChatOptions
+                {
+                    Instructions = SystemPrompt + " " + PromptBoundary.BoundaryRule
+                },
+                UseProvidedChatClientAsIs = true
+            })
+            .AsBuilder()
+            .UseOpenTelemetry()
+            .Build();
+
+        var response = await agent.RunAsync<CabinetSuggestionResponse>(
+            userMessage,
+            cancellationToken: cancellationToken);
+
+        return ResolveOutcome(response.Result, candidates);
+    }
+
+    /// <summary>
+    /// 把 LLM 的 <see cref="CabinetSuggestionResponse"/> 解析为 <see cref="CabinetSuggestionOutcome"/>：
+    /// 1-based 编号映射回候选 <see cref="Cabinet.Id"/>，越界 / null / 非法编号 → 弃选；置信度 clamp 到 0..1。
+    /// internal static 便于 Application.Tests 直接验证映射 / 弃选边界（与分类的 helper 同源）。
+    /// </summary>
+    internal CabinetSuggestionOutcome ResolveOutcome(
+        CabinetSuggestionResponse? parsed,
+        IReadOnlyList<Cabinet> candidates)
+    {
+        if (parsed?.CabinetIndex is not { } index)
+        {
+            return CabinetSuggestionOutcome.None;
+        }
+
+        // 1-based 编号；越界（含 LLM 返回 0 / 负数 / 超过候选数）→ 弃选，不写脏柜。
+        if (index < 1 || index > candidates.Count)
+        {
+            Logger.LogWarning(
+                "Cabinet suggestion returned out-of-range index {Index} for {CandidateCount} candidates; abstaining.",
+                index, candidates.Count);
+            return CabinetSuggestionOutcome.None;
+        }
+
+        return new CabinetSuggestionOutcome
+        {
+            CabinetId = candidates[index - 1].Id,
+            Confidence = ClampConfidence(parsed.Confidence)
+        };
+    }
+
+    internal static double ClampConfidence(double value)
+    {
+        if (double.IsNaN(value))
+            return 0d;
+        if (value < 0d) return 0d;
+        if (value > 1d) return 1d;
+        return value;
+    }
+
+    // 按 UTF-16 码元上限截断，但不切断代理对（与 DocumentClassificationWorkflow.TruncateAtCharBoundary 同源）。
+    // internal 便于 Application.Tests 直接验证边界逻辑。
+    internal static string TruncateAtCharBoundary(string text, int maxChars)
+    {
+        if (maxChars <= 0)
+            return string.Empty;
+        if (text.Length <= maxChars)
+            return text;
+
+        var end = char.IsHighSurrogate(text[maxChars - 1]) ? maxChars - 1 : maxChars;
+        return text[..end];
+    }
+
+    internal sealed class CabinetSuggestionResponse
+    {
+        /// <summary>1-based 候选编号；<c>null</c> 表示 LLM 弃选（无清晰匹配）。</summary>
+        public int? CabinetIndex { get; set; }
+
+        public double Confidence { get; set; }
+    }
+}
+
+/// <summary>
+/// 选柜结果。<see cref="CabinetId"/> 为 <c>null</c> 表示弃选（无候选 / LLM 弃选 / 编号越界）——
+/// 调用方据此保持文档「未归类」。<see cref="Confidence"/> 供调用方按阈值裁决。
+/// </summary>
+public sealed class CabinetSuggestionOutcome
+{
+    public Guid? CabinetId { get; init; }
+
+    public double Confidence { get; init; }
+
+    public static CabinetSuggestionOutcome None { get; } = new() { CabinetId = null, Confidence = 0d };
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Cabinets/DocumentCabinetSuggestionBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Cabinets/DocumentCabinetSuggestionBackgroundJob.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Threading;
+using Volo.Abp.Uow;
+
+namespace Dignite.Paperbase.Documents.Cabinets;
+
+/// <summary>
+/// 「留空 AI 兜底选柜」后台作业（#265）。<b>独立、一次性、best-effort</b>——由
+/// <c>DocumentTextExtractionBackgroundJob</c> 在文本提取<b>成功</b>（Markdown 就绪）时 fan-out 一次。
+/// <para>
+/// <b>守 #194 正交护栏</b>：本作业是文件柜（人工组织维度）的<b>唯一</b> AI 写入点，与内容 pipeline 解耦——
+/// 分类 / 字段抽取 / 文本提取的逻辑继续完全不读不写 <see cref="Document.CabinetId"/>。它<b>不</b>建
+/// <c>DocumentPipelineRun</c>、不进 <c>KeyPipelines</c>、不影响 <c>LifecycleStatus</c> / Ready 闸门、不可重试。
+/// </para>
+/// <para>
+/// <b>护栏 2（人工优先）</b>：仅在 <see cref="Document.CabinetId"/> 留空时填——Begin 段与 Complete 段各做一次
+/// <c>CabinetId == null</c> 门控（后者复检 LLM 期间操作员手动改派 #257 的竞态）。
+/// <b>护栏 3（一次性）</b>：由 Markdown write-once 不变式保证——文本提取成功路径每个文档至多命中一次，故 fan-out 至多一次。
+/// <b>Fail-open（吞下一切，含取消）</b>：本作业刻意<b>非 PipelineRun、不可重试</b>，故<b>任何</b>异常
+/// （LLM 故障 / provider 超时 <see cref="TaskCanceledException"/> / 解析失败 / 宿主停机取消）都记 warning、留「未归类」、
+/// <b>不</b> rethrow——绝不打挂主流程，也绝不进 ABP 重试机制（与 #210 归档 fail-open 同精神）。
+/// 这里<b>不</b>用 <c>when (ex is not OperationCanceledException)</c> 过滤：那会让 provider 的 per-call 超时
+/// （<see cref="TaskCanceledException"/> 派生自 <see cref="OperationCanceledException"/>）逃逸出 fail-open → 触发 ABP 重试风暴，
+/// 与本作业「不可重试」契约相悖。停机时的及时性由 <see cref="SuggestAsync"/> 传入 ambient 取消令牌保证
+/// （在飞 LLM 调用随令牌取消及时返回、不阻塞 worker），<b>取消异常本身仍被吞掉</b>——文档保持「未归类」即可。
+/// </para>
+/// <para>
+/// 三阶段 UoW 遵循 <c>.claude/rules/background-jobs.md</c>：Begin（短 UoW，加载 + 自门控 + 取候选）→
+/// External（无 UoW，LLM 调用）→ Complete（短 UoW，复检 + 写回）。
+/// </para>
+/// </summary>
+[BackgroundJobName("Paperbase.DocumentCabinetSuggestion")]
+public class DocumentCabinetSuggestionBackgroundJob
+    : AsyncBackgroundJob<DocumentCabinetSuggestionJobArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly ICabinetRepository _cabinetRepository;
+    private readonly CabinetSuggestionWorkflow _workflow;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly PaperbaseAIBehaviorOptions _options;
+    // ABP BackgroundJobExecuter 在调用 ExecuteAsync 前把作业取消令牌（默认 worker 来源是 host 停机令牌）压入 ambient，
+    // 外部慢工作（LLM 调用）据此可在停机时及时取消（与 DocumentTextExtractionBackgroundJob 同源）。
+    private readonly ICancellationTokenProvider _cancellationTokenProvider;
+
+    public DocumentCabinetSuggestionBackgroundJob(
+        IDocumentRepository documentRepository,
+        ICabinetRepository cabinetRepository,
+        CabinetSuggestionWorkflow workflow,
+        IUnitOfWorkManager unitOfWorkManager,
+        ICurrentTenant currentTenant,
+        IOptions<PaperbaseAIBehaviorOptions> options,
+        ICancellationTokenProvider cancellationTokenProvider)
+    {
+        _documentRepository = documentRepository;
+        _cabinetRepository = cabinetRepository;
+        _workflow = workflow;
+        _unitOfWorkManager = unitOfWorkManager;
+        _currentTenant = currentTenant;
+        _options = options.Value;
+        _cancellationTokenProvider = cancellationTokenProvider;
+    }
+
+    public override async Task ExecuteAsync(DocumentCabinetSuggestionJobArgs args)
+    {
+        try
+        {
+            var workItem = await PrepareAsync(args.DocumentId);
+            if (workItem == null)
+            {
+                // 自门控命中（人工已选 / 无 Markdown / 无候选柜）——静默结束，文档保持「未归类」。
+                return;
+            }
+
+            var outcome = await SuggestAsync(workItem);
+
+            await ApplyAsync(args.DocumentId, outcome);
+        }
+        catch (Exception ex)
+        {
+            // Fail-open（吞下一切，含取消）：本作业非 PipelineRun、不可重试，故任何异常都不 rethrow——
+            // 含 provider per-call 超时（TaskCanceledException : OperationCanceledException）与宿主停机取消。
+            // 关键：不加 `when (ex is not OperationCanceledException)` 过滤——否则 per-call 超时会逃逸 → ABP 重试风暴，
+            // 与「不可重试」契约相悖。停机及时性已由 SuggestAsync 传入 ambient 取消令牌保证（LLM 调用随之及时返回），
+            // 取消异常在此吞掉、文档保持「未归类」即可。
+            Logger.LogWarning(ex,
+                "AI cabinet suggestion failed for document {DocumentId}; leaving it uncategorized.",
+                args.DocumentId);
+        }
+    }
+
+    /// <summary>Begin 段（短 UoW）：加载文档、自门控、取当前层候选柜。门控命中返回 <c>null</c>。</summary>
+    protected virtual async Task<CabinetSuggestionWorkItem?> PrepareAsync(Guid documentId)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.GetAsync(documentId, includeDetails: false);
+
+        // 护栏 2：人工已选（或上一轮已填）→ 人工优先，AI 不覆盖。
+        // 选柜依据内容（#265）——尚无 Markdown 无从判断。
+        if (document.CabinetId.HasValue || string.IsNullOrEmpty(document.Markdown))
+        {
+            await uow.CompleteAsync();
+            return null;
+        }
+
+        // 候选集按 Document.TenantId 匹配单层（ambient IMultiTenant filter），按柜名稳定排序 + 截断。
+        List<Cabinet> candidates;
+        using (_currentTenant.Change(document.TenantId))
+        {
+            var all = await _cabinetRepository.GetListAsync();
+            candidates = all
+                .OrderBy(c => c.Name, StringComparer.Ordinal)
+                .Take(_options.MaxCabinetsInSuggestionPrompt)
+                .ToList();
+
+            // 柜数超上限：被裁掉的是字典序靠后的柜（无优先级概念，least-bad），正确柜可能落在截断外——记 warning 供运维可见。
+            if (all.Count > _options.MaxCabinetsInSuggestionPrompt)
+            {
+                Logger.LogWarning(
+                    "Document {DocumentId} layer has {CabinetCount} cabinets, exceeding the suggestion cap {Cap}; "
+                    + "candidates beyond the cap are excluded from the prompt.",
+                    document.Id, all.Count, _options.MaxCabinetsInSuggestionPrompt);
+            }
+        }
+
+        await uow.CompleteAsync();
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        return new CabinetSuggestionWorkItem(document.Id, document.TenantId, document.Markdown, candidates);
+    }
+
+    /// <summary>External 段（无 UoW）：LLM 选柜。保持 ambient 租户与候选集组装一致（防御未来 workflow 内二次查询）；
+    /// 传入 ambient 作业取消令牌，停机时可及时取消 LLM 调用。</summary>
+    protected virtual async Task<CabinetSuggestionOutcome> SuggestAsync(CabinetSuggestionWorkItem workItem)
+    {
+        using (_currentTenant.Change(workItem.TenantId))
+        {
+            return await _workflow.RunAsync(
+                workItem.Candidates, workItem.Markdown, _cancellationTokenProvider.Token);
+        }
+    }
+
+    /// <summary>Complete 段（短 UoW）：阈值裁决 + 竞态复检 + 写回 CabinetId。</summary>
+    protected virtual async Task ApplyAsync(Guid documentId, CabinetSuggestionOutcome outcome)
+    {
+        // 弃选（无候选 / LLM 弃选 / 编号越界）或置信度不达标 → 不写，保持「未归类」（宁缺毋滥，#265）。
+        if (outcome.CabinetId is not { } cabinetId
+            || outcome.Confidence < _options.MinCabinetSuggestionConfidence)
+        {
+            return;
+        }
+
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var document = await _documentRepository.GetAsync(documentId, includeDetails: false);
+
+        // 护栏 2 复检：LLM 期间操作员可能已手动改派（#257）——人工优先，不覆盖。
+        if (document.CabinetId.HasValue)
+        {
+            await uow.CompleteAsync();
+            return;
+        }
+
+        // 复检柜仍在当前层存在（LLM 期间可能被删柜）——不写悬空指向已删柜的 CabinetId。
+        using (_currentTenant.Change(document.TenantId))
+        {
+            var cabinet = await _cabinetRepository.FindAsync(cabinetId);
+            if (cabinet == null)
+            {
+                await uow.CompleteAsync();
+                return;
+            }
+        }
+
+        document.SetCabinet(cabinetId);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+
+        await uow.CompleteAsync();
+    }
+
+    public sealed record CabinetSuggestionWorkItem(
+        Guid DocumentId,
+        Guid? TenantId,
+        string Markdown,
+        IReadOnlyList<Cabinet> Candidates);
+}
+
+public class DocumentCabinetSuggestionJobArgs
+{
+    public Guid DocumentId { get; set; }
+}

--- a/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.Paperbase.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -7,6 +7,7 @@ using Dignite.Paperbase.Abstractions.Documents;
 using Dignite.Paperbase.Abstractions.TextExtraction;
 using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Cabinets;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,7 @@ public class DocumentTextExtractionBackgroundJob
     : DocumentPipelineBackgroundJobBase<DocumentTextExtractionJobArgs>, ITransientDependency
 {
     private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly ITextExtractor _textExtractor;
     private readonly IBlobContainer<PaperbaseDocumentContainer> _blobContainer;
     private readonly IDistributedEventBus _distributedEventBus;
@@ -50,6 +52,7 @@ public class DocumentTextExtractionBackgroundJob
         DocumentPipelineRunAccessor pipelineRunAccessor,
         IUnitOfWorkManager unitOfWorkManager,
         DocumentPipelineJobScheduler pipelineJobScheduler,
+        IBackgroundJobManager backgroundJobManager,
         ITextExtractor textExtractor,
         IBlobContainer<PaperbaseDocumentContainer> blobContainer,
         IDistributedEventBus distributedEventBus,
@@ -61,6 +64,7 @@ public class DocumentTextExtractionBackgroundJob
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _pipelineJobScheduler = pipelineJobScheduler;
+        _backgroundJobManager = backgroundJobManager;
         _textExtractor = textExtractor;
         _blobContainer = blobContainer;
         _distributedEventBus = distributedEventBus;
@@ -156,6 +160,16 @@ public class DocumentTextExtractionBackgroundJob
         // 文本提取完成即推进分类——OCR 不设质量门控
         // （#196：OCR 平均置信度预测不了真实质量；质量问题由分类审核 + 操作员重跑/重传事后处理）。
         await _pipelineJobScheduler.QueueAsync(document, PaperbasePipelines.Classification);
+
+        // #265：文本提取成功、Markdown 就绪后 fan-out「留空 AI 兜底选柜」作业。
+        // 它是正交于内容 pipeline 的独立 sibling（非 PipelineRun 阶段）——这里<b>不</b>读 document.CabinetId
+        // （文本提取 job 不触碰 cabinet，守 #194 护栏），人工/竞态门控全在 DocumentCabinetSuggestionBackgroundJob 内自做。
+        // 「一次性」（#265 护栏 3）由 Markdown write-once 不变式天然保证：CompleteTextExtractionAsync → SetMarkdown
+        // 在 Markdown 已存在时抛 MarkdownIsImmutable → FailRun，故本成功路径每个文档<b>至多命中一次</b>，
+        // retry 只对 Failed run 放行（首次成功即在此）、rerecognize 只重排 classification 不重跑文本提取——均不会重复 fan-out。
+        // 不用 AttemptNumber==1 门控：那会漏掉「首次尝试失败、retry 才成功」（成功 run 的 AttemptNumber>1）这一首次成功场景。
+        await _backgroundJobManager.EnqueueAsync(
+            new DocumentCabinetSuggestionJobArgs { DocumentId = document.Id });
 
         await uow.CompleteAsync();
     }

--- a/core/src/Dignite.Paperbase.Domain/Documents/Cabinets/Cabinet.cs
+++ b/core/src/Dignite.Paperbase.Domain/Documents/Cabinets/Cabinet.cs
@@ -13,8 +13,14 @@ namespace Dignite.Paperbase.Documents.Cabinets;
 /// <para>
 /// 与 DocumentType 的关键区别——<b>无字符串标识码</b>：DocumentType 的 TypeCode 之所以是字符串，是因为要喂
 /// LLM 分类 prompt、被下游业务按 <c>(TenantId, TypeCode)</c> 元组路由、允许跨层同码。Cabinet 三者皆无
-/// （#194 约束：正交于 pipeline，不进 LLM / 出口契约，只用于内部查询 / 筛选 / 分组），故用 Guid 主键
+/// （#194 约束：正交于<b>内容</b> pipeline，不进出口契约，只用于内部查询 / 筛选 / 分组），故用 Guid 主键
 /// + <see cref="Name"/> 层内唯一即可，<see cref="Document.CabinetId"/> 以可空 Guid 外键引用。
+/// <para>
+/// <b>#265 例外（不破坏 #194 正交）</b>：上传时若操作员留空柜，「AI 兜底选柜」会把本层柜的 <see cref="Name"/> 作为
+/// <b>候选编号列表</b>喂给 LLM 选一个（经 <c>PromptBoundary.WrapField</c> 包裹防注入）。这是<b>独立、一次性</b>的
+/// 上传时步骤，<b>分类 / 字段抽取 pipeline 仍完全不读不写 <see cref="Document.CabinetId"/></b>——柜没有退化成第二个
+/// DocumentType，AI 内容维度与人工组织维度依旧解耦（详见 <c>CabinetSuggestionWorkflow</c>）。
+/// </para>
 /// </para>
 /// </summary>
 public class Cabinet : FullAuditedAggregateRoot<Guid>, IMultiTenant

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Cabinets/CabinetSuggestionWorkflow_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Cabinets/CabinetSuggestionWorkflow_Tests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.Documents.Cabinets;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+/// <summary>
+/// <see cref="CabinetSuggestionWorkflow"/> 的纯解析 / 边界单元测试（无 DI、无真实 LLM）——
+/// 验证 1-based 编号 → 候选 <see cref="Cabinet.Id"/> 映射、弃选（null / 0 / 越界）、置信度 clamp、截断边界。
+/// </summary>
+public class CabinetSuggestionWorkflow_Tests
+{
+    private static CabinetSuggestionWorkflow CreateWorkflow(PaperbaseAIBehaviorOptions? options = null)
+        => new(
+            Substitute.For<IChatClient>(),
+            Options.Create(options ?? new PaperbaseAIBehaviorOptions()));
+
+    private static List<Cabinet> Candidates(params string[] names)
+    {
+        var list = new List<Cabinet>(names.Length);
+        foreach (var name in names)
+        {
+            list.Add(new Cabinet(Guid.NewGuid(), tenantId: null, name));
+        }
+        return list;
+    }
+
+    [Fact]
+    public void Maps_OneBased_Index_To_Candidate_Id()
+    {
+        var workflow = CreateWorkflow();
+        var candidates = Candidates("法务", "财务", "人事");
+
+        var outcome = workflow.ResolveOutcome(
+            new CabinetSuggestionWorkflow.CabinetSuggestionResponse { CabinetIndex = 2, Confidence = 0.9 },
+            candidates);
+
+        outcome.CabinetId.ShouldBe(candidates[1].Id);
+        outcome.Confidence.ShouldBe(0.9);
+    }
+
+    [Fact]
+    public void Selects_First_And_Last_Candidate_At_Boundaries()
+    {
+        var workflow = CreateWorkflow();
+        var candidates = Candidates("A", "B", "C");
+
+        workflow.ResolveOutcome(
+            new CabinetSuggestionWorkflow.CabinetSuggestionResponse { CabinetIndex = 1, Confidence = 0.8 },
+            candidates).CabinetId.ShouldBe(candidates[0].Id);
+
+        workflow.ResolveOutcome(
+            new CabinetSuggestionWorkflow.CabinetSuggestionResponse { CabinetIndex = 3, Confidence = 0.8 },
+            candidates).CabinetId.ShouldBe(candidates[2].Id);
+    }
+
+    [Fact]
+    public void Abstains_When_Index_Is_Null()
+    {
+        var workflow = CreateWorkflow();
+
+        var outcome = workflow.ResolveOutcome(
+            new CabinetSuggestionWorkflow.CabinetSuggestionResponse { CabinetIndex = null, Confidence = 0.2 },
+            Candidates("A", "B"));
+
+        outcome.CabinetId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Abstains_When_Response_Is_Null()
+    {
+        var workflow = CreateWorkflow();
+
+        var outcome = workflow.ResolveOutcome(null, Candidates("A", "B"));
+
+        outcome.CabinetId.ShouldBeNull();
+        outcome.Confidence.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(0)]    // LLM 返回 0（非 1-based）
+    [InlineData(-1)]   // 负数
+    [InlineData(3)]    // 超过候选数（2 个候选）
+    [InlineData(99)]
+    public void Abstains_When_Index_Out_Of_Range(int index)
+    {
+        var workflow = CreateWorkflow();
+
+        var outcome = workflow.ResolveOutcome(
+            new CabinetSuggestionWorkflow.CabinetSuggestionResponse { CabinetIndex = index, Confidence = 0.95 },
+            Candidates("A", "B"));
+
+        outcome.CabinetId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Clamps_Out_Of_Range_Confidence()
+    {
+        CabinetSuggestionWorkflow.ClampConfidence(1.5).ShouldBe(1.0);
+        CabinetSuggestionWorkflow.ClampConfidence(-0.2).ShouldBe(0.0);
+        CabinetSuggestionWorkflow.ClampConfidence(double.NaN).ShouldBe(0.0);
+        CabinetSuggestionWorkflow.ClampConfidence(0.42).ShouldBe(0.42);
+    }
+
+    [Fact]
+    public void Truncate_Does_Not_Split_Surrogate_Pair()
+    {
+        // "A" + 😀 (代理对) + "B"；maxChars=2 落在代理对中间 → 丢弃整个高位代理，得 "A"。
+        var result = CabinetSuggestionWorkflow.TruncateAtCharBoundary("A\U0001F600B", 2);
+
+        result.ShouldBe("A");
+        char.IsHighSurrogate(result[^1]).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Truncate_Returns_Text_Unchanged_When_Within_Limit()
+    {
+        CabinetSuggestionWorkflow.TruncateAtCharBoundary("hello", 10).ShouldBe("hello");
+    }
+}

--- a/core/test/Dignite.Paperbase.Application.Tests/Documents/Cabinets/DocumentCabinetSuggestionBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Paperbase.Application.Tests/Documents/Cabinets/DocumentCabinetSuggestionBackgroundJob_Tests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Ai;
+using Dignite.Paperbase.Documents.Cabinets;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Modularity;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Dignite.Paperbase.Documents;
+
+[DependsOn(typeof(PaperbaseApplicationTestModule))]
+public class DocumentCabinetSuggestionJobTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        context.Services.AddSingleton(Substitute.For<ICabinetRepository>());
+
+        var workflow = Substitute.ForPartsOf<CabinetSuggestionWorkflow>(
+            Substitute.For<IChatClient>(),
+            Options.Create(new PaperbaseAIBehaviorOptions()));
+        context.Services.AddSingleton(workflow);
+
+        context.Services.Configure<PaperbaseAIBehaviorOptions>(_ => { });
+    }
+}
+
+/// <summary>
+/// <see cref="DocumentCabinetSuggestionBackgroundJob"/> 行为测试（#265）：人工优先门控、弃选 / 阈值、
+/// 竞态复检、fail-open、LLM 调用在 UoW 之外。IChatClient / workflow 均 NSubstitute 替代，无真实 LLM。
+/// </summary>
+public class DocumentCabinetSuggestionBackgroundJob_Tests
+    : PaperbaseApplicationTestBase<DocumentCabinetSuggestionJobTestModule>
+{
+    private readonly DocumentCabinetSuggestionBackgroundJob _job;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly ICabinetRepository _cabinetRepository;
+    private readonly CabinetSuggestionWorkflow _workflow;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public DocumentCabinetSuggestionBackgroundJob_Tests()
+    {
+        _job = GetRequiredService<DocumentCabinetSuggestionBackgroundJob>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _cabinetRepository = GetRequiredService<ICabinetRepository>();
+        _workflow = GetRequiredService<CabinetSuggestionWorkflow>();
+        _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public async Task Writes_CabinetId_When_Confident_Match()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var doc = CreateDocument(markdown: "業務委託契約書の内容です。", cabinetId: null);
+        SetupRepositories(doc, cabinet);
+
+        StubWorkflow(new CabinetSuggestionOutcome { CabinetId = cabinet.Id, Confidence = 0.9 });
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBe(cabinet.Id);
+        await _documentRepository.Received().UpdateAsync(doc, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Skips_When_CabinetId_Already_Set_Manually()
+    {
+        var existing = Guid.NewGuid();
+        var doc = CreateDocument(markdown: "anything", cabinetId: existing);
+        SetupRepositories(doc, cabinet: null);
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBe(existing);
+        // 人工优先：自门控命中，连 LLM 都不调。
+        await _workflow.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Skips_When_Markdown_Empty()
+    {
+        var doc = CreateDocument(markdown: null, cabinetId: null);
+        SetupRepositories(doc, cabinet: null);
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBeNull();
+        await _workflow.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Skips_When_No_Cabinets_In_Layer()
+    {
+        var doc = CreateDocument(markdown: "some text", cabinetId: null);
+        SetupRepositories(doc, cabinet: null); // empty cabinet list
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBeNull();
+        await _workflow.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Does_Not_Write_When_Workflow_Abstains()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var doc = CreateDocument(markdown: "some text", cabinetId: null);
+        SetupRepositories(doc, cabinet);
+
+        StubWorkflow(CabinetSuggestionOutcome.None);
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Does_Not_Write_When_Below_Confidence_Threshold()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var doc = CreateDocument(markdown: "some text", cabinetId: null);
+        SetupRepositories(doc, cabinet);
+
+        // 默认阈值 0.6；0.4 应被拒。
+        StubWorkflow(new CabinetSuggestionOutcome { CabinetId = cabinet.Id, Confidence = 0.4 });
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task FailsOpen_When_Workflow_Throws()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var doc = CreateDocument(markdown: "some text", cabinetId: null);
+        SetupRepositories(doc, cabinet);
+
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<CabinetSuggestionOutcome>(_ => throw new TimeoutException("LLM down"));
+
+        // Fail-open：不 rethrow，文档保持未归类。
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBeNull();
+        // 断言 workflow 确被调用——否则 CabinetId==null 可能因前置门控短路（假阳性），catch 根本没被走到。
+        await _workflow.Received(1).RunAsync(
+            Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Does_Not_Overwrite_When_Operator_Reassigns_During_Llm()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var manualCabinetId = Guid.NewGuid();
+
+        // Begin 段加载到未归类文档；Complete 段重载时已被操作员手动改派（CabinetId 已设）。
+        var docAtBegin = CreateDocument(markdown: "some text", cabinetId: null);
+        var docAtComplete = CreateDocument(markdown: "some text", cabinetId: manualCabinetId, id: docAtBegin.Id);
+
+        _documentRepository
+            .GetAsync(docAtBegin.Id, false, Arg.Any<CancellationToken>())
+            .Returns(docAtBegin, docAtComplete);
+        _cabinetRepository
+            .GetListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Cabinet> { cabinet });
+        _cabinetRepository
+            .FindAsync(cabinet.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(cabinet);
+
+        StubWorkflow(new CabinetSuggestionOutcome { CabinetId = cabinet.Id, Confidence = 0.95 });
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = docAtBegin.Id });
+
+        // 人工改派的值不被 AI 覆盖。
+        docAtComplete.CabinetId.ShouldBe(manualCabinetId);
+        // load-bearing：任何文档实例都不应被写回（防御复检若误用 docAtBegin 实例 SetCabinet 的假阳性）。
+        await _documentRepository.DidNotReceive().UpdateAsync(
+            Arg.Any<Document>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Swallows_Provider_Timeout_FailOpen_Without_Triggering_Retry()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var doc = CreateDocument(markdown: "some text", cabinetId: null);
+        SetupRepositories(doc, cabinet);
+
+        // 本作业非 PipelineRun、不可重试：provider per-call 超时（TaskCanceledException : OperationCanceledException）
+        // 必须被 fail-open 吞掉、绝不逃逸出 ExecuteAsync（否则 ABP 会把它当失败重排 → 重试风暴）。
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<CabinetSuggestionOutcome>(_ => throw new TaskCanceledException("provider per-call timeout"));
+
+        // 不抛——吞掉（若 catch 误加 `when (ex is not OperationCanceledException)` 过滤，此调用会抛、测试失败）。
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBeNull();
+        await _workflow.Received(1).RunAsync(
+            Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Llm_Call_Runs_Outside_Any_UnitOfWork()
+    {
+        var cabinet = new Cabinet(Guid.NewGuid(), null, "法务");
+        var doc = CreateDocument(markdown: "some text", cabinetId: null);
+        SetupRepositories(doc, cabinet);
+
+        // background-jobs.md：外部慢工作（LLM）必须在 UoW 之外执行。
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                _unitOfWorkManager.Current.ShouldBeNull();
+                return Task.FromResult(new CabinetSuggestionOutcome { CabinetId = cabinet.Id, Confidence = 0.9 });
+            });
+
+        await _job.ExecuteAsync(new DocumentCabinetSuggestionJobArgs { DocumentId = doc.Id });
+
+        doc.CabinetId.ShouldBe(cabinet.Id);
+    }
+
+    private void StubWorkflow(CabinetSuggestionOutcome outcome)
+    {
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<Cabinet>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(outcome);
+    }
+
+    private void SetupRepositories(Document doc, Cabinet? cabinet)
+    {
+        _documentRepository
+            .GetAsync(doc.Id, false, Arg.Any<CancellationToken>())
+            .Returns(doc);
+
+        _cabinetRepository
+            .GetListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(cabinet == null ? new List<Cabinet>() : new List<Cabinet> { cabinet });
+
+        if (cabinet != null)
+        {
+            _cabinetRepository
+                .FindAsync(cabinet.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(cabinet);
+        }
+    }
+
+    private static Document CreateDocument(string? markdown, Guid? cabinetId, Guid? id = null)
+    {
+        var doc = new Document(
+            id ?? Guid.NewGuid(), null,
+            new FileOrigin(
+                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"),
+            cabinetId: cabinetId);
+
+        if (!string.IsNullOrEmpty(markdown))
+        {
+            typeof(Document)
+                .GetProperty(nameof(Document.Markdown))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(doc, [markdown]);
+        }
+
+        return doc;
+    }
+}

--- a/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.Paperbase.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Dignite.Paperbase.Abstractions.TextExtraction;
 using Dignite.Paperbase.Ai;
 using Dignite.Paperbase.Documents;
+using Dignite.Paperbase.Documents.Cabinets;
 using Dignite.Paperbase.Documents.Pipelines;
 using Dignite.Paperbase.Documents.Pipelines.Classification;
 using Dignite.Paperbase.Documents.Pipelines.TextExtraction;
@@ -105,6 +106,13 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
             Arg.Is<DocumentClassificationJobArgs>(x =>
                 x.DocumentId == documentId &&
                 x.PipelineRunId == classificationRunId),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+
+        // #265：文本提取成功后 fan-out「留空 AI 兜底选柜」作业（无条件——一次性由 Markdown write-once 保证，
+        // 成功路径每文档至多命中一次；不用 AttemptNumber==1 门控以免漏掉「首次失败、retry 才成功」场景）。
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentCabinetSuggestionJobArgs>(x => x.DocumentId == documentId),
             Arg.Any<BackgroundJobPriority>(),
             Arg.Any<TimeSpan?>());
     }


### PR DESCRIPTION
Closes #265

## Motivation
When an operator leaves the cabinet empty at upload time, the document stays in "uncategorized" indefinitely. This adds a convenience layer — **manual-first; if left empty, AI picks a cabinet based on document content as a fallback** — to reduce "uncategorized" accumulation while strictly respecting the #194 orthogonality guardrail (cabinet is a manual organization dimension, orthogonal to the AI content dimension).

## Design (three points confirmed via discussion)
- **Timing**: runs **asynchronously** after text extraction produces Markdown (cabinet selection depends on content, which does not exist at upload time).
- **Provenance**: **silently writes** `CabinetId` — no "AI-selected" provenance field is added to `Document`.
- **Observability**: isolated **best-effort** background job — no `DocumentPipelineRun` created, not included in `KeyPipelines`, does not affect `LifecycleStatus` / Ready gate, not retryable; failure or no-selection leaves the document "uncategorized".

## Changes
- **`CabinetSuggestionWorkflow`** (new): a single structured LLM call; cabinet candidates are fed as a **numbered list** (injection-resistant); cabinet names are wrapped with `PromptBoundary.WrapField`; compile-time `const` instructions; out-of-range index / no-selection → no write. Structure mirrors `DocumentClassificationWorkflow`, sharing `StructuredChatClientKey` (host can point to a smaller/cheaper model).
- **`DocumentCabinetSuggestionBackgroundJob`** (new): three-phase UoW (LLM call outside UoW, following `background-jobs.md`); dual `CabinetId==null` gate at Begin/Complete (including operator reassignment #257 race re-check, combined with `Document`'s EF optimistic concurrency to close TOCTOU); confidence threshold; stale-cabinet check on deletion. Ambient cancellation token passed into LLM call (returns promptly on shutdown without blocking the worker); **fail-open swallows all exceptions** (including per-call provider timeout `TaskCanceledException`) — no rethrow, no ABP retry storm.
- **`DocumentTextExtractionBackgroundJob`**: fan-out the cabinet suggestion job after text extraction **succeeds**. **Does not read `CabinetId`** (guards #194: text extraction does not touch cabinet); all gates are self-contained inside the cabinet suggestion job. "One-shot" is guaranteed by the **`Markdown` write-once invariant** (at most one successful fan-out per document), avoiding `AttemptNumber` gating to ensure "first attempt failed, retry succeeded" scenarios are not missed.
- **`PaperbaseAIBehaviorOptions`**: `MaxCabinetsInSuggestionPrompt`(50) + `MinCabinetSuggestionConfidence`(0.6); Markdown truncation reuses `MaxTextLengthPerExtraction`.
- **`Cabinet.cs` comment**: notes that #265 feeding cabinet names as LLM candidates is a **controlled exception** to #194 (the content pipeline still never reads or writes `CabinetId`; cabinets have not degraded into a second DocumentType).

## Guardrails maintained
1. AI cabinet selection is **isolated and one-shot**, not woven into classification / field extraction / text extraction workflow logic;
2. **Manual-first** — only fills `CabinetId` when it is null;
3. **One-shot** — the `Markdown` write-once invariant ensures at most one successful fan-out per document.

No new DTOs / contracts / permissions / exit contracts / migrations; no frontend changes (upload still returns synchronously; AI-filled cabinet appears in subsequent GET / list refresh).

## Tests
- `CabinetSuggestionWorkflow_Tests`: number-to-Guid mapping, no-selection (null/0/out-of-range), confidence clamp, truncation boundary.
- `DocumentCabinetSuggestionBackgroundJob_Tests`: manual-first gate, no-cabinet / empty Markdown skip, hit-write-back, low confidence no write, operator reassignment race re-check, fail-open swallows provider timeout (`TaskCanceledException`, no retry), LLM call outside UoW.
- Persistence tests add assertion for "fan-out cabinet suggestion job after text extraction succeeds".

Local: Application.Tests 217/217, EF Core 48/48, all green.

> Note: this branch is based on `main`; #264 (field-draft-suggestion) has not yet merged and has no file overlap with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)