### PR TITLE
Split Dignite Extract overview and document list routes

### DIFF
--- a/angular/packages/document-ai/config/src/providers/documents.provider.ts
+++ b/angular/packages/document-ai/config/src/providers/documents.provider.ts
@@ -21,7 +21,7 @@ export function provideDocuments(): EnvironmentProviders {
           layout: eLayoutType.application,
         },
         {
-          path: '/documents',
+          path: '/documents/list',
           name: '::Menu:DocumentList',
           iconClass: 'fas fa-list',
           parentName: '::Menu:Documents',
@@ -39,21 +39,12 @@ export function provideDocuments(): EnvironmentProviders {
           layout: eLayoutType.application,
         },
         {
-          path: '/documents/upload',
-          name: '::Menu:UploadDocument',
-          iconClass: 'fas fa-upload',
-          parentName: '::Menu:Documents',
-          requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Upload,
-          order: 3,
-          layout: eLayoutType.application,
-        },
-        {
           path: '/documents/types',
           name: '::Menu:DocumentTypes',
           iconClass: 'fas fa-tags',
           parentName: '::Menu:Documents',
           requiredPolicy: DOCUMENT_AI_PERMISSIONS.DocumentTypes.Default,
-          order: 4,
+          order: 3,
           layout: eLayoutType.application,
         },
         {
@@ -62,7 +53,7 @@ export function provideDocuments(): EnvironmentProviders {
           iconClass: 'fas fa-file-export',
           parentName: '::Menu:Documents',
           requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Templates.Default,
-          order: 5,
+          order: 4,
           layout: eLayoutType.application,
         },
         {
@@ -71,7 +62,7 @@ export function provideDocuments(): EnvironmentProviders {
           iconClass: 'fas fa-folder',
           parentName: '::Menu:Documents',
           requiredPolicy: DOCUMENT_AI_PERMISSIONS.Cabinets.Default,
-          order: 6,
+          order: 5,
           layout: eLayoutType.application,
         },
         {
@@ -80,7 +71,7 @@ export function provideDocuments(): EnvironmentProviders {
           iconClass: 'fas fa-trash-can',
           parentName: '::Menu:Documents',
           requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Restore,
-          order: 7,
+          order: 6,
           layout: eLayoutType.application,
         },
       ]);

--- a/angular/packages/document-ai/documents/src/lib/documents.routes.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents.routes.ts
@@ -8,14 +8,19 @@ export const DOCUMENTS_ROUTES: Routes = [
     canActivate: [authGuard, permissionGuard],
     data: { requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Default },
     loadComponent: () =>
+      import('./documents/document-home/document-home.component').then(c => c.DocumentHomeComponent),
+  },
+  {
+    path: 'list',
+    canActivate: [authGuard, permissionGuard],
+    data: { requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Default },
+    loadComponent: () =>
       import('./documents/document-list/document-list.component').then(c => c.DocumentListComponent),
   },
   {
     path: 'upload',
-    canActivate: [authGuard, permissionGuard],
-    data: { requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Upload },
-    loadComponent: () =>
-      import('./documents/document-upload/document-upload.component').then(c => c.DocumentUploadComponent),
+    pathMatch: 'full',
+    redirectTo: '',
   },
   {
     path: 'recycle',

--- a/angular/packages/document-ai/documents/src/lib/documents/document-detail/document-detail.component.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-detail/document-detail.component.ts
@@ -483,7 +483,7 @@ export class DocumentDetailComponent implements OnInit {
   }
 
   goBack(): void {
-    this.router.navigate(['/documents']);
+    this.router.navigate(['/documents/list']);
   }
 
   delete(): void {
@@ -499,7 +499,7 @@ export class DocumentDetailComponent implements OnInit {
           .subscribe({
           next: () => {
             this.toaster.success('::Document:DeletedSuccessfully', '::Success');
-            this.router.navigate(['/documents']);
+            this.router.navigate(['/documents/list']);
           },
         });
       });

--- a/angular/packages/document-ai/documents/src/lib/documents/document-home/document-home.component.html
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-home/document-home.component.html
@@ -1,0 +1,47 @@
+<div class="document-home">
+  <div class="document-home-header container-fluid py-4 pb-0">
+    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3">
+      <div>
+        <h4 class="mb-1">
+          <i class="fas fa-file-alt me-2"></i>
+          Dignite Document AI
+        </h4>
+        <p class="text-muted mb-0">
+          Upload document content and turn it into Markdown, metadata, and type-bound fields for downstream consumers.
+        </p>
+      </div>
+      <div class="d-flex flex-wrap gap-2">
+        <a class="btn btn-outline-secondary" routerLink="/documents/list">
+          <i class="fas fa-list me-1"></i>
+          {{ '::Menu:DocumentList' | abpLocalization }}
+        </a>
+        @if (canReview) {
+          <a class="btn btn-outline-warning" routerLink="/documents/review">
+            <i class="fas fa-clipboard-check me-1"></i>
+            {{ '::Menu:DocumentReviewQueue' | abpLocalization }}
+          </a>
+        }
+      </div>
+    </div>
+  </div>
+
+  @if (canUpload) {
+    <lib-document-upload />
+  } @else {
+    <div class="container py-4">
+      <div class="card shadow-sm">
+        <div class="card-body text-center py-5">
+          <i class="fas fa-lock fa-2x text-muted mb-3 d-block"></i>
+          <h5 class="mb-2">{{ '::Document:Documents' | abpLocalization }}</h5>
+          <p class="text-muted mb-3">
+            You can browse documents, but this account is not allowed to upload new files.
+          </p>
+          <a class="btn btn-primary" routerLink="/documents/list">
+            <i class="fas fa-list me-1"></i>
+            {{ '::Menu:DocumentList' | abpLocalization }}
+          </a>
+        </div>
+      </div>
+    </div>
+  }
+</div>

--- a/angular/packages/document-ai/documents/src/lib/documents/document-home/document-home.component.scss
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-home/document-home.component.scss
@@ -1,0 +1,3 @@
+.document-home-header {
+  max-width: 1320px;
+}

--- a/angular/packages/document-ai/documents/src/lib/documents/document-home/document-home.component.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-home/document-home.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { LocalizationPipe, PermissionService } from '@abp/ng.core';
+import { DOCUMENT_AI_PERMISSIONS } from '@dignite/document-ai';
+import { DocumentUploadComponent } from '../document-upload/document-upload.component';
+
+@Component({
+  selector: 'lib-document-home',
+  templateUrl: './document-home.component.html',
+  styleUrls: ['./document-home.component.scss'],
+  imports: [CommonModule, RouterModule, LocalizationPipe, DocumentUploadComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocumentHomeComponent {
+  private readonly permissionService = inject(PermissionService);
+
+  readonly canUpload = this.permissionService.getGrantedPolicy(
+    DOCUMENT_AI_PERMISSIONS.Documents.Upload,
+  );
+  readonly canReview = this.permissionService.getGrantedPolicy(
+    DOCUMENT_AI_PERMISSIONS.Documents.ConfirmClassification,
+  );
+}

--- a/angular/packages/document-ai/documents/src/lib/documents/document-list/document-list.component.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-list/document-list.component.ts
@@ -410,7 +410,7 @@ export class DocumentListComponent implements OnInit {
   }
 
   uploadNew(): void {
-    this.router.navigate(['/documents/upload']);
+    this.router.navigate(['/documents']);
   }
 
   delete(doc: DocumentListItemDto, event: Event): void {

--- a/angular/packages/document-ai/documents/src/lib/documents/document-upload/document-upload.component.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-upload/document-upload.component.ts
@@ -150,13 +150,13 @@ export class DocumentUploadComponent implements OnInit {
             this.hasDoneWithErrors.set(true);
           } else {
             this.toaster.success('::Document:UploadedSuccessfully', '::Success');
-            this.router.navigate(['/documents']);
+            this.router.navigate(['/documents/list']);
           }
         },
       });
   }
 
   continueToDocuments(): void {
-    this.router.navigate(['/documents']);
+    this.router.navigate(['/documents/list']);
   }
 }


### PR DESCRIPTION
## Summary

Closes #331.

This PR separates the Dignite Extract module entry from the document list route:

- `/documents` now renders a Dignite Extract home entry component.
- `/documents/list` now renders the existing document list.
- `/documents/upload` redirects back to `/documents` for compatibility.
- The Document List menu item now points to `/documents/list`.
- The standalone Upload Document menu item is removed from primary navigation.
- Existing list/detail/upload navigation is adjusted to respect the new route split.

The new home component is intentionally a small transition surface for this PR. It reuses the existing upload component so upload capability is preserved, while the fuller upload-first redesign remains scoped to #332.

## Validation

- `npm run build:dignite-extract`
- `npm run build:host`
- `npx nx lint dignite-extract`
- `npm test`

Browser smoke check: the Angular dev server served `/documents`, but the backend at `https://localhost:44348` was not running, so ABP OpenID/application-configuration requests failed before authenticated UI rendering could be verified.

## Notes

`npm run build:host` still reports the existing `apps/host/src/app/home/home.component.scss` style budget warning; this PR does not touch that file.