### PR TITLE
refactor: enforce layer-scoped uniqueness in the application layer (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Cross-database portability for layer-scoped uniqueness** — replaced the four soft-delete-filtered unique indexes on `DocumentTypes` (`TenantId, TypeCode`), `FieldDefinitions` (`TenantId, DocumentTypeId, Name`), `ExportTemplates` (`TenantId, Name`), and `Cabinets` (`TenantId, Name`) with application-layer uniqueness enforcement in dedicated domain services (`DocumentTypeManager` / `FieldDefinitionManager` / `ExportTemplateManager` / `CabinetManager`), #304. The schema now emits no provider-specific index DDL (no `HasFilter("IsDeleted = 0")` literal, no reliance on SQL Server's "unique index treats NULLs as equal" semantics) and applies cleanly on SQL Server and PostgreSQL — removing the v0.1.0 SQL-Server-only baseline caveat. Layer-scoped uniqueness (same key allowed across the Host / tenant layers, rejected within a layer), the soft-delete-aware `delete → recreate → restore` semantics, and the egress `(TenantId, DocumentTypeCode)` contract are all unchanged; the only behavioral change is an accepted TOCTOU race window on these low-frequency, admin-managed configuration entities.
+
 ## [0.1.0] - 2026-06-13
 
 First public release of Dignite Document AI — a **channel layer** that turns physical paper / scans / photos / PDF images / Office files into trustworthy digitized data (Markdown + structured metadata) for downstream RAG platforms, business systems, and AI clients. See [CLAUDE.md](./CLAUDE.md) for the full positioning and architecture contract.
@@ -35,7 +39,6 @@ First public release of Dignite Document AI — a **channel layer** that turns p
 ### Known limitations
 
 - **Test coverage gaps** — there are no test projects yet for the TextExtraction orchestrator, `Ocr.PaddleOcr`, `Ocr.AzureDocumentIntelligence`, or `HttpApi`.
-- **SQL Server is the host baseline** — the filtered unique indexes (`IsDeleted = 0`) on `DocumentTypes` / `FieldDefinitions` / `ExportTemplates` / `Cabinets` rely on SQL Server's "unique indexes treat NULLs as equal" semantics to enforce Host-layer (`TenantId IS NULL`) uniqueness. PostgreSQL defaults to `NULLS DISTINCT`, and the `HasFilter` literal is not portable — moving to another database requires re-evaluating these indexes. See [docs/deployment.md](./docs/deployment.md).
 - **Webhook exit is not yet implemented** — the exit contract names four exits (REST / MCP server / EventBus / Webhook); this release ships the first three.
 - **MCP server is pull-only** — no resource subscriptions or lifecycle notifications yet (follow-up increment, #197).
 

--- a/core/src/Dignite.DocumentAI.Application/Documents/Cabinets/CabinetAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Cabinets/CabinetAppService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Permissions;
 using Microsoft.AspNetCore.Authorization;
-using Volo.Abp;
 using Volo.Abp.Domain.Entities;
 
 namespace Dignite.DocumentAI.Documents.Cabinets;
@@ -17,13 +16,16 @@ public class CabinetAppService : DocumentAIAppService, ICabinetAppService
 {
     private readonly ICabinetRepository _repository;
     private readonly IDocumentRepository _documentRepository;
+    private readonly CabinetManager _cabinetManager;
 
     public CabinetAppService(
         ICabinetRepository repository,
-        IDocumentRepository documentRepository)
+        IDocumentRepository documentRepository,
+        CabinetManager cabinetManager)
     {
         _repository = repository;
         _documentRepository = documentRepository;
+        _cabinetManager = cabinetManager;
     }
 
     public virtual async Task<List<CabinetDto>> GetListAsync()
@@ -37,7 +39,7 @@ public class CabinetAppService : DocumentAIAppService, ICabinetAppService
     [Authorize(DocumentAIPermissions.Cabinets.Create)]
     public virtual async Task<CabinetDto> CreateAsync(CreateCabinetDto input)
     {
-        await EnsureNameAvailableAsync(input.Name);
+        await _cabinetManager.CheckNameAvailableAsync(input.Name);
 
         var entity = new Cabinet(GuidGenerator.Create(), CurrentTenant.Id, input.Name, input.Description);
         await _repository.InsertAsync(entity, autoSave: true);
@@ -59,7 +61,7 @@ public class CabinetAppService : DocumentAIAppService, ICabinetAppService
         // check to avoid falsely treating itself as a conflict.
         if (!string.Equals(entity.Name, input.Name, StringComparison.Ordinal))
         {
-            await EnsureNameAvailableAsync(input.Name);
+            await _cabinetManager.CheckNameAvailableAsync(input.Name);
         }
 
         entity.Update(input.Name, input.Description);
@@ -94,21 +96,5 @@ public class CabinetAppService : DocumentAIAppService, ICabinetAppService
         }
 
         await _repository.DeleteAsync(entity);
-    }
-
-    /// <summary>
-    /// Checks cabinet-name uniqueness in the current layer, considering only active cabinets and not
-    /// soft-deleted ones. Cabinets do not have a recycle bin; soft delete means forgotten, so the name
-    /// can be reused by a new cabinet. The unique index <c>(TenantId, Name)</c> is filtered by
-    /// <c>IsDeleted = 0</c>, so soft-deleted cabinets do not participate in the active constraint.
-    /// </summary>
-    protected virtual async Task EnsureNameAvailableAsync(string name)
-    {
-        var existing = await _repository.FindByNameAsync(name);
-        if (existing != null)
-        {
-            throw new BusinessException(DocumentAIErrorCodes.Cabinet.NameAlreadyExists)
-                .WithData("Name", name);
-        }
     }
 }

--- a/core/src/Dignite.DocumentAI.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
@@ -19,15 +19,21 @@ public class DocumentTypeAppService : DocumentAIAppService, IDocumentTypeAppServ
     private readonly IDocumentTypeRepository _repository;
     private readonly IDocumentRepository _documentRepository;
     private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+    private readonly DocumentTypeManager _documentTypeManager;
+    private readonly Fields.FieldDefinitionManager _fieldDefinitionManager;
 
     public DocumentTypeAppService(
         IDocumentTypeRepository repository,
         IDocumentRepository documentRepository,
-        IFieldDefinitionRepository fieldDefinitionRepository)
+        IFieldDefinitionRepository fieldDefinitionRepository,
+        DocumentTypeManager documentTypeManager,
+        Fields.FieldDefinitionManager fieldDefinitionManager)
     {
         _repository = repository;
         _documentRepository = documentRepository;
         _fieldDefinitionRepository = fieldDefinitionRepository;
+        _documentTypeManager = documentTypeManager;
+        _fieldDefinitionManager = fieldDefinitionManager;
     }
 
     public virtual async Task<List<DocumentTypeDto>> GetVisibleAsync()
@@ -70,21 +76,11 @@ public class DocumentTypeAppService : DocumentAIAppService, IDocumentTypeAppServ
     [Authorize(DocumentAIPermissions.DocumentTypes.Create)]
     public virtual async Task<DocumentTypeDto> CreateAsync(CreateDocumentTypeDto input)
     {
-        // Strict single-layer duplicate check. TypeCode is a per-layer namespace; Host and each tenant are independent.
-        // The same TypeCode across layers is valid as two rows distinguished by TenantId. Downstream consumers use
-        // the (TenantId, DocumentTypeCode) tuple.
-        // Disable the ISoftDelete filter so soft-deleted records also participate in duplicate checks. Otherwise the path
-        // "delete -> recreate same TypeCode -> restore old record" can cause unique index conflicts or two active rows with the same (TenantId, TypeCode).
-        DocumentType? existing;
-        using (DataFilter.Disable<ISoftDelete>())
-        {
-            existing = await _repository.FindByTypeCodeAsync(input.TypeCode);
-        }
-        if (existing != null)
-        {
-            throw new BusinessException(DocumentAIErrorCodes.DocumentType.CodeAlreadyExists)
-                .WithData("TypeCode", input.TypeCode);
-        }
+        // Strict single-layer duplicate check, owned by the domain service (#304): TypeCode is a per-layer namespace;
+        // Host and each tenant are independent, so the same TypeCode across layers is valid as two rows distinguished by
+        // TenantId (downstream consumers use the (TenantId, DocumentTypeCode) tuple). The check is soft-delete-aware so the
+        // "delete -> recreate same TypeCode -> restore old record" path cannot produce two active rows.
+        await _documentTypeManager.CheckCodeAvailableAsync(input.TypeCode);
 
         var entity = new DocumentType(
             GuidGenerator.Create(),
@@ -110,21 +106,12 @@ public class DocumentTypeAppService : DocumentAIAppService, IDocumentTypeAppServ
             throw new EntityNotFoundException(typeof(DocumentType), id);
         }
 
-        // Rename unlock (#207): run duplicate check only when TypeCode changes. Same-layer (TenantId, TypeCode) is unique;
-        // soft-deleted records occupy the name too, avoiding restore conflicts.
+        // Rename unlock (#207): run the domain duplicate check only when TypeCode changes. Same-layer (TenantId, TypeCode)
+        // is unique; soft-deleted records occupy the name too, avoiding restore conflicts.
         // Internal associations (Document / FieldDefinition / ExportTemplate) already use this type's immutable Id, so rename does not cascade to those tables.
         if (!string.Equals(input.TypeCode, entity.TypeCode, StringComparison.Ordinal))
         {
-            DocumentType? conflict;
-            using (DataFilter.Disable<ISoftDelete>())
-            {
-                conflict = await _repository.FindByTypeCodeAsync(input.TypeCode);
-            }
-            if (conflict != null)
-            {
-                throw new BusinessException(DocumentAIErrorCodes.DocumentType.CodeAlreadyExists)
-                    .WithData("TypeCode", input.TypeCode);
-            }
+            await _documentTypeManager.CheckCodeAvailableAsync(input.TypeCode);
         }
 
         entity.Update(input.TypeCode, input.DisplayName, input.Description, input.ConfidenceThreshold, input.Priority);
@@ -181,18 +168,8 @@ public class DocumentTypeAppService : DocumentAIAppService, IDocumentTypeAppServ
             }
 
             // Defense: an active row with the same (TenantId, TypeCode) already exists. CreateAsync duplicate checks should prevent this,
-            // but extreme cases such as manual DB edits / seed bypass can still happen; avoid unique index conflicts.
-            var typeQueryable = await _repository.GetQueryableAsync();
-            var typeConflict = await AsyncExecuter.AnyAsync(
-                typeQueryable.Where(t =>
-                    t.TenantId == entity.TenantId &&
-                    t.TypeCode == entity.TypeCode &&
-                    !t.IsDeleted));
-            if (typeConflict)
-            {
-                throw new BusinessException(DocumentAIErrorCodes.DocumentType.RestoreConflict)
-                    .WithData("TypeCode", entity.TypeCode);
-            }
+            // but extreme cases such as manual DB edits / seed bypass can still happen; the domain check rejects it (#304).
+            await _documentTypeManager.CheckRestorableAsync(entity);
 
             entity.IsDeleted = false;
             entity.DeletionTime = null;
@@ -210,12 +187,9 @@ public class DocumentTypeAppService : DocumentAIAppService, IDocumentTypeAppServ
 
             foreach (var field in deletedFields)
             {
-                var nameConflict = await AsyncExecuter.AnyAsync(
-                    fieldQueryable.Where(f =>
-                        f.TenantId == entity.TenantId &&
-                        f.DocumentTypeId == entity.Id &&
-                        f.Name == field.Name &&
-                        !f.IsDeleted));
+                // Per-field duplicate check routes through the domain service (#304); cascade restore skips conflicts
+                // (logs a warning) instead of aborting the whole type restore.
+                var nameConflict = await _fieldDefinitionManager.HasActiveNameConflictAsync(entity.Id, field.Name);
                 if (nameConflict)
                 {
                     Logger.LogWarning(

--- a/core/src/Dignite.DocumentAI.Application/Documents/Exports/ExportTemplateAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Exports/ExportTemplateAppService.cs
@@ -29,17 +29,20 @@ public class ExportTemplateAppService : DocumentAIAppService, IExportTemplateApp
     private readonly IDocumentRepository _documentRepository;
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+    private readonly ExportTemplateManager _exportTemplateManager;
 
     public ExportTemplateAppService(
         IExportTemplateRepository templateRepository,
         IDocumentRepository documentRepository,
         IDocumentTypeRepository documentTypeRepository,
-        IFieldDefinitionRepository fieldDefinitionRepository)
+        IFieldDefinitionRepository fieldDefinitionRepository,
+        ExportTemplateManager exportTemplateManager)
     {
         _templateRepository = templateRepository;
         _documentRepository = documentRepository;
         _documentTypeRepository = documentTypeRepository;
         _fieldDefinitionRepository = fieldDefinitionRepository;
+        _exportTemplateManager = exportTemplateManager;
     }
 
     public virtual async Task<ExportTemplateDto> GetAsync(Guid id)
@@ -62,7 +65,7 @@ public class ExportTemplateAppService : DocumentAIAppService, IExportTemplateApp
     [Authorize(DocumentAIPermissions.Documents.Templates.Create)]
     public virtual async Task<ExportTemplateDto> CreateAsync(CreateExportTemplateDto input)
     {
-        await EnsureTemplateNameAvailableAsync(input.Name);
+        await _exportTemplateManager.CheckNameAvailableAsync(input.Name);
         await EnsureDocumentTypeExistsAsync(input.DocumentTypeId);
         var columns = await MapColumnsAsync(input.Columns, input.DocumentTypeId);
 
@@ -86,7 +89,7 @@ public class ExportTemplateAppService : DocumentAIAppService, IExportTemplateApp
         // Check duplicates only when renaming. If the name did not change, no lookup is needed and self-match false positives are avoided.
         if (!string.Equals(entity.Name, input.Name, StringComparison.Ordinal))
         {
-            await EnsureTemplateNameAvailableAsync(input.Name);
+            await _exportTemplateManager.CheckNameAvailableAsync(input.Name);
         }
 
         await EnsureDocumentTypeExistsAsync(input.DocumentTypeId);
@@ -237,16 +240,6 @@ public class ExportTemplateAppService : DocumentAIAppService, IExportTemplateApp
         }
 
         return entity;
-    }
-
-    protected virtual async Task EnsureTemplateNameAvailableAsync(string name)
-    {
-        var existing = await _templateRepository.FindByNameAsync(name);
-        if (existing != null)
-        {
-            throw new BusinessException(DocumentAIErrorCodes.Export.TemplateNameAlreadyExists)
-                .WithData("Name", name);
-        }
     }
 
     /// <summary>Asserts that the document type constrained by the template exists in the current layer (#207 required, associated by immutable Id); missing loud-fails.</summary>

--- a/core/src/Dignite.DocumentAI.Application/Documents/Fields/FieldDefinitionAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Fields/FieldDefinitionAppService.cs
@@ -19,15 +19,18 @@ public class FieldDefinitionAppService : DocumentAIAppService, IFieldDefinitionA
     private readonly IFieldDefinitionRepository _repository;
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly IDocumentRepository _documentRepository;
+    private readonly FieldDefinitionManager _fieldDefinitionManager;
 
     public FieldDefinitionAppService(
         IFieldDefinitionRepository repository,
         IDocumentTypeRepository documentTypeRepository,
-        IDocumentRepository documentRepository)
+        IDocumentRepository documentRepository,
+        FieldDefinitionManager fieldDefinitionManager)
     {
         _repository = repository;
         _documentTypeRepository = documentTypeRepository;
         _documentRepository = documentRepository;
+        _fieldDefinitionManager = fieldDefinitionManager;
     }
 
     public virtual async Task<List<FieldDefinitionDto>> GetListAsync(GetFieldDefinitionListInput input)
@@ -94,19 +97,9 @@ public class FieldDefinitionAppService : DocumentAIAppService, IFieldDefinitionA
             throw new EntityNotFoundException(typeof(DocumentType), input.DocumentTypeId);
         }
 
-        // Disable ISoftDelete filter: the same (TenantId, DocumentTypeId, Name) counts as occupied even when soft-deleted,
-        // avoiding conflicts with new records on restore.
-        FieldDefinition? existing;
-        using (DataFilter.Disable<ISoftDelete>())
-        {
-            existing = await _repository.FindByNameAsync(input.DocumentTypeId, input.Name);
-        }
-        if (existing != null)
-        {
-            throw new BusinessException(DocumentAIErrorCodes.FieldDefinition.AlreadyExists)
-                .WithData("DocumentTypeCode", type.TypeCode)
-                .WithData("Name", input.Name);
-        }
+        // Soft-delete-aware duplicate check owned by the domain service (#304): the same (TenantId, DocumentTypeId, Name)
+        // counts as occupied even when soft-deleted, avoiding conflicts with new records on restore.
+        await _fieldDefinitionManager.CheckNameAvailableAsync(input.DocumentTypeId, input.Name);
 
         var entity = new FieldDefinition(
             GuidGenerator.Create(),
@@ -135,21 +128,11 @@ public class FieldDefinitionAppService : DocumentAIAppService, IFieldDefinitionA
             throw new EntityNotFoundException(typeof(FieldDefinition), id);
         }
 
-        // Rename unlock (#207): run duplicate check only when Name changes. Same layer + same type is unique, including soft-deleted occupancy.
+        // Rename unlock (#207): run the domain duplicate check only when Name changes. Same layer + same type is unique,
+        // including soft-deleted occupancy. The manager resolves the owning TypeCode for the error message only on conflict.
         if (!string.Equals(input.Name, entity.Name, StringComparison.Ordinal))
         {
-            FieldDefinition? conflict;
-            using (DataFilter.Disable<ISoftDelete>())
-            {
-                conflict = await _repository.FindByNameAsync(entity.DocumentTypeId, input.Name);
-            }
-            if (conflict != null)
-            {
-                // Resolve TypeCode only on the error path for human-readable messages; the happy path does not query it.
-                throw new BusinessException(DocumentAIErrorCodes.FieldDefinition.AlreadyExists)
-                    .WithData("DocumentTypeCode", await ResolveTypeCodeAsync(entity.DocumentTypeId) ?? string.Empty)
-                    .WithData("Name", input.Name);
-            }
+            await _fieldDefinitionManager.CheckNameAvailableAsync(entity.DocumentTypeId, input.Name);
         }
 
         // Two "forbid when extracted values exist" guards share the same fact: whether this field has any value rows.
@@ -220,20 +203,9 @@ public class FieldDefinitionAppService : DocumentAIAppService, IFieldDefinitionA
                     .WithData("Name", entity.Name);
             }
 
-            // Active field with the same name conflicts. CreateAsync duplicate checks should already prevent this; keep a defensive guard.
-            var queryable = await _repository.GetQueryableAsync();
-            var nameConflict = await AsyncExecuter.AnyAsync(
-                queryable.Where(f =>
-                    f.TenantId == entity.TenantId &&
-                    f.DocumentTypeId == entity.DocumentTypeId &&
-                    f.Name == entity.Name &&
-                    !f.IsDeleted));
-            if (nameConflict)
-            {
-                throw new BusinessException(DocumentAIErrorCodes.FieldDefinition.RestoreConflict)
-                    .WithData("DocumentTypeCode", documentTypeCode ?? string.Empty)
-                    .WithData("Name", entity.Name);
-            }
+            // Active field with the same name conflicts. CreateAsync duplicate checks should already prevent this; the domain
+            // service keeps a defensive guard and throws RestoreConflict (#304).
+            await _fieldDefinitionManager.CheckRestorableAsync(entity);
 
             entity.IsDeleted = false;
             entity.DeletionTime = null;
@@ -241,16 +213,6 @@ public class FieldDefinitionAppService : DocumentAIAppService, IFieldDefinitionA
             await _repository.UpdateAsync(entity);
 
             return ObjectMapper.Map<FieldDefinition, FieldDefinitionDto>(entity);
-        }
-    }
-
-    /// <summary>Resolves the owning type's TypeCode with soft-delete traversal, only for human-readable error messages (#207: API exports already use DocumentTypeId).</summary>
-    protected virtual async Task<string?> ResolveTypeCodeAsync(Guid documentTypeId)
-    {
-        using (DataFilter.Disable<ISoftDelete>())
-        {
-            var type = await _documentTypeRepository.FindAsync(documentTypeId);
-            return type?.TypeCode;
         }
     }
 }

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Cabinets/CabinetManager.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Cabinets/CabinetManager.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.Domain.Services;
+
+namespace Dignite.DocumentAI.Documents.Cabinets;
+
+/// <summary>
+/// Domain service owning the layer-scoped uniqueness invariant of <see cref="Cabinet"/> on
+/// <c>(TenantId, Name)</c> (#304). After dropping the soft-delete-filtered DB unique index (not portable
+/// across providers), this check is the <b>sole</b> guarantor of uniqueness, so every write path (create
+/// / rename) must route through it.
+/// <para>
+/// Layer scoping is delegated to ABP's <c>IMultiTenant</c> global filter; the same <c>Name</c> across
+/// layers is allowed, while a duplicate within one layer is rejected. No <c>CurrentTenant.Id</c>
+/// predicate is hand-written.
+/// </para>
+/// <para>
+/// Unlike <see cref="DocumentTypes.DocumentTypeManager"/> / <see cref="Fields.FieldDefinitionManager"/>,
+/// the check considers <b>active rows only</b> (the default <c>ISoftDelete</c> filter is left in place):
+/// Cabinet has no recycle bin / restore path, so a soft-deleted cabinet's name is intentionally free for
+/// reuse — there is no "delete -&gt; restore" path that two active duplicates could break. This preserves
+/// the exact behavior of the dropped <c>IsDeleted = 0</c> filtered index.
+/// </para>
+/// </summary>
+public class CabinetManager : DomainService
+{
+    private readonly ICabinetRepository _repository;
+
+    public CabinetManager(ICabinetRepository repository)
+    {
+        _repository = repository;
+    }
+
+    /// <summary>Asserts no active cabinet in the current layer already uses <paramref name="name"/>; used by create and rename.</summary>
+    public virtual async Task CheckNameAvailableAsync(string name)
+    {
+        var existing = await _repository.FindByNameAsync(name);
+        if (existing != null)
+        {
+            throw new BusinessException(DocumentAIErrorCodes.Cabinet.NameAlreadyExists)
+                .WithData("Name", name);
+        }
+    }
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/DocumentTypes/DocumentTypeManager.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/DocumentTypes/DocumentTypeManager.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Services;
+
+namespace Dignite.DocumentAI.Documents.DocumentTypes;
+
+/// <summary>
+/// Domain service owning the layer-scoped uniqueness invariant of <see cref="DocumentType"/> on
+/// <c>(TenantId, TypeCode)</c> (#304). After dropping the soft-delete-filtered DB unique index (not
+/// portable across providers), this check is the <b>sole</b> guarantor of uniqueness, so every write
+/// path (create / rename / restore) must route through it.
+/// <para>
+/// Layer scoping is delegated entirely to ABP's <c>IMultiTenant</c> global filter: the repository
+/// queries are automatically narrowed to the ambient <see cref="Volo.Abp.MultiTenancy.ICurrentTenant"/>
+/// layer (Host = <c>TenantId IS NULL</c>, tenant = its GUID). Therefore the same <c>TypeCode</c> across
+/// layers is allowed (two legitimate rows), while a duplicate within one layer is rejected. No
+/// <c>CurrentTenant.Id</c> predicate is hand-written.
+/// </para>
+/// <para>
+/// Tradeoff (accepted, #304): an application-layer check has a TOCTOU race window. These are
+/// low-frequency admin-managed config entities, so the window is acceptable; revisit with a
+/// serializable UoW / advisory lock / portable index if a high-concurrency write path is added.
+/// </para>
+/// </summary>
+public class DocumentTypeManager : DomainService
+{
+    private readonly IDocumentTypeRepository _repository;
+    private readonly IDataFilter _dataFilter;
+
+    public DocumentTypeManager(IDocumentTypeRepository repository, IDataFilter dataFilter)
+    {
+        _repository = repository;
+        _dataFilter = dataFilter;
+    }
+
+    /// <summary>
+    /// Asserts no document type in the current layer already uses <paramref name="typeCode"/>; used by
+    /// create and rename. Soft-delete-aware: the <see cref="ISoftDelete"/> filter is disabled so deleted
+    /// rows also occupy the code. Otherwise the path "delete -&gt; recreate same code -&gt; restore old"
+    /// could yield two active rows with the same <c>(TenantId, TypeCode)</c>.
+    /// </summary>
+    public virtual async Task CheckCodeAvailableAsync(string typeCode)
+    {
+        DocumentType? existing;
+        using (_dataFilter.Disable<ISoftDelete>())
+        {
+            existing = await _repository.FindByTypeCodeAsync(typeCode);
+        }
+
+        if (existing != null)
+        {
+            throw new BusinessException(DocumentAIErrorCodes.DocumentType.CodeAlreadyExists)
+                .WithData("TypeCode", typeCode);
+        }
+    }
+
+    /// <summary>
+    /// Asserts no <b>active</b> document type in the current layer already uses the code of the entity
+    /// being restored. Caller restores a soft-deleted row, so here the <see cref="ISoftDelete"/> filter
+    /// is (re-)enabled to consider active rows only: the soft-deleted entity itself is excluded, and any
+    /// match is a genuine conflict that would otherwise create two active rows with the same code.
+    /// </summary>
+    public virtual async Task CheckRestorableAsync(DocumentType entity)
+    {
+        DocumentType? conflict;
+        using (_dataFilter.Enable<ISoftDelete>())
+        {
+            conflict = await _repository.FindByTypeCodeAsync(entity.TypeCode);
+        }
+
+        if (conflict != null)
+        {
+            throw new BusinessException(DocumentAIErrorCodes.DocumentType.RestoreConflict)
+                .WithData("TypeCode", entity.TypeCode);
+        }
+    }
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Exports/ExportTemplateManager.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Exports/ExportTemplateManager.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using Volo.Abp;
+using Volo.Abp.Domain.Services;
+
+namespace Dignite.DocumentAI.Documents.Exports;
+
+/// <summary>
+/// Domain service owning the layer-scoped uniqueness invariant of <see cref="ExportTemplate"/> on
+/// <c>(TenantId, Name)</c> (#304). After dropping the soft-delete-filtered DB unique index (not portable
+/// across providers), this check is the <b>sole</b> guarantor of uniqueness, so every write path (create
+/// / rename) must route through it.
+/// <para>
+/// Layer scoping is delegated to ABP's <c>IMultiTenant</c> global filter; the same <c>Name</c> across
+/// layers is allowed, while a duplicate within one layer is rejected. No <c>CurrentTenant.Id</c>
+/// predicate is hand-written.
+/// </para>
+/// <para>
+/// Like <see cref="Cabinets.CabinetManager"/>, the check considers <b>active rows only</b>: an export
+/// template has no restore path, so a soft-deleted template's name is free for reuse. This preserves the
+/// exact behavior of the dropped <c>IsDeleted = 0</c> filtered index.
+/// </para>
+/// </summary>
+public class ExportTemplateManager : DomainService
+{
+    private readonly IExportTemplateRepository _repository;
+
+    public ExportTemplateManager(IExportTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    /// <summary>Asserts no active export template in the current layer already uses <paramref name="name"/>; used by create and rename.</summary>
+    public virtual async Task CheckNameAvailableAsync(string name)
+    {
+        var existing = await _repository.FindByNameAsync(name);
+        if (existing != null)
+        {
+            throw new BusinessException(DocumentAIErrorCodes.Export.TemplateNameAlreadyExists)
+                .WithData("Name", name);
+        }
+    }
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Fields/FieldDefinitionManager.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Fields/FieldDefinitionManager.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Documents.DocumentTypes;
+using Volo.Abp;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Services;
+
+namespace Dignite.DocumentAI.Documents.Fields;
+
+/// <summary>
+/// Domain service owning the layer-scoped uniqueness invariant of <see cref="FieldDefinition"/> on
+/// <c>(TenantId, DocumentTypeId, Name)</c> (#304). After dropping the soft-delete-filtered DB unique
+/// index (not portable across providers), this check is the <b>sole</b> guarantor of uniqueness, so
+/// every write path (create / rename / restore, including the bulk cascade restore driven by
+/// <c>DocumentTypeAppService.RestoreAsync</c>) must route through it.
+/// <para>
+/// Layer scoping is delegated to ABP's <c>IMultiTenant</c> global filter; the same <c>Name</c> across
+/// layers (or under a different type) is allowed, while a duplicate within one layer + type is rejected.
+/// No <c>CurrentTenant.Id</c> predicate is hand-written. See <see cref="DocumentTypeManager"/> for the
+/// accepted TOCTOU tradeoff.
+/// </para>
+/// </summary>
+public class FieldDefinitionManager : DomainService
+{
+    private readonly IFieldDefinitionRepository _repository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IDataFilter _dataFilter;
+
+    public FieldDefinitionManager(
+        IFieldDefinitionRepository repository,
+        IDocumentTypeRepository documentTypeRepository,
+        IDataFilter dataFilter)
+    {
+        _repository = repository;
+        _documentTypeRepository = documentTypeRepository;
+        _dataFilter = dataFilter;
+    }
+
+    /// <summary>
+    /// Asserts no field under <paramref name="documentTypeId"/> in the current layer already uses
+    /// <paramref name="name"/>; used by create and rename. Soft-delete-aware: deleted rows also occupy
+    /// the name so the "delete -&gt; recreate same name -&gt; restore old" path cannot produce two active
+    /// duplicates. The owning <c>TypeCode</c> for the error message is resolved only on the conflict
+    /// path.
+    /// </summary>
+    public virtual async Task CheckNameAvailableAsync(Guid documentTypeId, string name)
+    {
+        FieldDefinition? existing;
+        using (_dataFilter.Disable<ISoftDelete>())
+        {
+            existing = await _repository.FindByNameAsync(documentTypeId, name);
+        }
+
+        if (existing != null)
+        {
+            throw new BusinessException(DocumentAIErrorCodes.FieldDefinition.AlreadyExists)
+                .WithData("DocumentTypeCode", await ResolveTypeCodeAsync(documentTypeId))
+                .WithData("Name", name);
+        }
+    }
+
+    /// <summary>
+    /// Whether an <b>active</b> field with <paramref name="name"/> already exists under
+    /// <paramref name="documentTypeId"/> in the current layer. The <see cref="ISoftDelete"/> filter is
+    /// (re-)enabled so soft-deleted rows are excluded — callers run inside a soft-delete-disabled scope
+    /// (single-field restore / cascade restore) and need an active-only conflict signal. Returns a bool
+    /// so the cascade can skip-and-log while single restore throws.
+    /// </summary>
+    public virtual async Task<bool> HasActiveNameConflictAsync(Guid documentTypeId, string name)
+    {
+        using (_dataFilter.Enable<ISoftDelete>())
+        {
+            return await _repository.FindByNameAsync(documentTypeId, name) != null;
+        }
+    }
+
+    /// <summary>
+    /// Asserts the soft-deleted <paramref name="entity"/> can be restored: no active field with the same
+    /// name already exists under its type in the current layer. Throws <c>RestoreConflict</c> otherwise.
+    /// </summary>
+    public virtual async Task CheckRestorableAsync(FieldDefinition entity)
+    {
+        if (await HasActiveNameConflictAsync(entity.DocumentTypeId, entity.Name))
+        {
+            throw new BusinessException(DocumentAIErrorCodes.FieldDefinition.RestoreConflict)
+                .WithData("DocumentTypeCode", await ResolveTypeCodeAsync(entity.DocumentTypeId))
+                .WithData("Name", entity.Name);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the owning type's <c>TypeCode</c> for human-readable error messages only (#207: data
+    /// rows associate by immutable Id). Soft-delete traversal so the code is still resolvable if the type
+    /// row is itself deleted.
+    /// </summary>
+    protected virtual async Task<string> ResolveTypeCodeAsync(Guid documentTypeId)
+    {
+        using (_dataFilter.Disable<ISoftDelete>())
+        {
+            var type = await _documentTypeRepository.FindAsync(documentTypeId);
+            return type?.TypeCode ?? string.Empty;
+        }
+    }
+}

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -212,13 +212,12 @@ public static class DocumentAIDbContextModelCreatingExtensions
             b.Property(x => x.ConfidenceThreshold).IsRequired();
             b.Property(x => x.Priority).IsRequired();
 
-            // Unique constraint: (TenantId, TypeCode); the same TypeCode may be reused across layers. Soft-delete filtered.
-            // Portability: Host-layer uniqueness (TenantId IS NULL) relies on SQL Server's "unique index treats NULL as equal" behavior.
-            // PostgreSQL's default NULLS DISTINCT would silently invalidate this constraint for Host rows, and HasFilter literals are not cross-DB.
-            // Re-review when migrating providers. This applies to all four (TenantId, ...) + IsDeleted filtered unique indexes in this file.
-            b.HasIndex(x => new { x.TenantId, x.TypeCode })
-                .IsUnique()
-                .HasFilter("IsDeleted = 0");
+            // Layer-scoped uniqueness on (TenantId, TypeCode) is enforced by DocumentTypeManager in the application/domain
+            // layer (#304), not by a DB index. The previous soft-delete-filtered unique index relied on SQL Server's
+            // "unique index treats NULL as equal" semantics for Host rows (TenantId IS NULL) plus a HasFilter("IsDeleted = 0")
+            // literal — neither portable across providers (PostgreSQL defaults to NULLS DISTINCT, which would silently drop the
+            // Host-layer guarantee). Dropping it makes the schema cross-DB by construction; the accepted tradeoff is a TOCTOU
+            // race on these low-frequency admin-config entities. The same applies to FieldDefinition / ExportTemplate / Cabinet below.
         });
 
         builder.Entity<FieldDefinition>(b =>
@@ -238,12 +237,10 @@ public static class DocumentAIDbContextModelCreatingExtensions
                 .HasForeignKey(x => x.DocumentTypeId)
                 .OnDelete(DeleteBehavior.Restrict);
 
-            // Unique constraint: field names are unique per tenant and per type (#207: by DocumentTypeId). Soft-delete filtered.
-            b.HasIndex(x => new { x.TenantId, x.DocumentTypeId, x.Name })
-                .IsUnique()
-                .HasFilter("IsDeleted = 0");
+            // Layer-scoped uniqueness on (TenantId, DocumentTypeId, Name) is enforced by FieldDefinitionManager in the
+            // application/domain layer (#304), not by a DB index — see the DocumentType block above for the cross-DB rationale.
 
-            // Unfiltered index: supports listing fields by (tenant layer, type) in trash-bin paths (DataFilter.Disable<ISoftDelete>), where the unique index with IsDeleted=0 filter is unusable.
+            // Non-unique index: supports listing fields by (tenant layer, type), including trash-bin paths (DataFilter.Disable<ISoftDelete>).
             b.HasIndex(x => new { x.TenantId, x.DocumentTypeId });
         });
 
@@ -269,10 +266,8 @@ public static class DocumentAIDbContextModelCreatingExtensions
                 .HasForeignKey(x => x.DocumentTypeId)
                 .OnDelete(DeleteBehavior.Restrict);
 
-            // Unique constraint: (TenantId, Name); the same name across layers is allowed as two rows. Soft-delete filtered.
-            b.HasIndex(x => new { x.TenantId, x.Name })
-                .IsUnique()
-                .HasFilter("IsDeleted = 0");
+            // Layer-scoped uniqueness on (TenantId, Name) is enforced by ExportTemplateManager in the application/domain
+            // layer (#304), not by a DB index — see the DocumentType block above for the cross-DB rationale.
         });
 
         builder.Entity<Cabinet>(b =>
@@ -284,10 +279,9 @@ public static class DocumentAIDbContextModelCreatingExtensions
             // Nullable: cabinet selection helper description (#273), NULL = no description.
             b.Property(x => x.Description).HasMaxLength(CabinetConsts.MaxDescriptionLength);
 
-            // Unique constraint: (TenantId, Name), no duplicate names within a layer. Host and each tenant are independent universes. Soft-delete filtered.
-            b.HasIndex(x => new { x.TenantId, x.Name })
-                .IsUnique()
-                .HasFilter("IsDeleted = 0");
+            // Layer-scoped uniqueness on (TenantId, Name) is enforced by CabinetManager in the application/domain layer
+            // (#304), not by a DB index — see the DocumentType block above for the cross-DB rationale. Cabinet has no
+            // restore path, so the check considers active rows only.
         });
     }
 }

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/LayeredUniqueness_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/LayeredUniqueness_Tests.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Documents.Cabinets;
+using Dignite.DocumentAI.Documents.DocumentTypes;
+using Dignite.DocumentAI.Documents.Exports;
+using Dignite.DocumentAI.Documents.Fields;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.MultiTenancy;
+using Xunit;
+
+namespace Dignite.DocumentAI.EntityFrameworkCore.Documents;
+
+/// <summary>
+/// Integration tests for the application-layer, layer-scoped uniqueness enforcement that replaced the
+/// soft-delete-filtered DB unique indexes (#304). Run against a real database with ABP's
+/// <c>IMultiTenant</c> / <c>ISoftDelete</c> global filters, exercising the four app services end-to-end
+/// (the domain managers are the actual guarantors). They assert the three invariants the issue requires:
+/// <list type="bullet">
+/// <item>the same key is allowed across layers (Host <c>TenantId = null</c> vs a tenant GUID);</item>
+/// <item>a duplicate within a single layer is rejected with the entity's namespaced error code;</item>
+/// <item>the <c>delete -&gt; recreate -&gt; restore</c> semantics are preserved per entity (soft-delete-aware
+/// for DocumentType / FieldDefinition; active-only for the recycle-bin-less Cabinet / ExportTemplate).</item>
+/// </list>
+/// </summary>
+public class LayeredUniqueness_Tests : DocumentAIEntityFrameworkCoreTestBase
+{
+    private readonly IDocumentTypeAppService _documentTypeAppService;
+    private readonly IFieldDefinitionAppService _fieldDefinitionAppService;
+    private readonly ICabinetAppService _cabinetAppService;
+    private readonly IExportTemplateAppService _exportTemplateAppService;
+    private readonly ICurrentTenant _currentTenant;
+
+    private static readonly Guid TenantId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    public LayeredUniqueness_Tests()
+    {
+        _documentTypeAppService = GetRequiredService<IDocumentTypeAppService>();
+        _fieldDefinitionAppService = GetRequiredService<IFieldDefinitionAppService>();
+        _cabinetAppService = GetRequiredService<ICabinetAppService>();
+        _exportTemplateAppService = GetRequiredService<IExportTemplateAppService>();
+        _currentTenant = GetRequiredService<ICurrentTenant>();
+    }
+
+    // ─── DocumentType (soft-delete-aware, has restore) ─────────────────────────
+
+    [Fact]
+    public async Task DocumentType_Same_Code_Is_Allowed_Across_Layers()
+    {
+        // Host (TenantId = null) and a tenant may both define "contract": two legitimate rows distinguished by TenantId.
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.CreateAsync(NewType("contract")));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(TenantId))
+            {
+                var dto = await _documentTypeAppService.CreateAsync(NewType("contract"));
+                dto.TypeCode.ShouldBe("contract");
+            }
+        });
+
+        // Both rows persist and coexist, each visible only in its own layer (no leakage, exactly one per layer).
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var hostTypes = await _documentTypeAppService.GetVisibleAsync();
+            hostTypes.Count(t => t.TypeCode == "contract").ShouldBe(1);
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(TenantId))
+            {
+                var tenantTypes = await _documentTypeAppService.GetVisibleAsync();
+                tenantTypes.Count(t => t.TypeCode == "contract").ShouldBe(1);
+            }
+        });
+    }
+
+    [Fact]
+    public async Task DocumentType_Duplicate_Code_In_Same_Layer_Is_Rejected()
+    {
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.CreateAsync(NewType("contract")));
+
+        var ex = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _documentTypeAppService.CreateAsync(NewType("contract"))));
+        ex.Code.ShouldBe(DocumentAIErrorCodes.DocumentType.CodeAlreadyExists);
+    }
+
+    [Fact]
+    public async Task DocumentType_Delete_Recreate_Restore_Preserves_SoftDelete_Aware_Semantics()
+    {
+        var id = await WithUnitOfWorkAsync(async () =>
+            (await _documentTypeAppService.CreateAsync(NewType("contract"))).Id);
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.DeleteAsync(id));
+
+        // Recreate while a soft-deleted row still holds the code -> rejected (soft-delete-aware), so restoring the
+        // original cannot produce two active rows with the same (TenantId, TypeCode).
+        var ex = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _documentTypeAppService.CreateAsync(NewType("contract"))));
+        ex.Code.ShouldBe(DocumentAIErrorCodes.DocumentType.CodeAlreadyExists);
+
+        // Restoring the soft-deleted row succeeds because no active row holds the code.
+        var restored = await WithUnitOfWorkAsync(() => _documentTypeAppService.RestoreAsync(id));
+        restored.TypeCode.ShouldBe("contract");
+    }
+
+    // ─── FieldDefinition (soft-delete-aware, scoped to (TenantId, DocumentTypeId, Name)) ───
+
+    [Fact]
+    public async Task FieldDefinition_Duplicate_Name_Under_Same_Type_Is_Rejected()
+    {
+        var typeId = await WithUnitOfWorkAsync(async () =>
+            (await _documentTypeAppService.CreateAsync(NewType("contract"))).Id);
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.CreateAsync(NewField(typeId, "amount")));
+
+        var ex = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _fieldDefinitionAppService.CreateAsync(NewField(typeId, "amount"))));
+        ex.Code.ShouldBe(DocumentAIErrorCodes.FieldDefinition.AlreadyExists);
+    }
+
+    [Fact]
+    public async Task FieldDefinition_Same_Name_Under_Different_Types_Is_Allowed()
+    {
+        var (typeA, typeB) = await WithUnitOfWorkAsync(async () =>
+        {
+            var a = await _documentTypeAppService.CreateAsync(NewType("contract"));
+            var b = await _documentTypeAppService.CreateAsync(NewType("invoice"));
+            return (a.Id, b.Id);
+        });
+
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.CreateAsync(NewField(typeA, "amount")));
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var dto = await _fieldDefinitionAppService.CreateAsync(NewField(typeB, "amount"));
+            dto.Name.ShouldBe("amount");
+        });
+    }
+
+    [Fact]
+    public async Task FieldDefinition_Delete_Recreate_Restore_Preserves_SoftDelete_Aware_Semantics()
+    {
+        var (typeId, fieldId) = await WithUnitOfWorkAsync(async () =>
+        {
+            var t = await _documentTypeAppService.CreateAsync(NewType("contract"));
+            var f = await _fieldDefinitionAppService.CreateAsync(NewField(t.Id, "amount"));
+            return (t.Id, f.Id);
+        });
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.DeleteAsync(fieldId));
+
+        // Recreate the same name while a soft-deleted field holds it -> rejected (soft-delete-aware).
+        var ex = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _fieldDefinitionAppService.CreateAsync(NewField(typeId, "amount"))));
+        ex.Code.ShouldBe(DocumentAIErrorCodes.FieldDefinition.AlreadyExists);
+
+        var restored = await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.RestoreAsync(fieldId));
+        restored.Name.ShouldBe("amount");
+    }
+
+    // ─── Cabinet (active-only, no recycle bin) ─────────────────────────────────
+
+    [Fact]
+    public async Task Cabinet_Duplicate_Name_In_Same_Layer_Is_Rejected()
+    {
+        await WithUnitOfWorkAsync(() => _cabinetAppService.CreateAsync(new CreateCabinetDto { Name = "Legal" }));
+
+        var ex = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _cabinetAppService.CreateAsync(new CreateCabinetDto { Name = "Legal" })));
+        ex.Code.ShouldBe(DocumentAIErrorCodes.Cabinet.NameAlreadyExists);
+    }
+
+    [Fact]
+    public async Task Cabinet_Same_Name_Is_Allowed_Across_Layers()
+    {
+        await WithUnitOfWorkAsync(() => _cabinetAppService.CreateAsync(new CreateCabinetDto { Name = "Legal" }));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(TenantId))
+            {
+                var dto = await _cabinetAppService.CreateAsync(new CreateCabinetDto { Name = "Legal" });
+                dto.Name.ShouldBe("Legal");
+            }
+        });
+
+        // Both rows persist and coexist, each visible only in its own layer (no leakage, exactly one per layer).
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var hostCabinets = await _cabinetAppService.GetListAsync();
+            hostCabinets.Count(c => c.Name == "Legal").ShouldBe(1);
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(TenantId))
+            {
+                var tenantCabinets = await _cabinetAppService.GetListAsync();
+                tenantCabinets.Count(c => c.Name == "Legal").ShouldBe(1);
+            }
+        });
+    }
+
+    [Fact]
+    public async Task Cabinet_SoftDeleted_Name_Can_Be_Reused()
+    {
+        // Cabinet has no recycle bin / restore path, so the check is intentionally active-only: a soft-deleted
+        // name is free for reuse. This preserves the behavior of the dropped IsDeleted = 0 filtered index.
+        var id = await WithUnitOfWorkAsync(async () =>
+            (await _cabinetAppService.CreateAsync(new CreateCabinetDto { Name = "Legal" })).Id);
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(id));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var dto = await _cabinetAppService.CreateAsync(new CreateCabinetDto { Name = "Legal" });
+            dto.Name.ShouldBe("Legal");
+        });
+    }
+
+    // ─── ExportTemplate (active-only, no restore) ──────────────────────────────
+
+    [Fact]
+    public async Task ExportTemplate_Duplicate_Name_In_Same_Layer_Is_Rejected()
+    {
+        var (typeId, fieldId) = await WithUnitOfWorkAsync(async () =>
+        {
+            var t = await _documentTypeAppService.CreateAsync(NewType("contract"));
+            var f = await _fieldDefinitionAppService.CreateAsync(NewField(t.Id, "amount"));
+            return (t.Id, f.Id);
+        });
+
+        await WithUnitOfWorkAsync(() => _exportTemplateAppService.CreateAsync(NewTemplate("Monthly", typeId, fieldId)));
+
+        var ex = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _exportTemplateAppService.CreateAsync(NewTemplate("Monthly", typeId, fieldId))));
+        ex.Code.ShouldBe(DocumentAIErrorCodes.Export.TemplateNameAlreadyExists);
+    }
+
+    [Fact]
+    public async Task ExportTemplate_Same_Name_Is_Allowed_Across_Layers()
+    {
+        // Host template.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var t = await _documentTypeAppService.CreateAsync(NewType("contract"));
+            var f = await _fieldDefinitionAppService.CreateAsync(NewField(t.Id, "amount"));
+            await _exportTemplateAppService.CreateAsync(NewTemplate("Monthly", t.Id, f.Id));
+        });
+
+        // Same name in a tenant layer is a separate, legitimate row.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(TenantId))
+            {
+                var t = await _documentTypeAppService.CreateAsync(NewType("contract"));
+                var f = await _fieldDefinitionAppService.CreateAsync(NewField(t.Id, "amount"));
+                var dto = await _exportTemplateAppService.CreateAsync(NewTemplate("Monthly", t.Id, f.Id));
+                dto.Name.ShouldBe("Monthly");
+            }
+        });
+
+        // Both templates persist and coexist, each visible only in its own layer (no leakage, exactly one per layer).
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var hostTemplates = await _exportTemplateAppService.GetListAsync();
+            hostTemplates.Count(t => t.Name == "Monthly").ShouldBe(1);
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(TenantId))
+            {
+                var tenantTemplates = await _exportTemplateAppService.GetListAsync();
+                tenantTemplates.Count(t => t.Name == "Monthly").ShouldBe(1);
+            }
+        });
+    }
+
+    // ─── helpers ───────────────────────────────────────────────────────────────
+
+    private static CreateDocumentTypeDto NewType(string code) => new()
+    {
+        TypeCode = code,
+        DisplayName = code,
+        ConfidenceThreshold = 0.7,
+        Priority = 0
+    };
+
+    private static CreateFieldDefinitionDto NewField(Guid documentTypeId, string name) => new()
+    {
+        DocumentTypeId = documentTypeId,
+        Name = name,
+        DisplayName = name,
+        DataType = FieldDataType.Text
+    };
+
+    private static CreateExportTemplateDto NewTemplate(string name, Guid documentTypeId, Guid fieldDefinitionId) => new()
+    {
+        Name = name,
+        Format = ExportFormat.Csv,
+        DocumentTypeId = documentTypeId,
+        Columns = new List<ExportColumnInput> { new() { FieldDefinitionId = fieldDefinitionId, Order = 0 } }
+    };
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,13 +131,8 @@ When deploying to a new environment, upgrading critical dependencies, or shippin
 
 ## Database portability
 
-SQL Server is the host baseline, and one schema detail is **not** portable as-is: the filtered unique indexes that enforce per-layer uniqueness.
+SQL Server is the host baseline, but the schema is **provider-agnostic**: it emits no provider-specific index DDL, so it applies cleanly on SQL Server, PostgreSQL, and other relational providers with no per-provider re-evaluation.
 
-`DocumentTypes (TenantId, TypeCode)`, `FieldDefinitions (TenantId, DocumentTypeId, Name)`, `ExportTemplates (TenantId, Name)`, and `Cabinets (TenantId, Name)` are all declared as **unique indexes with a `HasFilter("IsDeleted = 0")` predicate**. The Host layer stores its rows with `TenantId IS NULL`, and these indexes rely on SQL Server's semantics that a **unique index treats NULLs as equal** — which is exactly what makes "one `host.contract` row in the Host layer" enforceable.
+Layer-scoped uniqueness — `DocumentTypes (TenantId, TypeCode)`, `FieldDefinitions (TenantId, DocumentTypeId, Name)`, `ExportTemplates (TenantId, Name)`, and `Cabinets (TenantId, Name)` — is enforced in the application/domain layer by dedicated domain services (`DocumentTypeManager` / `FieldDefinitionManager` / `ExportTemplateManager` / `CabinetManager`), **not** by a soft-delete-filtered DB unique index (#304). This is the ABP-idiomatic approach and removes the previous portability blockers: the non-portable `HasFilter("IsDeleted = 0")` literal, and the reliance on SQL Server's "a unique index treats NULLs as equal" semantics for Host-layer rows (`TenantId IS NULL`) — semantics PostgreSQL does not share by default (`NULLS DISTINCT`). Layer scoping is delegated to ABP's `IMultiTenant` global filter, so the same key is allowed across the Host and tenant layers while a duplicate within one layer is rejected.
 
-Two things break on other providers:
-
-- **PostgreSQL** defaults to `NULLS DISTINCT` for unique indexes, so multiple Host rows with the same `TypeCode` / `Name` would be allowed — Host-layer uniqueness silently stops being enforced. (PostgreSQL 15+ can opt back in with `NULLS NOT DISTINCT`, which EF Core does not emit by default.)
-- The `HasFilter("IsDeleted = 0")` literal is SQL-Server syntax and is not portable verbatim (quoting and boolean handling differ).
-
-If you ever retarget the core modules at a non-SQL-Server provider, re-evaluate these four indexes (filtered-unique semantics + the filter literal) before trusting the two-layer uniqueness guarantee. For the SQL Server baseline shipped here, the behavior is correct.
+The accepted tradeoff is a TOCTOU race window in the SELECT-then-INSERT check: two concurrent creates of the same key could both pass the check and both insert. This is acceptable for these four low-frequency, admin-managed configuration entities. If a high-concurrency write path is ever added for them, revisit (serializable unit of work / advisory lock / a portable normalized-column unique index).

--- a/host/src/Migrations/20260613054746_Drop_LayeredFilteredUniqueIndexes.Designer.cs
+++ b/host/src/Migrations/20260613054746_Drop_LayeredFilteredUniqueIndexes.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.DocumentAI.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.DocumentAI.Host.Migrations
 {
     [DbContext(typeof(DocumentAIHostDbContext))]
-    partial class DocumentAIHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613054746_Drop_LayeredFilteredUniqueIndexes")]
+    partial class Drop_LayeredFilteredUniqueIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260613054746_Drop_LayeredFilteredUniqueIndexes.cs
+++ b/host/src/Migrations/20260613054746_Drop_LayeredFilteredUniqueIndexes.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.DocumentAI.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Drop_LayeredFilteredUniqueIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DocAIFieldDefinitions_TenantId_DocumentTypeId_Name",
+                table: "DocAIFieldDefinitions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DocAIExportTemplates_TenantId_Name",
+                table: "DocAIExportTemplates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DocAIDocumentTypes_TenantId_TypeCode",
+                table: "DocAIDocumentTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DocAICabinets_TenantId_Name",
+                table: "DocAICabinets");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAIFieldDefinitions_TenantId_DocumentTypeId_Name",
+                table: "DocAIFieldDefinitions",
+                columns: new[] { "TenantId", "DocumentTypeId", "Name" },
+                unique: true,
+                filter: "IsDeleted = 0");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAIExportTemplates_TenantId_Name",
+                table: "DocAIExportTemplates",
+                columns: new[] { "TenantId", "Name" },
+                unique: true,
+                filter: "IsDeleted = 0");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAIDocumentTypes_TenantId_TypeCode",
+                table: "DocAIDocumentTypes",
+                columns: new[] { "TenantId", "TypeCode" },
+                unique: true,
+                filter: "IsDeleted = 0");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAICabinets_TenantId_Name",
+                table: "DocAICabinets",
+                columns: new[] { "TenantId", "Name" },
+                unique: true,
+                filter: "IsDeleted = 0");
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Implements #304. The four layer-scoped uniqueness guarantees were enforced by **soft-delete-filtered unique indexes** (`HasFilter("IsDeleted = 0")`) that are **not cross-DB portable** — they rely on SQL Server's "a unique index treats NULLs as equal" semantics for Host rows (`TenantId IS NULL`) plus a provider-specific filter literal (PostgreSQL defaults to `NULLS DISTINCT`, which would silently drop the Host-layer guarantee).

This PR moves uniqueness enforcement to the **application/domain layer** (Option A), so the schema emits **no provider-specific index DDL** and applies cleanly on SQL Server and PostgreSQL.

Closes #304.

## Approach

Four new domain services own the layer-scoped, soft-delete-aware duplicate check; layer scoping is delegated entirely to ABP's `IMultiTenant` global filter (no hand-written `CurrentTenant.Id` predicate), so the same key is allowed across the Host / tenant layers and rejected within a layer.

| Entity | Manager | Soft-delete semantics |
|---|---|---|
| DocumentType | `DocumentTypeManager` | soft-delete-aware (create/rename block deleted holders; restore = active-only) |
| FieldDefinition | `FieldDefinitionManager` | soft-delete-aware + bool helper for cascade restore |
| Cabinet | `CabinetManager` | active-only (no recycle bin — preserves the prior `IsDeleted = 0` index semantics) |
| ExportTemplate | `ExportTemplateManager` | active-only (no restore path) |

Every write path routes through a manager: **create, rename (#207), restore, and the cascade field restore**.

## Changes

- **Domain**: 4 new `*Manager` services (all public/protected methods `virtual`, reusable-module rule).
- **Application**: the four app services route through the managers; inline checks + now-dead helpers removed.
- **EF Core**: dropped the 4 filtered unique indexes (kept the non-unique `(TenantId, DocumentTypeId)` index) + migration `Drop_LayeredFilteredUniqueIndexes`.
- **Tests**: `LayeredUniqueness_Tests` (EF Core, real SQLite + ABP filters) — same key across layers allowed + coexistence read-back, duplicate within a layer rejected, `delete -> recreate -> restore` preserved.
- **Docs**: `docs/deployment.md` portability section rewritten; `CHANGELOG` `[Unreleased]` entry + removed the v0.1.0 SQL-Server-only caveat.

## Migration

`20260613054746_Drop_LayeredFilteredUniqueIndexes` — drops the 4 unique filtered indexes; `Down` recreates them. **Not applied** to any database by this PR.

## Tests

All green: Domain 171 · Application 247 · EF Core 67 (incl. 11 new) · Mcp 22. Host build: 0 errors.

## Design note (accepted tradeoff)

An app-layer SELECT-then-INSERT check has a TOCTOU window with no DB backstop. **Accepted** for these low-frequency, admin-managed config entities: the failure mode is a visible, self-correcting duplicate that never touches the `Document.Markdown` truth source, and the operator UI already disables the submit button while a write is in flight (the only realistic trigger). The re-evaluation trigger for adopting **Option B** (a portable normalized-key unique index) is recorded in the [#304 Decision Log](https://github.com/dignite-projects/dignite-extract/issues/304#issuecomment-4697784944).
