### PR TITLE
feat(text-extraction): reconstruct PDF digital-layer tables into Markdown tables (#329)

### DIFF
--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/ChartRenderer.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/ChartRenderer.cs
@@ -109,21 +109,26 @@ internal static class ChartRenderer
             sb.Append("**").Append(MarkdownText.EscapeInline(MarkdownText.InlineLabel(title))).Append("**\n\n");
         }
 
-        // Header: leading category column + one column per series.
-        sb.Append("| Category | ").Append(string.Join(" | ", series.Select(s => MarkdownText.EscapeCell(s.Name)))).Append(" |\n");
-        sb.Append("| --- |").Append(string.Concat(series.Select(_ => " --- |"))).Append('\n');
+        // Header: leading category column + one column per series, then one row per category. Source-text
+        // cells (series names, category labels, values) are inline-escaped here (#329, matching the PDF /
+        // Word / PPTX table paths), then the shared renderer emits the GFM grid.
+        var rows = new List<IReadOnlyList<string>>
+        {
+            new[] { "Category" }.Concat(series.Select(s => MarkdownText.EscapeInlineCell(s.Name))).ToList()
+        };
 
         foreach (var idx in rowIndices)
         {
             var label = categories.TryGetValue(idx, out var cat) && !string.IsNullOrWhiteSpace(cat)
                 ? cat
                 : (idx + 1).ToString();
-            sb.Append("| ").Append(MarkdownText.EscapeCell(label)).Append(" | ");
-            sb.Append(string.Join(" | ", series.Select(s =>
-                s.Values.TryGetValue(idx, out var v) ? MarkdownText.EscapeCell(v) : string.Empty)));
-            sb.Append(" |\n");
+            var row = new List<string> { MarkdownText.EscapeInlineCell(label) };
+            row.AddRange(series.Select(s =>
+                s.Values.TryGetValue(idx, out var v) ? MarkdownText.EscapeInlineCell(v) : string.Empty));
+            rows.Add(row);
         }
 
+        sb.Append(MarkdownText.RenderTable(rows));
         return sb.ToString().TrimEnd('\n');
     }
 

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/DrawingTableRenderer.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/DrawingTableRenderer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using D = DocumentFormat.OpenXml.Drawing;
 
 namespace Dignite.DocumentAI.TextExtraction.OpenXml;
@@ -37,31 +36,11 @@ internal static class DrawingTableRenderer
             return null;
         }
 
-        var sb = new StringBuilder();
-        for (var r = 0; r < rows.Count; r++)
-        {
-            AppendRow(sb, rows[r], columnCount);
-            if (r == 0)
-            {
-                sb.Append('|').Append(string.Concat(Enumerable.Repeat(" --- |", columnCount))).Append('\n');
-            }
-        }
-
-        return sb.ToString().TrimEnd('\n');
-    }
-
-    private static void AppendRow(StringBuilder sb, List<string> cells, int columnCount)
-    {
-        sb.Append("| ");
-        for (var c = 0; c < columnCount; c++)
-        {
-            sb.Append(c < cells.Count ? cells[c] : string.Empty);
-            sb.Append(c == columnCount - 1 ? " |" : " | ");
-        }
-
-        sb.Append('\n');
+        return MarkdownText.RenderTable(rows);
     }
 
     private static string CellText(D.TableCell cell)
-        => MarkdownText.EscapeCell(string.Join(" ", cell.Descendants<D.Text>().Select(t => t.InnerText)));
+        // Inline-escape + table-break-escape source text (#329, matching the PDF table path) so a literal
+        // '*' / '[' / '`' in a cell is not re-parsed as Markdown.
+        => MarkdownText.EscapeInlineCell(string.Join(" ", cell.Descendants<D.Text>().Select(t => t.InnerText)));
 }

--- a/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/WordTableRenderer.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.OpenXml/WordTableRenderer.cs
@@ -43,44 +43,23 @@ internal static class WordTableRenderer
             return null;
         }
 
-        var sb = new StringBuilder();
-        for (var r = 0; r < rows.Count; r++)
-        {
-            AppendRow(sb, rows[r], columnCount);
-            if (r == 0)
-            {
-                sb.Append('|').Append(string.Concat(Enumerable.Repeat(" --- |", columnCount))).Append('\n');
-            }
-        }
-
-        return sb.ToString().TrimEnd('\n');
-    }
-
-    private static void AppendRow(StringBuilder sb, List<string> cells, int columnCount)
-    {
-        sb.Append("| ");
-        for (var c = 0; c < columnCount; c++)
-        {
-            sb.Append(c < cells.Count ? cells[c] : string.Empty);
-            sb.Append(c == columnCount - 1 ? " |" : " | ");
-        }
-
-        sb.Append('\n');
+        return MarkdownText.RenderTable(rows);
     }
 
     private static string CellText(W.TableCell cell)
     {
         // Join the cell's paragraphs' text with a space — a Markdown table cell can't contain a newline — and
-        // escape table-breaking characters once. Use Descendants (not Elements) so paragraphs wrapped in a
-        // content control (w:sdt) or custom-XML inside the cell are still picked up; but skip paragraphs that
-        // belong to a NESTED table (a nested w:tbl's text is an accepted blind spot and must not bleed into
-        // this cell's own text).
+        // escape inline metacharacters + table breakers once (#329, matching the PDF table path so a literal
+        // '*' / '[' / '`' in source text is not re-parsed as emphasis / link / code inside the cell). Use
+        // Descendants (not Elements) so paragraphs wrapped in a content control (w:sdt) or custom-XML inside
+        // the cell are still picked up; but skip paragraphs that belong to a NESTED table (a nested w:tbl's
+        // text is an accepted blind spot and must not bleed into this cell's own text).
         var paragraphs = cell
             .Descendants<W.Paragraph>()
             .Where(p => !IsInNestedTable(p, cell))
             .Select(ParagraphPlainText)
             .Where(text => text.Length > 0);
-        return MarkdownText.EscapeCell(string.Join(" ", paragraphs));
+        return MarkdownText.EscapeInlineCell(string.Join(" ", paragraphs));
     }
 
     /// <summary>

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractor.cs
@@ -243,7 +243,7 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     }
                 }
 
-                var pageMarkdown = PdfReadingOrder.RenderPage(pageContent.Words, figures);
+                var pageMarkdown = PdfReadingOrder.RenderPage(pageContent.Words, figures, _options.ReconstructTables);
                 if (!string.IsNullOrWhiteSpace(pageMarkdown))
                 {
                     pageMarkdowns.Add(pageMarkdown);

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractorOptions.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractorOptions.cs
@@ -68,4 +68,18 @@ public class PdfExtractorOptions
     /// sandwich signature; a real figure never carries one. The vertical-span guard still applies.
     /// </summary>
     public double FullPageScanMinInvisibleTextRatio { get; set; } = 0.6;
+
+    /// <summary>
+    /// Whether to reconstruct a detected table region of the digital text layer into a Markdown table
+    /// (#310 Phase B). When a region confidently forms a 2-D grid (>= 2x2, aligned columns, sufficient
+    /// fill) its rows render as Markdown table rows, so a wrapped cell stays in its own cell instead of
+    /// interleaving with its row siblings (the #310 料金表 failure). Detection is <b>non-lossy</b>: a region
+    /// that fails the table test degrades to the Phase A column-aware paragraph linearization
+    /// (<see cref="PdfReadingOrder.RenderPage"/>) — never forcing a bad table, never dropping a cell. This is
+    /// a pure layout/rendering heuristic with no OCR cost; set <c>false</c> to keep the Phase A paragraph
+    /// rendering for every region. The grid-geometry thresholds themselves are internal constants of
+    /// <see cref="PdfTableReconstruction"/> (like the caption-distance / paragraph-pitch constants of
+    /// <see cref="PdfReadingOrder"/>), not options — only this on/off switch is host-configurable.
+    /// </summary>
+    public bool ReconstructTables { get; set; } = true;
 }

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfGeometry.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfGeometry.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UglyToad.PdfPig.Core;
+
+namespace Dignite.DocumentAI.TextExtraction.Pdf;
+
+/// <summary>
+/// Geometric helpers shared by the PDF layout reconstruction (#310): the page-level reading order
+/// (<see cref="PdfReadingOrder"/>) and the table reconstructor (<see cref="PdfTableReconstruction"/>) both
+/// cluster boxes into visual lines/rows by vertical overlap and scale thresholds by a median height. These
+/// live here so there is one definition rather than two hand-synced copies (#329 review).
+/// </summary>
+internal static class PdfGeometry
+{
+    /// <summary>
+    /// Vertical overlap of two rectangles as a fraction of the shorter one's height (0 when they do not
+    /// overlap). Used to decide whether two boxes share a visual line / row.
+    /// </summary>
+    public static double VerticalOverlapRatio(PdfRectangle a, PdfRectangle b)
+    {
+        var overlap = Math.Min(a.Top, b.Top) - Math.Max(a.Bottom, b.Bottom);
+        if (overlap <= 0)
+        {
+            return 0;
+        }
+
+        var minHeight = Math.Min(a.Height, b.Height);
+        return minHeight <= 0 ? 0 : overlap / minHeight;
+    }
+
+    /// <summary>The median of the positive values (0 when there are none). Non-positive values are ignored.</summary>
+    public static double Median(IEnumerable<double> values)
+    {
+        var sorted = values.Where(v => v > 0).OrderBy(v => v).ToList();
+        if (sorted.Count == 0)
+        {
+            return 0;
+        }
+
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 1
+            ? sorted[mid]
+            : (sorted[mid - 1] + sorted[mid]) / 2.0;
+    }
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfReadingOrder.cs
@@ -26,9 +26,16 @@ namespace Dignite.DocumentAI.TextExtraction.Pdf;
 /// label/body page no longer splices a left-column label into the middle of a right-column sentence —
 /// the failure mode of a flat <c>Top</c>-descending sort. Within a single block the order is still
 /// <c>Top</c> descending then <c>Left</c> ascending (see <see cref="Render"/>), which is correct for one
-/// column. Reconstructing a table's row of cells into a Markdown table row (so a wrapped cell is not
-/// split across other cells) is <b>deferred to Phase B (v0.3.0)</b>; this round is column/reading-order
-/// only. The flat path remains as a non-lossy fallback when segmentation finds a single region or faults.
+/// column.
+/// </para>
+/// <para>
+/// <b>Table row reconstruction (#310 Phase B).</b> On a multi-block page <see cref="RenderPage"/> also
+/// re-aggregates neighbouring blocks (<see cref="RecursiveXYCut"/> typically cuts a table along its column
+/// gutters and row gaps into per-cell blocks) and, when they confidently form a 2-D grid, renders the region
+/// as a <b>Markdown table</b> via <see cref="PdfTableReconstruction"/> so a wrapped cell stays in its own
+/// cell instead of interleaving with its row siblings. A region that does not read as a table degrades to
+/// the paragraph path. The flat path remains a non-lossy fallback when segmentation finds a single region or
+/// faults.
 /// </para>
 /// <para>
 /// Caption association is <b>placement/labeling only</b>: a caption is never sent into the OCR call.
@@ -60,6 +67,23 @@ internal static class PdfReadingOrder
     // median-line-heights (sits between single spacing ~1.0 and double spacing ~2.0).
     private const double ParagraphPitchLineHeights = 1.6;
 
+    // Two blocks share a visual row (table-row grouping) when their vertical ranges overlap by at least this
+    // ratio of the shorter block's height — see ClusterTableCandidateBlocks (#310 Phase B).
+    private const double RowConnectVerticalOverlap = 0.5;
+
+    // Consecutive visual rows belong to the same table candidate while the vertical gap between them stays
+    // within this many median-block-heights. Wide enough for a table's inter-row pitch, tight enough to cut
+    // the table off from a title / body paragraph above or below it (which sit farther away). See
+    // ClusterTableCandidateBlocks (#310 Phase B).
+    private const double RowGroupGapScale = 5.0;
+
+    // Two consecutive visual rows only chain into one table candidate when the shorter row's height is at
+    // least this fraction of the taller's. A tall multi-line paragraph / title block is then NOT chained onto
+    // a table's short cell rows even when it sits close — and a paragraph-dominated page (whose page-wide
+    // median height is large, inflating the gap threshold) can no longer over-merge (#329 review). See
+    // ClusterTableCandidateBlocks.
+    private const double RowHeightSimilarityRatio = 0.4;
+
     /// <summary>
     /// Reconstructs visual lines from the page's words: clusters words whose vertical ranges overlap into
     /// one line, orders words left-to-right within a line, and returns lines top-to-bottom.
@@ -88,7 +112,7 @@ internal static class PdfReadingOrder
                 // tall glyph (multi-line bracket / integral / tall CJK punctuation) would otherwise stretch
                 // the union's vertical extent and, via the min-height overlap denominator, let a word from
                 // the next physical line score >= 0.5 and merge into the wrong line.
-                if (VerticalOverlapRatio(clusterReference[i], word.BoundingBox) >= 0.5)
+                if (PdfGeometry.VerticalOverlapRatio(clusterReference[i], word.BoundingBox) >= 0.5)
                 {
                     clusters[i].Add(word);
                     clusterBounds[i] = Union(clusterBounds[i], word.BoundingBox);
@@ -158,7 +182,7 @@ internal static class PdfReadingOrder
     public static string Render(IReadOnlyList<TextLine> lines, IReadOnlyList<Figure> figures)
     {
         var medianLineHeight = lines.Count > 0
-            ? Median(lines.Select(l => l.Bounds.Height))
+            ? PdfGeometry.Median(lines.Select(l => l.Bounds.Height))
             : 0.0;
 
         // 1. Bind captions (placement/labeling only — never sent to OCR). For each figure, bind the
@@ -290,6 +314,15 @@ internal static class PdfReadingOrder
     /// are merged into the block order by their placement bbox (nearest block by squared centroid
     /// distance), so figure inlining + caption association (#301) keep working on the column-aware order.
     /// <para>
+    /// <b>Table regions (#310 Phase B).</b> Before the per-block paragraph pass, neighbouring blocks are
+    /// re-aggregated into candidate table clusters; a cluster whose fragments confidently form a 2-D grid is
+    /// emitted as a Markdown table (<see cref="PdfTableReconstruction"/>) at its lead block's reading
+    /// position, and its blocks are skipped by the paragraph pass. Non-table blocks render exactly as in
+    /// Phase A, so a page with no table is unchanged from #326. A figure bucketed into a table block is
+    /// appended after the table (non-lossy). Pass <paramref name="reconstructTables"/> = <c>false</c> to
+    /// disable this and keep the pure Phase A paragraph rendering.
+    /// </para>
+    /// <para>
     /// <b>Caption binding is per-block here.</b> Because each block is rendered through its own
     /// <see cref="Render(IReadOnlyList{TextLine}, IReadOnlyList{Figure})"/> pass, a figure binds a caption
     /// only from <i>its own</i> block. In the normal case a figure and its caption sit together in the
@@ -303,7 +336,8 @@ internal static class PdfReadingOrder
     /// best-effort quality improvement, never a correctness dependency, so no content is ever lost.
     /// </para>
     /// </summary>
-    public static string RenderPage(IReadOnlyList<Word> words, IReadOnlyList<Figure> figures)
+    public static string RenderPage(
+        IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables = true)
     {
         IReadOnlyList<DlaTextBlock> orderedBlocks;
         try
@@ -319,7 +353,9 @@ internal static class PdfReadingOrder
         }
 
         // A single region (or no/one-block segmentation) is exactly the #301 behavior — render the whole
-        // page as one column. This is also the path the existing single-column fixtures take.
+        // page as one column. This is also the path the existing single-column fixtures take. (A table is
+        // almost always cut into several blocks, so single-block table reconstruction is not
+        // attempted here — an accepted #329 first-pass limitation.)
         if (orderedBlocks.Count <= 1)
         {
             return Render(GroupWordsIntoLines(words), figures);
@@ -340,9 +376,41 @@ internal static class PdfReadingOrder
         // caption binding run within that block's single-region stream.
         var figuresByBlock = AssignFiguresToBlocks(orderedBlocks, figures);
 
+        // Phase B: re-aggregate neighbouring blocks into candidate table clusters and reconstruct the ones
+        // that confidently form a grid. A non-table page yields no clusters, so the loop below is exactly the
+        // Phase A per-block path; the host switch off -> empty maps -> identical to Phase A.
+        var tables = reconstructTables ? DetectTableClusters(orderedBlocks) : TableClusters.Empty;
+
         var rendered = new List<string>(orderedBlocks.Count);
+        var emittedTables = new HashSet<int>();
         for (var b = 0; b < orderedBlocks.Count; b++)
         {
+            // A block that belongs to a reconstructed table: emit the table once, at the reading position of
+            // the cluster's lead (first-encountered, lowest-index) block, then skip the cluster's blocks.
+            if (tables.LeadByBlock.TryGetValue(b, out var lead))
+            {
+                if (emittedTables.Add(lead))
+                {
+                    rendered.Add(tables.MarkdownByLead[lead]);
+
+                    // A table region is text; a figure that AssignFiguresToBlocks happened to bucket into one
+                    // of its blocks is rare, but must not be lost — append it after the table (non-lossy).
+                    var clusterFigures = tables.BlocksByLead[lead]
+                        .SelectMany(bi => figuresByBlock[bi])
+                        .ToList();
+                    if (clusterFigures.Count > 0)
+                    {
+                        var figureMarkdown = Render(Array.Empty<TextLine>(), clusterFigures);
+                        if (!string.IsNullOrWhiteSpace(figureMarkdown))
+                        {
+                            rendered.Add(figureMarkdown);
+                        }
+                    }
+                }
+
+                continue;
+            }
+
             // Re-group the block's words into visual lines with the existing robust clustering (rather than
             // the segmenter's own lines), so tall-glyph / CJK handling and paragraph folding are unchanged.
             var blockWords = orderedBlocks[b].TextLines.SelectMany(line => line.Words).ToList();
@@ -361,6 +429,176 @@ internal static class PdfReadingOrder
         }
 
         return string.Join("\n\n", rendered);
+    }
+
+    /// <summary>
+    /// Table clusters found on a page: which reconstructed table (if any) each block belongs to, the rendered
+    /// Markdown per lead block, and the blocks making up each cluster (for figure salvage).
+    /// </summary>
+    private sealed class TableClusters
+    {
+        public static readonly TableClusters Empty = new();
+
+        /// <summary>Lead (lowest-index) block of a cluster -> its rendered Markdown table.</summary>
+        public Dictionary<int, string> MarkdownByLead { get; } = new();
+
+        /// <summary>Any block that is part of a reconstructed table -> that cluster's lead block index.</summary>
+        public Dictionary<int, int> LeadByBlock { get; } = new();
+
+        /// <summary>Lead block index -> all block indices in the cluster (ascending).</summary>
+        public Dictionary<int, List<int>> BlocksByLead { get; } = new();
+    }
+
+    /// <summary>
+    /// Re-aggregates neighbouring blocks into clusters (<see cref="ClusterTableCandidateBlocks"/>) and
+    /// reconstructs the clusters that confidently form a Markdown table from their <b>words</b>
+    /// (<see cref="PdfTableReconstruction"/>). RecursiveXYCut splits a table into several blocks — per-cell at
+    /// a generous row pitch, per-column at a tight one — so the cluster's words (not its blocks) are fed to
+    /// the reconstructor, which derives the grid from glyph geometry either way. A cluster that does not
+    /// reconstruct as a table is absent from the result, so its blocks fall through to the Phase A paragraph path.
+    /// </summary>
+    private static TableClusters DetectTableClusters(IReadOnlyList<DlaTextBlock> blocks)
+    {
+        var medianHeight = PdfGeometry.Median(blocks.Select(b => b.BoundingBox.Height));
+        if (medianHeight <= 0)
+        {
+            return TableClusters.Empty;
+        }
+
+        var result = new TableClusters();
+        foreach (var cluster in ClusterTableCandidateBlocks(blocks, medianHeight))
+        {
+            // Reconstruct from the cluster's WORDS, not its blocks: RecursiveXYCut's block granularity is not
+            // stable for tables (#329 review) — a generous row pitch is cut into per-cell blocks, but a tight
+            // row pitch is cut into per-COLUMN blocks (each column one tall block of stacked rows). Feeding
+            // words lets TryRender derive the grid from real glyph geometry either way; its column x-projection
+            // + visual-row clustering + wrapped-cell merge handle both, including a 備考 cell wrapping to two
+            // lines (whether or not the segmenter pre-merged it).
+            var cells = cluster
+                .SelectMany(bi => blocks[bi].TextLines.SelectMany(line => line.Words))
+                .Where(word => !string.IsNullOrWhiteSpace(word.Text))
+                .Select(word => new PdfTableReconstruction.Cell(word.BoundingBox, word.Text))
+                .ToList();
+
+            var table = PdfTableReconstruction.TryRender(cells);
+            if (table is null)
+            {
+                continue;
+            }
+
+            var lead = cluster[0]; // cluster is sorted ascending, so [0] is the lead (lowest-index) block
+            result.MarkdownByLead[lead] = table;
+            result.BlocksByLead[lead] = cluster;
+            foreach (var bi in cluster)
+            {
+                result.LeadByBlock[bi] = lead;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Groups blocks into table-candidate clusters. RecursiveXYCut cuts a table into per-CELL blocks (its
+    /// column gutters and row gaps both exceed the cut threshold), so a cluster is built in two steps:
+    /// (1) union blocks whose vertical ranges overlap into <i>visual rows</i>; (2) chain vertically adjacent
+    /// rows (gap within <see cref="RowGroupGapScale"/> median-heights) into one cluster — which stops at the
+    /// larger gap to a title / body paragraph above or below. Each cluster's indices are sorted ascending so
+    /// the lead block is first; a lone row forms a singleton cluster (later rejected by
+    /// <see cref="PdfTableReconstruction.TryRender"/> for having too few rows).
+    /// </summary>
+    private static List<List<int>> ClusterTableCandidateBlocks(IReadOnlyList<DlaTextBlock> blocks, double medianHeight)
+    {
+        var n = blocks.Count;
+
+        // 1. Visual rows: union blocks whose vertical ranges overlap.
+        var parent = new int[n];
+        for (var i = 0; i < n; i++)
+        {
+            parent[i] = i;
+        }
+
+        int Find(int x)
+        {
+            while (parent[x] != x)
+            {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+
+            return x;
+        }
+
+        for (var i = 0; i < n; i++)
+        {
+            for (var j = i + 1; j < n; j++)
+            {
+                if (PdfGeometry.VerticalOverlapRatio(blocks[i].BoundingBox, blocks[j].BoundingBox) >= RowConnectVerticalOverlap)
+                {
+                    parent[Find(i)] = Find(j);
+                }
+            }
+        }
+
+        var rowGroups = new Dictionary<int, List<int>>();
+        for (var i = 0; i < n; i++)
+        {
+            var root = Find(i);
+            if (!rowGroups.TryGetValue(root, out var list))
+            {
+                list = new List<int>();
+                rowGroups[root] = list;
+            }
+
+            list.Add(i);
+        }
+
+        // Order the rows top to bottom by their highest edge.
+        var rows = rowGroups.Values
+            .OrderByDescending(group => group.Max(bi => blocks[bi].BoundingBox.Top))
+            .ToList();
+
+        // 2. Chain rows whose vertical gap stays within the threshold AND whose height is comparable into one
+        // cluster. The height check stops a tall multi-line body / title block (a RecursiveXYCut paragraph
+        // leaf) from being chained onto a table's short cell rows even when it sits close, and keeps a
+        // paragraph-dominated page (large page-wide median -> large gap threshold) from over-merging (#329
+        // review). A wider gap, or a height mismatch, starts a new cluster.
+        var gapThreshold = medianHeight * RowGroupGapScale;
+        var clusters = new List<List<int>>();
+        var current = new List<int>(rows[0]);
+        var currentBottom = rows[0].Min(bi => blocks[bi].BoundingBox.Bottom);
+        var currentRowHeight = PdfGeometry.Median(rows[0].Select(bi => blocks[bi].BoundingBox.Height));
+        for (var i = 1; i < rows.Count; i++)
+        {
+            var rowTop = rows[i].Max(bi => blocks[bi].BoundingBox.Top);
+            var rowHeight = PdfGeometry.Median(rows[i].Select(bi => blocks[bi].BoundingBox.Height));
+            var tallerHeight = Math.Max(currentRowHeight, rowHeight);
+            var heightComparable = tallerHeight <= 0
+                || Math.Min(currentRowHeight, rowHeight) >= tallerHeight * RowHeightSimilarityRatio;
+
+            if (currentBottom - rowTop <= gapThreshold && heightComparable)
+            {
+                current.AddRange(rows[i]);
+                currentBottom = Math.Min(currentBottom, rows[i].Min(bi => blocks[bi].BoundingBox.Bottom));
+                currentRowHeight = rowHeight;
+            }
+            else
+            {
+                clusters.Add(current);
+                current = new List<int>(rows[i]);
+                currentBottom = rows[i].Min(bi => blocks[bi].BoundingBox.Bottom);
+                currentRowHeight = rowHeight;
+            }
+        }
+
+        clusters.Add(current);
+
+        foreach (var cluster in clusters)
+        {
+            cluster.Sort();
+        }
+
+        return clusters;
     }
 
     /// <summary>
@@ -434,18 +672,6 @@ internal static class PdfReadingOrder
 
     private static bool LooksLikeCaption(string text) => CaptionPattern.IsMatch(text);
 
-    private static double VerticalOverlapRatio(PdfRectangle a, PdfRectangle b)
-    {
-        var overlap = Math.Min(a.Top, b.Top) - Math.Max(a.Bottom, b.Bottom);
-        if (overlap <= 0)
-        {
-            return 0;
-        }
-
-        var minHeight = Math.Min(a.Height, b.Height);
-        return minHeight <= 0 ? 0 : overlap / minHeight;
-    }
-
     private static PdfRectangle Union(PdfRectangle a, PdfRectangle b)
         => new(
             Math.Min(a.Left, b.Left),
@@ -457,20 +683,6 @@ internal static class PdfReadingOrder
         => ((r.Left + r.Right) / 2.0, (r.Bottom + r.Top) / 2.0);
 
     private static double Sq(double v) => v * v;
-
-    private static double Median(IEnumerable<double> values)
-    {
-        var sorted = values.Where(v => v > 0).OrderBy(v => v).ToList();
-        if (sorted.Count == 0)
-        {
-            return 0;
-        }
-
-        var mid = sorted.Count / 2;
-        return sorted.Count % 2 == 1
-            ? sorted[mid]
-            : (sorted[mid - 1] + sorted[mid]) / 2.0;
-    }
 
     private readonly record struct Item(PdfRectangle Bounds, string Text, bool IsFigure, string? Caption)
     {

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfTableReconstruction.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfTableReconstruction.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UglyToad.PdfPig.Core;
+
+namespace Dignite.DocumentAI.TextExtraction.Pdf;
+
+/// <summary>
+/// Reconstructs a candidate table region of a PDF's <b>digital text layer</b> into a GFM Markdown table
+/// (#310 Phase B). The input is a flat set of positioned text fragments (<see cref="Cell"/>, one per
+/// PdfPig <c>Word</c>); the output is a Markdown table, or <c>null</c> when the region does not confidently
+/// read as a 2-D grid.
+/// <para>
+/// <b>Why this exists.</b> Phase A (#326) orders blocks column-wise but still linearizes each block as
+/// paragraphs, so a table row's cells are emitted as separate fragments and a wrapped cell (the #310 日本語
+/// 料金表 <c>備考</c> cell, which spills onto a second visual line) interleaves with its row siblings —
+/// <c>…付随する無</c> … (other cells) … <c>償提供。税別対象外</c>. Grouping a row's cells into one Markdown
+/// table row keeps a wrapped cell intact in its own cell.
+/// </para>
+/// <para>
+/// <b>Non-lossy by construction.</b> Every input fragment is assigned to exactly one <c>(row, column)</c>
+/// cell, so a successful render contains all the region's text. When the region fails any grid test
+/// (too few columns/rows, rows not aligned across columns, too sparse) this returns <c>null</c> and the
+/// caller (<see cref="PdfReadingOrder.RenderPage"/>) keeps the Phase A paragraph linearization — never
+/// forcing a bad table, never dropping a fragment.
+/// </para>
+/// <para>
+/// <b>First solid pass — deferred (per #329 out-of-scope).</b> Borderless tables are handled (detection is
+/// whitespace-geometry only, never relies on ruling lines), but row-spanning / column-spanning / nested
+/// tables are not modeled. Two ambiguities plain geometry cannot resolve are settled on the safe side:
+/// (a) a line filling the SAME columns as the row above is always a new row, never a multi-cell wrap, so the
+/// rare "several cells of one row each wrap to an aligned second line" renders as an extra row rather than
+/// risk merging two genuine rows; (b) a table whose row gap is as tight as single-line leading may fold a
+/// sparse next row into a wrapped-cell continuation. All such cases stay non-lossy (text is preserved, only
+/// the grouping may be imperfect) and degrade rather than corrupt.
+/// </para>
+/// <para>
+/// PDF user space is bottom-left origin (larger Y = higher on the page), matching <see cref="PdfReadingOrder"/>.
+/// </para>
+/// </summary>
+internal static class PdfTableReconstruction
+{
+    /// <summary>A positioned text fragment (one PdfPig <c>Word</c>) — the lightweight, geometry-testable input.</summary>
+    public readonly record struct Cell(PdfRectangle Bounds, string Text);
+
+    // A table needs at least this many columns and rows; a 1xN or Nx1 strip is not a table.
+    private const int MinColumns = 2;
+    private const int MinRows = 2;
+
+    // Two fragments belong to the same column unless a horizontal gap wider than this (in median-glyph-height
+    // units) separates them — the column gutter. Sized so an ordinary inter-word space (a fraction of the
+    // glyph height) never reads as a column break, while a real gutter does.
+    private const double ColumnGutterScale = 0.8;
+
+    // Two fragments share a visual line when their vertical ranges overlap by at least this ratio (of the
+    // shorter one). Mirrors PdfReadingOrder.GroupWordsIntoLines so line grouping is consistent.
+    private const double RowOverlapRatio = 0.5;
+
+    // A visual line is a wrapped-cell CONTINUATION of the row above (rather than a new row) only when it
+    // occupies a strict subset of that row's columns AND the vertical GAP to it (bottom-to-top, NOT
+    // baseline-to-baseline) is within this many median-glyph-heights. Sized below a typical inter-row table
+    // gap (which carries cell padding) so a separate sparse row is not swallowed, while a single-leading wrap
+    // is folded. A wrap's gap and a tight row's gap are not perfectly separable from geometry alone (#329
+    // review tightened this from 1.35; the strict-subset requirement is the primary guard) — see class remarks.
+    private const double ContinuationPitchScale = 0.9;
+
+    // At least this fraction of the MERGED table rows must span >= 2 columns (computed after wrapped-cell
+    // continuation lines are folded in — #329 review). A multi-column BODY layout (Phase A's target) has each
+    // row living in a single column (left/right columns' lines don't share a y-band), so it fails this test
+    // and correctly degrades to paragraphs; a real table's rows span the columns.
+    private const double MinCrossColumnRowRatio = 0.5;
+
+    // The grid must be at least this filled (non-empty cells / rows x columns). Rejects a sparse scatter that
+    // happens to land in a few column bands but isn't a real table.
+    private const double MinFillRatio = 0.5;
+
+    /// <summary>
+    /// Renders <paramref name="cells"/> as a GFM Markdown table, or returns <c>null</c> when they do not form
+    /// a confident grid (the caller then keeps the Phase A paragraph rendering).
+    /// </summary>
+    public static string? TryRender(IReadOnlyList<Cell> cells)
+    {
+        var meaningful = cells.Where(c => !string.IsNullOrWhiteSpace(c.Text)).ToList();
+        if (meaningful.Count == 0)
+        {
+            return null;
+        }
+
+        // The whole geometry is scaled by the median fragment height (the dominant glyph size), so the
+        // thresholds are font-size independent.
+        var medianHeight = PdfGeometry.Median(meaningful.Select(c => c.Bounds.Height));
+        if (medianHeight <= 0)
+        {
+            return null;
+        }
+
+        // 1. Columns: project every fragment's x-range onto the x-axis and split at gutters wider than the
+        // threshold. Robust to left/right/centre cell alignment — a column's content lands in its band whatever
+        // its alignment, and the gutter between bands is empty.
+        var columns = DetectColumnBands(meaningful, medianHeight * ColumnGutterScale);
+        if (columns.Count < MinColumns)
+        {
+            return null;
+        }
+
+        // 2. Visual lines: cluster fragments whose vertical ranges overlap (same as the paragraph path), top
+        // to bottom.
+        var visualLines = GroupIntoVisualLines(meaningful);
+        if (visualLines.Count < MinRows)
+        {
+            return null;
+        }
+
+        // 3. Map each visual line to the columns it occupies.
+        var lineColumns = new List<Dictionary<int, List<Cell>>>(visualLines.Count);
+        foreach (var line in visualLines)
+        {
+            var byColumn = new Dictionary<int, List<Cell>>();
+            foreach (var cell in line)
+            {
+                var column = ColumnOf(cell, columns);
+                if (!byColumn.TryGetValue(column, out var list))
+                {
+                    list = new List<Cell>();
+                    byColumn[column] = list;
+                }
+
+                list.Add(cell);
+            }
+
+            lineColumns.Add(byColumn);
+        }
+
+        // 4. Fold wrapped-cell continuation lines into their parent row.
+        var rows = MergeRows(visualLines, lineColumns, columns.Count, medianHeight * ContinuationPitchScale);
+        if (rows.Count < MinRows)
+        {
+            return null;
+        }
+
+        // 5. Table-vs-multicolumn-body discriminator, computed on the MERGED rows (#329 review): a real table
+        // whose cell wraps across several single-column continuation lines must not be diluted below the ratio
+        // by those continuation lines — the fold in step 4 has already collapsed them into their parent row.
+        // A multi-column BODY layout still fails here (each of its rows lives in one column).
+        var crossColumnRows = rows.Count(row => row.Count(cell => cell.Length > 0) >= 2);
+        if ((double)crossColumnRows / rows.Count < MinCrossColumnRowRatio)
+        {
+            return null;
+        }
+
+        // 6. Fill ratio: reject a sparse scatter that lands in a few bands but isn't a real table.
+        var filled = rows.Sum(row => row.Count(cell => cell.Length > 0));
+        if ((double)filled / (rows.Count * columns.Count) < MinFillRatio)
+        {
+            return null;
+        }
+
+        return RenderGrid(rows);
+    }
+
+    /// <summary>
+    /// Splits the fragments into column bands by x-projection: merges overlapping/abutting x-ranges and starts
+    /// a new band wherever an empty horizontal gap exceeds <paramref name="gutterThreshold"/>. Each returned
+    /// band is the <c>[left, right]</c> extent of one column's content.
+    /// </summary>
+    private static List<(double Left, double Right)> DetectColumnBands(
+        IReadOnlyList<Cell> cells, double gutterThreshold)
+    {
+        var intervals = cells
+            .Select(c => (Left: Math.Min(c.Bounds.Left, c.Bounds.Right), Right: Math.Max(c.Bounds.Left, c.Bounds.Right)))
+            .OrderBy(iv => iv.Left)
+            .ToList();
+
+        var bands = new List<(double Left, double Right)>();
+        var left = intervals[0].Left;
+        var right = intervals[0].Right;
+        for (var i = 1; i < intervals.Count; i++)
+        {
+            var iv = intervals[i];
+            if (iv.Left - right > gutterThreshold)
+            {
+                bands.Add((left, right));
+                left = iv.Left;
+                right = iv.Right;
+            }
+            else
+            {
+                right = Math.Max(right, iv.Right);
+            }
+        }
+
+        bands.Add((left, right));
+        return bands;
+    }
+
+    /// <summary>Index of the column band whose extent contains the fragment's horizontal centre.</summary>
+    private static int ColumnOf(Cell cell, List<(double Left, double Right)> bands)
+    {
+        var centre = (cell.Bounds.Left + cell.Bounds.Right) / 2.0;
+        for (var i = 0; i < bands.Count; i++)
+        {
+            if (centre >= bands[i].Left && centre <= bands[i].Right)
+            {
+                return i;
+            }
+        }
+
+        // Unreachable: a cell's centre is the midpoint of its own x-range, which is contained in the band
+        // built as the union of that range with its column-mates'. Return the last band defensively (never
+        // throw on this not-supposed-to-happen path) so reconstruction stays non-lossy (#329 review).
+        return bands.Count - 1;
+    }
+
+    /// <summary>
+    /// Clusters fragments into visual lines (vertical-overlap clustering, top to bottom), each line's cells
+    /// ordered left to right. Mirrors <see cref="PdfReadingOrder.GroupWordsIntoLines"/> but keeps the cells
+    /// separate (it does not space-join them into one string, which would erase the cell boundaries the table
+    /// path needs).
+    /// </summary>
+    private static List<List<Cell>> GroupIntoVisualLines(IReadOnlyList<Cell> cells)
+    {
+        // Top to bottom so a line accretes its cells in vertical order; new lines are always appended below
+        // the existing ones, leaving the result ordered top to bottom.
+        var ordered = cells.OrderByDescending(c => c.Bounds.Top).ToList();
+
+        var lines = new List<List<Cell>>();
+        var reference = new List<PdfRectangle>(); // last cell added to each line — the overlap reference
+
+        foreach (var cell in ordered)
+        {
+            var placed = false;
+            for (var i = 0; i < lines.Count; i++)
+            {
+                // Compare against the most-recently-added cell (not an accreted union) so a single tall glyph
+                // cannot stretch the line's extent and pull a next-line cell in — same rationale as
+                // GroupWordsIntoLines.
+                if (PdfGeometry.VerticalOverlapRatio(reference[i], cell.Bounds) >= RowOverlapRatio)
+                {
+                    lines[i].Add(cell);
+                    reference[i] = cell.Bounds;
+                    placed = true;
+                    break;
+                }
+            }
+
+            if (!placed)
+            {
+                lines.Add(new List<Cell> { cell });
+                reference.Add(cell.Bounds);
+            }
+        }
+
+        foreach (var line in lines)
+        {
+            line.Sort((a, b) => a.Bounds.Left.CompareTo(b.Bounds.Left));
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Folds wrapped-cell continuation lines into their parent table row. A visual line is a continuation when
+    /// it occupies a STRICT subset of the current row's columns (a wrapped cell only continues columns the row
+    /// already has) AND sits within <paramref name="continuationPitch"/> below it; its text is appended to the
+    /// matching columns (space-joined). Otherwise it starts a new row. Returns rectangular rows
+    /// (<paramref name="columnCount"/> cells each, empty string for an unfilled cell).
+    /// </summary>
+    private static List<string[]> MergeRows(
+        List<List<Cell>> visualLines,
+        List<Dictionary<int, List<Cell>>> lineColumns,
+        int columnCount,
+        double continuationPitch)
+    {
+        var rows = new List<string[]>();
+        string[]? current = null;
+        HashSet<int>? currentColumns = null;
+        var currentBottom = 0.0;
+
+        for (var i = 0; i < visualLines.Count; i++)
+        {
+            var byColumn = lineColumns[i];
+            var occupied = byColumn.Keys.ToHashSet();
+            var lineTop = visualLines[i].Max(c => c.Bounds.Top);
+            var lineBottom = visualLines[i].Min(c => c.Bounds.Bottom);
+
+            var isContinuation =
+                current != null
+                // Strictly FEWER columns than the parent: a wrapped cell continues SOME of the row's columns.
+                // A line filling the SAME columns is treated as a new row, never a multi-cell wrap — geometry
+                // cannot tell "every cell of this row wrapped" from "the next record", and merging two real
+                // rows is worse than splitting the rare all-cells-wrap case (#329 review; see class remarks).
+                && occupied.Count < currentColumns!.Count
+                && occupied.IsSubsetOf(currentColumns)     // and only columns the parent row already has
+                && currentBottom - lineTop <= continuationPitch; // and tight against it (a single-line wrap)
+
+            if (isContinuation)
+            {
+                foreach (var (column, list) in byColumn)
+                {
+                    var text = JoinLineCells(list);
+                    current![column] = current[column].Length == 0 ? text : current[column] + " " + text;
+                }
+
+                currentBottom = lineBottom;
+                continue;
+            }
+
+            if (current != null)
+            {
+                rows.Add(current);
+            }
+
+            current = new string[columnCount];
+            for (var c = 0; c < columnCount; c++)
+            {
+                current[c] = string.Empty;
+            }
+
+            foreach (var (column, list) in byColumn)
+            {
+                current[column] = JoinLineCells(list);
+            }
+
+            currentColumns = occupied;
+            currentBottom = lineBottom;
+        }
+
+        if (current != null)
+        {
+            rows.Add(current);
+        }
+
+        return rows;
+    }
+
+    /// <summary>Joins the fragments that landed in one cell of one visual line, left to right, with a single space.</summary>
+    private static string JoinLineCells(List<Cell> cells)
+        => string.Join(" ", cells.OrderBy(c => c.Bounds.Left).Select(c => c.Text));
+
+    /// <summary>
+    /// Renders the rectangular grid as a GFM Markdown table via <see cref="MarkdownText.RenderTable"/>. Cells
+    /// are SOURCE TEXT (the PDF digital text layer), so each is escaped with
+    /// <see cref="MarkdownText.EscapeInlineCell"/> — escaping the inline metacharacters (<c>* ` [ ] &lt;</c>)
+    /// as well as the pipe/newline — so table cells get the same #320 source-text protection the paragraph
+    /// path has (a plain cell-escape would leave a literal <c>*</c>/<c>[</c> in a contract cell to be re-parsed).
+    /// </summary>
+    private static string RenderGrid(List<string[]> rows)
+    {
+        var escaped = rows
+            .Select(row => (IReadOnlyList<string>)row.Select(MarkdownText.EscapeInlineCell).ToArray())
+            .ToList();
+        return MarkdownText.RenderTable(escaped);
+    }
+}

--- a/core/src/Dignite.DocumentAI.TextExtraction/MarkdownText.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction/MarkdownText.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Dignite.DocumentAI.TextExtraction;
@@ -284,6 +286,69 @@ public static class MarkdownText
             .Replace("\r", " ")
             .Replace("\n", " ")
             .Trim();
+    }
+
+    /// <summary>
+    /// Escapes <b>source text</b> placed inside a Markdown table cell: first the inline metacharacter set
+    /// (<see cref="EscapeInline"/> — <c>\ ` * _ [ ] &lt;</c>) so a literal <c>*</c> / <c>[</c> / <c>&lt;</c> in
+    /// the source cannot open emphasis / a link / an autolink inside the cell, then the pipe column separator,
+    /// and finally CR/LF collapsed to a space. Use this (not <see cref="EscapeCell"/>) when the cell value is
+    /// literal document text rather than an already-safe value — it gives a PDF/source table cell the same
+    /// metacharacter protection the paragraph path gets from <see cref="EscapeInline"/> (#320 parity, #329).
+    /// <para>
+    /// The two halves compose without double-escaping: <see cref="EscapeInline"/> already backslash-escapes
+    /// <c>\</c> and never touches <c>|</c>, so the subsequent pipe replace only ever escapes an original
+    /// literal pipe, not a backslash that escaping just introduced.
+    /// </para>
+    /// </summary>
+    public static string EscapeInlineCell(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        return EscapeInline(text)
+            .Replace("|", "\\|")
+            .Replace("\r", " ")
+            .Replace("\n", " ")
+            .Trim();
+    }
+
+    /// <summary>
+    /// Renders a rectangular grid as a GFM Markdown table: the FIRST row is the header (followed by the
+    /// mandated <c>| --- |</c> separator), every row padded to the widest row's column count, with the
+    /// trailing newline trimmed. Cells are emitted <b>verbatim</b> — the caller must have escaped them already
+    /// (<see cref="EscapeCell"/> for already-safe values, <see cref="EscapeInlineCell"/> for source text).
+    /// Shared by the Word / DrawingML / chart renderers and the PDF table reconstructor so the GFM table shape
+    /// lives in one place (#329). Returns the empty string for an empty / zero-column grid.
+    /// </summary>
+    public static string RenderTable(IReadOnlyList<IReadOnlyList<string>> rows)
+    {
+        var columnCount = rows.Count == 0 ? 0 : rows.Max(row => row.Count);
+        if (columnCount == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        for (var r = 0; r < rows.Count; r++)
+        {
+            sb.Append("| ");
+            for (var c = 0; c < columnCount; c++)
+            {
+                sb.Append(c < rows[r].Count ? rows[r][c] : string.Empty);
+                sb.Append(c == columnCount - 1 ? " |" : " | ");
+            }
+
+            sb.Append('\n');
+            if (r == 0)
+            {
+                sb.Append('|').Append(string.Concat(Enumerable.Repeat(" --- |", columnCount))).Append('\n');
+            }
+        }
+
+        return sb.ToString().TrimEnd('\n');
     }
 
     /// <summary>

--- a/core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/PdfExtractor_Tests.cs
@@ -403,4 +403,63 @@ public class PdfExtractor_Tests
             .Substring(firstBodyWord, lastBodyWord - firstBodyWord)
             .ShouldNotContain("LABEL");
     }
+
+    [Fact]
+    public async Task Reconstructs_a_multi_column_table_into_markdown_table_rows()
+    {
+        // #310 Phase B end-to-end: a positioned multi-column fee schedule whose third-column cell wraps to a
+        // second visual line. Phase A would linearize the row's cells as separate paragraphs and split the
+        // wrapped cell; the table path must emit GFM table rows with the wrapped cell kept whole, while the
+        // title above the table stays its own (non-table) region.
+        var pdf = PdfFixtures.BuildPositioned(new[]
+        {
+            ("Service Fee Schedule", 50.0, 770.0), // title above the table (separate region)
+
+            ("Service", 50.0, 700.0), ("Fee", 230.0, 700.0), ("Note", 380.0, 700.0),
+            ("Basic", 50.0, 672.0), ("100", 230.0, 672.0), ("standard", 380.0, 672.0),
+            ("support", 380.0, 658.0), // wrapped continuation of the Note cell (single-line pitch below)
+            ("Premium", 50.0, 630.0), ("200", 230.0, 630.0), ("priority", 380.0, 630.0)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // A GFM table was produced.
+        result.Markdown.ShouldContain("| --- |");
+        // The wrapped Note cell stays intact in its own cell (not split across siblings).
+        result.Markdown.ShouldContain("standard support");
+        // All table content is present (non-lossy), and the title is preserved as its own region.
+        foreach (var token in new[]
+                 {
+                     "Service Fee Schedule", "Service", "Fee", "Note",
+                     "Basic", "100", "Premium", "200", "priority"
+                 })
+        {
+            result.Markdown.ShouldContain(token);
+        }
+    }
+
+    [Fact]
+    public async Task Reconstructs_a_tight_row_pitch_table()
+    {
+        // #329 review (efficacy): the multi-column fixture above uses a generous row pitch that RecursiveXYCut
+        // cuts into per-cell blocks; a tight row pitch is instead cut into per-COLUMN blocks (each column one
+        // tall block of stacked rows). Because reconstruction works at the WORD level, not the block level,
+        // the grid is recovered either way — a tight pitch is not just non-lossy but a real table.
+        var pdf = PdfFixtures.BuildPositioned(new[]
+        {
+            ("Item", 50.0, 700.0), ("Price", 230.0, 700.0),
+            ("Apple", 50.0, 688.0), ("100", 230.0, 688.0),
+            ("Pear", 50.0, 676.0), ("200", 230.0, 676.0),
+            ("Plum", 50.0, 664.0), ("300", 230.0, 664.0)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        result.Markdown.ShouldContain("| --- |"); // a real table, not a paragraph degrade
+
+        foreach (var token in new[] { "Item", "Price", "Apple", "100", "Pear", "200", "Plum", "300" })
+        {
+            result.Markdown.ShouldContain(token);
+        }
+    }
 }

--- a/core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/PdfTableReconstruction_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/PdfTableReconstruction_Tests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using Shouldly;
+using UglyToad.PdfPig.Core;
+using Xunit;
+
+namespace Dignite.DocumentAI.TextExtraction.Pdf;
+
+public class PdfTableReconstruction_Tests
+{
+    // PdfRectangle(left, bottom, right, top); PDF origin is bottom-left (larger Y = higher on the page).
+    // Cells are one PdfPig Word each. All fixtures use a 12pt-tall box so the median-height-scaled thresholds
+    // (column gutter, continuation pitch) are stable and easy to reason about.
+    private static PdfTableReconstruction.Cell Cell(string text, double left, double right, double centreY)
+        => new(new PdfRectangle(left, centreY - 6, right, centreY + 6), text);
+
+    [Fact]
+    public void Renders_a_simple_grid_as_a_markdown_table()
+    {
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Name", 50, 100, 700), Cell("Price", 200, 260, 700),
+            Cell("Apple", 50, 100, 680), Cell("10", 200, 230, 680)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| Name | Price |\n| --- | --- |\n| Apple | 10 |");
+    }
+
+    [Fact]
+    public void Keeps_a_wrapped_cell_intact_in_its_own_cell()
+    {
+        // The #310 料金表 failure, abstracted: the third column's cell wraps to a second visual line whose y
+        // sits between this row and the next. Phase A's flat linearization splits it across siblings; the
+        // table path must keep "fresh red variety" together in its own cell.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Name", 50, 100, 700), Cell("Price", 200, 250, 700), Cell("Note", 330, 400, 700),
+            Cell("Apple", 50, 100, 680), Cell("10", 200, 225, 680), Cell("fresh", 330, 370, 680), Cell("red", 375, 400, 680),
+            Cell("variety", 330, 390, 666), // wrapped continuation of the Note cell (single-line pitch below)
+            Cell("Pear", 50, 95, 645), Cell("20", 200, 225, 645), Cell("green", 330, 380, 645)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| Name | Price | Note |\n" +
+            "| --- | --- | --- |\n" +
+            "| Apple | 10 | fresh red variety |\n" +
+            "| Pear | 20 | green |");
+    }
+
+    [Fact]
+    public void Returns_null_for_a_single_column_paragraph()
+    {
+        // Words flow left to right with ordinary inter-word gaps (no column gutter), so the x-projection is a
+        // single band — not a table.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("The", 50, 68, 700), Cell("quick", 71, 101, 700), Cell("brown", 104, 140, 700),
+            Cell("fox", 50, 68, 680), Cell("jumps", 71, 110, 680),
+            Cell("over", 50, 80, 660), Cell("lazy", 83, 113, 660)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_multi_column_body_text_whose_rows_do_not_align()
+    {
+        // Two body columns (Phase A's target). There IS a gutter, so two column bands are found — but the
+        // left and right columns' lines do not share y-bands, so almost every visual line lives in a single
+        // column. The cross-column-row test rejects it and it degrades to paragraphs (non-lossy).
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Left", 50, 90, 700), Cell("para", 50, 90, 680), Cell("text", 50, 90, 660), Cell("more", 50, 90, 640),
+            Cell("Right", 320, 370, 690), Cell("side", 320, 360, 670), Cell("words", 320, 375, 650)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Returns_null_when_there_are_fewer_than_two_rows()
+    {
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("A", 50, 100, 700), Cell("B", 200, 260, 700)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_empty_input()
+    {
+        PdfTableReconstruction.TryRender(Array.Empty<PdfTableReconstruction.Cell>()).ShouldBeNull();
+
+        // Whitespace-only fragments carry no text and are dropped, leaving nothing to render.
+        PdfTableReconstruction.TryRender(new List<PdfTableReconstruction.Cell>
+        {
+            Cell("   ", 50, 100, 700), Cell("\t", 200, 260, 700),
+            Cell(" ", 50, 100, 680), Cell("", 200, 260, 680)
+        }).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Escapes_a_pipe_so_a_cell_cannot_split_the_row()
+    {
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("a|b", 50, 100, 700), Cell("x", 200, 260, 700),
+            Cell("c", 50, 100, 680), Cell("y", 200, 260, 680)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| a\\|b | x |\n| --- | --- |\n| c | y |");
+    }
+
+    [Fact]
+    public void Detects_a_right_aligned_numeric_column()
+    {
+        // The numeric column is right-aligned (its cells share a right edge, not a left edge). Column
+        // detection projects x-ranges, so it bands the column regardless of alignment.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Item", 50, 90, 700), Cell("Qty", 200, 230, 700),
+            Cell("Apple", 50, 100, 680), Cell("5", 220, 230, 680),
+            Cell("Pear", 50, 95, 660), Cell("100", 210, 230, 660)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| Item | Qty |\n| --- | --- |\n| Apple | 5 |\n| Pear | 100 |");
+    }
+
+    [Fact]
+    public void Does_not_merge_a_distant_partial_line_into_the_row_above()
+    {
+        // A line that occupies a subset of columns but sits far below (a real, separate row that happens to
+        // have empty cells) must NOT be folded as a wrapped-cell continuation — the pitch guard keeps it a
+        // row of its own.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("A", 50, 100, 700), Cell("B", 200, 260, 700),
+            Cell("C", 50, 100, 680), Cell("D", 200, 260, 680),
+            Cell("E", 200, 260, 620) // only the 2nd column, but ~5 line-heights below row 2
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| A | B |\n| --- | --- |\n| C | D |\n|  | E |");
+    }
+
+    [Fact]
+    public void Reconstructs_a_table_whose_cell_wraps_across_many_lines()
+    {
+        // #329 review: the cross-column-row test must run AFTER the wrapped-cell merge. A 2-column table whose
+        // 2nd-column cell wraps to four continuation lines would otherwise be diluted (3 cross-column / 7
+        // visual lines = 0.43 < 0.5) and wrongly rejected; folding first leaves 3 clean rows that all span 2
+        // columns.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("H1", 50, 100, 700), Cell("H2", 200, 300, 700),
+            Cell("a", 50, 100, 680), Cell("note", 200, 300, 680),
+            Cell("w1", 200, 290, 666),
+            Cell("w2", 200, 290, 652),
+            Cell("w3", 200, 290, 638),
+            Cell("w4", 200, 290, 624),
+            Cell("b", 50, 100, 600), Cell("z", 200, 260, 600)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| H1 | H2 |\n| --- | --- |\n| a | note w1 w2 w3 w4 |\n| b | z |");
+    }
+
+    [Fact]
+    public void Renders_an_all_columns_wrap_as_a_separate_row_documented_limitation()
+    {
+        // #329 review / class remarks (a): when EVERY cell of a row wraps to an aligned second line, plain
+        // geometry cannot tell it from the next record, so the safe choice renders it as an extra row
+        // (non-lossy) rather than risk merging two genuine rows. Documents the accepted behavior.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("H1", 50, 100, 700), Cell("H2", 200, 300, 700),
+            Cell("alpha", 50, 100, 680), Cell("beta", 200, 300, 680),
+            Cell("cont1", 50, 100, 668), Cell("cont2", 200, 300, 668) // both columns wrap, tight against row 2
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| H1 | H2 |\n| --- | --- |\n| alpha | beta |\n| cont1 | cont2 |");
+    }
+
+    [Fact]
+    public void Does_not_merge_a_partial_line_about_one_row_below()
+    {
+        // #329 review: the continuation pitch is the bottom-to-top GAP (tightened to 0.9 median-heights), so a
+        // partial-column line a full row-pitch below is a separate row, not a wrap. E's gap (12) exceeds
+        // 0.9*12=10.8 here but would have merged under the old 1.35 window.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("A", 50, 100, 700), Cell("B", 200, 260, 700),
+            Cell("C", 50, 100, 680), Cell("D", 200, 260, 680),
+            Cell("E", 200, 260, 656) // col-2 only, ~1 row-pitch below row 2
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| A | B |\n| --- | --- |\n| C | D |\n|  | E |");
+    }
+
+    [Fact]
+    public void Escapes_inline_markdown_metacharacters_in_a_cell()
+    {
+        // #329 review: a cell is source text; literal * [ ] < ` must be escaped (like the paragraph path,
+        // #320), not just the pipe — otherwise "*a*" renders as emphasis inside the cell.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("*a*", 50, 100, 700), Cell("b", 200, 260, 700),
+            Cell("c", 50, 100, 680), Cell("d", 200, 260, 680)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| \\*a\\* | b |\n| --- | --- |\n| c | d |");
+    }
+}

--- a/core/test/Dignite.DocumentAI.TextExtraction.Tests/MarkdownText_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.Tests/MarkdownText_Tests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Shouldly;
 using Xunit;
 
@@ -95,6 +97,56 @@ public class MarkdownText_Tests
 
     [Fact]
     public void EscapeCell_null_becomes_empty() => MarkdownText.EscapeCell(null).ShouldBe(string.Empty);
+
+    // --- EscapeInlineCell (source text in a table cell — #329) ---
+
+    [Fact]
+    public void EscapeInlineCell_escapes_inline_metacharacters_and_the_pipe()
+        => MarkdownText.EscapeInlineCell("*a*|b").ShouldBe("\\*a\\*\\|b");
+
+    [Fact]
+    public void EscapeInlineCell_does_not_double_escape_a_backslash()
+        => MarkdownText.EscapeInlineCell("a\\b").ShouldBe("a\\\\b");
+
+    [Fact]
+    public void EscapeInlineCell_collapses_newlines_to_spaces()
+        => MarkdownText.EscapeInlineCell("line1\nline2").ShouldBe("line1 line2");
+
+    [Fact]
+    public void EscapeInlineCell_leaves_an_intraword_underscore_untouched()
+        => MarkdownText.EscapeInlineCell("snake_case").ShouldBe("snake_case");
+
+    [Fact]
+    public void EscapeInlineCell_null_becomes_empty() => MarkdownText.EscapeInlineCell(null).ShouldBe(string.Empty);
+
+    // --- RenderTable (shared GFM grid renderer — #329) ---
+
+    [Fact]
+    public void RenderTable_renders_header_separator_and_rows()
+        => MarkdownText.RenderTable(new IReadOnlyList<string>[]
+        {
+            new[] { "a", "b" },
+            new[] { "c", "d" }
+        }).ShouldBe("| a | b |\n| --- | --- |\n| c | d |");
+
+    [Fact]
+    public void RenderTable_pads_short_rows_to_the_widest_row()
+        => MarkdownText.RenderTable(new IReadOnlyList<string>[]
+        {
+            new[] { "a", "b" },
+            new[] { "c" }
+        }).ShouldBe("| a | b |\n| --- | --- |\n| c |  |");
+
+    [Fact]
+    public void RenderTable_emits_only_header_and_separator_for_a_single_row()
+        => MarkdownText.RenderTable(new IReadOnlyList<string>[]
+        {
+            new[] { "a", "b" }
+        }).ShouldBe("| a | b |\n| --- | --- |");
+
+    [Fact]
+    public void RenderTable_returns_empty_for_no_rows()
+        => MarkdownText.RenderTable(Array.Empty<IReadOnlyList<string>>()).ShouldBe(string.Empty);
 
     // --- InlineLabel (consolidated from the former MarkdownCell.Inline) ---
 


### PR DESCRIPTION
## Summary

Phase B of #310 (Closes #329): reconstruct a table region of a PDF's digital text layer into a GFM Markdown table, so a wrapped cell — the Japanese 料金表 `備考` case — stays in its own cell instead of interleaving with its row siblings under flat linearization.

## Approach — block-locate + word-level reconstruction

- Cluster neighbouring blocks by row adjacency, then reconstruct the grid from the cluster's **words** (not blocks). This works whether RecursiveXYCut cuts the table into per-cell blocks (generous row pitch) or per-column blocks (tight pitch) — both verified end-to-end.
- `PdfTableReconstruction` (pure, unit-tested): column x-projection gutters → visual-row clustering → wrapped-cell merge → cross-column-row + fill-ratio guards. **Non-lossy fallback** to the Phase A paragraph linearization whenever a region is not confidently a table (never forces a bad table, never drops a cell).
- Host switch `PdfExtractorOptions.ReconstructTables` (default on).

## Shared refactor (no behavior change on existing paths)

- `MarkdownText.RenderTable` — single GFM table renderer, now reused by the Word / PPTX / chart renderers and the PDF reconstructor (OpenXml output byte-identical, asserted by 109 existing tests).
- `PdfGeometry` — shared `VerticalOverlapRatio` + `Median`.
- `MarkdownText.EscapeInlineCell` — inline-escape table cells so literal `*` / `[` / backtick in source text is not re-parsed inside a cell. Extends #320 to table cells across PDF / Word / PPTX / chart (closes a pre-existing escaping gap in the OpenXml table renderers).

## Reviews

Two independent multi-agent review passes (the second on a different model). Round 1 surfaced and fixed: the cross-column ratio computed before the wrapped-cell merge, continuation-pitch semantics, cell inline-escaping, the tight-pitch efficacy gap (the word-level fix above), and the title-vs-table clustering threshold. Round 2 confirmed no new correctness bugs in the fix pass.

> Note: an earlier Decision Log comment on #329 described a "block = cell" approach; the final implementation reconstructs at the **word** level (block granularity is not stable for tables), superseding that note.

## Tests

PDF 56 · TextExtraction 82 · OpenXml 109 — all green. New: pure-geometry reconstruction tests, end-to-end positioned-PDF tests (generous + tight row pitch), `EscapeInlineCell` / `RenderTable` unit tests.
