### PR TITLE
feat(text-extraction): Scenario B figure candidate persistence (#306, PR1)

### DIFF
--- a/core/src/Dignite.DocumentAI.Abstractions/Documents/OCRCompletedEto.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/Documents/OCRCompletedEto.cs
@@ -32,4 +32,12 @@ public class OCRCompletedEto
     /// Whether OCR was actually used: true = image OCR; false = digital-native direct extraction.
     /// </summary>
     public bool UsedOcr { get; init; }
+
+    /// <summary>
+    /// Number of embedded images transcribed via figure-OCR (#306). <see cref="UsedOcr"/> still means
+    /// "scan vs digital" (a path fact); this is the named figure-OCR signal so downstream
+    /// cost-attribution can see that embedded-image OCR occurred on a digital document. 0 when none ran.
+    /// New optional field; defaults to 0 for producers / consumers that predate it.
+    /// </summary>
+    public int FigureOcrCount { get; init; }
 }

--- a/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/Figure.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/Figure.cs
@@ -1,0 +1,41 @@
+namespace Dignite.DocumentAI.Abstractions.TextExtraction;
+
+/// <summary>
+/// An embedded figure surfaced by a text-extraction provider as an <b>out-of-band</b> signal (#306):
+/// the decoded image bytes plus its OCR transcription and minimal provenance. Orthogonal to the
+/// inline-into-Markdown figure output (#301) — inlining stays the document's text payload; this object
+/// is the separate channel that lets the pipeline persist a candidate crop and route a figure that is
+/// itself a document to its own derived <see cref="Documents.Document"/> (Scenario B).
+/// <para>
+/// <b>Identity is content, not position.</b> A figure is keyed downstream by the SHA-256 of
+/// <see cref="Content"/> (which doubles as the derived document's <c>FileOrigin.ContentHash</c> /
+/// <c>OriginFigureKey</c>), never by bbox — bbox drifts across provider / re-extraction (#210). The
+/// transient <see cref="PageNumber"/> is provenance only.
+/// </para>
+/// </summary>
+public sealed class Figure
+{
+    /// <summary>Decoded image-file bytes (PNG / JPEG), the same bytes fed to <c>IOcrProvider.RecognizeAsync</c>.</summary>
+    public byte[] Content { get; }
+
+    /// <summary>Image MIME type, for example <c>image/png</c>.</summary>
+    public string ContentType { get; }
+
+    /// <summary>
+    /// OCR transcription of the figure (Markdown). This is the input the sub-document routing gate
+    /// classifies against the source's tenant type layer; it is also already inlined into the source
+    /// document's Markdown at the figure's reading position (#301).
+    /// </summary>
+    public string Transcription { get; }
+
+    /// <summary>1-based source page the figure was found on, or <c>null</c> when the format has no page concept. Provenance only.</summary>
+    public int? PageNumber { get; }
+
+    public Figure(byte[] content, string contentType, string transcription, int? pageNumber = null)
+    {
+        Content = content;
+        ContentType = contentType;
+        Transcription = transcription;
+        PageNumber = pageNumber;
+    }
+}

--- a/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/TextExtractionResult.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/TextExtractionResult.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Dignite.DocumentAI.Abstractions.TextExtraction;
 
 public class TextExtractionResult
@@ -34,4 +36,23 @@ public class TextExtractionResult
     /// DB</b> and is <b>not exposed as a parallel text field</b>.
     /// </summary>
     public NativePayload? NativePayload { get; set; }
+
+    /// <summary>
+    /// Out-of-band embedded-figure signal (#306): named / strongly-typed / nullable (the #210
+    /// <c>PageBlocks</c> precedent, <b>not</b> a <c>Dictionary&lt;string,object&gt;</c> bag, #206). Carries
+    /// each transcribed embedded image's bytes + provenance so the channel can persist candidate crops and
+    /// route a figure that is itself a document to its own derived <c>Document</c> (Scenario B).
+    /// <b>Orthogonal to inline-into-Markdown (#301)</b>: inlining stays the text payload; this is the
+    /// separate out-of-band channel. <c>null</c> when the provider surfaces no figures.
+    /// </summary>
+    public IReadOnlyList<Figure>? Figures { get; set; }
+
+    /// <summary>
+    /// Number of embedded images transcribed via figure-OCR (#306). A digital document reports
+    /// <see cref="UsedOcr"/> = false (it is a digital extraction) yet may transcribe embedded figures
+    /// through <c>IOcrProvider</c>; this named counter lets downstream audit / cost-attribution see that
+    /// embedded-image OCR occurred without overloading the binary <see cref="UsedOcr"/> "scan vs digital"
+    /// flag. 0 when no figure OCR ran.
+    /// </summary>
+    public int FigureOcrCount { get; set; }
 }

--- a/core/src/Dignite.DocumentAI.Application/DocumentAIApplicationGlobalUsings.cs
+++ b/core/src/Dignite.DocumentAI.Application/DocumentAIApplicationGlobalUsings.cs
@@ -2,5 +2,6 @@ global using Dignite.DocumentAI.Documents.Cabinets;
 global using Dignite.DocumentAI.Documents.DocumentTypes;
 global using Dignite.DocumentAI.Documents.Exports;
 global using Dignite.DocumentAI.Documents.Fields;
+global using Dignite.DocumentAI.Documents.Figures;
 global using Dignite.DocumentAI.Documents.Pipelines;
 global using Dignite.DocumentAI.Slugging;

--- a/core/src/Dignite.DocumentAI.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/DocumentAppService.cs
@@ -17,6 +17,7 @@ using Volo.Abp.BlobStoring;
 using Volo.Abp.Content;
 using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities;
+using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EventBus.Distributed;
 
 namespace Dignite.DocumentAI.Documents;
@@ -32,6 +33,9 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
     private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
     private readonly IDistributedEventBus _distributedEventBus;
     private readonly ReviewStateEvaluator _reviewEvaluator;
+    // #306: Scenario B candidate figures (own aggregate, default repository). Used to clean up candidate crop
+    // blobs on permanent delete; sub-document routing reads these in a later phase.
+    private readonly IRepository<DocumentFigure, Guid> _documentFigureRepository;
 
     public DocumentAppService(
         IDocumentRepository documentRepository,
@@ -42,7 +46,8 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
         DocumentPipelineRunManager pipelineRunManager,
         DocumentPipelineJobScheduler pipelineJobScheduler,
         IDistributedEventBus distributedEventBus,
-        ReviewStateEvaluator reviewEvaluator)
+        ReviewStateEvaluator reviewEvaluator,
+        IRepository<DocumentFigure, Guid> documentFigureRepository)
     {
         _documentRepository = documentRepository;
         _documentTypeRepository = documentTypeRepository;
@@ -53,6 +58,7 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
         _pipelineJobScheduler = pipelineJobScheduler;
         _distributedEventBus = distributedEventBus;
         _reviewEvaluator = reviewEvaluator;
+        _documentFigureRepository = documentFigureRepository;
     }
 
     public virtual async Task<DocumentDto> GetAsync(Guid id)
@@ -360,10 +366,17 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
     public virtual async Task PermanentDeleteAsync(Guid id)
     {
         Document document;
+        List<string> figureCropBlobNames;
         using (DataFilter.Disable<ISoftDelete>())
         {
             // Permanent delete needs only scalar fields + owned FileOrigin (blob name); no child collections are needed.
             document = await _documentRepository.GetAsync(id, includeDetails: false);
+
+            // #306: capture candidate figure crop blob names BEFORE the hard delete removes their rows by FK
+            // CASCADE. Derived documents promoted from these figures own independent copied blobs, so deleting
+            // the candidate crops never affects a derived document.
+            var figures = await _documentFigureRepository.GetListAsync(f => f.SourceDocumentId == id);
+            figureCropBlobNames = figures.Select(f => f.CropBlobName).ToList();
         }
 
         await _documentRepository.HardDeleteAsync(id);
@@ -393,6 +406,22 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
                 Logger.LogError(ex,
                     "Failed to delete native payload blob {BlobName} for document {DocumentId}.",
                     nativePayloadBlobName, id);
+            }
+        }
+
+        // #306: permanently delete the candidate figure crop blobs together (best-effort, like the original
+        // file and native payload blobs); their DocumentFigure rows were already removed by the FK CASCADE.
+        foreach (var cropBlobName in figureCropBlobNames)
+        {
+            try
+            {
+                await _blobContainer.DeleteAsync(cropBlobName);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex,
+                    "Failed to delete figure crop blob {BlobName} for document {DocumentId}.",
+                    cropBlobName, id);
             }
         }
 

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -15,7 +15,9 @@ using Microsoft.Extensions.Options;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
 using Volo.Abp.Threading;
 using Volo.Abp.Timing;
 using Volo.Abp.Uow;
@@ -45,6 +47,10 @@ public class DocumentTextExtractionBackgroundJob
     // ICancellationTokenProvider.Use(...) before calling ExecuteAsync. By default the worker source is the host shutdown token,
     // allowing slow external work to be cancelled.
     private readonly ICancellationTokenProvider _cancellationTokenProvider;
+    // #306: Scenario B candidate figures are an independent aggregate (default repository), persisted in
+    // this job's Complete phase from the crops written in its External phase.
+    private readonly IRepository<DocumentFigure, Guid> _documentFigureRepository;
+    private readonly IGuidGenerator _guidGenerator;
 
     public DocumentTextExtractionBackgroundJob(
         IDocumentRepository documentRepository,
@@ -61,7 +67,9 @@ public class DocumentTextExtractionBackgroundJob
         [FromKeyedServices(DocumentAIConsts.TitleGeneratorChatClientKey)] IChatClient titleGeneratorChatClient,
         IPromptProvider promptProvider,
         IOptions<DocumentAIBehaviorOptions> behaviorOptions,
-        ICancellationTokenProvider cancellationTokenProvider)
+        ICancellationTokenProvider cancellationTokenProvider,
+        IRepository<DocumentFigure, Guid> documentFigureRepository,
+        IGuidGenerator guidGenerator)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _pipelineJobScheduler = pipelineJobScheduler;
@@ -74,12 +82,17 @@ public class DocumentTextExtractionBackgroundJob
         _promptProvider = promptProvider;
         _behaviorOptions = behaviorOptions.Value;
         _cancellationTokenProvider = cancellationTokenProvider;
+        _documentFigureRepository = documentFigureRepository;
+        _guidGenerator = guidGenerator;
     }
 
     public override async Task ExecuteAsync(DocumentTextExtractionJobArgs args)
     {
         var workItem = await BeginRunAsync(args);
 
+        // Hoisted so a Complete-phase failure can reclaim the crop blobs already written in the External phase:
+        // they are written before the DocumentFigure rows commit, so a rollback would otherwise orphan them.
+        IReadOnlyList<FigureCandidate> figureCandidates = Array.Empty<FigureCandidate>();
         try
         {
             // The caller owns the blob stream. With the FileSystem provider this is a FileStream holding an OS file handle,
@@ -103,12 +116,29 @@ public class DocumentTextExtractionBackgroundJob
             // Archiving fails open: over limit / write failure / disabled archive affects only the manifest, not text extraction completion below.
             var extractionMetadata = await ArchiveNativePayloadAndBuildMetadataAsync(args.DocumentId, result);
 
+            // External phase (no UoW): persist each de-duplicated embedded figure crop (#306) to blob storage
+            // as a Scenario B routing candidate. Fails open per figure (auxiliary work must not break the main
+            // Markdown pipeline); the Complete phase below turns the returned descriptors into DocumentFigure rows.
+            figureCandidates = await PersistFigureCropsAsync(args.DocumentId, result, _cancellationTokenProvider.Token);
+
+            // The decoded crop bytes are dead once the candidates (which carry only hash / blobName / contentType /
+            // transcription) are built; drop them so the whole set is not pinned in memory through the title LLM
+            // call's result reference and the Complete-phase reload + commit. CompleteRunAsync never reads Figures.
+            result.Figures = null;
+
             await CompleteRunAsync(
-                args.DocumentId, workItem.RunId, result, title, extractionMetadata);
+                args.DocumentId, workItem.RunId, result, title, extractionMetadata, figureCandidates);
         }
         catch (Exception ex)
         {
             await FailRunAsync(args.DocumentId, workItem.RunId, ex.Message, DocumentAIPipelines.TextExtraction);
+
+            // The Complete-phase DocumentFigure inserts are atomic with the Markdown commit, so a throw means no
+            // row references the crops written in the External phase — reclaim them best-effort so a failed (and
+            // possibly never-retried) run does not leak orphan blobs. A later retry re-writes the same
+            // content-hash keys, so deleting here is safe. Cleanup failures must not mask the original error.
+            await TryDeleteFigureCropsAsync(args.DocumentId, figureCandidates);
+
             throw;
         }
     }
@@ -136,7 +166,8 @@ public class DocumentTextExtractionBackgroundJob
         Guid runId,
         TextExtractionResult result,
         string? title,
-        DocumentTextExtractionMetadata extractionMetadata)
+        DocumentTextExtractionMetadata extractionMetadata,
+        IReadOnlyList<FigureCandidate> figureCandidates)
     {
         using var uow = UnitOfWorkManager.Begin(requiresNew: true);
 
@@ -148,6 +179,25 @@ public class DocumentTextExtractionBackgroundJob
             language: result.DetectedLanguage,
             extractionMetadata: extractionMetadata);
 
+        // #306: persist Scenario B candidate figures in the SAME UoW as text-extraction completion, so the
+        // figure rows and the Markdown commit atomically. The Markdown write-once invariant makes this success
+        // path run at most once per document (a retry after a failed commit re-runs cleanly; a retry after a
+        // committed success is rejected by SetMarkdown before reaching here), so candidates insert exactly
+        // once. Intra-batch de-duplication by ContentHash already happened during crop persistence; the unique
+        // (SourceDocumentId, ContentHash) index is the final guard. RoutedDocumentId stays null until routing.
+        foreach (var candidate in figureCandidates)
+        {
+            await _documentFigureRepository.InsertAsync(new DocumentFigure(
+                _guidGenerator.Create(),
+                document.TenantId,
+                document.Id,
+                candidate.ContentHash,
+                candidate.CropBlobName,
+                candidate.ContentType,
+                candidate.Transcription,
+                candidate.PageNumber));
+        }
+
         // Publish OCRCompletedEto with a thin payload; downstream consumers pull Markdown back through REST.
         await _distributedEventBus.PublishAsync(
             new OCRCompletedEto
@@ -155,7 +205,8 @@ public class DocumentTextExtractionBackgroundJob
                 DocumentId = document.Id,
                 TenantId = document.TenantId,
                 EventTime = _clock.Now,
-                UsedOcr = result.UsedOcr
+                UsedOcr = result.UsedOcr,
+                FigureOcrCount = result.FigureOcrCount
             });
 
         // Advance classification as soon as text extraction completes. OCR has no quality gate:
@@ -196,6 +247,101 @@ public class DocumentTextExtractionBackgroundJob
         var manifest = await TryArchiveNativePayloadAsync(documentId, result.NativePayload);
         return new DocumentTextExtractionMetadata(
             result.ProviderName, manifest, result.IsComplete, result.IncompleteReason);
+    }
+
+    /// <summary>
+    /// External phase (no UoW): persists each de-duplicated embedded figure crop (#306) to blob storage as a
+    /// Scenario B routing candidate, keyed by content hash (<c>figures/{documentId}/{contentHash}</c>), and
+    /// returns the descriptors the Complete phase turns into <see cref="DocumentFigure"/> rows. The content
+    /// hash doubles as the derived document's <c>OriginFigureKey</c> / <c>FileOrigin.ContentHash</c>, tying
+    /// storage and routing idempotency together.
+    /// <para>
+    /// <b>Fails open per figure</b>: a crop is an auxiliary routing input, so empty bytes or a blob-write
+    /// failure skips only that candidate (logged) — text extraction still succeeds and the figure's
+    /// transcription is already inlined into the Markdown.
+    /// </para>
+    /// </summary>
+    protected virtual async Task<IReadOnlyList<FigureCandidate>> PersistFigureCropsAsync(
+        Guid documentId, TextExtractionResult result, CancellationToken cancellationToken = default)
+    {
+        if (result.Figures is not { Count: > 0 } figures)
+        {
+            return Array.Empty<FigureCandidate>();
+        }
+
+        var candidates = new List<FigureCandidate>(figures.Count);
+        var seen = new HashSet<string>();
+        foreach (var figure in figures)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (figure.Content is not { Length: > 0 })
+            {
+                continue;
+            }
+
+            // Fail-open at the source: a Figure with a blank ContentType cannot build a valid DocumentFigure
+            // / derived FileOrigin (the entity ctor's Check.NotNullOrWhiteSpace would throw and break the main
+            // Markdown pipeline). Skip it here — the figure's transcription is already inlined into Markdown.
+            // Today's PdfExtractor always supplies a non-empty image/* type; this guards any other producer.
+            if (string.IsNullOrWhiteSpace(figure.ContentType))
+            {
+                Logger.LogWarning(
+                    "Embedded figure for document {DocumentId} has a blank ContentType; skipping this Scenario B candidate (text extraction still succeeds).",
+                    documentId);
+                continue;
+            }
+
+            var contentHash = ContentHasher.Sha256Hex(figure.Content);
+            // De-dupe identical embedded images within one document: same bytes -> same hash -> one crop blob
+            // + one candidate row (the unique (SourceDocumentId, ContentHash) index is the final guard).
+            if (!seen.Add(contentHash))
+            {
+                continue;
+            }
+
+            var blobName = $"figures/{documentId}/{contentHash}";
+            try
+            {
+                using var stream = new MemoryStream(figure.Content, writable: false);
+                await _blobContainer.SaveAsync(blobName, stream, overrideExisting: true, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(ex,
+                    "Failed to persist figure crop {BlobName} for document {DocumentId}; skipping this Scenario B candidate (text extraction still succeeds).",
+                    blobName, documentId);
+                continue;
+            }
+
+            candidates.Add(new FigureCandidate(
+                contentHash, blobName, figure.ContentType, figure.PageNumber, figure.Transcription));
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Best-effort cleanup of figure crop blobs written in the External phase when the Complete phase failed
+    /// (#306). The Complete-phase <see cref="DocumentFigure"/> inserts are atomic with the Markdown commit, so a
+    /// failure means no committed row references these crops; without this they orphan, because permanent delete
+    /// only reclaims crops via committed rows. Failures here are swallowed so cleanup never masks the original error.
+    /// </summary>
+    private async Task TryDeleteFigureCropsAsync(Guid documentId, IReadOnlyList<FigureCandidate> figureCandidates)
+    {
+        foreach (var candidate in figureCandidates)
+        {
+            try
+            {
+                await _blobContainer.DeleteAsync(candidate.CropBlobName);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex,
+                    "Failed to clean up orphaned figure crop {BlobName} for document {DocumentId} after a failed text-extraction completion.",
+                    candidate.CropBlobName, documentId);
+            }
+        }
     }
 
     private async Task<NativePayloadManifest?> TryArchiveNativePayloadAsync(Guid documentId, NativePayload? payload)
@@ -308,6 +454,14 @@ public class DocumentTextExtractionBackgroundJob
         string BlobName,
         string ContentType,
         string? OriginalFileName);
+
+    /// <summary>
+    /// Descriptor of a persisted candidate figure crop (#306). <c>protected</c> because it appears in the
+    /// signature of the overridable <see cref="PersistFigureCropsAsync"/>; turned into a
+    /// <see cref="DocumentFigure"/> row in the Complete phase.
+    /// </summary>
+    protected sealed record FigureCandidate(
+        string ContentHash, string CropBlobName, string ContentType, int? PageNumber, string Transcription);
 }
 
 public class DocumentTextExtractionJobArgs

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentFigureConsts.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentFigureConsts.cs
@@ -1,0 +1,15 @@
+namespace Dignite.DocumentAI.Documents.Figures;
+
+/// <summary>
+/// Length limits for <see cref="DocumentFigure"/> columns (#306). Mirrors <see cref="FileOriginConsts"/>
+/// for the storage-key / content-type / hash fields; the transcription is intentionally unbounded
+/// (nvarchar(max), like <c>Document.Markdown</c>) because it is a figure-OCR snapshot, never indexed.
+/// </summary>
+public static class DocumentFigureConsts
+{
+    public static int MaxContentHashLength { get; set; } = 64;
+
+    public static int MaxCropBlobNameLength { get; set; } = 512;
+
+    public static int MaxContentTypeLength { get; set; } = 256;
+}

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentFigureStatus.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentFigureStatus.cs
@@ -1,0 +1,18 @@
+namespace Dignite.DocumentAI.Documents.Figures;
+
+/// <summary>
+/// Routing lifecycle of a <see cref="DocumentFigure"/> candidate (#306). Sub-document routing uses this as a
+/// durable, resumable work-queue marker: it processes <see cref="Pending"/> candidates, so a crash mid-routing
+/// resumes only the unfinished ones without duplicate-spawning or re-paying the gate classification.
+/// </summary>
+public enum DocumentFigureStatus
+{
+    /// <summary>Not yet evaluated by sub-document routing (the initial state).</summary>
+    Pending = 0,
+
+    /// <summary>Routed to a derived <c>Document</c> (recorded in <see cref="DocumentFigure.RoutedDocumentId"/>).</summary>
+    Spawned = 1,
+
+    /// <summary>The routing gate judged the figure not itself a document; its candidate crop blob is deleted.</summary>
+    NotADocument = 2
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Figures/DocumentFigure.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Figures/DocumentFigure.cs
@@ -1,0 +1,103 @@
+using System;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+using Volo.Abp.MultiTenancy;
+
+namespace Dignite.DocumentAI.Documents.Figures;
+
+/// <summary>
+/// A candidate embedded figure extracted from a source <see cref="Document"/> (#306, Scenario B): the
+/// persisted crop blob + its figure-OCR transcription + minimal provenance. Produced by the
+/// text-extraction pipeline (one row per de-duplicated embedded image) and later consumed by
+/// sub-document routing, which decides whether the figure is itself a document and, if so, spawns a
+/// derived <see cref="Document"/> from <see cref="CropBlobName"/>.
+/// <para>
+/// <b>Own aggregate root, not a <see cref="Document"/> child collection</b> — same rationale as the #216
+/// <c>DocumentPipelineRun</c> split: it is written by background jobs and keeps the source aggregate
+/// small (no load/lock contention between a contract and its many candidate figures). It references the
+/// source by id through <see cref="SourceDocumentId"/> (DDD reference-by-id, no navigation property),
+/// while the DB keeps an FK + CASCADE so hard-deleting the source also removes its candidate rows. There
+/// is no soft delete: a candidate figure is working state, not an independently restorable document (the
+/// derived document it may spawn is the first-class, restorable artifact).
+/// </para>
+/// <para>
+/// <b>Identity is content, not position.</b> <see cref="ContentHash"/> is the SHA-256 of the figure
+/// bytes and doubles as the derived document's <c>FileOrigin.ContentHash</c> / <c>OriginFigureKey</c>,
+/// giving idempotent routing (unique <c>(SourceDocumentId, ContentHash)</c>); bbox is deliberately not
+/// persisted as identity because it drifts across provider / re-extraction (#210). <see cref="PageNumber"/>
+/// is provenance only.
+/// </para>
+/// </summary>
+public class DocumentFigure : CreationAuditedAggregateRoot<Guid>, IMultiTenant
+{
+    public virtual Guid? TenantId { get; private set; }
+
+    /// <summary>Owning source document id (reference-by-id; DB keeps FK + CASCADE).</summary>
+    public virtual Guid SourceDocumentId { get; private set; }
+
+    /// <summary>
+    /// SHA-256 (lowercase hex) of the figure bytes. Doubles as the derived document's
+    /// <c>OriginFigureKey</c> / <c>FileOrigin.ContentHash</c> and is unique per source
+    /// (<c>(SourceDocumentId, ContentHash)</c>), so re-extraction / job retry never duplicate-spawn.
+    /// </summary>
+    public virtual string ContentHash { get; private set; } = default!;
+
+    /// <summary>BlobStore key of the persisted candidate crop (<c>figures/{sourceDocumentId}/{contentHash}</c>).</summary>
+    public virtual string CropBlobName { get; private set; } = default!;
+
+    /// <summary>Crop image MIME type, for example <c>image/png</c>; carried so routing can build the derived <c>FileOrigin</c>.</summary>
+    public virtual string ContentType { get; private set; } = default!;
+
+    /// <summary>1-based source page the figure was found on, or <c>null</c> for page-less formats. Provenance only.</summary>
+    public virtual int? PageNumber { get; private set; }
+
+    /// <summary>
+    /// Figure-OCR transcription snapshot — the input the routing gate classifies against the source's
+    /// tenant type layer. This is working state on a candidate aggregate, <b>not</b> a channel text
+    /// egress, so it does not conflict with Markdown-first (which governs the <see cref="Document"/>
+    /// aggregate's text payload). The same text is already inlined into the source <c>Document.Markdown</c>.
+    /// </summary>
+    public virtual string Transcription { get; private set; } = default!;
+
+    /// <summary>
+    /// The derived <see cref="Document"/> spawned from this figure, or <c>null</c> when not (yet) routed.
+    /// Written by sub-document routing; until then every candidate is unrouted.
+    /// </summary>
+    public virtual Guid? RoutedDocumentId { get; private set; }
+
+    /// <summary>
+    /// Routing progress (#306): <see cref="DocumentFigureStatus.Pending"/> until routing evaluates this
+    /// candidate, then <see cref="DocumentFigureStatus.Spawned"/> (a derived document was created — see
+    /// <see cref="RoutedDocumentId"/>) or <see cref="DocumentFigureStatus.NotADocument"/> (the gate rejected it
+    /// and its crop blob was deleted). This is the durable, resumable work-queue marker that lets routing crash
+    /// and resume from the remaining <see cref="DocumentFigureStatus.Pending"/> candidates without
+    /// duplicate-spawning or re-paying the gate classification for already-evaluated figures. Mutated by the
+    /// routing job (added with that job).
+    /// </summary>
+    public virtual DocumentFigureStatus Status { get; private set; }
+
+    protected DocumentFigure()
+    {
+    }
+
+    public DocumentFigure(
+        Guid id,
+        Guid? tenantId,
+        Guid sourceDocumentId,
+        string contentHash,
+        string cropBlobName,
+        string contentType,
+        string transcription,
+        int? pageNumber = null)
+        : base(id)
+    {
+        TenantId = tenantId;
+        SourceDocumentId = Check.NotDefaultOrNull<Guid>(sourceDocumentId, nameof(sourceDocumentId));
+        ContentHash = Check.NotNullOrWhiteSpace(contentHash, nameof(contentHash), DocumentFigureConsts.MaxContentHashLength);
+        CropBlobName = Check.NotNullOrWhiteSpace(cropBlobName, nameof(cropBlobName), DocumentFigureConsts.MaxCropBlobNameLength);
+        ContentType = Check.NotNullOrWhiteSpace(contentType, nameof(contentType), DocumentFigureConsts.MaxContentTypeLength);
+        Transcription = transcription ?? string.Empty;
+        PageNumber = pageNumber;
+        Status = DocumentFigureStatus.Pending;
+    }
+}

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/DocumentAIEntityFrameworkCoreGlobalUsings.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/DocumentAIEntityFrameworkCoreGlobalUsings.cs
@@ -2,4 +2,5 @@ global using Dignite.DocumentAI.Documents.Cabinets;
 global using Dignite.DocumentAI.Documents.DocumentTypes;
 global using Dignite.DocumentAI.Documents.Exports;
 global using Dignite.DocumentAI.Documents.Fields;
+global using Dignite.DocumentAI.Documents.Figures;
 global using Dignite.DocumentAI.Documents.Pipelines;

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -69,8 +69,8 @@ public class EfCoreDocumentRepository
         // Traverse only soft delete to physically delete already-soft-deleted rows, while preserving the IMultiTenant tenant boundary.
         // Never use IgnoreQueryFilters(), because it would also disable IMultiTenant and allow future callers without app-layer tenant validation
         // to hard-delete across tenants (#220).
-        // ExecuteDeleteAsync relies on DB-level ON DELETE CASCADE. Both child FKs, DocumentExtractedField and DocumentPipelineRun,
-        // use OnDelete(Cascade), and the narrowed filter does not affect cascading.
+        // ExecuteDeleteAsync relies on DB-level ON DELETE CASCADE. All three child FKs — DocumentExtractedField,
+        // DocumentPipelineRun, and DocumentFigure (#306) — use OnDelete(Cascade), and the narrowed filter does not affect cascading.
         using (DataFilter.Disable<ISoftDelete>())
         {
             var dbContext = await GetDbContextAsync();

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContext.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContext.cs
@@ -10,6 +10,7 @@ public class DocumentAIDbContext : AbpDbContext<DocumentAIDbContext>, IDocumentA
 {
     public DbSet<Document> Documents { get; set; }
     public DbSet<DocumentPipelineRun> DocumentPipelineRuns { get; set; }
+    public DbSet<DocumentFigure> DocumentFigures { get; set; }
     public DbSet<DocumentType> DocumentTypes { get; set; }
     public DbSet<FieldDefinition> FieldDefinitions { get; set; }
     public DbSet<ExportTemplate> ExportTemplates { get; set; }

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -200,6 +200,34 @@ public static class DocumentAIDbContextModelCreatingExtensions
                 .IsUnique();
         });
 
+        builder.Entity<DocumentFigure>(b =>
+        {
+            b.ToTable(DocumentAIDbProperties.DbTablePrefix + "DocumentFigures", DocumentAIDbProperties.DbSchema);
+            b.ConfigureByConvention();
+
+            b.Property(x => x.ContentHash).IsRequired().HasMaxLength(DocumentFigureConsts.MaxContentHashLength);
+            b.Property(x => x.CropBlobName).IsRequired().HasMaxLength(DocumentFigureConsts.MaxCropBlobNameLength);
+            b.Property(x => x.ContentType).IsRequired().HasMaxLength(DocumentFigureConsts.MaxContentTypeLength);
+            // Transcription is a figure-OCR snapshot (nvarchar(max), like Document.Markdown); not indexed.
+            b.Property(x => x.Transcription).IsRequired();
+            b.Property(x => x.Status).IsRequired();
+
+            // #306: candidate figure -> source Document, FK + CASCADE so hard-deleting the source removes its
+            // candidate rows (mirrors the #216 DocumentPipelineRun child-side declaration). RoutedDocumentId is
+            // a soft pointer to the spawned derived Document with NO FK constraint: the derived document is a
+            // peer that must outlive the source, so it must not cascade from / be constrained by this table.
+            b.HasOne<Document>()
+                .WithMany()
+                .HasForeignKey(x => x.SourceDocumentId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Idempotent routing / re-extraction: one candidate per (source, figure-content). A job retry that
+            // re-persists the same figure bytes collides here instead of duplicate-spawning downstream. Both
+            // columns are non-nullable, so this is a plain (portable) unique index, not a filtered one.
+            b.HasIndex(x => new { x.SourceDocumentId, x.ContentHash })
+                .IsUnique();
+        });
+
         builder.Entity<DocumentType>(b =>
         {
             b.ToTable(DocumentAIDbProperties.DbTablePrefix + "DocumentTypes", DocumentAIDbProperties.DbSchema);

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/IDocumentAIDbContext.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/IDocumentAIDbContext.cs
@@ -10,6 +10,7 @@ public interface IDocumentAIDbContext : IEfCoreDbContext
 {
     DbSet<Document> Documents { get; }
     DbSet<DocumentPipelineRun> DocumentPipelineRuns { get; }
+    DbSet<DocumentFigure> DocumentFigures { get; }
     DbSet<DocumentType> DocumentTypes { get; }
     DbSet<FieldDefinition> FieldDefinitions { get; }
     DbSet<ExportTemplate> ExportTemplates { get; }

--- a/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.DocumentAI.TextExtraction.Pdf/PdfExtractor.cs
@@ -130,9 +130,15 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
             var undecodable = 0;
             var truncatedOcr = 0;
             var failedFigureOcr = 0;
+            var figureOcrCount = 0;
             // Distinct from failedPages (GetWords fault → whole page dropped): here GetImages faulted but
             // the page's text was already extracted and is retained — only its images are skipped.
             var pagesWithSkippedImages = 0;
+            // Out-of-band figure signal (#306): the decoded crop bytes + transcription + provenance for
+            // each transcribed embedded image, surfaced on TextExtractionResult.Figures so the pipeline can
+            // persist a candidate crop and route a figure that is itself a document to its own derived
+            // Document (Scenario B). Orthogonal to the inline-into-Markdown output (#301) built below.
+            var outOfBandFigures = new List<Figure>();
 
             var languageHints = ResolveLanguageHints(context);
 
@@ -203,6 +209,10 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     }
 
                     imageBudget--;
+                    // Count the dispatched OCR call up front (the bytes are about to be sent to the provider),
+                    // so FigureOcrCount reflects every attempt — including one that throws below — per its
+                    // cost-attribution contract ("counted whether or not it yields text").
+                    figureOcrCount++;
 
                     OcrResult ocr;
                     try
@@ -239,7 +249,16 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     var transcription = ocr.Markdown?.Trim() ?? string.Empty;
                     if (transcription.Length > 0)
                     {
+                        // Inline output (#301): woven into the page Markdown at the reading position.
                         figures.Add(new PdfReadingOrder.Figure(image.BoundingBox, transcription));
+                        // Out-of-band output (#306): the crop bytes + transcription + page for sub-document
+                        // routing. Same transcription as the inline copy; downstream identity is the content
+                        // hash of the bytes (computed by the consumer), never the bbox (#210 drift).
+                        outOfBandFigures.Add(new Figure(
+                            payload.Value.Bytes,
+                            payload.Value.ContentType,
+                            transcription,
+                            pageContent.Page.Number));
                     }
                 }
 
@@ -279,7 +298,11 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                 IncompleteReason = incompleteReason,
                 // PdfPig text layer + per-image OCR has no single aggregated spatial payload to archive
                 // this round (#210). Left null deliberately.
-                NativePayload = null
+                NativePayload = null,
+                // Out-of-band figure signal (#306): null (not empty) when no figure produced a
+                // transcription, so a downstream "has figures?" check stays a simple null test.
+                Figures = outOfBandFigures.Count > 0 ? outOfBandFigures : null,
+                FigureOcrCount = figureOcrCount
             };
         }
     }

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -23,6 +23,8 @@ public class DocumentAppServiceDeleteTestModule : AbpModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        // #306: DocumentAppService depends on the DocumentFigure repository (permanent-delete crop cleanup).
+        context.Services.AddSingleton(Substitute.For<Volo.Abp.Domain.Repositories.IRepository<Figures.DocumentFigure, Guid>>());
         context.Services.AddSingleton(Substitute.For<IDocumentTypeRepository>());
         context.Services.AddSingleton(Substitute.For<IFieldDefinitionRepository>());
         context.Services.AddSingleton(Substitute.For<ICabinetRepository>());

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Rerecognize_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Rerecognize_Tests.cs
@@ -21,6 +21,8 @@ public class DocumentAppServiceRerecognizeTestModule : AbpModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        // #306: DocumentAppService depends on the DocumentFigure repository (permanent-delete crop cleanup).
+        context.Services.AddSingleton(Substitute.For<Volo.Abp.Domain.Repositories.IRepository<Figures.DocumentFigure, Guid>>());
         context.Services.AddSingleton(Substitute.For<IDocumentTypeRepository>());
         context.Services.AddSingleton(Substitute.For<IFieldDefinitionRepository>());
         context.Services.AddSingleton(Substitute.For<ICabinetRepository>());

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Retry_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Retry_Tests.cs
@@ -25,6 +25,8 @@ public class DocumentAppServiceRetryTestModule : AbpModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        // #306: DocumentAppService depends on the DocumentFigure repository (permanent-delete crop cleanup).
+        context.Services.AddSingleton(Substitute.For<Volo.Abp.Domain.Repositories.IRepository<Figures.DocumentFigure, Guid>>());
         context.Services.AddSingleton(Substitute.For<IDocumentTypeRepository>());
         context.Services.AddSingleton(Substitute.For<IFieldDefinitionRepository>());
         context.Services.AddSingleton(Substitute.For<ICabinetRepository>());

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Review_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentAppService_Review_Tests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Dignite.DocumentAI.Documents.Figures;
 using Dignite.DocumentAI.Documents.Pipelines;
 using Dignite.DocumentAI.Documents.Review;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,6 +12,7 @@ using NSubstitute;
 using Shouldly;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
+using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Modularity;
 using Volo.Abp.Validation;
@@ -24,6 +26,8 @@ public class DocumentAppServiceReviewTestModule : AbpModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
+        // #306: DocumentAppService depends on the DocumentFigure repository (permanent-delete crop cleanup).
+        context.Services.AddSingleton(Substitute.For<IRepository<DocumentFigure, Guid>>());
         context.Services.AddSingleton(Substitute.For<ICabinetRepository>());
         context.Services.AddSingleton(Substitute.For<IBlobContainer<DocumentAIDocumentContainer>>());
         context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
@@ -322,7 +326,8 @@ public class DocumentAppService_Review_Tests
                 new DocumentPipelineRunManager(runRepoSubstitute),
                 Substitute.For<IBackgroundJobManager>()),
             Substitute.For<IDistributedEventBus>(),
-            new ReviewStateEvaluator());
+            new ReviewStateEvaluator(),
+            Substitute.For<IRepository<DocumentFigure, Guid>>());
 
         var method = typeof(DocumentAppService).GetMethod(
             "ApplyFilter",

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
@@ -58,13 +58,17 @@ public class EtoContract_Tests
             DocumentId = Guid.NewGuid(),
             TenantId = null,
             EventTime = SampleEventTime,
-            UsedOcr = true
+            UsedOcr = true,
+            // Non-zero so a serialization regression (getter-only / [JsonIgnore] / rename) is actually caught;
+            // at the default 0 the round-trip would survive a broken contract (#306 review).
+            FigureOcrCount = 3
         };
 
         var roundTrip = RoundTrip(eto);
 
         roundTrip.EventTime.ShouldBe(eto.EventTime);
         roundTrip.UsedOcr.ShouldBeTrue();
+        roundTrip.FigureOcrCount.ShouldBe(3);
     }
 
     [Fact]

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -7,6 +8,7 @@ using Dignite.DocumentAI.Abstractions.TextExtraction;
 using Dignite.DocumentAI.Ai;
 using Dignite.DocumentAI.Documents;
 using Dignite.DocumentAI.Documents.Cabinets;
+using Dignite.DocumentAI.Documents.Figures;
 using Dignite.DocumentAI.Documents.Pipelines;
 using Dignite.DocumentAI.Documents.Pipelines.Classification;
 using Dignite.DocumentAI.Documents.Pipelines.TextExtraction;
@@ -17,6 +19,7 @@ using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
+using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Guids;
 using Volo.Abp.Modularity;
 using Volo.Abp.Uow;
@@ -57,6 +60,7 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
     private readonly IGuidGenerator _guidGenerator;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
     private readonly IDocumentAppService _documentAppService;
+    private readonly IRepository<DocumentFigure, Guid> _figureRepository;
 
     public DocumentPipelineBackgroundJobPersistence_Tests()
     {
@@ -70,6 +74,7 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
         _guidGenerator = GetRequiredService<IGuidGenerator>();
         _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
         _documentAppService = GetRequiredService<IDocumentAppService>();
+        _figureRepository = GetRequiredService<IRepository<DocumentFigure, Guid>>();
     }
 
     [Fact]
@@ -334,6 +339,127 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
             "blobs/test.pdf", Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task Text_Extraction_Job_Persists_Scenario_B_Candidate_Figures()
+    {
+        var documentId = _guidGenerator.Create();
+        var textExtractionRunId = await ArrangeQueuedTextExtractionAsync(documentId);
+
+        var figureBytes = new byte[] { 9, 8, 7, 6 };
+        StubExtraction("# Contract\n\nbody", usedOcr: false,
+            figures: new[] { new Figure(figureBytes, "image/png", "INVOICE No. 42", pageNumber: 2) },
+            figureOcrCount: 1);
+
+        await _textExtractionJob.ExecuteAsync(new DocumentTextExtractionJobArgs
+        {
+            DocumentId = documentId,
+            PipelineRunId = textExtractionRunId
+        });
+
+        var contentHash = Sha256Hex(figureBytes);
+
+        // The crop is persisted to blob under the content-hash key (overwrite semantics).
+        await _blobContainer.Received(1).SaveAsync(
+            $"figures/{documentId}/{contentHash}", Arg.Any<Stream>(), overrideExisting: true, Arg.Any<CancellationToken>());
+
+        // One DocumentFigure candidate row carrying provenance + the content hash that doubles as OriginFigureKey.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var figures = await _figureRepository.GetListAsync(f => f.SourceDocumentId == documentId);
+            var figure = figures.ShouldHaveSingleItem();
+            figure.ContentHash.ShouldBe(contentHash);
+            figure.CropBlobName.ShouldBe($"figures/{documentId}/{contentHash}");
+            figure.ContentType.ShouldBe("image/png");
+            figure.PageNumber.ShouldBe(2);
+            figure.Transcription.ShouldBe("INVOICE No. 42");
+            figure.RoutedDocumentId.ShouldBeNull();
+            figure.Status.ShouldBe(DocumentFigureStatus.Pending);
+        });
+    }
+
+    [Fact]
+    public async Task Text_Extraction_Job_Deduplicates_Identical_Candidate_Figures()
+    {
+        var documentId = _guidGenerator.Create();
+        var textExtractionRunId = await ArrangeQueuedTextExtractionAsync(documentId);
+
+        // Two embedded images with identical bytes -> one candidate (same content hash); the unique
+        // (SourceDocumentId, ContentHash) index is the final guard, intra-batch de-dup avoids the collision.
+        var bytes = new byte[] { 4, 4, 4 };
+        StubExtraction("# Doc\n\nbody", usedOcr: false,
+            figures: new[]
+            {
+                new Figure(bytes, "image/png", "same figure", pageNumber: 1),
+                new Figure(bytes, "image/png", "same figure", pageNumber: 3)
+            },
+            figureOcrCount: 2);
+
+        await _textExtractionJob.ExecuteAsync(new DocumentTextExtractionJobArgs
+        {
+            DocumentId = documentId,
+            PipelineRunId = textExtractionRunId
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var figures = await _figureRepository.GetListAsync(f => f.SourceDocumentId == documentId);
+            figures.ShouldHaveSingleItem();
+        });
+    }
+
+    [Fact]
+    public async Task PermanentDelete_Removes_Candidate_Figure_Crop_Blobs()
+    {
+        var documentId = _guidGenerator.Create();
+        var textExtractionRunId = await ArrangeQueuedTextExtractionAsync(documentId);
+
+        var figureBytes = new byte[] { 5, 5, 5, 5 };
+        StubExtraction("# Contract\n\nbody", usedOcr: false,
+            figures: new[] { new Figure(figureBytes, "image/png", "fig", pageNumber: 1) },
+            figureOcrCount: 1);
+
+        await _textExtractionJob.ExecuteAsync(new DocumentTextExtractionJobArgs
+        {
+            DocumentId = documentId,
+            PipelineRunId = textExtractionRunId
+        });
+
+        await _documentAppService.PermanentDeleteAsync(documentId);
+
+        // The candidate crop blob is deleted alongside the original-file blob; its DocumentFigure row was
+        // already removed by the FK CASCADE on hard delete.
+        await _blobContainer.Received(1).DeleteAsync(
+            $"figures/{documentId}/{Sha256Hex(figureBytes)}", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Failed_Complete_Phase_Reclaims_Orphaned_Figure_Crop_Blobs()
+    {
+        var documentId = _guidGenerator.Create();
+        var textExtractionRunId = await ArrangeQueuedTextExtractionAsync(documentId);
+
+        var figureBytes = new byte[] { 1, 2, 3, 9 };
+        StubExtraction("# Contract\n\nbody", usedOcr: false,
+            figures: new[] { new Figure(figureBytes, "image/png", "fig", pageNumber: 1) },
+            figureOcrCount: 1);
+
+        // Force the Complete phase to throw AFTER the External phase wrote the crop blob: the cabinet-suggestion
+        // fan-out enqueue runs inside CompleteRunAsync before the UoW commits, so the figure-row inserts roll back.
+        _backgroundJobManager.EnqueueAsync(
+                Arg.Any<DocumentCabinetSuggestionJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>())
+            .ThrowsAsync(new InvalidOperationException("complete-phase boom"));
+
+        await Should.ThrowAsync<InvalidOperationException>(() => _textExtractionJob.ExecuteAsync(
+            new DocumentTextExtractionJobArgs { DocumentId = documentId, PipelineRunId = textExtractionRunId }));
+
+        // The crop was written in the External phase; the Complete UoW threw before commit, so the catch path
+        // reclaims the crop blob instead of leaking it. (Asserting the DocumentFigure rows rolled back is left to
+        // production transaction semantics — the in-memory SQLite test harness does not roll back autoSaved
+        // inserts; this test pins the blob-reclaim behavior the fix adds.)
+        await _blobContainer.Received(1).DeleteAsync(
+            $"figures/{documentId}/{Sha256Hex(figureBytes)}", Arg.Any<CancellationToken>());
+    }
+
     private async Task<Guid> ArrangeQueuedTextExtractionAsync(Guid documentId)
     {
         Guid textExtractionRunId = default;
@@ -350,7 +476,8 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
 
     // Stub callback assertion that external extraction work runs outside the ambient UoW, matching the
     // background-jobs.md short-UoW rule.
-    private void StubExtraction(string markdown, bool usedOcr, NativePayload? nativePayload = null)
+    private void StubExtraction(string markdown, bool usedOcr, NativePayload? nativePayload = null,
+        IReadOnlyList<Figure>? figures = null, int figureOcrCount = 0)
     {
         _blobContainer.GetAsync(Arg.Any<string>())
             .Returns(Task.FromResult<Stream>(new MemoryStream([1, 2, 3])));
@@ -367,10 +494,16 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
                     DetectedLanguage = "en",
                     UsedOcr = usedOcr,
                     ProviderName = usedOcr ? "PaddleOCR" : "ElBruno.MarkItDotNet",
-                    NativePayload = nativePayload
+                    NativePayload = nativePayload,
+                    Figures = figures,
+                    FigureOcrCount = figureOcrCount
                 };
             });
     }
+
+    // Delegate to the production canonical hasher so the test asserts the figure crop key against the exact
+    // hash convention the code under test uses, rather than a parallel hand-rolled copy that could drift (#306 review).
+    private static string Sha256Hex(byte[] bytes) => ContentHasher.Sha256Hex(bytes);
 
     private static Document CreateDocument(Guid id)
     {

--- a/core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.DocumentAI.TextExtraction.Pdf.Tests/PdfExtractor_Tests.cs
@@ -96,6 +96,64 @@ public class PdfExtractor_Tests
     }
 
     [Fact]
+    public async Task Surfaces_each_transcribed_image_as_an_out_of_band_figure()
+    {
+        StubOcr("INVOICE No. 42");
+
+        var png = TinyPng.CreateSolid(48, 48);
+        var pdf = PdfFixtures.Build(
+            texts: new[] { ("Body text", 700.0) },
+            images: new[] { (png, new PdfRectangle(50, 400, 200, 550)) });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // #306 out-of-band signal: the transcribed image is surfaced on Figures with its bytes + provenance,
+        // while UsedOcr stays false (a digital extraction) and FigureOcrCount records the embedded-image OCR.
+        result.UsedOcr.ShouldBeFalse();
+        result.FigureOcrCount.ShouldBe(1);
+
+        result.Figures.ShouldNotBeNull();
+        result.Figures!.Count.ShouldBe(1);
+        var figure = result.Figures[0];
+        figure.Transcription.ShouldBe("INVOICE No. 42");
+        figure.Content.Length.ShouldBeGreaterThan(0);
+        figure.ContentType.ShouldStartWith("image/");
+        figure.PageNumber.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Leaves_figures_null_and_count_zero_when_no_image_is_transcribed()
+    {
+        var pdf = PdfFixtures.Build(texts: new[] { ("Just digital text", 700.0) });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // Null (not empty) so a downstream "has figures?" check stays a simple null test; no OCR ran.
+        result.Figures.ShouldBeNull();
+        result.FigureOcrCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Counts_a_dispatched_figure_ocr_even_when_it_throws()
+    {
+        // The OCR call is dispatched (bytes sent) then throws (provider timeout / rate-limit). FigureOcrCount
+        // is a cost-attribution signal that counts dispatched calls, so the failed call must still be counted.
+        _ocr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("provider down"));
+
+        var png = TinyPng.CreateSolid(48, 48);
+        var pdf = PdfFixtures.Build(
+            texts: new[] { ("Body text", 700.0) },
+            images: new[] { (png, new PdfRectangle(50, 400, 200, 550)) });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        result.FigureOcrCount.ShouldBe(1);   // dispatched, even though it threw
+        result.Figures.ShouldBeNull();       // no transcription produced -> no out-of-band figure
+        result.IsComplete.ShouldBeFalse();   // #268 trips on the failed figure OCR
+    }
+
+    [Fact]
     public async Task Feeds_image_bytes_to_the_ocr_provider()
     {
         StubOcr("FIGURE");

--- a/host/src/Migrations/20260616061248_Added_DocumentFigures.Designer.cs
+++ b/host/src/Migrations/20260616061248_Added_DocumentFigures.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.DocumentAI.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.DocumentAI.Host.Migrations
 {
     [DbContext(typeof(DocumentAIHostDbContext))]
-    partial class DocumentAIHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616061248_Added_DocumentFigures")]
+    partial class Added_DocumentFigures
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260616061248_Added_DocumentFigures.cs
+++ b/host/src/Migrations/20260616061248_Added_DocumentFigures.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.DocumentAI.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Added_DocumentFigures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DocAIDocumentFigures",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SourceDocumentId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ContentHash = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    CropBlobName = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    ContentType = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    PageNumber = table.Column<int>(type: "int", nullable: true),
+                    Transcription = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    RoutedDocumentId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DocAIDocumentFigures", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DocAIDocumentFigures_DocAIDocuments_SourceDocumentId",
+                        column: x => x.SourceDocumentId,
+                        principalTable: "DocAIDocuments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAIDocumentFigures_SourceDocumentId_ContentHash",
+                table: "DocAIDocumentFigures",
+                columns: new[] { "SourceDocumentId", "ContentHash" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DocAIDocumentFigures");
+        }
+    }
+}


### PR DESCRIPTION
## PR1 of #306 (Scenario B): figure contract + candidate persistence

First of two PRs for #306. Lands the out-of-band figure contract and the durable candidate ledger the PR2 routing job will consume. An embedded figure that is itself a document becomes its own derived `Document` in PR2; this PR captures and persists the candidates without routing yet. Design recorded in the #306 Decision Log comments.

### What this PR does

- **Contract** (`Abstractions`): new `Figure` (decoded bytes + transcription + page); `TextExtractionResult.Figures` + `FigureOcrCount`; `OCRCompletedEto.FigureOcrCount` (named figure-OCR signal, not overloading `UsedOcr`). Named / strongly-typed / nullable — the #210 `PageBlocks` precedent, no `Dictionary<string,object>` bag.
- **Provider** (`PdfExtractor`): populates `Figures` + `FigureOcrCount` alongside the existing inline-into-Markdown output (#301). `FigureOcrCount` counts every dispatched embedded-image OCR call, including ones that throw.
- **Domain**: `DocumentFigure` aggregate root (own aggregate, #216 pattern) with `Status` (Pending / Spawned / NotADocument) as the resumable routing work-queue marker. `ContentHash` doubles as the derived document's `OriginFigureKey`.
- **Text-extraction job**: persists de-duplicated figure crops to blob (fail-open: skips blank ContentType, forwards the cancellation token); inserts `DocumentFigure` rows atomically with `Markdown`; reclaims crop blobs on a failed completion; releases figure bytes after persistence.
- **Permanent delete**: reclaims candidate crop blobs.
- **EF**: `DocumentFigures` table + FK CASCADE to the source document + unique `(SourceDocumentId, ContentHash)`; migration `Added_DocumentFigures`.

### Recovery / stability

`DocumentFigure` is the durable, resumable routing ledger: the source's text extraction completes reliably (candidates persisted atomically with `Markdown`), and routing (PR2) runs as a separately-retried job that resumes from `Pending` candidates after a crash — without coupling the unreliable LLM routing to the must-succeed main pipeline.

### Tests

PdfExtractor figure population (+ dispatched-OCR counting incl. failures), text-extraction candidate persistence + de-dup, failed-completion crop reclaim, permanent-delete crop cleanup, and the `OCRCompletedEto.FigureOcrCount` serialization round-trip. Full suites green: Application 250, EntityFrameworkCore 74, TextExtraction.Pdf 59.

A code review of the branch was run; its findings (figure-OCR-count contract, fail-open figure inserts, crop-orphan reclaim on failed completion, stale cascade comment, cancellation-token forwarding, ETO round-trip coverage, hash-helper de-duplication) were applied in this PR.

### Out of scope (PR2)

`DocumentFigureRoutingJob` (gate + spawn + resume), `Document.OriginDocumentId`/`OriginFigureKey`, derived-document OCR seeding, and egress provenance.

Part of #306.
