### PR TITLE
feat(mcp): expose OAuth Protected Resource Metadata (RFC 9728) at /mcp to enable MCP client auto-discovery of authorization (#278)

### DIFF
--- a/Dignite.Paperbase.slnx
+++ b/Dignite.Paperbase.slnx
@@ -33,4 +33,8 @@
         <Project Path="host/src/Dignite.Paperbase.Host.csproj" />
     </Folder>
 
+    <Folder Name="/host/test/">
+        <Project Path="host/test/Dignite.Paperbase.Host.Tests/Dignite.Paperbase.Host.Tests.csproj" />
+    </Folder>
+
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,6 +113,7 @@
 
     <ItemGroup Label="Test">
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -21,6 +21,25 @@ The `/mcp` endpoint reuses the host's existing **OpenIddict Bearer** auth — th
 
 Every request to `/mcp` requires a valid Bearer token (`RequireAuthorization` on the endpoint). In addition, each tool/resource call performs an explicit server-side permission assertion: the caller must be granted **`Paperbase.Documents`** (`PaperbasePermissions.Documents.Default`). A token without that permission gets an authorization error even though the endpoint accepted the connection (fail-closed, defense in depth).
 
+There are two ways for a client to present that token. Both end at the same Bearer validation — they differ only in **how the client obtains the token**.
+
+### 1. Manual token (static `Authorization` header)
+
+Obtain a token from the Paperbase auth server (`AuthServer:Authority`) using your normal OAuth flow (e.g. client-credentials for a service client, or an interactive user token), then grant the client/user the `Paperbase.Documents` permission via the admin UI. Present it as a static `Authorization: Bearer <token>` header. This is what the `mcp-remote` bridge and a manually-configured MCP Inspector use (see the connection examples below). A request that already carries a valid token is validated directly and **never triggers the discovery flow** — these paths are unchanged.
+
+### 2. Automatic discovery (OAuth Protected Resource Metadata, RFC 9728)
+
+Spec-compliant MCP clients (Claude Desktop native Custom Connectors, claude.ai connectors, MCP Inspector's *Guided OAuth*, Cursor) can discover the authorization server and log in interactively, without a pre-provisioned token:
+
+1. The client connects to `/mcp` **without** a token → receives `401` with a `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource/mcp"` pointer.
+2. It fetches that **Protected Resource Metadata** document, which advertises the Paperbase auth server (`AuthServer:Authority`) under `authorization_servers`, plus `scopes_supported: ["Paperbase"]` and `bearer_methods_supported: ["header"]`.
+3. It fetches the auth server's `/.well-known/openid-configuration` to find the `authorize` / `token` endpoints.
+4. It runs Authorization Code + PKCE (a browser login/consent), obtains a token, and connects.
+
+The discovery metadata and the `WWW-Authenticate` pointer come from the `ModelContextProtocol.AspNetCore` MCP authentication scheme (`McpAuth`), wired in `PaperbaseHostModule.ConfigureMcpAuthentication`. In this host the `McpAuth` scheme does **not** validate tokens and is **not** part of the `/mcp` authorization policy — it only (a) self-serves `/.well-known/oauth-protected-resource` (its handler runs in the authentication middleware, so there is no separately-mapped controller), and (b) supplies the 401 challenge. Token validation, ABP dynamic claims, and tenant resolution stay on the endpoint's default policy and the existing OpenIddict chain — unchanged. The challenge is routed to `McpAuth` only for the `/mcp` endpoint, by a small `IAuthorizationMiddlewareResultHandler` (`McpDiscoveryAuthorizationResultHandler`) keyed off an endpoint marker; every other endpoint (admin UI, REST, Swagger) keeps the framework-default challenge, so the UI cookie login redirect is untouched. The discovery path is therefore purely additive and never alters the principal used for authorization — the manual-token paths above are byte-for-byte unchanged.
+
+> **Auth-server-side prerequisite.** Exposing the resource metadata is only the resource-server half of the handshake. For a native client to complete step 4 end-to-end, the OpenIddict authorization server must accept that client — i.e. a **public PKCE client** whose redirect URI matches the MCP client's callback must be registered (statically seeded, or via Dynamic Client Registration / RFC 7591, which is a separate authorization-server concern with its own security review). Until such a client exists for your MCP client, use the manual-token path above.
+
 Obtain a token from the Paperbase auth server (`AuthServer:Authority`) using your normal OAuth flow (e.g. client-credentials for a service client, or an interactive user token), then grant the client/user the `Paperbase.Documents` permission via the admin UI.
 
 > Multi-tenancy is currently disabled (`PaperbaseHostModule.IsMultiTenant = false`), so all access resolves to the host document space. Tenant isolation is still enforced fail-closed in code (explicit `TenantId` predicate), so it stays correct if multi-tenancy is later enabled.

--- a/host/src/Authentication/McpDiscoveryAuthorizationResultHandler.cs
+++ b/host/src/Authentication/McpDiscoveryAuthorizationResultHandler.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.AspNetCore.Authentication;
+
+namespace Dignite.Paperbase.Host.Authentication;
+
+/// <summary>
+/// #278：仅对带 <see cref="McpDiscoveryChallengeMarker"/> 的端点（/mcp），把"未认证"的 challenge
+/// 路由到 McpAuth scheme，使 401 携带 <c>WWW-Authenticate: Bearer resource_metadata="..."</c>
+/// 发现指针（RFC 9728）。其余端点一律委托框架默认 handler。
+///
+/// 为什么不直接把 McpAuth 加进端点授权策略的 AuthenticationSchemes：那会让 PolicyEvaluator
+/// 重新经 McpAuth → OpenIddict authenticate，得到一个未经 ABP dynamic claims 富化的 principal，
+/// 覆盖 UseDynamicClaims 富化过的 ambient User —— 既丢失签发后变更的角色（可能误拒合法 token），
+/// 也绕过"令牌签发后吊销/禁用用户"的实时失效（安全回归）。这里只覆盖 challenge：authenticate
+/// 仍走端点默认策略（RequireAuthenticatedUser，无显式 scheme），复用 ambient 富化 User。
+///
+/// 也不把全局 DefaultChallengeScheme 改成 McpAuth —— 那会破坏管理后台 UI 的 cookie 登录重定向。
+/// </summary>
+public class McpDiscoveryAuthorizationResultHandler : IAuthorizationMiddlewareResultHandler
+{
+    private static readonly AuthorizationMiddlewareResultHandler Default = new();
+
+    public async Task HandleAsync(
+        RequestDelegate next,
+        HttpContext context,
+        AuthorizationPolicy policy,
+        PolicyAuthorizationResult authorizeResult)
+    {
+        // 仅 401（未认证）走 McpAuth challenge 注入发现指针；403（已认证、权限不足）保持框架默认行为。
+        if (authorizeResult.Challenged
+            && !authorizeResult.Forbidden
+            && context.GetEndpoint()?.Metadata.GetMetadata<McpDiscoveryChallengeMarker>() != null)
+        {
+            await context.ChallengeAsync(McpAuthenticationDefaults.AuthenticationScheme);
+            return;
+        }
+
+        await Default.HandleAsync(next, context, policy, authorizeResult);
+    }
+}
+
+/// <summary>
+/// 端点标记：声明该端点的未认证 challenge 走 MCP OAuth Protected Resource Metadata 发现链路（#278）。
+/// 由 <see cref="McpDiscoveryAuthorizationResultHandler"/> 识别。
+/// </summary>
+public sealed class McpDiscoveryChallengeMarker
+{
+    public static readonly McpDiscoveryChallengeMarker Instance = new();
+
+    private McpDiscoveryChallengeMarker()
+    {
+    }
+}

--- a/host/src/PaperbaseHostModule.cs
+++ b/host/src/PaperbaseHostModule.cs
@@ -68,6 +68,9 @@ using Volo.Abp.Timing;
 using Volo.Abp.UI.Navigation.Urls;
 using Volo.Abp.VirtualFileSystem;
 using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Dignite.Paperbase.Host.Authentication;
 
 namespace Dignite.Paperbase.Host;
 
@@ -278,6 +281,46 @@ public class PaperbaseHostModule : AbpModule
         {
             options.IsDynamicClaimsEnabled = true;
         });
+
+        ConfigureMcpAuthentication(context);
+    }
+
+    // #278：给 /mcp 出口补 OAuth Protected Resource Metadata 自动发现链路（RFC 9728）。纯增量，
+    // 不破坏现有手动 token 路径。McpAuth scheme 在本 host 只承担两件事，都不参与 token 验证：
+    //   1. 自服务 `/.well-known/oauth-protected-resource`——McpAuthenticationHandler 实现
+    //      IAuthenticationRequestHandler，在 UseAuthentication() 阶段对该路径直接吐 metadata JSON，
+    //      不依赖任何授权策略，无需单独映射端点；
+    //   2. 提供 401 challenge——注入 `WWW-Authenticate: Bearer resource_metadata="..."` 指针。
+    // 注意 McpAuth 不进入 /mcp 端点的授权策略 AuthenticationSchemes（否则 PolicyEvaluator 会重新
+    // authenticate，丢掉 UseDynamicClaims 富化过的 principal），challenge 由
+    // McpDiscoveryAuthorizationResultHandler 仅对带标记的 /mcp 端点定向触发。详见该 handler 注释。
+    // token 验证、dynamic claims、租户解析全部仍走端点默认策略 + 现有 OpenIddict 链，手动 token
+    //（mcp-remote 静态 Bearer / Inspector 手填 / password-grant）零影响；发现仅在未带 token 的 401 触发。
+    private void ConfigureMcpAuthentication(ServiceConfigurationContext context)
+    {
+        var configuration = context.Services.GetConfiguration();
+        var authority = configuration["AuthServer:Authority"];
+        if (string.IsNullOrWhiteSpace(authority))
+        {
+            // 没有 authority 就无从指向授权服务器，发现链路无意义；不注册半成品 metadata、不接管 challenge。
+            // 此时 /mcp 仍受 RequireAuthorization 保护，手动 token 路径不受影响。
+            return;
+        }
+
+        context.Services.AddAuthentication().AddMcp(options =>
+        {
+            options.ResourceMetadata = new ProtectedResourceMetadata
+            {
+                // Resource 留空：使用默认 well-known 端点时由 handler 从请求自动推断（/mcp 绝对 URL）。
+                AuthorizationServers = new List<string> { authority },
+                ScopesSupported = new List<string> { "Paperbase" },
+                BearerMethodsSupported = new List<string> { "header" },
+                ResourceName = "Paperbase MCP"
+            };
+        });
+
+        // 只覆盖 challenge、不动 authenticate：保留 ABP dynamic claims 富化的 principal（见 handler 注释）。
+        context.Services.Replace(ServiceDescriptor.Singleton<IAuthorizationMiddlewareResultHandler, McpDiscoveryAuthorizationResultHandler>());
     }
 
     private void ConfigureBundles(IHostEnvironment hostingEnvironment)
@@ -657,8 +700,13 @@ public class PaperbaseHostModule : AbpModule
         app.UseConfiguredEndpoints(endpoints =>
         {
             // MCP 出口端点（Streamable HTTP）。复用 host 现有 OpenIddict Bearer：
-            // RequireAuthorization 在端点强制鉴权；tool / resource 方法体内再做显式权限断言（fail-closed 双保险）。
-            endpoints.MapMcp("/mcp").RequireAuthorization();
+            // RequireAuthorization 在端点强制鉴权（authenticate 走默认策略，保留 dynamic claims 富化）；
+            // tool / resource 方法体内再做显式权限断言（fail-closed 双保险）。
+            // #278：McpDiscoveryChallengeMarker 让未带 token 的 401 由 McpDiscoveryAuthorizationResultHandler
+            // 定向走 McpAuth challenge，注入 `WWW-Authenticate: Bearer resource_metadata="..."` 发现指针。
+            endpoints.MapMcp("/mcp")
+                .RequireAuthorization()
+                .WithMetadata(McpDiscoveryChallengeMarker.Instance);
         });
     }
 }

--- a/host/test/Dignite.Paperbase.Host.Tests/Authentication/McpDiscoveryAuthorization_Tests.cs
+++ b/host/test/Dignite.Paperbase.Host.Tests/Authentication/McpDiscoveryAuthorization_Tests.cs
@@ -1,0 +1,205 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Dignite.Paperbase.Host.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Authentication;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Paperbase.Host.Authentication;
+
+/// <summary>
+/// #278 回归护栏：把"为什么 /mcp 必须用 scheme-free 授权策略 + <see cref="McpDiscoveryAuthorizationResultHandler"/>
+/// 定向 challenge、而不是把 McpAuth 直接挂进策略的 AuthenticationSchemes"这条隐性约束锁死。
+///
+/// 用最小 ASP.NET 管线（TestServer）精确镜像 host 的 MCP 接线：默认 token scheme +
+/// 一个模仿 ABP UseDynamicClaims 的富化中间件（把认证结果改写成带 stage=enriched 的 principal）+
+/// 真实的 <see cref="McpDiscoveryAuthorizationResultHandler"/> / <see cref="McpDiscoveryChallengeMarker"/> +
+/// SDK 的 AddMcp。不引 ABP 宿主 / DB / OpenIddict。
+///
+/// 关键对照（<see cref="Authenticated_request_keeps_dynamic_claims_enriched_principal"/> vs
+/// <see cref="Explicit_scheme_policy_drops_enrichment_documents_the_regression"/>）：scheme-free 策略 →
+/// 端点看到 enriched principal；显式挂 scheme → PolicyEvaluator 重新认证、覆盖 context.User → 退回 raw。
+/// 后人若"顺手简化"把 McpAuth 挂回策略，前一个测试会变红。
+/// </summary>
+public class McpDiscoveryAuthorization_Tests
+{
+    private const string TokenScheme = "Token";
+    private const string EnrichedClaim = "enriched";
+    private const string RawClaim = "raw";
+
+    [Fact]
+    public async Task Authenticated_request_keeps_dynamic_claims_enriched_principal()
+    {
+        using var server = await BuildServerAsync(withDiscovery: true, useExplicitScheme: false);
+        using var client = server.CreateClient();
+
+        var response = await WithTokenAsync(client).GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        // scheme-free 策略 → 授权读取 UseDynamicClaims 富化过的 ambient principal，不重新认证。
+        (await response.Content.ReadAsStringAsync()).ShouldBe(EnrichedClaim);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_request_gets_401_with_resource_metadata_pointer()
+    {
+        using var server = await BuildServerAsync(withDiscovery: true, useExplicitScheme: false);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        // McpDiscoveryAuthorizationResultHandler 把 challenge 定向到 McpAuth，注入 RFC 9728 发现指针。
+        var wwwAuth = response.Headers.WwwAuthenticate.ToString();
+        wwwAuth.ShouldContain("resource_metadata");
+        wwwAuth.ShouldContain("/.well-known/oauth-protected-resource");
+    }
+
+    [Fact]
+    public async Task Explicit_scheme_policy_drops_enrichment_documents_the_regression()
+    {
+        // 反例：把 token scheme 挂进策略 AuthenticationSchemes（= 被否决的"简单版"）。
+        using var server = await BuildServerAsync(withDiscovery: false, useExplicitScheme: true);
+        using var client = server.CreateClient();
+
+        var response = await WithTokenAsync(client).GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        // PolicyEvaluator 因显式 scheme 重新认证 → 覆盖 context.User → 富化丢失，退回 raw。
+        (await response.Content.ReadAsStringAsync()).ShouldBe(RawClaim);
+    }
+
+    private static HttpClient WithTokenAsync(HttpClient client)
+    {
+        // StubTokenHandler 只看 Authorization header 是否存在，不校验内容。
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+        return client;
+    }
+
+    private static async Task<TestServer> BuildServerAsync(bool withDiscovery, bool useExplicitScheme)
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+
+                    var auth = services
+                        .AddAuthentication(TokenScheme)
+                        .AddScheme<AuthenticationSchemeOptions, StubTokenHandler>(TokenScheme, null);
+
+                    if (withDiscovery)
+                    {
+                        auth.AddMcp(options => options.ResourceMetadata = new ProtectedResourceMetadata
+                        {
+                            AuthorizationServers = new List<string> { "https://auth.example/" },
+                            ScopesSupported = new List<string> { "Paperbase" },
+                            BearerMethodsSupported = new List<string> { "header" }
+                        });
+                    }
+
+                    services.AddAuthorization();
+
+                    if (withDiscovery)
+                    {
+                        services.Replace(ServiceDescriptor.Singleton<IAuthorizationMiddlewareResultHandler, McpDiscoveryAuthorizationResultHandler>());
+                    }
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+
+                    // 模仿 ABP UseDynamicClaims：认证后把 IAuthenticateResultFeature 改写成富化 principal。
+                    app.Use(async (ctx, next) =>
+                    {
+                        if (ctx.User.Identity?.IsAuthenticated == true)
+                        {
+                            var feature = ctx.Features.Get<IAuthenticateResultFeature>();
+                            if (feature?.AuthenticateResult is not null)
+                            {
+                                var identity = new ClaimsIdentity(TokenScheme);
+                                identity.AddClaim(new Claim("stage", EnrichedClaim));
+                                feature.AuthenticateResult = AuthenticateResult.Success(
+                                    new AuthenticationTicket(new ClaimsPrincipal(identity), TokenScheme));
+                            }
+                        }
+
+                        await next();
+                    });
+
+                    app.UseAuthorization();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        var endpoint = endpoints.MapGet(
+                            "/mcp",
+                            (HttpContext context) => context.User.FindFirst("stage")?.Value ?? "none");
+
+                        if (useExplicitScheme)
+                        {
+                            endpoint.RequireAuthorization(policy => policy
+                                .RequireAuthenticatedUser()
+                                .AddAuthenticationSchemes(TokenScheme));
+                        }
+                        else
+                        {
+                            endpoint.RequireAuthorization();
+                        }
+
+                        if (withDiscovery)
+                        {
+                            endpoint.WithMetadata(McpDiscoveryChallengeMarker.Instance);
+                        }
+                    });
+                });
+            })
+            .StartAsync();
+
+        return host.GetTestServer();
+    }
+
+    // 站位的 token scheme：有 Authorization header 即认证成功（raw principal），否则 NoResult（触发 challenge）。
+    // 对应 OpenIddict validation 从 bearer token 重新解析出未富化 principal。
+    private sealed class StubTokenHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public StubTokenHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey("Authorization"))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var identity = new ClaimsIdentity(TokenScheme);
+            identity.AddClaim(new Claim("stage", RawClaim));
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), TokenScheme)));
+        }
+    }
+}

--- a/host/test/Dignite.Paperbase.Host.Tests/Dignite.Paperbase.Host.Tests.csproj
+++ b/host/test/Dignite.Paperbase.Host.Tests/Dignite.Paperbase.Host.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Dignite.Paperbase.Host</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dignite.Paperbase.Host.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Goal (#278)

Add the **OAuth Protected Resource Metadata auto-discovery chain (RFC 9728)** to the `/mcp` exit, so that MCP-authorization-spec-compliant clients (Claude Desktop native Custom Connectors / claude.ai connectors / MCP Inspector Guided OAuth / Cursor) can authenticate with a single click without pre-provisioning a token:

1. Connect to `/mcp` without a token → `401` + `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource/mcp"`
2. Fetch `/.well-known/oauth-protected-resource/mcp` → discover the authorization server (host OpenIddict)
3. Fetch `/.well-known/openid-configuration` → retrieve the authorize/token endpoints
4. Run Authorization Code + PKCE → obtain token automatically → establish connection

## Implementation (host layer, purely additive)

- **`ConfigureMcpAuthentication`**: `AddAuthentication().AddMcp(...)` registers the `McpAuth` scheme + `ProtectedResourceMetadata` (`authorization_servers = AuthServer:Authority`, `scopes_supported = ["Paperbase"]`, `bearer_methods_supported = ["header"]`). If `authority` is empty, returns early without registering incomplete metadata — fail-safe degradation.
- **McpAuth does exactly two things, neither of which validates tokens**: ① serve `/.well-known/oauth-protected-resource` (`IAuthenticationRequestHandler`, emits JSON directly in the `UseAuthentication()` stage with no separate endpoint mapping); ② provide the 401 challenge injection pointer.
- **`McpDiscoveryAuthorizationResultHandler`** (custom `IAuthorizationMiddlewareResultHandler`): only for `/mcp` endpoints tagged with `McpDiscoveryChallengeMarker`, routes the 401 challenge to `McpAuth`, reusing the SDK's native `WWW-Authenticate` construction; all other endpoints delegate to the framework default.

### Key design constraints (why this is not a three-line "simple version")

`McpAuth` does **not** enter the `/mcp` authorization policy's `AuthenticationSchemes` — doing so would cause `PolicyEvaluator` to re-authenticate and produce a principal **not enriched by ABP dynamic claims**, overwriting the `UseDynamicClaims`-enriched ambient `User`:

- **Security relaxation**: if a user is deleted/disabled after token issuance, dynamic claims would reset the principal to anonymous (stateless-JWT real-time revocation), but bypassing this would still allow a stale token through;
- **Functional regression**: role changes after issuance would be lost → permissions granted via role for `Paperbase.Documents` might be falsely denied (403), violating "existing tokens must remain valid".

This PR uses a custom result handler to **only override the challenge, not authentication**; token validation / dynamic claims / tenant resolution all continue through the endpoint's default policy and the existing OpenIddict chain. It also does **not** change the global `DefaultChallengeScheme` to `McpAuth` (that would break the management UI's cookie login redirect). `IAuthorizationMiddlewareResultHandler` is the extension point officially documented by Microsoft for "change challenge without changing authenticate per endpoint" — vanilla ASP.NET has no other hook (`AuthenticationSchemes` is a shared list for both authenticate and challenge).

## Compatibility (hard constraints, verified line-by-line)

- ✅ `mcp-remote` + static Bearer header: a valid token passes authentication directly, **not triggering** the discovery flow
- ✅ Inspector with manually entered Bearer token: same as above
- ✅ Existing `password` grant + `Paperbase_App` token (audience `Paperbase` / scope `Paperbase` / permission `Paperbase.Documents`): principal and dataflow are **verbatim equivalent** to before the change
- The discovery flow is triggered **only on a token-free 401**, mutually exclusive with manual token presentation

## Scope / boundaries

- ✅ Authentication discovery chain only (exit-contract surface) + host config + docs; does not change MCP tool/resource semantics or the permission model (still `Paperbase.Documents` + fail-closed assertions in method bodies)
- ⚠️ This PR only fills in the **resource-server half of the handshake**. Native client end-to-end interactive login (acceptance #3) also requires **authorization-server-side** registration of a public PKCE client (static seed or RFC 7591 DCR, including security assessment) — documented and flagged, deferred to follow-up, not in this PR
- ❌ Does not introduce a new API-key scheme

## Verification

- `dotnet build host/src`: 0 errors, only 4 pre-existing warnings (unrelated to this change)
- **Three rounds of code review** (each round fixed until clean):
  1. ABP architecture / dependency direction / middleware boundaries → clean
  2. Runtime authentication wiring → fixed `ForwardAuthenticate` pointing to a non-existent `"Bearer"` scheme that caused 500 for requests with tokens (the host OpenIddict validation scheme name is `"OpenIddict.Validation.AspNetCore"`, not `"Bearer"`)
  3. Adversarial security/regression → fixed the regression caused by explicit `AddAuthenticationSchemes("McpAuth")` losing dynamic-claims enrichment (i.e. the "key design constraints" above, which triggered this result-handler refactor)
  4. Finalization confirmation → ready to merge
- SDK 1.3.0 / ABP 10.2 / OpenIddict authorization behavior all verified via `ilspycmd` decompiled assemblies, and proven at runtime with a minimal ASP.NET pipeline (scheme-free → enriched principal, explicit scheme → unenriched)
- **Regression guard tests** (new `host/test/Dignite.Paperbase.Host.Tests`, first host test project in the repo): TestServer minimal pipeline with real handler/marker + SDK `AddMcp`, 3 assertions all green — ① with token (scheme-free) → enriched principal; ② without token → 401 + `resource_metadata`; ③ counterexample: explicit scheme → falls back to unenriched (documents the rejected simple version). If anyone adds McpAuth back to the policy, ① turns red.

## Acceptance criteria

- [x] No token → 401 and `WWW-Authenticate` contains `resource_metadata`
- [x] `GET /.well-known/oauth-protected-resource/mcp` returns valid metadata pointing to the host authorization server
- [x] Manual-token two paths regression pass (tests + line-by-line verification)
- [x] `docs/mcp-server.md` Authentication section updated
- [ ] Inspector without token → Guided OAuth end-to-end (depends on authorization-server-side PKCE client registration; see "Scope / boundaries"; follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)