### PR TITLE
feat(text-extraction): PPTX image/chart/table/notes extraction via OpenXML (#307)

### DIFF
--- a/Dignite.DocumentAI.slnx
+++ b/Dignite.DocumentAI.slnx
@@ -19,6 +19,7 @@
         <Project Path="core/src/Dignite.DocumentAI.TextExtraction/Dignite.DocumentAI.TextExtraction.csproj" />
         <Project Path="core/src/Dignite.DocumentAI.TextExtraction.ElBrunoMarkItDown/Dignite.DocumentAI.TextExtraction.ElBrunoMarkItDown.csproj" />
         <Project Path="core/src/Dignite.DocumentAI.TextExtraction.Pdf/Dignite.DocumentAI.TextExtraction.Pdf.csproj" />
+        <Project Path="core/src/Dignite.DocumentAI.TextExtraction.OpenXml/Dignite.DocumentAI.TextExtraction.OpenXml.csproj" />
     </Folder>
 
     <Folder Name="/core/test/">
@@ -29,6 +30,7 @@
         <Project Path="core/test/Dignite.DocumentAI.Mcp.Tests/Dignite.DocumentAI.Mcp.Tests.csproj" />
         <Project Path="core/test/Dignite.DocumentAI.Ocr.VisionLlm.Tests/Dignite.DocumentAI.Ocr.VisionLlm.Tests.csproj" />
         <Project Path="core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/Dignite.DocumentAI.TextExtraction.Pdf.Tests.csproj" />
+        <Project Path="core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/Dignite.DocumentAI.TextExtraction.OpenXml.Tests.csproj" />
     </Folder>
 
     <Folder Name="/host/" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,6 +103,10 @@
              Pinned to the exact version ElBruno.MarkItDotNet 0.6.0 pulls transitively, so the host process
              resolves a single PdfPig (no upgrade/downgrade conflict between the two providers). -->
         <PackageVersion Include="PdfPig" Version="0.1.14" />
+        <!-- OpenXML SDK: PPTX (#307) / DOCX (#308) structural extraction for the OpenXmlExtractor stack.
+             Pinned to the exact version ElBruno.MarkItDotNet 0.6.0 pulls transitively (3.3.0), so the host
+             process resolves a single DocumentFormat.OpenXml (no conflict between the two providers). -->
+        <PackageVersion Include="DocumentFormat.OpenXml" Version="3.3.0" />
         <PackageVersion Include="PDFtoImage" Version="5.2.1" />
         <!-- Must exactly match the SkiaSharp main package version transitively used by PDFtoImage 5.2.1 (3.119.2). -->
         <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />

--- a/core/src/Dignite.DocumentAI.Ocr.VisionLlm/VisionLlmOcrProvider.cs
+++ b/core/src/Dignite.DocumentAI.Ocr.VisionLlm/VisionLlmOcrProvider.cs
@@ -280,47 +280,11 @@ public class VisionLlmOcrProvider : IOcrProvider, ITransientDependency
     private static string NormalizeContentType(string? contentType)
         => contentType?.Split(';')[0].Trim().ToLowerInvariant() ?? string.Empty;
 
-    private static bool IsPdfMagic(byte[] b)
-        => b.Length >= 5 && b[0] == 0x25 && b[1] == 0x50 && b[2] == 0x44 && b[3] == 0x46 && b[4] == 0x2D; // "%PDF-"
+    // Magic-byte detection lives in the shared Ocr-contract helper so the signature table is defined once
+    // across all providers (was previously duplicated here / in PdfImagePayload / in PptxImagePayload).
+    private static bool IsPdfMagic(byte[] b) => ImageSignature.IsPdf(b);
 
-    private static string? SniffImageMediaType(byte[] b)
-    {
-        if (b.Length >= 3 && b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF)
-        {
-            return "image/jpeg";
-        }
-
-        if (b.Length >= 8 && b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47
-            && b[4] == 0x0D && b[5] == 0x0A && b[6] == 0x1A && b[7] == 0x0A)
-        {
-            return "image/png";
-        }
-
-        if (b.Length >= 4 && b[0] == 0x47 && b[1] == 0x49 && b[2] == 0x46 && b[3] == 0x38) // "GIF8"
-        {
-            return "image/gif";
-        }
-
-        if (b.Length >= 2 && b[0] == 0x42 && b[1] == 0x4D) // "BM"
-        {
-            return "image/bmp";
-        }
-
-        if (b.Length >= 12 && b[0] == 0x52 && b[1] == 0x49 && b[2] == 0x46 && b[3] == 0x46 // "RIFF"
-            && b[8] == 0x57 && b[9] == 0x45 && b[10] == 0x42 && b[11] == 0x50) // "WEBP"
-        {
-            return "image/webp";
-        }
-
-        if (b.Length >= 4
-            && ((b[0] == 0x49 && b[1] == 0x49 && b[2] == 0x2A && b[3] == 0x00)   // "II*\0" little-endian TIFF
-                || (b[0] == 0x4D && b[1] == 0x4D && b[2] == 0x00 && b[3] == 0x2A))) // "MM\0*" big-endian TIFF
-        {
-            return "image/tiff";
-        }
-
-        return null;
-    }
+    private static string? SniffImageMediaType(byte[] b) => ImageSignature.SniffMediaType(b);
 
     private enum InputKind
     {

--- a/core/src/Dignite.DocumentAI.Ocr/ImageSignature.cs
+++ b/core/src/Dignite.DocumentAI.Ocr/ImageSignature.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace Dignite.DocumentAI.Ocr;
+
+/// <summary>
+/// Content-based detection of image / PDF formats by their leading magic bytes. Lives in the OCR
+/// contract layer (the common floor referenced by every OCR provider and every Markdown extractor) so the
+/// signature table is defined <b>once</b> rather than re-implemented per provider with divergent coverage.
+/// Magic bytes are authoritative: a Content-Type / file extension is a caller-supplied hint and must not
+/// override what the bytes actually are.
+/// </summary>
+public static class ImageSignature
+{
+    /// <summary>
+    /// Returns the raster image media type the bytes carry (<c>image/png</c>, <c>image/jpeg</c>,
+    /// <c>image/gif</c>, <c>image/bmp</c>, <c>image/webp</c>, <c>image/tiff</c>), or <c>null</c> when the
+    /// bytes match no recognized raster signature (vector EMF/WMF, an unknown/exotic codec such as
+    /// HEIC/AVIF, or corrupt/truncated data).
+    /// </summary>
+    // Signature prefixes as ReadOnlySpan<byte> properties: each compiles to a span over a static data
+    // section, so the comparisons below allocate nothing per call (unlike a `params byte[]`).
+    private static ReadOnlySpan<byte> Jpeg => [0xFF, 0xD8, 0xFF];
+    private static ReadOnlySpan<byte> Png => [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    private static ReadOnlySpan<byte> Gif => [0x47, 0x49, 0x46, 0x38]; // "GIF8"
+    private static ReadOnlySpan<byte> Bmp => [0x42, 0x4D];             // "BM"
+    private static ReadOnlySpan<byte> Riff => [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+    private static ReadOnlySpan<byte> Webp => [0x57, 0x45, 0x42, 0x50]; // "WEBP"
+    private static ReadOnlySpan<byte> TiffLe => [0x49, 0x49, 0x2A, 0x00]; // "II*\0"
+    private static ReadOnlySpan<byte> TiffBe => [0x4D, 0x4D, 0x00, 0x2A]; // "MM\0*"
+    private static ReadOnlySpan<byte> Pdf => [0x25, 0x50, 0x44, 0x46, 0x2D]; // "%PDF-"
+
+    public static string? SniffMediaType(ReadOnlySpan<byte> b)
+    {
+        if (b.StartsWith(Jpeg))
+        {
+            return "image/jpeg";
+        }
+
+        if (b.StartsWith(Png))
+        {
+            return "image/png";
+        }
+
+        if (b.StartsWith(Gif))
+        {
+            return "image/gif";
+        }
+
+        if (b.StartsWith(Bmp))
+        {
+            return "image/bmp";
+        }
+
+        // "RIFF" .... "WEBP"
+        if (b.StartsWith(Riff) && b.Length >= 12 && b.Slice(8, 4).SequenceEqual(Webp))
+        {
+            return "image/webp";
+        }
+
+        if (b.StartsWith(TiffLe) || b.StartsWith(TiffBe))
+        {
+            return "image/tiff";
+        }
+
+        return null;
+    }
+
+    /// <summary>Whether the bytes carry a recognized raster image signature.</summary>
+    public static bool IsRaster(ReadOnlySpan<byte> bytes) => SniffMediaType(bytes) is not null;
+
+    /// <summary>Whether the bytes begin with the PDF signature (<c>%PDF-</c>).</summary>
+    public static bool IsPdf(ReadOnlySpan<byte> b) => b.StartsWith(Pdf);
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/ChartRenderer.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/ChartRenderer.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Renders a chart's <b>backing data</b> (categories + series values cached in the <see cref="ChartPart"/>
+/// XML) as a Markdown table. This is <b>pure structured extraction from the format</b> — no OCR, no
+/// vision, no LLM, and no vector blind spot — and is explicitly distinct from the deferred
+/// "chart → structured via VLM" (#299 decision log).
+/// <para>
+/// Parsing is by element <c>LocalName</c> rather than strong types so a single pass covers the common
+/// category/value chart families (bar / column / line / pie / area) regardless of the specific
+/// <c>c:barChart</c> / <c>c:lineChart</c> wrapper. Chart families without a category/value cache
+/// (scatter / bubble, which use <c>xVal</c>/<c>yVal</c>) yield no rows here and the caller treats the
+/// chart as unrendered (completeness signal), matching the "skip what we can't faithfully extract" stance.
+/// </para>
+/// </summary>
+internal static class ChartRenderer
+{
+    /// <returns>A Markdown table (optionally preceded by the chart title), or <c>null</c> when no
+    /// category/value data could be read.</returns>
+    public static string? Render(ChartPart chartPart)
+    {
+        var chartSpace = chartPart.ChartSpace;
+        if (chartSpace is null)
+        {
+            return null;
+        }
+
+        var seriesElements = chartSpace
+            .Descendants<OpenXmlElement>()
+            .Where(e => e.LocalName == "ser")
+            .ToList();
+        if (seriesElements.Count == 0)
+        {
+            return null;
+        }
+
+        var series = new List<(string Name, IReadOnlyDictionary<int, string> Values)>();
+        var categories = new SortedDictionary<int, string>();
+
+        foreach (var ser in seriesElements)
+        {
+            var name = ReadSeriesName(ser, series.Count + 1);
+            var values = ReadCache(FirstChildByLocalName(ser, "val"));
+            if (values.Count == 0)
+            {
+                // Series carries no value cache (e.g. scatter xVal/yVal, or an empty series). Skip it.
+                continue;
+            }
+
+            series.Add((name, values));
+
+            // Merge each series' category labels into one shared axis, validating the shared-axis
+            // assumption as we go:
+            //  - a new index → add it (union: a later series may carry labels at indices an earlier one
+            //    lacked, so we must not drop them — that would degrade the row to a numeric fallback);
+            //  - same index, an established blank label vs a real one → upgrade to the real label (a cached
+            //    blank category must not veto a later series' real labels);
+            //  - same index, two DIFFERENT non-blank labels → the series do not share one axis, so a single
+            //    wide table would silently hang values under the wrong category. Bail to null; the caller
+            //    counts it as a chart failure (#268) — an honest "could not be rendered as a table" signal
+            //    instead of misaligned data.
+            foreach (var (idx, label) in ReadCache(FirstChildByLocalName(ser, "cat")))
+            {
+                if (!categories.TryGetValue(idx, out var existing))
+                {
+                    categories[idx] = label;
+                }
+                else if (existing.Length > 0 && label.Length > 0 && existing != label)
+                {
+                    return null;
+                }
+                else if (existing.Length == 0 && label.Length > 0)
+                {
+                    categories[idx] = label;
+                }
+            }
+        }
+
+        if (series.Count == 0)
+        {
+            return null;
+        }
+
+        // Row index set: the union of category indices and every series' value indices, so a series with
+        // more points than there are category labels still renders all its rows.
+        var rowIndices = new SortedSet<int>(categories.Keys);
+        foreach (var (_, values) in series)
+        {
+            foreach (var idx in values.Keys)
+            {
+                rowIndices.Add(idx);
+            }
+        }
+
+        var sb = new StringBuilder();
+
+        var title = ReadTitle(chartSpace);
+        if (!string.IsNullOrWhiteSpace(title))
+        {
+            // Collapse newlines so a multi-line / pipe-bearing title cannot break the bold run or the
+            // table header directly below it.
+            sb.Append("**").Append(MarkdownCell.Inline(title)).Append("**\n\n");
+        }
+
+        // Header: leading category column + one column per series.
+        sb.Append("| Category | ").Append(string.Join(" | ", series.Select(s => MarkdownCell.Escape(s.Name)))).Append(" |\n");
+        sb.Append("| --- |").Append(string.Concat(series.Select(_ => " --- |"))).Append('\n');
+
+        foreach (var idx in rowIndices)
+        {
+            var label = categories.TryGetValue(idx, out var cat) && !string.IsNullOrWhiteSpace(cat)
+                ? cat
+                : (idx + 1).ToString();
+            sb.Append("| ").Append(MarkdownCell.Escape(label)).Append(" | ");
+            sb.Append(string.Join(" | ", series.Select(s =>
+                s.Values.TryGetValue(idx, out var v) ? MarkdownCell.Escape(v) : string.Empty)));
+            sb.Append(" |\n");
+        }
+
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>Series display name from its <c>c:tx</c> string cache, or a positional fallback.</summary>
+    private static string ReadSeriesName(OpenXmlElement series, int ordinal)
+    {
+        var tx = FirstChildByLocalName(series, "tx");
+        var value = tx?.Descendants<OpenXmlElement>().FirstOrDefault(e => e.LocalName == "v")?.InnerText;
+        return string.IsNullOrWhiteSpace(value) ? $"Series {ordinal}" : value.Trim();
+    }
+
+    /// <summary>
+    /// Chart title text from the <c>c:chart/c:title</c> rich-text runs, if any. Scoped to the chart's own
+    /// direct title child — NOT any descendant <c>title</c> — so a deleted chart title does not get
+    /// replaced by an <b>axis</b> title (<c>c:catAx/c:title</c> / <c>c:valAx/c:title</c>).
+    /// </summary>
+    private static string? ReadTitle(OpenXmlElement chartSpace)
+    {
+        var chart = FirstChildByLocalName(chartSpace, "chart");
+        var title = chart is null ? null : FirstChildByLocalName(chart, "title");
+        if (title is null)
+        {
+            return null;
+        }
+
+        // Drawing text runs (a:t) hold the displayed title characters.
+        var text = string.Concat(title.Descendants<OpenXmlElement>()
+            .Where(e => e.LocalName == "t")
+            .Select(e => e.InnerText));
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    /// <summary>
+    /// Reads a <c>c:cat</c> / <c>c:val</c> container's cached points into an index → text map. Uses the
+    /// number/string cache (<c>c:numCache</c> / <c>c:strCache</c>) so the rendered table reflects what the
+    /// deck author saw, without resolving external workbook references. A <c>c:pt</c> whose <c>idx</c> is
+    /// absent (the schema default is the next position, and some generators omit it) falls back to the
+    /// running position rather than being dropped — otherwise that data point silently disappears and
+    /// shifts the category/value alignment.
+    /// </summary>
+    private static IReadOnlyDictionary<int, string> ReadCache(OpenXmlElement? container)
+    {
+        var result = new Dictionary<int, string>();
+        if (container is null)
+        {
+            return result;
+        }
+
+        var nextIndex = 0;
+        foreach (var pt in container.Descendants<OpenXmlElement>().Where(e => e.LocalName == "pt"))
+        {
+            var idxAttr = pt.GetAttributes().FirstOrDefault(a => a.LocalName == "idx");
+            var idx = int.TryParse(idxAttr.Value, out var parsed) ? parsed : nextIndex;
+            nextIndex = idx + 1;
+
+            // c:v is a direct child of c:pt — read the child, not the whole subtree.
+            var value = pt.ChildElements.FirstOrDefault(e => e.LocalName == "v")?.InnerText ?? string.Empty;
+            result[idx] = value.Trim();
+        }
+
+        return result;
+    }
+
+    private static OpenXmlElement? FirstChildByLocalName(OpenXmlElement parent, string localName)
+        => parent.ChildElements.FirstOrDefault(e => e.LocalName == localName);
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/Dignite.DocumentAI.TextExtraction.OpenXml.csproj
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/Dignite.DocumentAI.TextExtraction.OpenXml.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Dignite.DocumentAI.TextExtraction.OpenXml</RootNamespace>
+    <Description>OpenXML Markdown text provider for Dignite Document AI: owns the full PPTX parsing pass (slide text + native alt-text + speaker notes), extracts embedded raster images and transcribes each through the host-selected IOcrProvider, renders ChartPart backing data as Markdown tables, and inlines everything into the Markdown at its slide/shape reading position. EMF/WMF vector images are an accepted blind spot. Shared OpenXML stack for the later DOCX phase (#308).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Volo.Abp.Core" />
+    <!-- OpenXML SDK: PresentationDocument parsing (slide text, embedded ImageParts, ChartPart backing
+         data, native alt-text). Version pinned to match the DocumentFormat.OpenXml that
+         ElBruno.MarkItDotNet pulls transitively (3.3.0), so the host process resolves a single OpenXml
+         (no upgrade/downgrade conflict between the two Markdown providers — same discipline as PdfPig). -->
+    <PackageReference Include="DocumentFormat.OpenXml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- References the orchestrator project (IMarkdownTextProvider), which transitively brings the Ocr
+         contract (IOcrProvider) and Abstractions (TextExtractionResult). No keyed Vision IChatClient is
+         injected here: embedded-image transcription goes through the host-selected IOcrProvider only. -->
+    <ProjectReference Include="..\Dignite.DocumentAI.TextExtraction\Dignite.DocumentAI.TextExtraction.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dignite.DocumentAI.TextExtraction.OpenXml.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/DocumentAITextExtractionOpenXmlModule.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/DocumentAITextExtractionOpenXmlModule.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp.Modularity;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Registers the OpenXML-based Markdown providers. This round ships <see cref="PptxExtractor"/>, which
+/// claims the <c>.pptx</c> extension; the DOCX phase (#308) adds a Word provider to the same module.
+/// Markdown providers coexist and are dispatched per file by extension, so a host that includes this
+/// module routes <c>.pptx</c> to <see cref="PptxExtractor"/>. <b>This module is required for <c>.pptx</c></b>:
+/// the catch-all ElBruno provider does not support PresentationML, so omitting this module makes
+/// <c>.pptx</c> fall through to ElBruno and yield empty Markdown (and, being non-<c>.pdf</c>, it gets no
+/// whole-page OCR fallback either) — there was no prior <c>.pptx</c> capability to preserve.
+/// <para>
+/// Depends only on the text-extraction orchestrator module, which transitively brings the OCR contract
+/// (<c>IOcrProvider</c>) consumed for embedded-image transcription. The concrete OCR provider is chosen
+/// by the host (VisionLlm / PaddleOCR / Azure DI).
+/// </para>
+/// </summary>
+[DependsOn(typeof(DocumentAITextExtractionModule))]
+public class DocumentAITextExtractionOpenXmlModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Bind the cost/noise caps + notes flag from the "OpenXmlExtractor" configuration section,
+        // matching the appsettings-driven convention of the OCR / Pdf provider modules. Absent the
+        // section, OpenXmlExtractorOptions keeps its defaults. PptxExtractor itself self-registers via
+        // ITransientDependency + [ExposeServices(typeof(IMarkdownTextProvider))].
+        var configuration = context.Services.GetConfiguration();
+        context.Services.Configure<OpenXmlExtractorOptions>(configuration.GetSection("OpenXmlExtractor"));
+    }
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/DrawingTableRenderer.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/DrawingTableRenderer.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using D = DocumentFormat.OpenXml.Drawing;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Renders a native DrawingML table (<c>a:tbl</c>, carried by a <c>GraphicFrame</c>) as a Markdown table.
+/// This is pure structured extraction (no OCR / no vision / no LLM); it exists because <see cref="PptxExtractor"/>
+/// owns the whole <c>.pptx</c> pass, so a table's text would otherwise be lost entirely. The first row is
+/// treated as the header.
+/// </summary>
+internal static class DrawingTableRenderer
+{
+    public static string? Render(D.Table table)
+    {
+        var rows = table
+            .Elements<D.TableRow>()
+            .Select(row => row.Elements<D.TableCell>().Select(CellText).ToList())
+            .Where(cells => cells.Count > 0)
+            .ToList();
+        if (rows.Count == 0)
+        {
+            return null;
+        }
+
+        // The Markdown table must be rectangular: the separator and every row use the WIDEST row's column
+        // count, padding short rows with empty cells. A ragged table (e.g. a merged single-cell title row
+        // over multi-column data) would otherwise emit a separator narrower than the data rows and render
+        // as a broken grid.
+        var columnCount = rows.Max(r => r.Count);
+        var hasContent = rows.Any(r => r.Any(cell => cell.Length > 0));
+        if (columnCount == 0 || !hasContent)
+        {
+            // An all-empty grid (e.g. a layout table used for spacing) carries no text — drop it.
+            return null;
+        }
+
+        var sb = new StringBuilder();
+        for (var r = 0; r < rows.Count; r++)
+        {
+            AppendRow(sb, rows[r], columnCount);
+            if (r == 0)
+            {
+                sb.Append('|').Append(string.Concat(Enumerable.Repeat(" --- |", columnCount))).Append('\n');
+            }
+        }
+
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    private static void AppendRow(StringBuilder sb, List<string> cells, int columnCount)
+    {
+        sb.Append("| ");
+        for (var c = 0; c < columnCount; c++)
+        {
+            sb.Append(c < cells.Count ? cells[c] : string.Empty);
+            sb.Append(c == columnCount - 1 ? " |" : " | ");
+        }
+
+        sb.Append('\n');
+    }
+
+    private static string CellText(D.TableCell cell)
+        => MarkdownCell.Escape(string.Join(" ", cell.Descendants<D.Text>().Select(t => t.InnerText)));
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/FodyWeavers.xml
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/FodyWeavers.xml
@@ -1,0 +1,3 @@
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/MarkdownCell.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/MarkdownCell.cs
@@ -1,0 +1,49 @@
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Escaping for a value placed inside a Markdown table cell. Shared by <see cref="ChartRenderer"/> and
+/// <see cref="DrawingTableRenderer"/> so the rule is defined once.
+/// </summary>
+internal static class MarkdownCell
+{
+    /// <summary>
+    /// Escapes a cell value so it cannot break the surrounding Markdown table: backslash first (so the
+    /// pipe-escape we add next is not itself neutralized by a pre-existing trailing backslash), then the
+    /// pipe column separator, and finally collapse any CR/LF to a space (a literal newline would split
+    /// the row).
+    /// </summary>
+    public static string Escape(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        // Fast path: the overwhelming majority of cells contain none of the table-breaking characters, so
+        // avoid the four-Replace allocation chain and just trim.
+        if (text.IndexOfAny(SpecialChars) < 0)
+        {
+            return text.Trim();
+        }
+
+        return text
+            .Replace("\\", "\\\\")
+            .Replace("|", "\\|")
+            .Replace("\r", " ")
+            .Replace("\n", " ")
+            .Trim();
+    }
+
+    private static readonly char[] SpecialChars = { '\\', '|', '\r', '\n' };
+
+    /// <summary>
+    /// Normalizes a value used as an <b>inline</b> label (a chart title, a figure caption) rendered inside
+    /// a <c>**bold**</c> run: collapses every run of whitespace — including newlines that would otherwise
+    /// split the bold run or leak into a table header below it — to a single space, and trims. Pipes are
+    /// left as-is (an inline label is not a table row), so the displayed text stays readable.
+    /// </summary>
+    public static string Inline(string? text)
+        => string.IsNullOrWhiteSpace(text)
+            ? string.Empty
+            : string.Join(" ", text.Split((char[]?)null, System.StringSplitOptions.RemoveEmptyEntries));
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/OpenXmlExtractorOptions.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/OpenXmlExtractorOptions.cs
@@ -1,0 +1,56 @@
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Tuning for the OpenXML providers (PPTX now, DOCX in #308). Each embedded image becomes one
+/// <c>IOcrProvider.RecognizeAsync</c> call (potentially one paid vision-LLM call), so the image knobs
+/// guard cost and noise. The image-count / pixel knobs mirror <c>PdfExtractorOptions</c>; the byte cap
+/// (<see cref="MaxImageBytesPerImage"/>) is OpenXML-specific (ZIP-container decompression-bomb guard) and
+/// has no PDF counterpart. A host can override via <c>Configure&lt;OpenXmlExtractorOptions&gt;</c> / the
+/// <c>OpenXmlExtractor</c> configuration section (see the host appsettings for an example).
+/// </summary>
+public class OpenXmlExtractorOptions
+{
+    /// <summary>
+    /// Hard cap on how many embedded images are transcribed per file. Images beyond the cap are skipped
+    /// and the result is marked incomplete (#268) — the document text is still returned, so an image-heavy
+    /// file degrades gracefully instead of failing or running away on OCR cost. Named per-file (not
+    /// per-presentation) because this options class is shared with the DOCX phase (#308).
+    /// </summary>
+    public int MaxImagesPerFile { get; set; } = 50;
+
+    /// <summary>
+    /// Minimum pixel count (<c>width * height</c>) for an embedded image to be transcribed. Smaller
+    /// images (icons, bullets, logos, spacers) are decorative, not figure content, and are skipped
+    /// silently (not counted against completeness). Default ≈ 64×64.
+    /// <para>
+    /// <b>Unit caveat:</b> for OpenXML the dimensions are the shape's <b>display</b> extents (EMU → px at
+    /// 96 DPI), <i>not</i> the raster's native sample count (PPTX does not expose that without decoding the
+    /// bytes). So a high-resolution photo shrunk to a small thumbnail on a slide is judged by its displayed
+    /// size, not its source resolution — set this conservatively if decks scale figures down heavily. (The
+    /// PDF provider's same-named option is closer to native samples; keep that difference in mind when
+    /// tuning across formats.)
+    /// </para>
+    /// </summary>
+    public int MinImagePixels { get; set; } = 64 * 64;
+
+    /// <summary>
+    /// Hard cap on the decompressed byte size of a single embedded image. An image part exceeding this is
+    /// skipped (never fully buffered into managed memory) and the result is marked incomplete (#268).
+    /// <para>
+    /// This guards a real amplification vector that <see cref="MaxImagesPerFile"/> does not: a PPTX/DOCX is
+    /// a ZIP container, so a small file can carry a highly-compressed image part that inflates to gigabytes
+    /// when read — without a byte cap a single such part would OOM / thrash the extraction worker before any
+    /// recoverable signal. Default 16 MiB (a conservative ceiling for a single embedded figure).
+    /// </para>
+    /// </summary>
+    public long MaxImageBytesPerImage { get; set; } = 16L * 1024 * 1024;
+
+    /// <summary>
+    /// Whether to append each slide's speaker notes to the Markdown (under a per-slide "Speaker notes"
+    /// heading). <b>Default off.</b> Speaker notes are author-private content that is <b>not visible to the
+    /// audience</b>; since Markdown is the channel's sole egress payload (REST / MCP / EventBus / Webhook),
+    /// including notes by default would silently leak internal annotations into every downstream consumer.
+    /// A host/admin that wants notes indexed must <b>explicitly opt in</b> by setting this to <c>true</c>.
+    /// </summary>
+    public bool IncludeSpeakerNotes { get; set; } = false;
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/PptxExtractor.cs
@@ -1,0 +1,688 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.TextExtraction;
+using Dignite.DocumentAI.Ocr;
+using DocumentFormat.OpenXml.Packaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+using D = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using P = DocumentFormat.OpenXml.Presentation;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// OpenXML-based Markdown provider for PowerPoint decks (#307, Phase 2 of #299). Owns the full
+/// <c>.pptx</c> parsing pass so it can extract slide text (with native heading/table structure and
+/// speaker notes) <b>and</b> the embedded raster images, transcribe each image through the host-selected
+/// <see cref="IOcrProvider"/>, render <c>ChartPart</c> backing data as Markdown tables, and inline
+/// everything into the Markdown at its slide/shape reading position. This closes the silent-image-loss
+/// gap where embedded figures in decks never reached the channel output — the exact inline-only
+/// mechanism proven by <c>PdfExtractor</c> in #301.
+/// <para>
+/// <b>Image → text uses <see cref="IOcrProvider"/> only</b> (no keyed Vision <c>IChatClient</c> here, no
+/// new LLM call site). Semantics are transcription only; the figure's bytes are the OCR input, so there
+/// is no user free-text entering a prompt and no <c>PromptBoundary</c> concern. Charts and tables are
+/// pure structured extraction from the OpenXML format (no OCR / no vision / no LLM).
+/// </para>
+/// <para>
+/// <b>Reading order.</b> PPTX is semantically fixed-layout per slide, so blocks are ordered by shape
+/// offset (top-to-bottom, then left-to-right) within slide order — PDF-like, not flow-based.
+/// </para>
+/// <para>
+/// <b>Difference from <c>PdfExtractor</c>.</b> A PDF with no text layer returns empty so the
+/// orchestrator's whole-page OCR fallback owns it. There is <b>no</b> such fallback for PPTX
+/// (it is PDF-only in <c>DefaultTextExtractor</c>), and once this module is installed it owns
+/// <c>.pptx</c> outright. So an unopenable deck does not silently return empty Markdown — it returns
+/// empty + <see cref="TextExtractionResult.IsComplete"/> <c>= false</c> with a reason (#268), the honest
+/// escape hatch.
+/// </para>
+/// <para>
+/// <b>This module is required for <c>.pptx</c> text.</b> The catch-all ElBruno provider does <b>not</b>
+/// support <c>.pptx</c> (its converter set covers PDF/Word/HTML/CSV/RTF/EPUB but not PresentationML), so
+/// omitting this module makes <c>.pptx</c> fall through to ElBruno, which returns empty Markdown — and
+/// because <c>.pptx</c> is not <c>.pdf</c>, the orchestrator's whole-page OCR fallback does not fire
+/// either. So this is <b>not</b> a "graceful degradation preserving prior behavior": there was no prior
+/// <c>.pptx</c> capability; this module is what gives <c>.pptx</c> any text at all.
+/// </para>
+/// </summary>
+[ExposeServices(typeof(IMarkdownTextProvider))]
+public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
+{
+    /// <summary>Provider family name surfaced on <see cref="TextExtractionResult.ProviderName"/> for auditability.</summary>
+    public const string ProviderIdentifier = "OpenXmlPptx";
+
+    /// <summary>EMU per pixel at 96 DPI (914400 EMU/inch ÷ 96). Used to size images for the decorative threshold.</summary>
+    private const long EmuPerPixel96 = 9525;
+
+    private readonly IOcrProvider _ocrProvider;
+    private readonly OpenXmlExtractorOptions _options;
+    private readonly DocumentAIOcrOptions _ocrOptions;
+
+    public ILogger<PptxExtractor> Logger { get; set; } = NullLogger<PptxExtractor>.Instance;
+
+    public PptxExtractor(
+        IOcrProvider ocrProvider,
+        IOptions<OpenXmlExtractorOptions> options,
+        IOptions<DocumentAIOcrOptions> ocrOptions)
+    {
+        _ocrProvider = ocrProvider;
+        _options = options.Value;
+        _ocrOptions = ocrOptions.Value;
+    }
+
+    /// <inheritdoc/>
+    public virtual bool CanHandle(string fileExtension)
+        => string.Equals(fileExtension, ".pptx", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public virtual int Priority => MarkdownProviderPriorities.Specialized;
+
+    public virtual async Task<TextExtractionResult> ExtractAsync(
+        Stream fileStream,
+        TextExtractionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var bytes = await TextExtractionStreams.ReadAllBytesAsync(fileStream, cancellationToken);
+
+        PresentationDocument document;
+        try
+        {
+            document = PresentationDocument.Open(new MemoryStream(bytes, writable: false), isEditable: false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Corrupt / not-actually-a-pptx. There is NO whole-page OCR fallback for PPTX (PDF-only), and
+            // this provider already owns .pptx, so returning bare empty would silently drop the document.
+            // Report empty + incomplete instead — the honest #268 escape hatch.
+            Logger.LogWarning(ex, "Could not open the PPTX ({Bytes} bytes); reporting empty + incomplete.", bytes.Length);
+            return new TextExtractionResult
+            {
+                Markdown = string.Empty,
+                ProviderName = ProviderIdentifier,
+                UsedOcr = false,
+                IsComplete = false,
+                IncompleteReason = "The presentation could not be opened (corrupt or unsupported file)."
+            };
+        }
+
+        using (document)
+        {
+            var presentation = document.PresentationPart?.Presentation;
+            var slideIds = presentation?.SlideIdList?.Elements<P.SlideId>().ToList() ?? new List<P.SlideId>();
+
+            var state = new ExtractionState
+            {
+                ImageBudget = _options.MaxImagesPerFile,
+                LanguageHints = ResolveLanguageHints(context)
+            };
+
+            var slideMarkdowns = new List<string>(slideIds.Count);
+
+            foreach (var slideId in slideIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var relId = slideId.RelationshipId?.Value;
+                if (string.IsNullOrEmpty(relId))
+                {
+                    continue;
+                }
+
+                SlidePart slidePart;
+                try
+                {
+                    slidePart = (SlidePart)document.PresentationPart!.GetPartById(relId);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Logger.LogWarning(ex, "Could not resolve a slide part; skipping the slide.");
+                    state.FailedSlides++;
+                    continue;
+                }
+
+                string slideMarkdown;
+                try
+                {
+                    slideMarkdown = await ProcessSlideAsync(slidePart, state, cancellationToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // OpenXML parses lazily, so a malformed slide can fault here on access. Skip it and
+                    // mark the result incomplete rather than failing the whole deck.
+                    Logger.LogWarning(ex, "Failed to process a slide; skipping it.");
+                    state.FailedSlides++;
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(slideMarkdown))
+                {
+                    slideMarkdowns.Add(slideMarkdown);
+                }
+            }
+
+            // Single source of truth for the #268 signal: the reason is built from the counters and is
+            // null iff nothing was lost; completeness derives from it (no parallel hand-synced predicate).
+            var incompleteReason = BuildIncompleteReason(
+                state.FailedSlides, state.DroppedByCap, state.Undecodable, state.OversizedImages,
+                state.TruncatedOcr, state.FailedFigureOcr, state.ChartFailures);
+            var complete = incompleteReason is null;
+            if (!complete)
+            {
+                Logger.LogWarning("PPTX extraction incomplete: {Reason}", incompleteReason);
+            }
+
+            return new TextExtractionResult
+            {
+                Markdown = string.Join("\n\n", slideMarkdowns),
+                DetectedLanguage = null,
+                // UsedOcr means "scan vs digital" (true = physical-scan OCR). A PPTX is a digital
+                // extraction even when embedded figures were transcribed via IOcrProvider — figure OCR is
+                // auxiliary. Do NOT flip this to true; same contract reasoning as PdfExtractor (#301).
+                UsedOcr = false,
+                ProviderName = ProviderIdentifier,
+                IsComplete = complete,
+                IncompleteReason = incompleteReason,
+                // PPTX text + per-image OCR has no single aggregated spatial payload to archive (#210).
+                NativePayload = null
+            };
+        }
+    }
+
+    /// <summary>Builds one slide's Markdown: ordered shape blocks, then the optional speaker-notes block.</summary>
+    private async Task<string> ProcessSlideAsync(
+        SlidePart slidePart, ExtractionState state, CancellationToken cancellationToken)
+    {
+        var shapeTree = slidePart.Slide?.CommonSlideData?.ShapeTree;
+        var blocks = new List<SlideReadingOrder.SlideBlock>();
+
+        if (shapeTree is not null)
+        {
+            await WalkShapesAsync(shapeTree, slidePart, inGroup: false, groupY: 0, groupX: 0, blocks, state, cancellationToken);
+        }
+
+        var body = SlideReadingOrder.Render(blocks);
+
+        if (_options.IncludeSpeakerNotes)
+        {
+            var notes = ReadSpeakerNotes(slidePart);
+            if (!string.IsNullOrWhiteSpace(notes))
+            {
+                var notesBlock = "### Speaker notes\n\n" + notes;
+                body = string.IsNullOrWhiteSpace(body) ? notesBlock : body + "\n\n" + notesBlock;
+            }
+        }
+
+        return body;
+    }
+
+    /// <summary>
+    /// Walks a shape container (the slide's shape tree or a grouped shape) in document order, dispatching
+    /// pictures to OCR, charts/tables to structured rendering, and text shapes to Markdown. Recurses into
+    /// grouped shapes; for items inside a group, the group's own offset anchors their reading position and
+    /// document-encounter order (<see cref="ExtractionState.Sequence"/>) breaks ties within the group —
+    /// avoiding the child-coordinate-space math a precise absolute position would require.
+    /// </summary>
+    private async Task WalkShapesAsync(
+        DocumentFormat.OpenXml.OpenXmlElement container,
+        SlidePart slidePart,
+        bool inGroup,
+        long groupY,
+        long groupX,
+        List<SlideReadingOrder.SlideBlock> blocks,
+        ExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        foreach (var child in container.ChildElements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            switch (child)
+            {
+                case P.GroupShape group:
+                {
+                    var (gy, gx) = inGroup ? (groupY, groupX) : OffsetOf(group);
+                    await WalkShapesAsync(group, slidePart, inGroup: true, gy, gx, blocks, state, cancellationToken);
+                    break;
+                }
+
+                case P.Picture picture:
+                {
+                    var (y, x) = PositionFor(picture, inGroup, groupY, groupX);
+                    await HandlePictureAsync(picture, slidePart, y, x, blocks, state, cancellationToken);
+                    break;
+                }
+
+                case P.GraphicFrame graphicFrame:
+                {
+                    var (y, x) = PositionFor(graphicFrame, inGroup, groupY, groupX);
+                    HandleGraphicFrame(graphicFrame, slidePart, y, x, blocks, state);
+                    break;
+                }
+
+                case P.Shape shape:
+                {
+                    var (y, x) = PositionFor(shape, inGroup, groupY, groupX);
+                    HandleTextShape(shape, y, x, blocks, state);
+                    break;
+                }
+
+                // ConnectionShape / non-visual property elements / unknown: nothing to extract.
+            }
+        }
+    }
+
+    private async Task HandlePictureAsync(
+        P.Picture picture,
+        SlidePart slidePart,
+        long y,
+        long x,
+        List<SlideReadingOrder.SlideBlock> blocks,
+        ExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        if (IsDecorative(picture))
+        {
+            // Icon / bullet / logo / spacer — not figure content, not counted against completeness.
+            return;
+        }
+
+        var embed = picture.BlipFill?.Blip?.Embed?.Value;
+        if (string.IsNullOrEmpty(embed))
+        {
+            // A picture shape with no image relationship (e.g. an unfilled placeholder). Nothing to OCR.
+            return;
+        }
+
+        if (state.ImageBudget <= 0)
+        {
+            state.DroppedByCap++;
+            return;
+        }
+
+        PptxImagePayload.ResolvedImage resolved;
+        try
+        {
+            var part = slidePart.GetPartById(embed);
+            resolved = part is ImagePart imagePart
+                ? PptxImagePayload.TryResolve(imagePart, _options.MaxImageBytesPerImage)
+                // A dangling relationship / non-image part: treat as undecodable.
+                : new PptxImagePayload.ResolvedImage(PptxImagePayload.ImageOutcome.Undecodable, null, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logger.LogWarning(ex, "Failed to resolve/decode an embedded PPTX image; skipping it.");
+            resolved = new PptxImagePayload.ResolvedImage(PptxImagePayload.ImageOutcome.Undecodable, null, null);
+        }
+
+        switch (resolved.Outcome)
+        {
+            case PptxImagePayload.ImageOutcome.Oversized:
+                // A single image larger than the per-image byte cap (e.g. a ZIP-decompression bomb). Skipped
+                // before full materialization; trips the completeness signal but never OOMs the worker.
+                Logger.LogWarning("Skipped an embedded image exceeding the {Cap}-byte per-image cap.", _options.MaxImageBytesPerImage);
+                state.OversizedImages++;
+                return;
+
+            case PptxImagePayload.ImageOutcome.Undecodable:
+                // Vector (EMF/WMF), dangling relationship, or undecodable/mislabeled bytes.
+                state.Undecodable++;
+                return;
+
+            case PptxImagePayload.ImageOutcome.Ok:
+                break;
+
+            default:
+                // A future outcome added to the enum must not silently fall through to RecognizeAsync with
+                // possibly-null bytes — fail closed by treating it as undecodable.
+                Logger.LogWarning("Unhandled image outcome {Outcome}; treating as undecodable.", resolved.Outcome);
+                state.Undecodable++;
+                return;
+        }
+
+        state.ImageBudget--;
+
+        OcrResult ocr;
+        try
+        {
+            using var imageStream = new MemoryStream(resolved.Bytes!, writable: false);
+            ocr = await _ocrProvider.RecognizeAsync(
+                imageStream,
+                new OcrOptions
+                {
+                    ContentType = resolved.ContentType!,
+                    LanguageHints = state.LanguageHints
+                },
+                cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A single figure's OCR failing (provider timeout / rate-limit / auth / one bad image) must
+            // NOT discard the slide text already extracted — figure OCR is an auxiliary augmentation, not
+            // the deck's primary payload (the #210/#268 "auxiliary step must not break the main pipeline"
+            // principle). Skip this figure and mark the result incomplete. OperationCanceledException
+            // still propagates so a host/job shutdown aborts promptly.
+            Logger.LogWarning(ex, "Embedded-image OCR failed; keeping the slide text, skipping this figure.");
+            state.FailedFigureOcr++;
+            return;
+        }
+
+        if (!ocr.IsComplete)
+        {
+            // OCR truncated at the token limit or discarded by the repetition guard.
+            state.TruncatedOcr++;
+        }
+
+        var transcription = ocr.Markdown?.Trim() ?? string.Empty;
+        if (transcription.Length == 0)
+        {
+            return;
+        }
+
+        // Native alt-text (p:cNvPr/@descr, fallback @title) is a real caption signal — strictly better
+        // than PDF's nearest-text heuristic. Render it as the figure block's label. Alt-text is
+        // author-controlled free text (often multi-line), so collapse newlines via MarkdownCell.Inline so
+        // the bold caption can't break the OCR block (often a table) directly below it.
+        var caption = AltTextOf(picture);
+        var markdown = string.IsNullOrWhiteSpace(caption)
+            ? transcription
+            : "**" + MarkdownCell.Inline(caption) + "**\n\n" + transcription;
+
+        blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, markdown));
+    }
+
+    private void HandleGraphicFrame(
+        P.GraphicFrame graphicFrame,
+        SlidePart slidePart,
+        long y,
+        long x,
+        List<SlideReadingOrder.SlideBlock> blocks,
+        ExtractionState state)
+    {
+        var graphicData = graphicFrame.Graphic?.GraphicData;
+        if (graphicData is null)
+        {
+            return;
+        }
+
+        // Chart: ChartPart backing data → Markdown table (pure structured, no OCR/vision/LLM).
+        var chartReference = graphicData.Descendants<C.ChartReference>().FirstOrDefault();
+        if (!string.IsNullOrEmpty(chartReference?.Id?.Value))
+        {
+            string? table;
+            try
+            {
+                var part = slidePart.GetPartById(chartReference!.Id!.Value!);
+                table = part is ChartPart chartPart ? ChartRenderer.Render(chartPart) : null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(ex, "Failed to render an embedded chart; skipping it.");
+                table = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(table))
+            {
+                // Unsupported chart family (scatter/bubble) or unreadable cache — count it as lost (#268).
+                state.ChartFailures++;
+                return;
+            }
+
+            blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, table!));
+            return;
+        }
+
+        // Native table (a:tbl): real text content that would otherwise be lost, since this provider owns
+        // the whole .pptx pass. Render directly as a Markdown table (no OCR).
+        var drawingTable = graphicData.Descendants<D.Table>().FirstOrDefault();
+        if (drawingTable is not null)
+        {
+            var rendered = DrawingTableRenderer.Render(drawingTable);
+            if (!string.IsNullOrWhiteSpace(rendered))
+            {
+                blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, rendered!));
+            }
+
+            return;
+        }
+
+        // SmartArt / diagram / embedded OLE: vector-rendered, no faithful text extraction this round —
+        // accepted blind spot like vector graphics, NOT counted against completeness (#307 decision).
+    }
+
+    private void HandleTextShape(
+        P.Shape shape,
+        long y,
+        long x,
+        List<SlideReadingOrder.SlideBlock> blocks,
+        ExtractionState state)
+    {
+        // Skip auto-generated slide-number / date fields so they do not pollute the text payload — the
+        // same exclusion ReadSpeakerNotes applies to the notes slide (a slide-number placeholder's cached
+        // value would otherwise leak as a stray "1" / date into the body Markdown).
+        if (IsAutoFieldPlaceholder(shape))
+        {
+            return;
+        }
+
+        var text = ShapeText(shape);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        // Title placeholders are a real structural signal — render as a Markdown heading. Collapse any
+        // internal line/paragraph breaks to single spaces so a multi-paragraph title is one clean heading.
+        if (IsTitle(shape))
+        {
+            text = "## " + string.Join(" ", text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, text));
+    }
+
+    /// <summary>Whether the shape is an auto-generated slide-number / date placeholder (excluded from text).</summary>
+    private static bool IsAutoFieldPlaceholder(P.Shape shape)
+    {
+        var type = PlaceholderTypeOf(shape);
+        return type == P.PlaceholderValues.SlideNumber || type == P.PlaceholderValues.DateAndTime;
+    }
+
+    private static P.PlaceholderValues? PlaceholderTypeOf(P.Shape shape)
+        => shape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape?.Type?.Value;
+
+    /// <summary>Whether the picture's display size is below the decorative threshold (skipped silently).</summary>
+    protected virtual bool IsDecorative(P.Picture picture)
+    {
+        var extents = picture.ShapeProperties?.Transform2D?.Extents;
+        if (extents?.Cx is null || extents.Cy is null)
+        {
+            // No display extents (e.g. inherited from layout): cannot judge — do not skip.
+            return false;
+        }
+
+        // Compute the area before dividing so neither dimension is truncated toward zero first (which
+        // would shrink a borderline figure below the threshold and drop it). EMU values are well within
+        // long range for any real slide, so the product cannot overflow.
+        var pixelArea = extents.Cx.Value * extents.Cy.Value / (EmuPerPixel96 * EmuPerPixel96);
+        return pixelArea < _options.MinImagePixels;
+    }
+
+    /// <summary>Reads a slide's speaker notes, excluding the slide-number / date placeholders.</summary>
+    protected virtual string? ReadSpeakerNotes(SlidePart slidePart)
+    {
+        var notesSlide = slidePart.NotesSlidePart?.NotesSlide;
+        if (notesSlide is null)
+        {
+            return null;
+        }
+
+        var parts = new List<string>();
+        foreach (var shape in notesSlide.Descendants<P.Shape>())
+        {
+            if (IsAutoFieldPlaceholder(shape))
+            {
+                continue;
+            }
+
+            var text = ShapeText(shape);
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                parts.Add(text);
+            }
+        }
+
+        return parts.Count == 0 ? null : string.Join("\n\n", parts);
+    }
+
+    private static (long Y, long X) PositionFor(
+        DocumentFormat.OpenXml.OpenXmlElement shape, bool inGroup, long groupY, long groupX)
+        => inGroup ? (groupY, groupX) : OffsetOf(shape);
+
+    /// <summary>The shape's own top-left offset in EMU, or (0,0) when it inherits position from the layout.</summary>
+    private static (long Y, long X) OffsetOf(DocumentFormat.OpenXml.OpenXmlElement shape)
+    {
+        var offset = shape switch
+        {
+            P.Picture p => p.ShapeProperties?.Transform2D?.Offset,
+            P.Shape s => s.ShapeProperties?.Transform2D?.Offset,
+            P.GraphicFrame g => g.Transform?.Offset,
+            P.GroupShape grp => grp.GroupShapeProperties?.TransformGroup?.Offset,
+            _ => null
+        };
+
+        // A shape with no explicit xfrm inherits its position from the slide layout/master; we cannot
+        // resolve that here, so it sorts to the top by position and keeps document order via Sequence.
+        return offset is null ? (0, 0) : (offset.Y?.Value ?? 0, offset.X?.Value ?? 0);
+    }
+
+    private static string ShapeText(P.Shape shape)
+    {
+        var body = shape.TextBody;
+        if (body is null)
+        {
+            return string.Empty;
+        }
+
+        var paragraphs = body
+            .Elements<D.Paragraph>()
+            .Select(ParagraphText)
+            .Where(line => line.Length > 0);
+
+        // Join paragraphs with a blank line so each stays a distinct Markdown paragraph. A single newline
+        // would fold consecutive bullets/lines into one rendered paragraph downstream, losing the list
+        // structure that the text-extraction rules call a real signal.
+        return string.Join("\n\n", paragraphs);
+    }
+
+    private static string ParagraphText(D.Paragraph paragraph)
+    {
+        // Walk the paragraph in document order, emitting run text (a:t, including a:fld field text) and
+        // turning a soft line break (a:br) into a newline. Concatenating only a:t would silently fuse the
+        // two sides of a break (e.g. "123 Main St" + "Suite 400" → "123 Main StSuite 400").
+        var sb = new System.Text.StringBuilder();
+        foreach (var element in paragraph.Descendants<DocumentFormat.OpenXml.OpenXmlElement>())
+        {
+            switch (element.LocalName)
+            {
+                case "t":
+                    sb.Append(element.InnerText);
+                    break;
+                case "br":
+                    sb.Append('\n');
+                    break;
+            }
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private static string? AltTextOf(P.Picture picture)
+    {
+        var props = picture.NonVisualPictureProperties?.NonVisualDrawingProperties;
+        var description = props?.Description?.Value;
+        return !string.IsNullOrWhiteSpace(description) ? description : props?.Title?.Value;
+    }
+
+    private static bool IsTitle(P.Shape shape)
+    {
+        var type = PlaceholderTypeOf(shape);
+        return type == P.PlaceholderValues.Title || type == P.PlaceholderValues.CenteredTitle;
+    }
+
+    /// <summary>
+    /// Resolves the OCR language hints for embedded-image transcription, mirroring
+    /// <c>DefaultTextExtractor</c>: the per-document hints when present, otherwise the host's configured
+    /// defaults — so the figure path and the whole-page OCR path apply the same defaulting.
+    /// </summary>
+    protected virtual IList<string> ResolveLanguageHints(TextExtractionContext context)
+        => context.LanguageHints?.Count > 0 ? context.LanguageHints : _ocrOptions.DefaultLanguageHints;
+
+    /// <summary>
+    /// Builds the #268 incompleteness reason from the loss counters, or returns <c>null</c> when nothing
+    /// was lost. Single source of truth for both the reason text and completeness
+    /// (<c>IsComplete = reason is null</c>), so a new counter cannot drift out of sync.
+    /// </summary>
+    internal static string? BuildIncompleteReason(
+        int failedSlides, int droppedByCap, int undecodable, int oversizedImages, int truncatedOcr, int failedFigureOcr, int chartFailures)
+    {
+        var parts = new List<string>();
+        if (failedSlides > 0)
+        {
+            parts.Add($"{failedSlides} slide(s) could not be parsed and were skipped");
+        }
+
+        if (undecodable > 0)
+        {
+            parts.Add($"{undecodable} embedded image(s) could not be decoded to a supported raster format (e.g. EMF/WMF vector)");
+        }
+
+        if (oversizedImages > 0)
+        {
+            parts.Add($"{oversizedImages} embedded image(s) exceeded the per-image size cap and were skipped");
+        }
+
+        if (failedFigureOcr > 0)
+        {
+            parts.Add($"{failedFigureOcr} embedded image(s) failed OCR (provider error)");
+        }
+
+        if (truncatedOcr > 0)
+        {
+            parts.Add($"{truncatedOcr} image transcription(s) were truncated or discarded by the OCR provider");
+        }
+
+        if (chartFailures > 0)
+        {
+            parts.Add($"{chartFailures} chart(s) could not be rendered as a table");
+        }
+
+        if (droppedByCap > 0)
+        {
+            parts.Add($"{droppedByCap} image(s) were skipped after reaching the per-file image cap");
+        }
+
+        return parts.Count == 0 ? null : string.Join("; ", parts) + ".";
+    }
+
+    /// <summary>Mutable per-extraction accumulator: image budget, block sequence, and #268 loss counters.</summary>
+    private sealed class ExtractionState
+    {
+        public int ImageBudget;
+        public int Sequence;
+        public int FailedSlides;
+        public int DroppedByCap;
+        public int Undecodable;
+        public int OversizedImages;
+        public int TruncatedOcr;
+        public int FailedFigureOcr;
+        public int ChartFailures;
+        public IList<string> LanguageHints = new List<string>();
+    }
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/PptxImagePayload.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/PptxImagePayload.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using Dignite.DocumentAI.Ocr;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Resolves an embedded <see cref="ImagePart"/> into image-file bytes + MIME type suitable for feeding
+/// to <c>IOcrProvider.RecognizeAsync</c>. Unlike the PDF path, PPTX stores each image as a self-contained
+/// image file (PNG/JPEG/GIF/BMP/TIFF/WebP), so the bytes pass straight through with no re-encoding.
+/// <para>
+/// The media type is taken from the <b>bytes' own signature</b> (<see cref="ImageSignature.SniffMediaType"/>),
+/// not the part's declared content type — a mislabeled part (e.g. an EMF renamed to <c>.png</c>) or a
+/// truncated/corrupt stream therefore reports <see cref="ImageOutcome.Undecodable"/>, as do genuine vector
+/// parts (EMF/WMF), per the #299 decision to skip cross-platform vector rasterization.
+/// </para>
+/// <para>
+/// The part stream is read with a <b>hard byte cap</b> and aborts as soon as the cap is exceeded, so a
+/// ZIP-decompression-bomb image part can never be fully inflated into managed memory — it reports
+/// <see cref="ImageOutcome.Oversized"/> instead. The caller trips the completeness signal (#268) for both
+/// non-OK outcomes.
+/// </para>
+/// </summary>
+internal static class PptxImagePayload
+{
+    internal enum ImageOutcome
+    {
+        Ok,
+        Undecodable,
+        Oversized
+    }
+
+    internal readonly record struct ResolvedImage(ImageOutcome Outcome, byte[]? Bytes, string? ContentType);
+
+    public static ResolvedImage TryResolve(ImagePart imagePart, long maxBytes)
+    {
+        using var stream = imagePart.GetStream(FileMode.Open, FileAccess.Read);
+
+        if (!TextExtractionStreams.TryReadAllBytesBounded(stream, maxBytes, out var bytes))
+        {
+            // Exceeded the cap mid-read — never materialized beyond the cap (the zip-bomb guard).
+            return new ResolvedImage(ImageOutcome.Oversized, null, null);
+        }
+
+        var contentType = ImageSignature.SniffMediaType(bytes);
+        return contentType is null
+            ? new ResolvedImage(ImageOutcome.Undecodable, null, null)
+            : new ResolvedImage(ImageOutcome.Ok, bytes, contentType);
+    }
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/SlideReadingOrder.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/SlideReadingOrder.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Reading-order assembly for a single slide. PPTX is semantically <b>fixed-layout per slide</b>
+/// (PDF-like, position-based — not flow-based), so blocks are ordered by their shape's top-left offset
+/// (EMU): top-to-bottom (<see cref="SlideBlock.OrderY"/> ascending), then left-to-right
+/// (<see cref="SlideBlock.OrderX"/> ascending). Unlike PDF user space, DrawingML's Y axis points
+/// <b>downward</b> (origin top-left), so ascending Y is already natural reading order — no inversion.
+/// <para>
+/// <see cref="SlideBlock.Sequence"/> is the document-encounter order, used as the final tiebreak so
+/// shapes that share a position (or carry no offset) keep their declared order, and images discovered
+/// inside a grouped shape stay in group-encounter order under the group's position.
+/// </para>
+/// </summary>
+internal static class SlideReadingOrder
+{
+    /// <summary>
+    /// One renderable block on a slide: a text shape's Markdown, an embedded image's transcription, or a
+    /// chart's data table. <see cref="OrderY"/>/<see cref="OrderX"/> are EMU offsets (top-left); a block
+    /// whose shape carries no offset sorts to the front by position but keeps document order via
+    /// <see cref="Sequence"/>.
+    /// </summary>
+    public readonly record struct SlideBlock(long OrderY, long OrderX, int Sequence, string Markdown);
+
+    /// <summary>
+    /// Orders the slide's blocks into reading order and joins them with blank lines. Returns an empty
+    /// string when there is nothing renderable.
+    /// </summary>
+    public static string Render(IReadOnlyList<SlideBlock> blocks)
+    {
+        if (blocks.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var ordered = blocks
+            .OrderBy(b => b.OrderY)
+            .ThenBy(b => b.OrderX)
+            .ThenBy(b => b.Sequence)
+            .Select(b => b.Markdown)
+            .Where(md => !string.IsNullOrWhiteSpace(md));
+
+        return string.Join("\n\n", ordered);
+    }
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractor.cs
@@ -68,7 +68,7 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
         TextExtractionContext context,
         CancellationToken cancellationToken = default)
     {
-        var bytes = await ReadAllBytesAsync(fileStream, cancellationToken);
+        var bytes = await TextExtractionStreams.ReadAllBytesAsync(fileStream, cancellationToken);
 
         PdfDocument document;
         try
@@ -335,25 +335,6 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
         }
 
         return parts.Count == 0 ? null : string.Join("; ", parts) + ".";
-    }
-
-    private static async Task<byte[]> ReadAllBytesAsync(Stream stream, CancellationToken cancellationToken)
-    {
-        // The orchestrator (DefaultTextExtractor) already buffers the upload into a seekable MemoryStream,
-        // so a single ToArray() copy suffices on the production path. Only re-buffer a non-MemoryStream.
-        if (stream is MemoryStream memoryStream)
-        {
-            return memoryStream.ToArray();
-        }
-
-        if (stream.CanSeek)
-        {
-            stream.Position = 0;
-        }
-
-        using var copy = new MemoryStream();
-        await stream.CopyToAsync(copy, cancellationToken);
-        return copy.ToArray();
     }
 
     private readonly record struct PageContent(Page Page, IReadOnlyList<Word> Words);

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfImagePayload.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfImagePayload.cs
@@ -1,4 +1,4 @@
-using System;
+using Dignite.DocumentAI.Ocr;
 using UglyToad.PdfPig.Content;
 
 namespace Dignite.DocumentAI.TextExtraction.Pdf;
@@ -22,30 +22,19 @@ internal static class PdfImagePayload
         }
 
         // PdfPig does not decode DCT (JPEG) without an external filter; for those, the raw stream IS a
-        // valid JPEG file. TryGetBytesAsMemory reverses non-DCT filters; otherwise use the raw bytes.
+        // valid image file. TryGetBytesAsMemory reverses non-DCT filters; otherwise use the raw bytes.
         var raw = image.TryGetBytesAsMemory(out var decoded) ? decoded : image.RawMemory;
 
-        // Inspect the signature on the span first; only materialize a byte[] when we will actually return
-        // it (an unsupported/headerless image otherwise pays a full-buffer copy just to be discarded).
-        var span = raw.Span;
-        if (LooksLikeJpeg(span))
+        // Inspect the signature on the span first (via the shared Ocr-contract sniffer); only materialize a
+        // byte[] when we will actually return it (an unsupported/headerless image otherwise pays a
+        // full-buffer copy just to be discarded).
+        var contentType = ImageSignature.SniffMediaType(raw.Span);
+        if (contentType is not null)
         {
-            return (raw.ToArray(), "image/jpeg");
-        }
-
-        if (LooksLikePng(span))
-        {
-            return (raw.ToArray(), "image/png");
+            return (raw.ToArray(), contentType);
         }
 
         // Unsupported codec (JBIG2 / JPX / CCITT) or undecoded raw samples without a file header.
         return null;
     }
-
-    private static bool LooksLikeJpeg(ReadOnlySpan<byte> b)
-        => b.Length >= 3 && b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF;
-
-    private static bool LooksLikePng(ReadOnlySpan<byte> b)
-        => b.Length >= 8 && b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47
-           && b[4] == 0x0D && b[5] == 0x0A && b[6] == 0x1A && b[7] == 0x0A;
 }

--- a/core/src/Dignite.DocumentAI.TextExtraction/TextExtractionStreams.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction/TextExtractionStreams.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dignite.DocumentAI.TextExtraction;
+
+/// <summary>
+/// Shared stream helpers for <see cref="IMarkdownTextProvider"/> implementations. Lives in the
+/// orchestrator project (referenced by every provider module) so the buffering logic is defined once
+/// rather than copied per provider (PdfExtractor / PptxExtractor / future DOCX).
+/// </summary>
+public static class TextExtractionStreams
+{
+    /// <summary>
+    /// Materializes the whole stream into a byte array. The orchestrator (<c>DefaultTextExtractor</c>)
+    /// already buffers the upload into a seekable <see cref="MemoryStream"/>, so a single
+    /// <see cref="MemoryStream.ToArray"/> copy suffices on the production path; only a non-MemoryStream is
+    /// re-buffered.
+    /// </summary>
+    public static async Task<byte[]> ReadAllBytesAsync(Stream stream, CancellationToken cancellationToken = default)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        if (stream.CanSeek)
+        {
+            stream.Position = 0;
+        }
+
+        using var copy = new MemoryStream();
+        await stream.CopyToAsync(copy, cancellationToken);
+        return copy.ToArray();
+    }
+
+    /// <summary>
+    /// Reads the stream into <paramref name="bytes"/>, aborting (returning <c>false</c>) the moment the
+    /// running total exceeds <paramref name="maxBytes"/> — used to bound an untrusted, potentially
+    /// ZIP-inflating embedded-image part so it can never be fully materialized (a decompression-bomb
+    /// guard). Shared so every OpenXML container provider (PPTX now, DOCX in #308) reuses one hardened
+    /// implementation rather than copying it.
+    /// <para>
+    /// Memory: the copy buffer chunk is pooled (no per-call allocation). On success the bytes are returned
+    /// via <see cref="MemoryStream.ToArray"/>, so peak transient memory is up to ~2× the final size for a
+    /// near-cap stream (the growing <see cref="MemoryStream"/> buffer plus the ToArray copy) — still
+    /// bounded by the cap, never unbounded.
+    /// </para>
+    /// </summary>
+    public static bool TryReadAllBytesBounded(Stream stream, long maxBytes, out byte[] bytes)
+    {
+        var chunk = ArrayPool<byte>.Shared.Rent(81920);
+        try
+        {
+            using var buffer = new MemoryStream();
+            long total = 0;
+            int read;
+            while ((read = stream.Read(chunk, 0, chunk.Length)) > 0)
+            {
+                total += read;
+                if (total > maxBytes)
+                {
+                    bytes = Array.Empty<byte>();
+                    return false;
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+
+            bytes = buffer.ToArray();
+            return true;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(chunk);
+        }
+    }
+}

--- a/core/test/Dignite.DocumentAI.Ocr.VisionLlm.Tests/ImageSignature_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Ocr.VisionLlm.Tests/ImageSignature_Tests.cs
@@ -1,0 +1,55 @@
+using Shouldly;
+using Xunit;
+using Dignite.DocumentAI.Ocr;
+
+namespace Dignite.DocumentAI.Ocr;
+
+/// <summary>
+/// Unit tests for the shared magic-byte detector (consolidated from the three former per-provider
+/// sniffers). Positive cases for every supported raster signature, plus the PDF signature and the
+/// no-match path.
+/// </summary>
+public class ImageSignature_Tests
+{
+    [Theory]
+    [InlineData("image/jpeg", new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00 })]
+    [InlineData("image/png", new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A })]
+    [InlineData("image/gif", new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 })]
+    [InlineData("image/bmp", new byte[] { 0x42, 0x4D, 0x00, 0x00 })]
+    [InlineData("image/tiff", new byte[] { 0x49, 0x49, 0x2A, 0x00 })]
+    [InlineData("image/tiff", new byte[] { 0x4D, 0x4D, 0x00, 0x2A })]
+    public void Sniffs_each_supported_raster_signature(string expected, byte[] bytes)
+    {
+        ImageSignature.SniffMediaType(bytes).ShouldBe(expected);
+        ImageSignature.IsRaster(bytes).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Sniffs_webp_only_with_the_RIFF_and_WEBP_markers()
+    {
+        var webp = new byte[] { 0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50 };
+        ImageSignature.SniffMediaType(webp).ShouldBe("image/webp");
+
+        // RIFF but not WEBP (e.g. a WAV) is not a raster image.
+        var riffNotWebp = new byte[] { 0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45 };
+        ImageSignature.SniffMediaType(riffNotWebp).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 })]   // garbage
+    [InlineData(new byte[] { 0x01, 0x00, 0x00, 0x00 })]          // EMF-ish (vector) — not a raster
+    [InlineData(new byte[] { })]                                  // empty
+    [InlineData(new byte[] { 0xFF, 0xD8 })]                       // truncated JPEG prefix (too short)
+    public void Returns_null_for_non_raster_or_truncated_bytes(byte[] bytes)
+    {
+        ImageSignature.SniffMediaType(bytes).ShouldBeNull();
+        ImageSignature.IsRaster(bytes).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Detects_the_pdf_signature()
+    {
+        ImageSignature.IsPdf(new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31 }).ShouldBeTrue(); // %PDF-1
+        ImageSignature.IsPdf(new byte[] { 0x89, 0x50, 0x4E, 0x47 }).ShouldBeFalse();
+    }
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/Dignite.DocumentAI.TextExtraction.OpenXml.Tests.csproj
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/Dignite.DocumentAI.TextExtraction.OpenXml.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Dignite.DocumentAI.TextExtraction.OpenXml</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Pure unit tests: NSubstitute the IOcrProvider, build PPTX fixtures in-code with the OpenXML SDK
+         (no on-disk assets), and generate embedded PNGs with a tiny pure-managed encoder (no SkiaSharp /
+         native dependency). No ABP TestBase, no DB. -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <!-- OpenXML SDK directly, for building PPTX fixtures (also flows transitively via the src project). -->
+    <PackageReference Include="DocumentFormat.OpenXml" />
+    <!-- For ExposedServiceExplorer in the DI-registration regression test. -->
+    <PackageReference Include="Volo.Abp.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dignite.DocumentAI.TextExtraction.OpenXml\Dignite.DocumentAI.TextExtraction.OpenXml.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/MarkdownCell_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/MarkdownCell_Tests.cs
@@ -1,0 +1,33 @@
+using Shouldly;
+using Xunit;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+public class MarkdownCell_Tests
+{
+    [Fact]
+    public void Escapes_pipe_so_a_cell_cannot_split_the_row()
+    {
+        MarkdownCell.Escape("a|b").ShouldBe("a\\|b");
+    }
+
+    [Fact]
+    public void Escapes_backslash_before_pipe_so_a_trailing_backslash_does_not_neutralize_the_escape()
+    {
+        // "a\|b": the backslash is escaped first (-> "a\\"), then the pipe (-> "\\|"), giving "a\\\\|b"
+        // which renders as a literal backslash followed by an escaped pipe — the cell stays one column.
+        MarkdownCell.Escape("a\\|b").ShouldBe("a\\\\\\|b");
+    }
+
+    [Fact]
+    public void Collapses_newlines_to_spaces()
+    {
+        MarkdownCell.Escape("line1\nline2").ShouldBe("line1 line2");
+    }
+
+    [Fact]
+    public void Null_becomes_empty()
+    {
+        MarkdownCell.Escape(null).ShouldBe(string.Empty);
+    }
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxExtractorRegistration_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxExtractorRegistration_Tests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Dignite.DocumentAI.Ocr;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Guards the ABP conventional-registration metadata and the extension self-declaration for
+/// <see cref="PptxExtractor"/>. The behavior tests construct the extractor with <c>new(...)</c>, so they
+/// cannot catch a missing DI registration. <c>PptxExtractor</c> does not end with <c>MarkdownTextProvider</c>,
+/// so <see cref="IMarkdownTextProvider"/> is exposed only via the explicit <c>[ExposeServices]</c> — this
+/// asserts it stays exposed (otherwise DefaultTextExtractor would never see it for <c>.pptx</c> dispatch),
+/// and that it claims only <c>.pptx</c> (so other extensions are left to their own providers / the ElBruno catch-all).
+/// </summary>
+public class PptxExtractorRegistration_Tests
+{
+    [Fact]
+    public void Provider_Exposes_IMarkdownTextProvider()
+    {
+        ExposedServiceExplorer.GetExposedServices(typeof(PptxExtractor))
+            .ShouldContain(typeof(IMarkdownTextProvider));
+    }
+
+    [Fact]
+    public void Provider_Is_Conventionally_Registered_Via_ITransientDependency()
+    {
+        typeof(ITransientDependency).IsAssignableFrom(typeof(PptxExtractor)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Claims_only_the_pptx_extension_and_outranks_the_fallback()
+    {
+        var extractor = new PptxExtractor(
+            Substitute.For<IOcrProvider>(),
+            Options.Create(new OpenXmlExtractorOptions()),
+            Options.Create(new DocumentAIOcrOptions { DefaultLanguageHints = new List<string>() }));
+
+        extractor.CanHandle(".pptx").ShouldBeTrue();
+        extractor.CanHandle(".PPTX").ShouldBeTrue();
+        extractor.CanHandle(".pdf").ShouldBeFalse();
+        extractor.CanHandle(".docx").ShouldBeFalse();
+        extractor.CanHandle(".ppt").ShouldBeFalse();
+        extractor.CanHandle(string.Empty).ShouldBeFalse();
+
+        extractor.Priority.ShouldBeGreaterThan(MarkdownProviderPriorities.Fallback);
+    }
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -1,0 +1,683 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.TextExtraction;
+using Dignite.DocumentAI.Ocr;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+public class PptxExtractor_Tests
+{
+    private readonly IOcrProvider _ocr = Substitute.For<IOcrProvider>();
+
+    private PptxExtractor CreateExtractor(
+        int minImagePixels = 0,
+        int maxImages = 50,
+        bool includeNotes = true,
+        long maxImageBytes = 16L * 1024 * 1024,
+        DocumentAIOcrOptions? ocrOptions = null)
+        => new(
+            _ocr,
+            Options.Create(new OpenXmlExtractorOptions
+            {
+                MinImagePixels = minImagePixels,
+                MaxImagesPerFile = maxImages,
+                MaxImageBytesPerImage = maxImageBytes,
+                IncludeSpeakerNotes = includeNotes
+            }),
+            // Default to empty hints so unrelated tests don't get defaults injected unexpectedly.
+            Options.Create(ocrOptions ?? new DocumentAIOcrOptions { DefaultLanguageHints = new List<string>() }));
+
+    private static TextExtractionContext PptxContext()
+        => new() { ContentType = "application/vnd.openxmlformats-officedocument.presentationml.presentation", FileExtension = ".pptx" };
+
+    private void StubOcr(string markdown, bool isComplete = true, string? reason = null)
+        => _ocr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new OcrResult
+            {
+                Markdown = markdown,
+                ProviderName = "FakeOcr",
+                IsComplete = isComplete,
+                IncompleteReason = reason
+            });
+
+    private static PptxFixtures.ImageSpec Png(string? alt, long x, long y, long extent = 914400)
+        => new(TinyPng.CreateSolid(48, 48), "image/png", alt, x, y, extent, extent);
+
+    [Fact]
+    public async Task Inlines_image_transcription_at_its_reading_position()
+    {
+        StubOcr("BRAVO");
+
+        // EMU Y increases downward, so smaller Y is higher on the slide.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("ALPHA", y: 100)
+            .Image(Png(alt: null, x: 100, y: 2_000_000))
+            .Text("CHARLIE", y: 4_000_000));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        var alpha = result.Markdown.IndexOf("ALPHA", StringComparison.Ordinal);
+        var bravo = result.Markdown.IndexOf("BRAVO", StringComparison.Ordinal);
+        var charlie = result.Markdown.IndexOf("CHARLIE", StringComparison.Ordinal);
+
+        alpha.ShouldBeGreaterThanOrEqualTo(0);
+        bravo.ShouldBeGreaterThan(alpha, "the figure transcription must come after the text above it");
+        charlie.ShouldBeGreaterThan(bravo, "the figure transcription must come before the text below it");
+
+        result.UsedOcr.ShouldBeFalse();
+        result.ProviderName.ShouldBe(PptxExtractor.ProviderIdentifier);
+        result.IsComplete.ShouldBeTrue();
+        result.IncompleteReason.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Feeds_image_bytes_to_the_ocr_provider()
+    {
+        StubOcr("FIGURE");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        await _ocr.Received(1).RecognizeAsync(
+            Arg.Any<Stream>(),
+            Arg.Is<OcrOptions>(o => o.ContentType.StartsWith("image/", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Uses_native_alt_text_as_caption()
+    {
+        StubOcr("transcribed chart text");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Image(Png(alt: "Quarterly Revenue Diagram", x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("**Quarterly Revenue Diagram**");
+        var caption = result.Markdown.IndexOf("Quarterly Revenue Diagram", StringComparison.Ordinal);
+        var body = result.Markdown.IndexOf("transcribed chart text", StringComparison.Ordinal);
+        body.ShouldBeGreaterThan(caption, "the alt-text caption labels the figure block above the transcription");
+    }
+
+    [Fact]
+    public async Task Marks_incomplete_when_ocr_truncates_a_figure()
+    {
+        StubOcr("PARTIAL", isComplete: false, reason: "truncated at the token limit");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason.ShouldNotBeNullOrEmpty();
+        result.Markdown.ShouldContain("PARTIAL");
+    }
+
+    [Fact]
+    public async Task Skips_decorative_images_below_min_pixels()
+    {
+        StubOcr("SHOULD_NOT_APPEAR");
+
+        // 300000 EMU ≈ 31 px per side → ~961 px², below the 1000 threshold.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000, extent: 300_000)));
+
+        var result = await CreateExtractor(minImagePixels: 1000).ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Body text");
+        result.Markdown.ShouldNotContain("SHOULD_NOT_APPEAR");
+        result.IsComplete.ShouldBeTrue();
+        await _ocr.DidNotReceive().RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Caps_images_per_presentation_and_marks_incomplete()
+    {
+        StubOcr("FIG");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000))
+            .Image(Png(alt: null, x: 100, y: 2_000_000)));
+
+        var result = await CreateExtractor(maxImages: 1).ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason.ShouldNotBeNull();
+        result.IncompleteReason!.ShouldContain("cap");
+        await _ocr.Received(1).RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Keeps_slide_text_when_an_embedded_image_OCR_throws()
+    {
+        _ocr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("vision provider down"));
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("SLIDEBODYTEXT")
+            .Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("SLIDEBODYTEXT");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason.ShouldNotBeNull();
+        result.IncompleteReason!.ShouldContain("OCR");
+    }
+
+    [Fact]
+    public async Task Skips_vector_images_and_marks_incomplete()
+    {
+        StubOcr("SHOULD_NOT_BE_CALLED");
+
+        var emf = new PptxFixtures.ImageSpec(new byte[] { 1, 2, 3, 4 }, "image/x-emf", null, 100, 1_000_000);
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(emf));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Body text");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("decoded");
+        await _ocr.DidNotReceive().RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Renders_chart_backing_data_as_a_markdown_table()
+    {
+        var chart = new PptxFixtures.ChartSpec(
+            Title: "Quarterly Revenue",
+            Categories: new[] { "Q1", "Q2" },
+            Series: new[] { ("Revenue", (IReadOnlyList<string>)new[] { "10", "20" }) });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Slide title", isTitle: true, y: 100)
+            .Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Quarterly Revenue");
+        result.Markdown.ShouldContain("| Category | Revenue |");
+        result.Markdown.ShouldContain("| Q1 | 10 |");
+        result.Markdown.ShouldContain("| Q2 | 20 |");
+        result.IsComplete.ShouldBeTrue();
+        // Charts are pure structured extraction — no OCR call.
+        await _ocr.DidNotReceive().RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Marks_incomplete_for_a_chart_whose_series_have_conflicting_categories()
+    {
+        // Two series with a DIFFERENT label at the same category index do not share one axis; a single wide
+        // table would hang the second series' values under the wrong category. Rather than emit that silent
+        // mismatch, the chart is dropped and the completeness signal trips (honest signal).
+        var chart = new PptxFixtures.ChartSpec(
+            Title: "Conflicting",
+            Categories: new[] { "Q1", "Q2" },
+            Series: new[]
+            {
+                ("Revenue", (IReadOnlyList<string>)new[] { "10", "20" }),
+                ("Cost", (IReadOnlyList<string>)new[] { "3", "4" })
+            },
+            SecondSeriesCategories: new[] { "Spring", "Summer" });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Slide body")
+            .Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Slide body");          // slide text retained
+        result.Markdown.ShouldNotContain("Spring");           // the misaligned table is not emitted
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("chart");
+    }
+
+    [Fact]
+    public async Task Renders_a_multi_series_chart_that_shares_one_category_axis()
+    {
+        // Sanity: two series sharing the SAME categories must still render a single wide table (the guard
+        // must not over-fire on the normal shared-axis case).
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: new[] { "Q1", "Q2" },
+            Series: new[]
+            {
+                ("Revenue", (IReadOnlyList<string>)new[] { "10", "20" }),
+                ("Cost", (IReadOnlyList<string>)new[] { "3", "4" })
+            });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("| Category | Revenue | Cost |");
+        result.Markdown.ShouldContain("| Q1 | 10 | 3 |");
+        result.Markdown.ShouldContain("| Q2 | 20 | 4 |");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Accepts_an_image_whose_size_is_exactly_the_byte_cap()
+    {
+        StubOcr("FIGURE");
+
+        // An image of exactly N bytes must be ACCEPTED (the cap aborts on > cap, not >= cap). Guards a
+        // `>` → `>=` regression of the bounded read.
+        var bytes = TinyPng.CreateSolid(48, 48);
+        var image = new PptxFixtures.ImageSpec(bytes, "image/png", null, 100, 1_000_000);
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Text("Body text").Image(image));
+
+        var result = await CreateExtractor(maxImageBytes: bytes.Length).ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("FIGURE");
+        result.IsComplete.ShouldBeTrue();
+        await _ocr.Received(1).RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Seeds_chart_categories_from_a_later_series_when_the_first_omits_them()
+    {
+        // The first series carries no category cache; categories must seed from the second series, not
+        // degrade to numeric labels.
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: new[] { "Q1", "Q2" },
+            Series: new[]
+            {
+                ("Revenue", (IReadOnlyList<string>)new[] { "10", "20" }),
+                ("Cost", (IReadOnlyList<string>)new[] { "3", "4" })
+            },
+            FirstSeriesOmitsCategories: true);
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("| Q1 | 10 | 3 |");
+        result.Markdown.ShouldContain("| Q2 | 20 | 4 |");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Unions_extra_non_conflicting_category_labels_from_a_later_series()
+    {
+        // Series 1 labels indices 0-1; series 2 additionally labels index 2 ("Q3") without conflicting.
+        // The extra label must be UNIONed in (not dropped to the numeric "3" fallback).
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: new[] { "Q1", "Q2" },
+            Series: new[]
+            {
+                ("Revenue", (IReadOnlyList<string>)new[] { "10", "20" }),
+                ("Cost", (IReadOnlyList<string>)new[] { "3", "4", "5" })
+            },
+            SecondSeriesCategories: new[] { "Q1", "Q2", "Q3" });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // The idx-2 row carries the real "Q3" label (a numeric fallback would label it "3") and series-2's
+        // value 5.
+        result.Markdown.ShouldContain("| Q3 |  | 5 |");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Collapses_a_multi_line_chart_title_to_one_line()
+    {
+        var chart = new PptxFixtures.ChartSpec(
+            Title: "Revenue\nby Quarter",
+            Categories: new[] { "Q1" },
+            Series: new[] { ("Revenue", (IReadOnlyList<string>)new[] { "10" }) });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // The newline in the title must collapse so the bold run / table header is not broken.
+        result.Markdown.ShouldContain("**Revenue by Quarter**");
+    }
+
+    [Fact]
+    public async Task Renders_native_table()
+    {
+        var table = new PptxFixtures.TableSpec(new IReadOnlyList<string>[]
+        {
+            new[] { "Name", "Amount" },
+            new[] { "Widget", "42" }
+        });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Table(table));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("| Name | Amount |");
+        result.Markdown.ShouldContain("| Widget | 42 |");
+    }
+
+    [Fact]
+    public async Task Renders_a_ragged_table_as_a_rectangular_markdown_table()
+    {
+        // First row is a single (merged-style) title cell; data rows have 3 columns. The separator and
+        // every row must use the widest row's column count, or the Markdown table renders broken.
+        var table = new PptxFixtures.TableSpec(new IReadOnlyList<string>[]
+        {
+            new[] { "Summary" },
+            new[] { "A", "B", "C" },
+            new[] { "1", "2", "3" }
+        });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Table(table));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // Separator row must have 3 columns (the widest), not 1 (the header row's count).
+        result.Markdown.ShouldContain("| --- | --- | --- |");
+        // The short header row is padded out to 3 columns.
+        result.Markdown.ShouldContain("| Summary |  |  |");
+        result.Markdown.ShouldContain("| A | B | C |");
+    }
+
+    [Fact]
+    public async Task Preserves_soft_line_breaks_without_fusing_text()
+    {
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .TextWithSoftBreak("123 Main St", "Suite 400"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // The a:br must not fuse the two runs into "123 Main StSuite 400".
+        result.Markdown.ShouldNotContain("StSuite");
+        result.Markdown.ShouldContain("123 Main St");
+        result.Markdown.ShouldContain("Suite 400");
+    }
+
+    [Fact]
+    public async Task Keeps_separate_paragraphs_as_distinct_markdown_blocks()
+    {
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Revenue up 10%\nCosts flat\nHiring freeze"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // Paragraphs are joined with a blank line so they don't collapse into one rendered paragraph.
+        result.Markdown.ShouldContain("Revenue up 10%\n\nCosts flat");
+        result.Markdown.ShouldContain("Costs flat\n\nHiring freeze");
+    }
+
+    [Fact]
+    public async Task Does_not_use_an_axis_title_as_the_chart_caption()
+    {
+        // No chart title, but a value-axis title exists. The renderer must not promote the axis title.
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: new[] { "Q1", "Q2" },
+            Series: new[] { ("Revenue", (IReadOnlyList<string>)new[] { "10", "20" }) },
+            AxisTitle: "USD millions");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("| Q1 | 10 |");          // table still rendered
+        result.Markdown.ShouldNotContain("**USD millions**");  // axis title not used as the chart caption
+    }
+
+    [Fact]
+    public async Task Keeps_all_chart_points_when_idx_is_omitted()
+    {
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: new[] { "Jan", "Feb", "Mar" },
+            Series: new[] { ("Sales", (IReadOnlyList<string>)new[] { "7", "8", "9" }) },
+            OmitPointIdx: true);
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // The positional fallback keeps every point aligned even though no pt carries an idx attribute.
+        result.Markdown.ShouldContain("| Jan | 7 |");
+        result.Markdown.ShouldContain("| Feb | 8 |");
+        result.Markdown.ShouldContain("| Mar | 9 |");
+    }
+
+    [Fact]
+    public async Task Skips_a_mislabeled_image_whose_bytes_are_not_a_known_raster()
+    {
+        StubOcr("SHOULD_NOT_BE_CALLED");
+
+        // Declared image/png, but the bytes carry no PNG signature (corrupt / mislabeled part).
+        var bogus = new PptxFixtures.ImageSpec(new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 }, "image/png", null, 100, 1_000_000);
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Text("Body text").Image(bogus));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Body text");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("decoded");
+        // No OCR call wasted on garbage bytes.
+        await _ocr.DidNotReceive().RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Renders_title_placeholder_as_heading()
+    {
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Annual Report", isTitle: true, y: 100));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("## Annual Report");
+    }
+
+    [Fact]
+    public async Task Excludes_slide_number_field_from_the_body_text()
+    {
+        // A slide-number placeholder's cached value ("7") must not leak into the body Markdown — matching
+        // the exclusion the notes path already applies.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Real slide content")
+            .WithSlideNumberField("7"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Real slide content");
+        result.Markdown.ShouldNotContain("7");
+    }
+
+    [Fact]
+    public async Task Renders_a_multi_paragraph_title_as_a_single_clean_heading()
+    {
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Annual Report\n2024", isTitle: true, y: 100));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        // Paragraph breaks in a title collapse to a single space (no "## Annual Report  2024" double space).
+        result.Markdown.ShouldContain("## Annual Report 2024");
+        result.Markdown.ShouldNotContain("Annual Report  2024");
+    }
+
+    [Fact]
+    public async Task Includes_speaker_notes_when_enabled()
+    {
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Visible content")
+            .WithNotes("Remember to mention the Q3 numbers"));
+
+        var result = await CreateExtractor(includeNotes: true).ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("### Speaker notes");
+        result.Markdown.ShouldContain("Remember to mention the Q3 numbers");
+    }
+
+    [Fact]
+    public async Task Excludes_speaker_notes_by_default()
+    {
+        // The production default must NOT include notes (author-private content must not silently reach the
+        // egress); a host has to opt in. Construct with default options to assert the shipped default.
+        var extractor = new PptxExtractor(
+            _ocr,
+            Options.Create(new OpenXmlExtractorOptions()),
+            Options.Create(new DocumentAIOcrOptions { DefaultLanguageHints = new List<string>() }));
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Visible content")
+            .WithNotes("Internal-only speaker note"));
+
+        var result = await extractor.ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Visible content");
+        result.Markdown.ShouldNotContain("Speaker notes");
+        result.Markdown.ShouldNotContain("Internal-only speaker note");
+    }
+
+    [Fact]
+    public async Task Skips_an_oversized_image_and_marks_incomplete()
+    {
+        StubOcr("SHOULD_NOT_BE_CALLED");
+
+        // A valid PNG whose decompressed size exceeds a tiny per-image byte cap. It must be skipped before
+        // full materialization (the ZIP-decompression-bomb guard), not transcribed.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor(maxImageBytes: 50).ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Body text");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("size cap");
+        await _ocr.DidNotReceive().RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Excludes_speaker_notes_when_disabled()
+    {
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Visible content")
+            .WithNotes("Hidden author note"));
+
+        var result = await CreateExtractor(includeNotes: false).ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Visible content");
+        result.Markdown.ShouldNotContain("Speaker notes");
+        result.Markdown.ShouldNotContain("Hidden author note");
+    }
+
+    [Fact]
+    public async Task Orders_slides_in_presentation_order()
+    {
+        var pptx = PptxFixtures.Build(
+            new PptxFixtures.SlideSpec().Text("FIRST_SLIDE"),
+            new PptxFixtures.SlideSpec().Text("SECOND_SLIDE"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        var first = result.Markdown.IndexOf("FIRST_SLIDE", StringComparison.Ordinal);
+        var second = result.Markdown.IndexOf("SECOND_SLIDE", StringComparison.Ordinal);
+        first.ShouldBeGreaterThanOrEqualTo(0);
+        second.ShouldBeGreaterThan(first);
+    }
+
+    [Fact]
+    public async Task Returns_empty_and_incomplete_for_an_unopenable_file()
+    {
+        var notPptx = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("this is not a pptx"));
+
+        var result = await CreateExtractor().ExtractAsync(notPptx, PptxContext());
+
+        // No whole-page OCR fallback exists for PPTX, so an unopenable deck is reported as empty +
+        // incomplete (the honest #268 signal), not a silent empty success.
+        result.Markdown.ShouldBeNullOrEmpty();
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason.ShouldNotBeNullOrEmpty();
+        result.ProviderName.ShouldBe(PptxExtractor.ProviderIdentifier);
+        await _ocr.DidNotReceive().RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Transcribes_images_nested_inside_a_grouped_shape()
+    {
+        StubOcr("GROUPED_FIGURE_TEXT");
+
+        // The image lives inside a p:grpSp; the walker must recurse into the group to find it (#307 decision).
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Slide body")
+            .ImageInGroup(Png(alt: "Nested diagram", x: 100, y: 100)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("GROUPED_FIGURE_TEXT");
+        result.Markdown.ShouldContain("**Nested diagram**");
+        await _ocr.Received(1).RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Marks_incomplete_when_a_chart_cannot_be_rendered()
+    {
+        // A chart whose series carries no cached values (e.g. scatter-style data) yields no table; it is
+        // counted as lost via the completeness signal rather than silently dropped.
+        var chart = new PptxFixtures.ChartSpec(
+            Title: "Unsupported",
+            Categories: System.Array.Empty<string>(),
+            Series: new[] { ("S", (IReadOnlyList<string>)System.Array.Empty<string>()) });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Slide body")
+            .Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Slide body");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("chart");
+    }
+
+    [Fact]
+    public async Task Applies_default_language_hints_when_the_context_has_none()
+    {
+        StubOcr("FIGURE");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        var extractor = CreateExtractor(ocrOptions: new DocumentAIOcrOptions());
+        await extractor.ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        await _ocr.Received(1).RecognizeAsync(
+            Arg.Any<Stream>(),
+            Arg.Is<OcrOptions>(o => o.LanguageHints.Contains("ja") && o.LanguageHints.Contains("en")),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxFixtures.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxFixtures.cs
@@ -1,0 +1,401 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Builds minimal-but-valid PPTX packages in memory for the extractor tests. Slides are composed as
+/// hand-rolled DrawingML/PresentationML XML (the most direct way to control shape offsets, alt-text,
+/// placeholder types, embedded-image relationships, charts, tables, and notes) and attached to real
+/// <c>SlidePart</c>s via the OpenXML SDK so <c>PptxExtractor</c> parses exactly what a host would see.
+/// </summary>
+internal static class PptxFixtures
+{
+    private const string NsP = "http://schemas.openxmlformats.org/presentationml/2006/main";
+    private const string NsA = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    private const string NsR = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    private const string NsC = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    private const string ChartUri = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+    private const string TableUri = "http://schemas.openxmlformats.org/drawingml/2006/table";
+
+    /// <summary>A picture to embed: raster bytes, MIME type, optional alt-text, EMU offset, EMU display size.</summary>
+    public sealed record ImageSpec(
+        byte[] Bytes,
+        string ContentType,
+        string? AltText,
+        long OffsetX,
+        long OffsetY,
+        long ExtentCx = 914400,
+        long ExtentCy = 914400);
+
+    /// <summary>A text shape: the text, whether it is a title placeholder, and its EMU offset.</summary>
+    public sealed record TextSpec(string Text, bool IsTitle, long OffsetX, long OffsetY);
+
+    /// <summary>A chart: title + category labels + named series (each with values aligned to the categories).</summary>
+    public sealed record ChartSpec(
+        string? Title,
+        IReadOnlyList<string> Categories,
+        IReadOnlyList<(string Name, IReadOnlyList<string> Values)> Series,
+        long OffsetX = 100,
+        long OffsetY = 5_000_000,
+        // A value-axis title; used to verify ReadTitle ignores axis titles when the chart title is absent.
+        string? AxisTitle = null,
+        // When true, the cached c:pt elements omit their idx attribute (some generators do), to verify the
+        // positional fallback keeps every point.
+        bool OmitPointIdx = false,
+        // When set, the SECOND series emits these category labels instead of the shared ones — used to
+        // build a divergent-category-axis chart (different label at the same index) that must not render,
+        // or a union case (extra non-conflicting labels) that must.
+        IReadOnlyList<string>? SecondSeriesCategories = null,
+        // When true, the FIRST series omits its c:cat cache entirely (categories must seed from a later
+        // series instead of the first).
+        bool FirstSeriesOmitsCategories = false);
+
+    /// <summary>A native table: rows of cells (first row is the header), at an EMU offset.</summary>
+    public sealed record TableSpec(IReadOnlyList<IReadOnlyList<string>> Rows, long OffsetX = 100, long OffsetY = 6_000_000);
+
+    public sealed class SlideSpec
+    {
+        public List<TextSpec> Texts { get; } = new();
+        public List<ImageSpec> Images { get; } = new();
+        public List<ImageSpec> GroupedImages { get; } = new();
+        public List<ChartSpec> Charts { get; } = new();
+        public List<TableSpec> Tables { get; } = new();
+        public string? Notes { get; set; }
+
+        /// <summary>The cached display value of a slide-number placeholder field (p:ph type="sldNum" + a:fld), if any.</summary>
+        public string? SlideNumberFieldText { get; set; }
+
+        /// <summary>Adds a slide-number placeholder shape carrying a cached field value, to verify it is excluded from the text payload.</summary>
+        public SlideSpec WithSlideNumberField(string cachedValue)
+        {
+            SlideNumberFieldText = cachedValue;
+            return this;
+        }
+
+        /// <summary>Adds an image nested inside a grouped shape (p:grpSp), to exercise group recursion.</summary>
+        public SlideSpec ImageInGroup(ImageSpec image)
+        {
+            GroupedImages.Add(image);
+            return this;
+        }
+
+        public List<(string Line1, string Line2, long X, long Y)> SoftBreakTexts { get; } = new();
+
+        public SlideSpec Text(string text, bool isTitle = false, long x = 100, long y = 100)
+        {
+            Texts.Add(new TextSpec(text, isTitle, x, y));
+            return this;
+        }
+
+        /// <summary>Adds a text shape whose single paragraph contains an a:br soft line break between the two runs.</summary>
+        public SlideSpec TextWithSoftBreak(string line1, string line2, long x = 100, long y = 100)
+        {
+            SoftBreakTexts.Add((line1, line2, x, y));
+            return this;
+        }
+
+        public SlideSpec Image(ImageSpec image)
+        {
+            Images.Add(image);
+            return this;
+        }
+
+        public SlideSpec Chart(ChartSpec chart)
+        {
+            Charts.Add(chart);
+            return this;
+        }
+
+        public SlideSpec Table(TableSpec table)
+        {
+            Tables.Add(table);
+            return this;
+        }
+
+        public SlideSpec WithNotes(string notes)
+        {
+            Notes = notes;
+            return this;
+        }
+    }
+
+    public static byte[] Build(params SlideSpec[] slides)
+    {
+        using var stream = new MemoryStream();
+        using (var document = PresentationDocument.Create(stream, PresentationDocumentType.Presentation))
+        {
+            var presentationPart = document.AddPresentationPart();
+            var slideIdList = new SlideIdList();
+
+            uint slideId = 256;
+            var index = 0;
+            foreach (var slide in slides)
+            {
+                var relId = $"rIdSlide{index}";
+                var slidePart = presentationPart.AddNewPart<SlidePart>(relId);
+                PopulateSlide(slidePart, slide, index);
+
+                slideIdList.Append(new SlideId { Id = slideId++, RelationshipId = relId });
+                index++;
+            }
+
+            presentationPart.Presentation = new Presentation(slideIdList);
+            presentationPart.Presentation.Save();
+        }
+
+        return stream.ToArray();
+    }
+
+    private static void PopulateSlide(SlidePart slidePart, SlideSpec slide, int slideIndex)
+    {
+        var shapes = new StringBuilder();
+        var shapeId = 2u;
+
+        foreach (var text in slide.Texts)
+        {
+            shapes.Append(TextShapeXml(shapeId++, text));
+        }
+
+        foreach (var (line1, line2, x, y) in slide.SoftBreakTexts)
+        {
+            shapes.Append(SoftBreakShapeXml(shapeId++, line1, line2, x, y));
+        }
+
+        var imageRel = 0;
+        foreach (var image in slide.Images)
+        {
+            var relId = $"rIdImg{slideIndex}_{imageRel++}";
+            var imagePart = slidePart.AddNewPart<ImagePart>(image.ContentType, relId);
+            using (var s = imagePart.GetStream(FileMode.Create, FileAccess.Write))
+            {
+                s.Write(image.Bytes, 0, image.Bytes.Length);
+            }
+
+            shapes.Append(PictureXml(shapeId++, image, relId));
+        }
+
+        var chartRel = 0;
+        foreach (var chart in slide.Charts)
+        {
+            var relId = $"rIdChart{slideIndex}_{chartRel++}";
+            var chartPart = slidePart.AddNewPart<ChartPart>(relId);
+            chartPart.ChartSpace = new C.ChartSpace(ChartSpaceXml(chart));
+            shapes.Append(ChartFrameXml(shapeId++, chart, relId));
+        }
+
+        foreach (var table in slide.Tables)
+        {
+            shapes.Append(TableFrameXml(shapeId++, table));
+        }
+
+        if (slide.SlideNumberFieldText is { Length: > 0 } slideNumber)
+        {
+            shapes.Append(SlideNumberFieldXml(shapeId++, slideNumber));
+        }
+
+        if (slide.GroupedImages.Count > 0)
+        {
+            var groupShapes = new StringBuilder();
+            foreach (var image in slide.GroupedImages)
+            {
+                var relId = $"rIdGrpImg{slideIndex}_{imageRel++}";
+                var imagePart = slidePart.AddNewPart<ImagePart>(image.ContentType, relId);
+                using (var s = imagePart.GetStream(FileMode.Create, FileAccess.Write))
+                {
+                    s.Write(image.Bytes, 0, image.Bytes.Length);
+                }
+
+                groupShapes.Append(PictureXml(shapeId++, image, relId));
+            }
+
+            shapes.Append(GroupXml(shapeId++, groupShapes.ToString()));
+        }
+
+        slidePart.Slide = new Slide(SlideXml(shapes.ToString()));
+
+        if (slide.Notes is { Length: > 0 })
+        {
+            var notesPart = slidePart.AddNewPart<NotesSlidePart>($"rIdNotes{slideIndex}");
+            notesPart.NotesSlide = new NotesSlide(NotesXml(slide.Notes));
+        }
+    }
+
+    private static string SlideXml(string shapes) =>
+        $"""
+         <p:sld xmlns:p="{NsP}" xmlns:a="{NsA}" xmlns:r="{NsR}">
+           <p:cSld><p:spTree>
+             <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+             <p:grpSpPr/>
+             {shapes}
+           </p:spTree></p:cSld>
+         </p:sld>
+         """;
+
+    private static string GroupXml(uint id, string childShapes) =>
+        $"""
+         <p:grpSp>
+           <p:nvGrpSpPr><p:cNvPr id="{id}" name="Group{id}"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+           <p:grpSpPr><a:xfrm>
+             <a:off x="500000" y="500000"/><a:ext cx="3000000" cy="3000000"/>
+             <a:chOff x="0" y="0"/><a:chExt cx="3000000" cy="3000000"/>
+           </a:xfrm></p:grpSpPr>
+           {childShapes}
+         </p:grpSp>
+         """;
+
+    private static string TextShapeXml(uint id, TextSpec text)
+    {
+        var placeholder = text.IsTitle ? "<p:ph type=\"title\"/>" : string.Empty;
+        var paragraphs = string.Concat(text.Text.Split('\n').Select(line =>
+            $"<a:p><a:r><a:t>{Escape(line)}</a:t></a:r></a:p>"));
+        return $"""
+                <p:sp>
+                  <p:nvSpPr><p:cNvPr id="{id}" name="Text{id}"/><p:cNvSpPr/><p:nvPr>{placeholder}</p:nvPr></p:nvSpPr>
+                  <p:spPr><a:xfrm><a:off x="{text.OffsetX}" y="{text.OffsetY}"/><a:ext cx="3000000" cy="500000"/></a:xfrm></p:spPr>
+                  <p:txBody><a:bodyPr/><a:lstStyle/>{paragraphs}</p:txBody>
+                </p:sp>
+                """;
+    }
+
+    private static string SlideNumberFieldXml(uint id, string cachedValue) =>
+        $"""
+         <p:sp>
+           <p:nvSpPr><p:cNvPr id="{id}" name="Slide Number Placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="sldNum" idx="10"/></p:nvPr></p:nvSpPr>
+           <p:spPr><a:xfrm><a:off x="8000000" y="6500000"/><a:ext cx="1000000" cy="300000"/></a:xfrm></p:spPr>
+           <p:txBody><a:bodyPr/><a:lstStyle/>
+             <a:p><a:fld id="slidenum1" type="slidenum"><a:t>{Escape(cachedValue)}</a:t></a:fld></a:p>
+           </p:txBody>
+         </p:sp>
+         """;
+
+    private static string SoftBreakShapeXml(uint id, string line1, string line2, long x, long y) =>
+        $"""
+         <p:sp>
+           <p:nvSpPr><p:cNvPr id="{id}" name="Break{id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+           <p:spPr><a:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="3000000" cy="500000"/></a:xfrm></p:spPr>
+           <p:txBody><a:bodyPr/><a:lstStyle/>
+             <a:p><a:r><a:t>{Escape(line1)}</a:t></a:r><a:br/><a:r><a:t>{Escape(line2)}</a:t></a:r></a:p>
+           </p:txBody>
+         </p:sp>
+         """;
+
+    private static string PictureXml(uint id, ImageSpec image, string relId)
+    {
+        var descr = image.AltText is { Length: > 0 } ? $" descr=\"{Escape(image.AltText)}\"" : string.Empty;
+        return $"""
+                <p:pic>
+                  <p:nvPicPr><p:cNvPr id="{id}" name="Pic{id}"{descr}/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+                  <p:blipFill><a:blip r:embed="{relId}"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+                  <p:spPr><a:xfrm><a:off x="{image.OffsetX}" y="{image.OffsetY}"/><a:ext cx="{image.ExtentCx}" cy="{image.ExtentCy}"/></a:xfrm></p:spPr>
+                </p:pic>
+                """;
+    }
+
+    private static string ChartFrameXml(uint id, ChartSpec chart, string relId) =>
+        $"""
+         <p:graphicFrame>
+           <p:nvGraphicFramePr><p:cNvPr id="{id}" name="Chart{id}"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>
+           <p:xfrm><a:off x="{chart.OffsetX}" y="{chart.OffsetY}"/><a:ext cx="4000000" cy="3000000"/></p:xfrm>
+           <a:graphic><a:graphicData uri="{ChartUri}">
+             <c:chart xmlns:c="{NsC}" xmlns:r="{NsR}" r:id="{relId}"/>
+           </a:graphicData></a:graphic>
+         </p:graphicFrame>
+         """;
+
+    private static string TableFrameXml(uint id, TableSpec table)
+    {
+        var columns = table.Rows.Count == 0 ? 0 : table.Rows.Max(r => r.Count);
+        var grid = string.Concat(Enumerable.Repeat("<a:gridCol w=\"1000000\"/>", columns));
+        var rows = string.Concat(table.Rows.Select(row =>
+        {
+            var cells = string.Concat(row.Select(cell =>
+                $"<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(cell)}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"));
+            return $"<a:tr h=\"370000\">{cells}</a:tr>";
+        }));
+
+        return $"""
+                <p:graphicFrame>
+                  <p:nvGraphicFramePr><p:cNvPr id="{id}" name="Table{id}"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>
+                  <p:xfrm><a:off x="{table.OffsetX}" y="{table.OffsetY}"/><a:ext cx="4000000" cy="2000000"/></p:xfrm>
+                  <a:graphic><a:graphicData uri="{TableUri}">
+                    <a:tbl><a:tblPr/><a:tblGrid>{grid}</a:tblGrid>{rows}</a:tbl>
+                  </a:graphicData></a:graphic>
+                </p:graphicFrame>
+                """;
+    }
+
+    private static string ChartSpaceXml(ChartSpec chart)
+    {
+        var title = chart.Title is { Length: > 0 }
+            ? $"<c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(chart.Title)}</a:t></a:r></a:p></c:rich></c:tx></c:title>"
+            : string.Empty;
+
+        string Idx(int i) => chart.OmitPointIdx ? string.Empty : $" idx=\"{i}\"";
+
+        string CategoryCache(IReadOnlyList<string> cats)
+        {
+            var points = string.Concat(cats.Select((cat, i) => $"<c:pt{Idx(i)}><c:v>{Escape(cat)}</c:v></c:pt>"));
+            return $"<c:cat><c:strRef><c:f>cats</c:f><c:strCache><c:ptCount val=\"{cats.Count}\"/>{points}</c:strCache></c:strRef></c:cat>";
+        }
+
+        var seriesXml = string.Concat(chart.Series.Select((ser, si) =>
+        {
+            var valuePoints = string.Concat(ser.Values.Select((v, i) =>
+                $"<c:pt{Idx(i)}><c:v>{Escape(v)}</c:v></c:pt>"));
+            var cats = si == 1 && chart.SecondSeriesCategories is not null ? chart.SecondSeriesCategories : chart.Categories;
+            // The first series can be made to omit its category cache so seeding falls to a later series.
+            var catXml = si == 0 && chart.FirstSeriesOmitsCategories ? string.Empty : CategoryCache(cats);
+            return $"""
+                    <c:ser>
+                      <c:idx val="{si}"/><c:order val="{si}"/>
+                      <c:tx><c:strRef><c:f>name</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>{Escape(ser.Name)}</c:v></c:pt></c:strCache></c:strRef></c:tx>
+                      {catXml}
+                      <c:val><c:numRef><c:f>vals</c:f><c:numCache><c:formatCode>General</c:formatCode><c:ptCount val="{ser.Values.Count}"/>{valuePoints}</c:numCache></c:numRef></c:val>
+                    </c:ser>
+                    """;
+        }));
+
+        // A value axis carrying its own title — used to verify the chart title reader does NOT pick it up.
+        var valueAxis = chart.AxisTitle is { Length: > 0 }
+            ? $"<c:valAx><c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(chart.AxisTitle)}</a:t></a:r></a:p></c:rich></c:tx></c:title></c:valAx>"
+            : string.Empty;
+
+        return $"""
+                <c:chartSpace xmlns:c="{NsC}" xmlns:a="{NsA}" xmlns:r="{NsR}">
+                  <c:chart>
+                    {title}
+                    <c:plotArea><c:layout/><c:barChart><c:barDir val="col"/>{seriesXml}</c:barChart>{valueAxis}</c:plotArea>
+                  </c:chart>
+                </c:chartSpace>
+                """;
+    }
+
+    private static string NotesXml(string notes)
+    {
+        var paragraphs = string.Concat(notes.Split('\n').Select(line =>
+            $"<a:p><a:r><a:t>{Escape(line)}</a:t></a:r></a:p>"));
+        return $"""
+                <p:notes xmlns:p="{NsP}" xmlns:a="{NsA}" xmlns:r="{NsR}">
+                  <p:cSld><p:spTree>
+                    <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+                    <p:grpSpPr/>
+                    <p:sp>
+                      <p:nvSpPr><p:cNvPr id="2" name="Notes Placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>
+                      <p:spPr/>
+                      <p:txBody><a:bodyPr/><a:lstStyle/>{paragraphs}</p:txBody>
+                    </p:sp>
+                  </p:spTree></p:cSld>
+                </p:notes>
+                """;
+    }
+
+    private static string Escape(string text) => new System.Xml.Linq.XText(text).ToString();
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxIncompleteReason_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/PptxIncompleteReason_Tests.cs
@@ -1,0 +1,44 @@
+using Shouldly;
+using Xunit;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Unit tests for the single source of truth of the #268 completeness signal: the reason string is null
+/// iff nothing was lost, and lists every loss cause that occurred. Guards against a new counter drifting
+/// out of sync with a separate boolean predicate.
+/// </summary>
+public class PptxIncompleteReason_Tests
+{
+    [Fact]
+    public void Null_when_nothing_was_lost()
+    {
+        PptxExtractor.BuildIncompleteReason(0, 0, 0, 0, 0, 0, 0).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Describes_each_loss_cause_that_occurred()
+    {
+        var reason = PptxExtractor.BuildIncompleteReason(
+            failedSlides: 1, droppedByCap: 2, undecodable: 3, oversizedImages: 7,
+            truncatedOcr: 4, failedFigureOcr: 5, chartFailures: 6);
+
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("1 slide");
+        reason.ShouldContain("3 embedded image");   // undecodable
+        reason.ShouldContain("7 embedded image");   // oversized
+        reason.ShouldContain("size cap");
+        reason.ShouldContain("5 embedded image");   // failed OCR
+        reason.ShouldContain("4 image transcription");
+        reason.ShouldContain("6 chart");
+        reason.ShouldContain("2 image");            // cap
+        reason.ShouldEndWith(".");
+    }
+
+    [Fact]
+    public void Single_cause_reads_cleanly()
+    {
+        PptxExtractor.BuildIncompleteReason(0, 0, 1, 0, 0, 0, 0)
+            .ShouldBe("1 embedded image(s) could not be decoded to a supported raster format (e.g. EMF/WMF vector).");
+    }
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/TinyPng.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.OpenXml.Tests/TinyPng.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Dignite.DocumentAI.TextExtraction.OpenXml;
+
+/// <summary>
+/// Minimal pure-managed encoder for a solid-color 8-bit RGB PNG. Used to embed valid raster images into
+/// test PPTX fixtures without pulling SkiaSharp / any native image dependency into the test project.
+/// </summary>
+internal static class TinyPng
+{
+    public static byte[] CreateSolid(int width, int height, byte r = 0x20, byte g = 0x60, byte b = 0xA0)
+    {
+        // Raw scanlines: each row is a filter byte (0 = None) followed by width*3 RGB samples.
+        var raw = new byte[height * (1 + (width * 3))];
+        var p = 0;
+        for (var y = 0; y < height; y++)
+        {
+            raw[p++] = 0;
+            for (var x = 0; x < width; x++)
+            {
+                raw[p++] = r;
+                raw[p++] = g;
+                raw[p++] = b;
+            }
+        }
+
+        byte[] idat;
+        using (var compressed = new MemoryStream())
+        {
+            using (var zlib = new ZLibStream(compressed, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                zlib.Write(raw, 0, raw.Length);
+            }
+
+            idat = compressed.ToArray();
+        }
+
+        using var output = new MemoryStream();
+        output.Write(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A });
+
+        var ihdr = new byte[13];
+        WriteBigEndian(ihdr, 0, width);
+        WriteBigEndian(ihdr, 4, height);
+        ihdr[8] = 8;  // bit depth
+        ihdr[9] = 2;  // color type: truecolor RGB
+        ihdr[10] = 0; // compression
+        ihdr[11] = 0; // filter
+        ihdr[12] = 0; // interlace
+        WriteChunk(output, "IHDR", ihdr);
+        WriteChunk(output, "IDAT", idat);
+        WriteChunk(output, "IEND", Array.Empty<byte>());
+
+        return output.ToArray();
+    }
+
+    private static void WriteBigEndian(byte[] buffer, int offset, int value)
+    {
+        buffer[offset] = (byte)((value >> 24) & 0xFF);
+        buffer[offset + 1] = (byte)((value >> 16) & 0xFF);
+        buffer[offset + 2] = (byte)((value >> 8) & 0xFF);
+        buffer[offset + 3] = (byte)(value & 0xFF);
+    }
+
+    private static void WriteChunk(Stream stream, string type, byte[] data)
+    {
+        var length = new byte[4];
+        WriteBigEndian(length, 0, data.Length);
+        stream.Write(length);
+
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        stream.Write(typeBytes);
+        stream.Write(data);
+
+        var crc = new byte[4];
+        WriteBigEndian(crc, 0, unchecked((int)Crc32(typeBytes, data)));
+        stream.Write(crc);
+    }
+
+    private static readonly uint[] CrcTable = BuildCrcTable();
+
+    private static uint[] BuildCrcTable()
+    {
+        var table = new uint[256];
+        for (uint n = 0; n < 256; n++)
+        {
+            var c = n;
+            for (var k = 0; k < 8; k++)
+            {
+                c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
+            }
+
+            table[n] = c;
+        }
+
+        return table;
+    }
+
+    private static uint Crc32(byte[] type, byte[] data)
+    {
+        var c = 0xFFFFFFFFu;
+        foreach (var b in type)
+        {
+            c = CrcTable[(c ^ b) & 0xFF] ^ (c >> 8);
+        }
+
+        foreach (var b in data)
+        {
+            c = CrcTable[(c ^ b) & 0xFF] ^ (c >> 8);
+        }
+
+        return c ^ 0xFFFFFFFFu;
+    }
+}

--- a/host/src/Dignite.DocumentAI.Host.csproj
+++ b/host/src/Dignite.DocumentAI.Host.csproj
@@ -95,6 +95,11 @@
          host-selected IOcrProvider (#301). Coexists with ElBruno; claims .pdf. Omit it and .pdf falls
          back to ElBruno. -->
     <ProjectReference Include="..\..\core\src\Dignite.DocumentAI.TextExtraction.Pdf\Dignite.DocumentAI.TextExtraction.Pdf.csproj" />
+    <!-- OpenXML Markdown provider: PPTX slide text / charts / tables / speaker notes + embedded-image
+         transcription via the host-selected IOcrProvider (#307). Claims .pptx. REQUIRED for .pptx text:
+         ElBruno (catch-all) has no PresentationML converter, so without this module .pptx yields empty
+         Markdown (no OCR fallback). Shared stack for the later DOCX phase (#308). -->
+    <ProjectReference Include="..\..\core\src\Dignite.DocumentAI.TextExtraction.OpenXml\Dignite.DocumentAI.TextExtraction.OpenXml.csproj" />
     <ProjectReference Include="..\..\core\src\Dignite.DocumentAI.TextExtraction.ElBrunoMarkItDown\Dignite.DocumentAI.TextExtraction.ElBrunoMarkItDown.csproj" />
     <!-- OCR provider — IOcrProvider implementations are mutually exclusive; enable only one.
          Current default: VisionLlm (photos / thermal receipts / image-only PDFs, #259).

--- a/host/src/DocumentAIHostModule.cs
+++ b/host/src/DocumentAIHostModule.cs
@@ -9,6 +9,7 @@ using Dignite.DocumentAI.Localization;
 using Dignite.DocumentAI.Ocr.VisionLlm;
 using Dignite.DocumentAI.TextExtraction;
 using Dignite.DocumentAI.TextExtraction.ElBrunoMarkItDown;
+using Dignite.DocumentAI.TextExtraction.OpenXml;
 using Dignite.DocumentAI.TextExtraction.Pdf;
 using Microsoft.Extensions.AI;
 using Microsoft.EntityFrameworkCore;
@@ -141,6 +142,7 @@ namespace Dignite.DocumentAI.Host;
     // DocumentAI infrastructure modules
     typeof(DocumentAITextExtractionModule),
     typeof(DocumentAITextExtractionPdfModule),             // PdfPig: digital-PDF text layer + embedded-image transcription (#301). Claims .pdf; coexists with ElBruno (catch-all). Omitting it makes .pdf fall back to ElBruno.
+    typeof(DocumentAITextExtractionOpenXmlModule),         // OpenXML: PPTX slide text/charts/tables/notes + embedded-image transcription (#307). Claims .pptx. REQUIRED for .pptx text: ElBruno (catch-all) has no PresentationML converter, so omitting this module makes .pptx yield empty Markdown (no OCR fallback, .pptx != .pdf).
     typeof(DocumentAITextExtractionElBrunoMarkItDownModule),
     typeof(DocumentAIVisionLlmOcrModule)                  // Vision-LLM OCR for photos, receipts, and image PDFs; current default OCR provider (#259). IOcrProvider implementations are mutually exclusive: when switching providers, update the .csproj ProjectReference and ConfigureAI keyed vision IChatClient together. See docs/ocr-vision-llm.md.
     // typeof(DocumentAIPaddleOcrModule),                 // Local PaddleOCR sidecar (free CPU, PP-StructureV3); to switch back, uncomment this, comment VisionLlm, and restore its .csproj ProjectReference

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -66,6 +66,12 @@
     "ModelName": "PP-StructureV3",
     "Languages": [ "ja", "en" ]
   },
+  "OpenXmlExtractor": {
+    "MaxImagesPerFile": 50,
+    "MinImagePixels": 4096,
+    "MaxImageBytesPerImage": 16777216,
+    "IncludeSpeakerNotes": false
+  },
   "AuthServer": {
     "Authority": "https://localhost:44348",
     "RequireHttpsMetadata": true,


### PR DESCRIPTION
## What & why

Phase 2 of #299 (after PDF #301): stop silently dropping PPTX content. A new coexisting `IMarkdownTextProvider` (`PptxExtractor`, claims `.pptx`) in a shared `…TextExtraction.OpenXml` module owns the full deck parse — slide text (titles as headings), embedded raster images, charts, native tables, and (opt-in) speaker notes — inlined into `Document.Markdown` at slide/shape reading order. **Same inline-only mechanism as #301: `TextExtractionResult` is unchanged** (no `Figures` field — that's #306).

> ⚠️ ElBruno does **not** support `.pptx`, so this module is **required** for any `.pptx` text (it does not "gracefully fall back").

## Capability

- **Embedded raster images → host-selected `IOcrProvider` only** (no keyed Vision `IChatClient`, no new LLM call site, no `PromptBoundary` concern); native alt-text (`cNvPr/@descr`) as the figure caption.
- **`ChartPart` backing data → Markdown table** (pure structured, no OCR/vision/LLM); a divergent category axis (same index, different non-blank labels) is dropped + marked incomplete rather than rendering misaligned data.
- **Native `a:tbl` tables** and **recursed grouped shapes**; EMF/WMF vector + SmartArt/OLE are accepted blind spots.
- **#268 completeness signal** trips on dropped/undecodable/oversized images, truncated figure OCR, image-cap hits, chart failures, per-slide parse loss.

## Security / resilience (from review)

- **Speaker notes default OFF** — author-private content must not silently reach the egress; host opts in via `OpenXmlExtractor:IncludeSpeakerNotes`.
- **Per-image 16 MiB byte cap** with a bounded, abort-on-overflow read so a ZIP-decompression-bomb image part can never OOM the worker; oversized → skipped + incomplete.
- **Media type from the bytes' own signature**, not the declared content type (mislabeled/corrupt parts → undecodable, no wasted OCR call).
- **Slide-number/date placeholder fields excluded** from the text payload.

## Shared refactors

- New **`ImageSignature`** (Ocr contract layer): single magic-byte detector consolidating the former per-provider sniffers (VisionLlm / Pdf / Pptx), zero-alloc `ReadOnlySpan` signatures.
- **`TextExtractionStreams`**: shared `ReadAllBytesAsync` + bounded read (DOCX #308 reuse).

## Wiring

Host `[DependsOn]` + `ProjectReference`; `DocumentFormat.OpenXml` 3.3.0 pinned to ElBruno's transitive version; `appsettings` `OpenXmlExtractor` section; `slnx`.

## Tests

44 OpenXml unit tests (in-code pptx fixtures, NSubstitute `IOcrProvider`) + `ImageSignature` tests. Pdf (31) and VisionLlm (35) unaffected. Full solution builds clean.

## Review trail

5 rounds of `/code-review` + 2 Codex adversarial passes; findings fixed and verified (notes-default, byte-cap, signature consolidation, chart category union/conflict, escaping, etc.).

## Follow-ups (tracked, out of scope here)

- #313 — reading-order (group/layout-inherited offsets) + chart fidelity (multi-level categories / merged cells / combo-chart long table)
- #306 — sub-document routing + `Figures` out-of-band signal
- #308 — DOCX; will share `MarkdownCell` / image sniff+cap+outcome / a `BuildIncompleteReason` accumulator (deferred until a second consumer exists)

Closes #307.
