### PR TITLE
Finalize Dignite Extract home cleanup

### DIFF
--- a/angular/packages/document-ai/documents/src/lib/documents.routes.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents.routes.ts
@@ -18,11 +18,6 @@ export const DOCUMENTS_ROUTES: Routes = [
       import('./documents/document-list/document-list.component').then(c => c.DocumentListComponent),
   },
   {
-    path: 'upload',
-    pathMatch: 'full',
-    redirectTo: '',
-  },
-  {
     path: 'recycle',
     canActivate: [authGuard, permissionGuard],
     data: { requiredPolicy: DOCUMENT_AI_PERMISSIONS.Documents.Restore },

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/en.json
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/en.json
@@ -17,7 +17,6 @@
     "Menu:Documents": "Documents",
     "Menu:DocumentList": "Document List",
     "Menu:DocumentReviewQueue": "Review Queue",
-    "Menu:UploadDocument": "Upload Document",
     "Menu:DocumentRecycleBin": "Recycle Bin",
 
     "Document:Documents": "Documents",

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/zh-Hans.json
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/zh-Hans.json
@@ -83,7 +83,6 @@
     "Menu:Documents": "文档",
     "Menu:DocumentList": "文档列表",
     "Menu:DocumentReviewQueue": "审核队列",
-    "Menu:UploadDocument": "上传文档",
     "Menu:DocumentRecycleBin": "回收站",
     "Document:RecycleBin": "回收站",
     "Document:RecycleBinEmpty": "回收站为空。",


### PR DESCRIPTION
## Summary

Final cleanup for #330 after the host home and Dignite Extract upload-first home work landed.

- Remove the legacy `/documents/upload` compatibility redirect so `/documents` is the single upload-first module home.
- Keep `/documents/list` as the canonical document list route.
- Remove the unused `Menu:UploadDocument` localization entries from English and Simplified Chinese resources.

The reusable `DocumentUploadComponent` and `/api/dignite-extract/documents/upload` API remain in place because the Dignite Extract home uses them for the upload workflow.

Closes #330

## Validation

- `npm run build:dignite-extract` passed.
- `npx nx lint dignite-extract` passed.
- `dotnet build core/src/Dignite.Extract.Domain.Shared/Dignite.Extract.Domain.Shared.csproj --no-restore` passed.
- `dotnet build Dignite.Extract.slnx --no-restore -p:BaseOutputPath=D:/dignite-projects/dignite-extract/.codex-tmp/solution-build/` passed with existing host warnings.

Note: a normal-output `dotnet build Dignite.Extract.slnx --no-restore` was also attempted first, but the local `Dignite.Extract.Host.exe` process at `host/src/bin/Debug/net10.0` (PID 15476) locked the host output DLLs and blocked the copy step. The isolated output build above avoids that local file lock.