### PR TITLE
docs: flag Azure Document Intelligence OCR provider as awaiting real-world validation (#327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Document AI ships three OCR providers; the host enables exactly one (`[DependsOn
 
 * **Vision LLM** — the host's current default (#259). Sends images / rasterized PDF pages to a vision-capable `IChatClient` model; the strongest option for phone photos, thermal receipts, and image-only PDFs. No sidecar — only a vision model id. See [docs/ocr-vision-llm.md](./docs/ocr-vision-llm.md).
 * **PaddleOCR** — local Docker sidecar (PP-StructureV3, CPU); data never leaves the network. See [docs/ocr-paddleocr.md](./docs/ocr-paddleocr.md).
-* **Azure Document Intelligence** — cloud option (`prebuilt-layout`, high accuracy) when data is allowed to leave the network. See [docs/ocr-azure-document-intelligence.md](./docs/ocr-azure-document-intelligence.md).
+* **Azure Document Intelligence** — cloud option (`prebuilt-layout`, high accuracy) when data is allowed to leave the network. See [docs/ocr-azure-document-intelligence.md](./docs/ocr-azure-document-intelligence.md). **Not yet validated against a live Azure resource — community testing welcome ([#327](https://github.com/dignite-projects/document-ai/issues/327)).**
 
 Full selection guidance, configuration, and resource footprint: see [docs/text-extraction.md](./docs/text-extraction.md).
 

--- a/docs/ocr-azure-document-intelligence.md
+++ b/docs/ocr-azure-document-intelligence.md
@@ -2,6 +2,8 @@
 
 > One of Document AI's OCR providers. Overview & comparison: [text-extraction.md](text-extraction.md).
 
+> 🧪 **Status: awaiting real-world validation.** The provider is implemented and unit-tested (at the mocked SDK boundary), but has not yet been run against a live Azure Document Intelligence resource. If you use Azure DI, testing and feedback are very welcome — see [#327](https://github.com/dignite-projects/document-ai/issues/327).
+
 Recommended for production workloads where data is allowed to leave the network and the team prefers not to operate a sidecar.
 
 1. Create an Azure AI Document Intelligence resource (F0 for trial, S0 for production).

--- a/docs/ocr-azure-document-intelligence.md
+++ b/docs/ocr-azure-document-intelligence.md
@@ -8,7 +8,7 @@ Recommended for production workloads where data is allowed to leave the network 
 
 1. Create an Azure AI Document Intelligence resource (F0 for trial, S0 for production).
 2. Copy the **Endpoint** and **API Key**.
-3. In `host/src/DocumentAIHostModule.cs`, swap `DocumentAIPaddleOcrModule` for `DocumentAIAzureDocumentIntelligenceModule`. Re-enable the matching `ProjectReference` in `host/src/Dignite.DocumentAI.Host.csproj`.
+3. In `host/src/DocumentAIHostModule.cs`, swap `DocumentAIVisionLlmOcrModule` (the current default) for `DocumentAIAzureDocumentIntelligenceModule`, and re-enable the matching `ProjectReference` in `host/src/Dignite.DocumentAI.Host.csproj`. You can also drop the Vision-LLM vision `IChatClient` block in `ConfigureAI` — it fail-fasts on `DocumentAI:VisionOcrModelId`.
 4. Add to `host/src/appsettings.Development.json` (or `appsettings.Production.json`):
 
 ```json


### PR DESCRIPTION
Adds pointers from the README OCR-provider list and the dedicated Azure DI doc to #327 (community testing against a live Azure resource), and corrects the doc switch instructions to reference the current default provider.

- README + Azure DI doc: link to #327, mark the provider as awaiting real-world validation
- Azure DI doc: swap instruction now points at `Dignite.ExtractVisionLlmOcrModule` (the current default since #259), with a note to drop the `ConfigureAI` vision `IChatClient` block (it fail-fasts on `Dignite.Extract:VisionOcrModelId`)