### PR TITLE
feat(mcp): seed Paperbase_Mcp client and disable resource validation to wire up Guided OAuth (#281)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -436,6 +436,7 @@ FodyWeavers.xsd
 .claude/settings.local.json
 .claude/worktrees/
 .obsidian/
+codex-tmp/
 
 # Code coverage and analysis
 .sonarqube/

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -38,9 +38,78 @@ Spec-compliant MCP clients (Claude Desktop native Custom Connectors, claude.ai c
 
 The discovery metadata and the `WWW-Authenticate` pointer come from the `ModelContextProtocol.AspNetCore` MCP authentication scheme (`McpAuth`), wired in `PaperbaseHostModule.ConfigureMcpAuthentication`. In this host the `McpAuth` scheme does **not** validate tokens and is **not** part of the `/mcp` authorization policy — it only (a) self-serves `/.well-known/oauth-protected-resource` (its handler runs in the authentication middleware, so there is no separately-mapped controller), and (b) supplies the 401 challenge. Token validation, ABP dynamic claims, and tenant resolution stay on the endpoint's default policy and the existing OpenIddict chain — unchanged. The challenge is routed to `McpAuth` only for the `/mcp` endpoint, by a small `IAuthorizationMiddlewareResultHandler` (`McpDiscoveryAuthorizationResultHandler`) keyed off an endpoint marker; every other endpoint (admin UI, REST, Swagger) keeps the framework-default challenge, so the UI cookie login redirect is untouched. The discovery path is therefore purely additive and never alters the principal used for authorization — the manual-token paths above are byte-for-byte unchanged.
 
-> **Auth-server-side prerequisite.** Exposing the resource metadata is only the resource-server half of the handshake. For a native client to complete step 4 end-to-end, the OpenIddict authorization server must accept that client — i.e. a **public PKCE client** whose redirect URI matches the MCP client's callback must be registered (statically seeded, or via Dynamic Client Registration / RFC 7591, which is a separate authorization-server concern with its own security review). Until such a client exists for your MCP client, use the manual-token path above.
+> **Auth-server-side prerequisite — satisfied out of the box (#281).** Exposing the resource metadata is only the resource-server half of the handshake; completing step 4 also needs the OpenIddict authorization server to accept the client. Paperbase seeds **one preset public + PKCE + native client** for exactly this — client_id **`Paperbase_Mcp`** — so Guided OAuth works without per-client registration. Paperbase deliberately does **not** run Dynamic Client Registration (RFC 7591): it is self-hosted and faces a knowable set of clients, so an open registration endpoint would be pure attack surface. Instead you paste the preset client_id into each client's OAuth settings — every real target supports a manually specified client_id.
 
-Obtain a token from the Paperbase auth server (`AuthServer:Authority`) using your normal OAuth flow (e.g. client-credentials for a service client, or an interactive user token), then grant the client/user the `Paperbase.Documents` permission via the admin UI.
+#### Configure the preset client
+
+Point your client at `https://<host>/mcp` with **no** token and supply the client_id `Paperbase_Mcp` (no client secret — it is a public PKCE client):
+
+- **MCP Inspector** — in the OAuth / Authentication settings panel set **Client ID** to `Paperbase_Mcp`, then run *Guided OAuth*.
+- **Claude Desktop / claude.ai custom connector** — in the connector's *Advanced settings* set the **OAuth Client ID** to `Paperbase_Mcp` (this field exists precisely for servers that don't offer DCR).
+- **mcp-remote / Cursor** — set the configured OAuth client id to `Paperbase_Mcp`.
+
+The browser opens the Paperbase login; you sign in, and — because this is a public client with a published client_id — you get an **explicit consent screen** (`ConsentType = Explicit`) before any token is issued. The client then connects automatically.
+
+> The preset client only carries the `Paperbase` scope (plus minimal `profile` / `email` identity scopes). Actual data access is still gated by the **logged-in user's** `Paperbase.Documents` permission — grant it via the admin UI. The auth-code flow logs in a *user*; the client itself holds no data permission, so a user without `Paperbase.Documents` is denied fail-closed even after a successful login.
+
+#### Local TLS: trust the dev certificate (test only)
+
+MCP Inspector and `mcp-remote` run on Node, which does **not** trust the ASP.NET Core HTTPS development certificate by default — connecting to `https://localhost:44348/mcp` fails up front with `self-signed certificate` (`MCP error -32099`), before OAuth even starts. This affects local testing against the dev cert only; a host behind a real CA-signed certificate needs none of it.
+
+Tell Node to trust the OS certificate store before launching the tool (PowerShell):
+
+```powershell
+# Node 22+: trust the Windows cert store, where the ASP.NET Core dev cert is
+# registered after `dotnet dev-certs https --trust`.
+$env:NODE_OPTIONS = "--use-system-ca"
+npx @modelcontextprotocol/inspector
+```
+
+On older Node without `--use-system-ca`, fall back to `$env:NODE_TLS_REJECT_UNAUTHORIZED = "0"`, which disables TLS verification for that process — **dev machines only, never a shared or CI environment**.
+
+#### Browser-based clients need a CORS origin
+
+MCP Inspector's web UI — and any browser-hosted MCP client (e.g. a claude.ai web connector) — runs the OAuth **token exchange and discovery fetches from the browser**, so they are cross-origin calls to the Paperbase host. The browser blocks them unless the client's origin is allowed, surfacing as `OAuth Authorization Error: … Failed to fetch` *after* the login/consent redirect already succeeded. Native bridges (`mcp-remote`, Cursor, Claude Desktop) fetch server-side and are unaffected.
+
+Add the client's origin to `App:CorsOrigins` in `appsettings.json` (comma-separated). MCP Inspector defaults to `http://localhost:6274`:
+
+```json
+"App": {
+  "CorsOrigins": "https://*.Paperbase.com,http://localhost:4200,http://localhost:6274"
+}
+```
+
+`http://localhost:4200` (the Angular dev origin) ships by default; append your client's origin next to it. In production, set this via `appsettings.Production.json` or environment variables.
+
+#### Registered callbacks (and how to add your own)
+
+Native desktop clients bind a **random loopback port**, so the seeded client is `ApplicationType = native`, which activates OpenIddict's RFC 8252 loopback relaxation: a callback registered **without a port** matches any `http://<loopback>:<port>/<path>` (scheme / host / path must still match exactly — only the port is relaxed, and only for loopback hosts). The seeded defaults cover the mainstream clients:
+
+| Registered redirect URI | Client |
+| --- | --- |
+| `http://localhost/oauth/callback` | mcp-remote (default host); MCP Inspector auto flow (any port, incl. 6274) |
+| `http://127.0.0.1/oauth/callback` | mcp-remote started with `--host 127.0.0.1` |
+| `http://localhost/oauth/callback/debug` | MCP Inspector manual/debug flow |
+| `https://claude.ai/api/mcp/auth_callback` | Claude.ai / Claude Desktop / mobile (fixed hosted callback) |
+
+`127.0.0.1` and `localhost` are **distinct host strings** to OpenIddict, so both loopback hosts are listed. To support a client whose callback isn't above — e.g. **Cursor**'s custom-scheme `cursor://anysphere.cursor-mcp/oauth/callback`, or **Claude Code**'s `http://localhost/callback` (note the different path) — override the whole set in `appsettings.json`:
+
+```json
+"OpenIddict": {
+  "Applications": {
+    "Paperbase_Mcp": {
+      "ClientId": "Paperbase_Mcp",
+      "RedirectUris": [
+        "http://localhost/oauth/callback",
+        "http://127.0.0.1/oauth/callback",
+        "cursor://anysphere.cursor-mcp/oauth/callback"
+      ]
+    }
+  }
+}
+```
+
+`RedirectUris` **replaces** the built-in defaults (it does not merge), so list every URI you still need. Re-run the host with `--migrate-database` to re-seed after changing it. A client's exact callback path can be captured from the `redirect_uri` query parameter on the `/authorize` request during a connect attempt.
 
 > Multi-tenancy is currently disabled (`PaperbaseHostModule.IsMultiTenant = false`), so all access resolves to the host document space. Tenant isolation is still enforced fail-closed in code (explicit `TenantId` predicate), so it stays correct if multi-tenancy is later enabled.
 

--- a/host/src/Data/OpenIddictDataSeedContributor.cs
+++ b/host/src/Data/OpenIddictDataSeedContributor.cs
@@ -36,12 +36,19 @@ public class OpenIddictDataSeedContributor : OpenIddictDataSeedContributorBase, 
 
     private async Task CreateScopesAsync()
     {
-        await CreateScopesAsync(new OpenIddictScopeDescriptor 
+        // The Paperbase API is a SINGLE OpenIddict resource named "Paperbase" — this is the token
+        // audience for every client (Angular, Swagger, and MCP alike). MCP's RFC 8707 `resource`
+        // parameter does NOT introduce a second audience: the resource gates are turned off in
+        // PaperbaseHostModule (the parameter is accepted-but-ignored), so an MCP-issued token's aud
+        // stays "Paperbase", matching the validation layer's AddAudiences("Paperbase").
+        var scopeDescriptor = new OpenIddictScopeDescriptor
         {
-            Name = "Paperbase", 
-            DisplayName = "Paperbase API", 
-            Resources = { "Paperbase" }
-        });
+            Name = "Paperbase",
+            DisplayName = "Paperbase API"
+        };
+        scopeDescriptor.Resources.Add("Paperbase");
+
+        await CreateScopesAsync(scopeDescriptor);
     }
 
     private async Task CreateApplicationsAsync()
@@ -104,6 +111,86 @@ public class OpenIddictDataSeedContributor : OpenIddictDataSeedContributorBase, 
                 },
                 scopes: commonScopes,
                 redirectUris: new List<string> { $"{swaggerRootUrl}/swagger/oauth2-redirect.html" }
+            );
+        }
+
+        // MCP native client (#281): one preset public + PKCE + native client that enables Guided OAuth
+        // (Authorization Code + PKCE interactive browser login) for native MCP clients — MCP Inspector,
+        // mcp-remote, Claude Desktop / claude.ai connectors — that connect to /mcp without a token. This
+        // is the authorization-server half of the RFC 9728 discovery flow whose resource-server half was
+        // wired in #278/#280. We deliberately do NOT implement Dynamic Client Registration (RFC 7591):
+        // Paperbase is a self-hosted channel facing a knowable set of clients, so an open registration
+        // endpoint is pure attack surface. Instead the client_id is documented (docs/mcp-server.md) and
+        // operators paste it into each client's OAuth settings — every real target supports a manually
+        // specified client_id.
+        //
+        // ApplicationType MUST be Native: that is what activates OpenIddict's RFC 8252 loopback port
+        // relaxation — a redirect_uri registered WITHOUT a port (e.g. http://127.0.0.1/oauth/callback)
+        // then matches any ephemeral port http://127.0.0.1:<port>/oauth/callback (scheme/host/path/query/
+        // fragment must still be byte-equal; only the port is relaxed, and only for loopback hosts). Native
+        // desktop clients bind a random loopback port, so this single preset client covers them all.
+        // Web/default-type clients (Paperbase_App / Paperbase_Swagger above) do NOT get this relaxation.
+        //
+        // ConsentType is Explicit: this is a PUBLIC client whose client_id is published and non-secret, so
+        // any application can present it. We require an interactive consent screen rather than silently
+        // issuing tokens (OAuth 2.1 BCP for public clients). Data access stays gated fail-closed by the
+        // logged-in user's Paperbase.Documents permission — the auth-code flow logs in a user, and the
+        // client itself holds no data permission.
+        var mcpClientId = configurationSection["Paperbase_Mcp:ClientId"];
+        if (!mcpClientId.IsNullOrWhiteSpace())
+        {
+            // Operators may override the entire callback set via
+            // OpenIddict:Applications:Paperbase_Mcp:RedirectUris (replace semantics — list every URI you
+            // want, including any built-ins you still need). When unset we seed the researched defaults
+            // below. Loopback entries are registered WITHOUT a port and rely on the Native-type port
+            // relaxation to match the client's ephemeral port; 127.0.0.1 and localhost are DISTINCT host
+            // strings to OpenIddict, so both are listed. Paths are matched exactly. Verified against each
+            // client's source (#281):
+            //   http://localhost/oauth/callback        → mcp-remote (default host) + MCP Inspector auto flow (any port, incl. 6274)
+            //   http://127.0.0.1/oauth/callback         → mcp-remote --host 127.0.0.1
+            //   http://localhost/oauth/callback/debug   → MCP Inspector manual/debug flow
+            //   https://claude.ai/api/mcp/auth_callback → Claude.ai / Claude Desktop / mobile (fixed hosted callback)
+            // Cursor (custom cursor:// scheme) and Claude Code CLI (/callback path) are NOT seeded by
+            // default — add them via the config override if needed (see docs/mcp-server.md).
+            var mcpRedirectUris = configurationSection
+                .GetSection("Paperbase_Mcp:RedirectUris")
+                .Get<List<string>>();
+
+            if (mcpRedirectUris == null || mcpRedirectUris.Count == 0)
+            {
+                mcpRedirectUris = new List<string>
+                {
+                    "http://localhost/oauth/callback",
+                    "http://127.0.0.1/oauth/callback",
+                    "http://localhost/oauth/callback/debug",
+                    "https://claude.ai/api/mcp/auth_callback"
+                };
+            }
+
+            await CreateOrUpdateApplicationAsync(
+                applicationType: OpenIddictConstants.ApplicationTypes.Native,
+                name: mcpClientId,
+                type: OpenIddictConstants.ClientTypes.Public,
+                consentType: OpenIddictConstants.ConsentTypes.Explicit,
+                displayName: "Paperbase MCP (native clients)",
+                secret: null,
+                grantTypes: new List<string>
+                {
+                    OpenIddictConstants.GrantTypes.AuthorizationCode,
+                    OpenIddictConstants.GrantTypes.RefreshToken
+                },
+                // Mirror the advertised resource metadata (scopes_supported: ["Paperbase"]) plus minimal
+                // OIDC identity scopes for the interactive login. Address/Phone/Roles are intentionally
+                // omitted (least privilege + a clean Explicit-consent screen). openid is implicit in
+                // OpenIddict and needs no scope permission; offline_access is gated by the RefreshToken
+                // grant above.
+                scopes: new List<string>
+                {
+                    OpenIddictConstants.Permissions.Scopes.Profile,
+                    OpenIddictConstants.Permissions.Scopes.Email,
+                    "Paperbase"
+                },
+                redirectUris: mcpRedirectUris
             );
         }
     }

--- a/host/src/PaperbaseHostModule.cs
+++ b/host/src/PaperbaseHostModule.cs
@@ -155,10 +155,38 @@ public class PaperbaseHostModule : AbpModule
         {
             builder.AddValidation(options =>
             {
+                // Single audience for the whole Paperbase API. REST and MCP are two exit adapters
+                // over the same OpenIddict-Bearer resource — every token's aud is "Paperbase",
+                // regardless of how it was obtained (manual static Bearer or MCP Guided OAuth).
                 options.AddAudiences("Paperbase");
                 options.UseLocalServer();
                 options.UseAspNetCore();
             });
+        });
+
+        // MCP Guided-OAuth clients (RFC 9728 + RFC 8707) MUST send a `resource` parameter naming
+        // the MCP server's canonical URI on every /authorize and /token request (docs/mcp-server.md).
+        // OpenIddict's default resource handling would reject that parameter two ways:
+        //   - ValidateResources         → ID2190 (invalid_target) unless the URI is pre-registered;
+        //   - ValidateResourcePermissions → ID2192 unless the client carries an `rsrc:<uri>` grant.
+        // Paperbase is a SINGLE protected resource (audience "Paperbase"); REST and MCP are just two
+        // exit adapters over it. The token aud is derived from the granted scope's resources during
+        // sign-in, NOT from this request parameter — verified by decompiling OpenIddict 7.2.0:
+        // nothing in OpenIddictServerHandlers narrows the principal's resources by the request
+        // `resource`, and ABP's authorize controller resolves resources from scopes alone. So the
+        // resource indicator carries no isolation value here and there is no "other resource" to gate
+        // against. We therefore turn OFF both resource gates (accept-but-ignore the parameter) rather
+        // than minting the MCP URL as a first-class resource, which would scatter URL coupling across
+        // scope resources, validation audiences, and per-client permissions. Both gates only fire for
+        // requests that actually carry a `resource` param — the Angular / Swagger clients never do, so
+        // this is a no-op for them. IgnoreResourcePermissions is flagged "NOT recommended" by
+        // OpenIddict for the general multi-resource case; it is the correct, minimal choice for a
+        // single-resource server. If Paperbase ever becomes multi-resource, revisit (re-enable the
+        // gates, RegisterResources per resource, and seed rsrc: grants per client).
+        PreConfigure<OpenIddictServerBuilder>(serverBuilder =>
+        {
+            serverBuilder.DisableResourceValidation();
+            serverBuilder.IgnoreResourcePermissions();
         });
 
         if (!hostingEnvironment.IsDevelopment())
@@ -307,11 +335,21 @@ public class PaperbaseHostModule : AbpModule
             return;
         }
 
+        var selfUrl = configuration["App:SelfUrl"]?.TrimEnd('/');
+
         context.Services.AddAuthentication().AddMcp(options =>
         {
             options.ResourceMetadata = new ProtectedResourceMetadata
             {
-                // Resource 留空：使用默认 well-known 端点时由 handler 从请求自动推断（/mcp 绝对 URL）。
+                // RFC 9728 `resource`: the MCP server's canonical URI. The MCP authorization spec
+                // says a client SHOULD use the most-specific URI it can, so we advertise the full
+                // /mcp endpoint (not the bare host origin). The client echoes this back as the
+                // RFC 8707 `resource` parameter on /authorize + /token; OpenIddict accepts-but-
+                // ignores it because both resource gates are turned off in PreConfigureServices
+                // (see the rationale there), so the issued token's aud stays "Paperbase". Set
+                // explicitly rather than left to handler inference so it remains correct behind a
+                // reverse proxy (inference derives it from request host/scheme headers).
+                Resource = string.IsNullOrWhiteSpace(selfUrl) ? null : $"{selfUrl}/mcp",
                 AuthorizationServers = new List<string> { authority },
                 ScopesSupported = new List<string> { "Paperbase" },
                 BearerMethodsSupported = new List<string> { "header" },

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -2,7 +2,7 @@
   "App": {
     "SelfUrl": "https://localhost:44348",
     "ClientUrl": "http://localhost:4200",
-    "CorsOrigins": "https://*.Paperbase.com,http://localhost:4200",
+    "CorsOrigins": "https://*.Paperbase.com,http://localhost:4200,http://localhost:6274",
     "RedirectAllowedUrls": "http://localhost:4200",
     "HealthCheckUrl": "/health-status"
   },
@@ -97,6 +97,9 @@
       "Paperbase_Swagger": {
         "ClientId": "Paperbase_Swagger",
         "RootUrl": "https://localhost:44348"
+      },
+      "Paperbase_Mcp": {
+        "ClientId": "Paperbase_Mcp"
       }
     }
   }


### PR DESCRIPTION
## Background

#278/#280 completed the RFC 9728 **resource server side**: `/mcp` exposes Protected Resource Metadata + `WWW-Authenticate` discovery pointer. This PR fills in the **authorization server side** (#281), enabling MCP clients (MCP Inspector / mcp-remote / Claude Desktop / claude.ai) to connect to `/mcp` via Guided OAuth (Authorization Code + PKCE browser login) without needing a pre-provisioned token.

## Changes

### Pre-seeded client
- One public + PKCE + native client `client_id=Paperbase_Mcp` (`OpenIddictDataSeedContributor` + `appsettings.json`).
- No DCR (RFC 7591): Paperbase is self-hosted and targets known clients; an open registration endpoint is pure attack surface. `client_id` is documented for operators to enter in their OAuth client settings.
- `ApplicationType=Native` activates RFC 8252 loopback port relaxation, covering all local clients binding to random loopback ports with a single client.
- `ConsentType=Explicit`: a published public `client_id` requires an explicit consent screen.
- Default 4 redirect URIs covering mainstream clients (mcp-remote / Inspector / claude.ai), overridable via appsettings (replace semantics).
- Minimal scopes only: `Paperbase` + `profile`/`email`.

### End-to-end wiring (fixes found during integration testing)
- **Disable OpenIddict resource validation**: MCP mandates the `resource` parameter in `/authorize` + `/token` per RFC 8707; OpenIddict rejects it by default with **ID2190** (unregistered resource) / **ID2192** (client lacks `rsrc:` permission). Paperbase is a **single protected resource** (aud=`Paperbase`); REST and MCP are two exit adapters of the same API. Token `aud` is resolved from granted scope resources at login time and is **unrelated to the request `resource` parameter** (confirmed by decompiling OpenIddict 7.2.0 + ABP 10.2.0: no handler uses the request resource to narrow principal resources). `DisableResourceValidation()` + `IgnoreResourcePermissions()` cause the parameter to be accepted but ignored; token `aud` remains `Paperbase`, consistent with the manual static Bearer path. Both gates only apply to requests carrying `resource`; Angular/Swagger are unaffected.
- **Protected Resource Metadata `resource`**: set to the most-specific canonical URI `{SelfUrl}/mcp` (MCP spec requires most-specific).
- **CORS**: add `http://localhost:6274` to `CorsOrigins` (MCP Inspector default port) — OAuth token exchange/discovery from in-browser clients is a cross-origin fetch; without this, the login callback succeeds but still reports `Failed to fetch`.

### Documentation
- `docs/mcp-server.md`: document full Guided OAuth flow — pre-seeded client configuration, dev self-signed certificate trust (`NODE_OPTIONS=--use-system-ca`, test-only), CORS origin, redirect URI registration.

### Incidental
- `chore`: add `codex-tmp/` to `.gitignore` (standalone commit, unrelated repository hygiene).

## Testing
- MCP Inspector v0.22.0 Guided OAuth e2e validated: discovery → browser login → consent screen → connection successful.
- Manual static Bearer path (mcp-remote): token `aud` unchanged, no regression.

## Security
- Data access fail-closed: auth-code flow authenticates the *user*; the client itself holds no data permissions. Users without `Paperbase.Documents` permission are rejected even after a successful login.
- Disabling resource validation does not weaken authentication: token must still be valid, `aud=Paperbase`, and the user must have `Paperbase.Documents`. Resource indicators provide no isolation value for a single-resource server. If Paperbase becomes multi-resource in the future, this must be reverted (re-enable gates + `RegisterResources` + `rsrc:` grants per client seed).

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)