### PR TITLE
feat(documents): route figure sub-documents to derived documents (#306, PR2)

### DIFF
--- a/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReadyEto.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReadyEto.cs
@@ -37,4 +37,12 @@ public class DocumentReadyEto
     public required DateTime EventTime { get; init; }
 
     public string? DocumentTypeCode { get; init; }
+
+    /// <summary>
+    /// Provenance link for a Scenario B sub-document (#306): when this document was derived from an embedded
+    /// figure of another document, the id of that source document; <c>null</c> for normally-uploaded documents.
+    /// Downstream may follow it to associate the derived document with its source. New optional field; defaults
+    /// to <c>null</c> for producers / consumers that predate it.
+    /// </summary>
+    public Guid? OriginDocumentId { get; init; }
 }

--- a/core/src/Dignite.DocumentAI.Application.Contracts/Documents/DocumentDto.cs
+++ b/core/src/Dignite.DocumentAI.Application.Contracts/Documents/DocumentDto.cs
@@ -15,6 +15,12 @@ public class DocumentDto : EntityDto<Guid>
     /// <summary>Owning cabinet (#194). null means uncategorized. The frontend maps cabinet names from the cabinet list.</summary>
     public Guid? CabinetId { get; set; }
 
+    /// <summary>
+    /// Provenance link for a Scenario B sub-document (#306): when this document was derived from an embedded
+    /// figure of another document, the id of that source document; <c>null</c> for normally-uploaded documents.
+    /// </summary>
+    public Guid? OriginDocumentId { get; set; }
+
     public string? DocumentTypeCode { get; set; }
     public DocumentLifecycleStatus LifecycleStatus { get; set; }
     public DocumentReviewDisposition ReviewDisposition { get; set; }

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler.cs
@@ -77,7 +77,9 @@ public class DocumentReadyEventHandler
                 DocumentId = document.Id,
                 TenantId = document.TenantId,
                 EventTime = _clock.Now,
-                DocumentTypeCode = documentTypeCode
+                DocumentTypeCode = documentTypeCode,
+                // #306: provenance link for a Scenario B sub-document (null for normally-uploaded documents).
+                OriginDocumentId = document.OriginDocumentId
             });
 
         _logger.LogInformation(

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
@@ -37,8 +37,9 @@ namespace Dignite.DocumentAI.Documents.Pipelines.Routing;
 /// each figure's evaluation commits atomically with its status change, so a crash resumes the remaining
 /// candidates without re-paying the gate classification or duplicate-spawning. The unique
 /// <c>(OriginDocumentId, OriginFigureKey)</c> index on <see cref="Document"/> is the final backstop against a
-/// concurrent double-route. Per-figure failures are isolated: one bad figure is logged and left
-/// <see cref="DocumentFigureStatus.Pending"/> for a later retry without blocking the others.
+/// concurrent double-route. Per-figure failures are isolated (one bad figure does not block the others) and
+/// surfaced: a figure left <see cref="DocumentFigureStatus.Pending"/> by a fault makes the job rethrow so ABP
+/// retries it, re-loading only the still-Pending candidates.
 /// </para>
 /// <para>
 /// <b>UoW discipline</b> (background-jobs.md): the gate LLM call and blob IO run outside any UoW; only the
@@ -103,6 +104,13 @@ public class DocumentFigureRoutingJob
             return;
         }
 
+        // Per-figure faults are isolated (one bad figure must not block the rest) but NOT swallowed: each is
+        // collected, and if any remain the job rethrows at the end so ABP reschedules it. Routing is enqueued
+        // exactly once (by the write-once text-extraction job), so swallowing here would strand the figure Pending
+        // forever — never spawned, its crop never reclaimed. On retry LoadAsync re-loads ONLY the still-Pending
+        // figures (spawned/rejected ones are terminal), so retries are cheap and never duplicate-spawn.
+        var failures = new List<Exception>();
+
         if (workItem.CandidateTypes.Count == 0)
         {
             // No document types in the source's layer -> nothing can be classified as a document. Mark every
@@ -113,27 +121,49 @@ public class DocumentFigureRoutingJob
             foreach (var figure in workItem.PendingFigures)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await SafeRejectAsync(workItem, figure);
+                await RouteWithIsolationAsync(
+                    failures, figure, args.SourceDocumentId, () => SafeRejectAsync(workItem, figure));
             }
-
-            return;
+        }
+        else
+        {
+            foreach (var figure in workItem.PendingFigures)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await RouteWithIsolationAsync(
+                    failures, figure, args.SourceDocumentId, () => RouteFigureAsync(workItem, figure, cancellationToken));
+            }
         }
 
-        foreach (var figure in workItem.PendingFigures)
+        if (failures.Count > 0)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            try
-            {
-                await RouteFigureAsync(workItem, figure, cancellationToken);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                // Per-figure isolation: a single bad figure (gate error, blob fault, transient DB error) must
-                // not block the rest. Leave it Pending so a later job retry re-attempts it.
-                Logger.LogWarning(ex,
-                    "Routing figure {FigureId} of source {SourceDocumentId} failed; leaving it Pending for retry.",
-                    figure.FigureId, args.SourceDocumentId);
-            }
+            // Surface the faults so ABP reschedules the job; the figures that already spawned/rejected are
+            // terminal and will not be reprocessed. A persistently-failing figure is retried under ABP's backoff
+            // until ABP gives up, leaving a durably visible failure rather than a silent permanent-Pending.
+            throw new AggregateException(
+                $"Figure routing left {failures.Count} candidate figure(s) of source {args.SourceDocumentId} Pending; the job will be retried.",
+                failures);
+        }
+    }
+
+    /// <summary>
+    /// Runs one figure's routing action with per-figure isolation: a fault is logged and collected (so
+    /// <see cref="ExecuteAsync"/> can rethrow and trigger a job retry) instead of aborting the remaining figures.
+    /// Cancellation is never collected — it propagates so the job is treated as cancelled, not failed.
+    /// </summary>
+    private async Task RouteWithIsolationAsync(
+        List<Exception> failures, FigureSnapshot figure, Guid sourceDocumentId, Func<Task> route)
+    {
+        try
+        {
+            await route();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logger.LogWarning(ex,
+                "Routing figure {FigureId} of source {SourceDocumentId} failed; left Pending for job retry.",
+                figure.FigureId, sourceDocumentId);
+            failures.Add(ex);
         }
     }
 
@@ -175,6 +205,15 @@ public class DocumentFigureRoutingJob
     protected virtual async Task RouteFigureAsync(
         RoutingWorkItem workItem, FigureSnapshot figure, CancellationToken cancellationToken)
     {
+        // A figure whose OCR transcription is empty/whitespace (decorative image, logo, or OCR found no text)
+        // cannot be a document — reject it without paying a gate LLM call, and without risking the model inventing
+        // a confident type from the candidate list alone with no content to ground it.
+        if (string.IsNullOrWhiteSpace(figure.Transcription))
+        {
+            await SafeRejectAsync(workItem, figure);
+            return;
+        }
+
         // Gate (external, no UoW): classify the figure transcription against the source's tenant type layer.
         DocumentClassificationOutcome outcome;
         using (_currentTenant.Change(workItem.TenantId))
@@ -247,11 +286,12 @@ public class DocumentFigureRoutingJob
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // The spawn UoW failed and rolled back, so the copied blob references no committed document — reclaim
-            // it, then rethrow so the per-figure handler leaves the figure Pending for a later retry (which writes
-            // a fresh copy). Mirrors the text-extraction job's failed-completion crop cleanup. The
-            // already-routed / concurrent-double-spawn paths inside CommitSpawnAsync delete the blob themselves
-            // and return without throwing, so they are not double-deleted here.
+            // The spawn UoW failed and rolled back (a concurrent unique-index collision, or any other fault), so
+            // the copied blob now references no committed document — reclaim it, then rethrow so the per-figure
+            // handler records the fault and the job is retried (which writes a fresh copy next time). Mirrors the
+            // text-extraction job's failed-completion crop cleanup. The one CommitSpawnAsync path that returns
+            // without throwing (the candidate is already non-Pending) deletes its own orphan blob, so it is not
+            // double-deleted here.
             await TryDeleteBlobAsync(derivedBlobName);
             throw;
         }
@@ -290,21 +330,13 @@ public class DocumentFigureRoutingJob
             var derived = Document.CreateDerived(
                 derivedDocumentId, workItem.TenantId, fileOrigin, workItem.SourceDocumentId, figure.ContentHash);
 
-            try
-            {
-                await _documentRepository.InsertAsync(derived, autoSave: true);
-            }
-            catch (Exception ex) when (IsUniqueConstraintViolation(ex))
-            {
-                // A concurrent route already spawned this figure's derived document (the unique
-                // (OriginDocumentId, OriginFigureKey) index fired). Roll back, drop our orphan blob, and stop;
-                // the winning run owns the figure's status.
-                Logger.LogInformation(
-                    "Figure {FigureId} of source {SourceDocumentId} was already spawned concurrently; skipping.",
-                    figure.FigureId, workItem.SourceDocumentId);
-                await TryDeleteBlobAsync(derivedBlobName);
-                return;
-            }
+            // A concurrent route that already committed this figure's derived document trips the unique
+            // (OriginDocumentId, OriginFigureKey) index here. The failure propagates to SpawnDerivedDocumentAsync,
+            // which reclaims this run's orphan blob and rethrows so the job retries; on retry LoadAsync sees the
+            // figure as Spawned (the winner committed it) and skips it — self-healing, no duplicate. Not narrowing
+            // to a specific exception type is deliberate: any non-unique DB failure also surfaces (job retry)
+            // instead of being silently swallowed as a "concurrency skip".
+            await _documentRepository.InsertAsync(derived, autoSave: true);
 
             entity.MarkSpawned(derivedDocumentId);
             await _figureRepository.UpdateAsync(entity);
@@ -338,26 +370,6 @@ public class DocumentFigureRoutingJob
         {
             Logger.LogWarning(ex, "Failed to delete blob {BlobName} during figure routing cleanup.", blobName);
         }
-    }
-
-    /// <summary>Whether the exception is (or wraps) a DB unique-constraint violation, used to detect a concurrent double-spawn.</summary>
-    protected virtual bool IsUniqueConstraintViolation(Exception ex)
-    {
-        for (var current = ex; current != null; current = current.InnerException)
-        {
-            if (current is Volo.Abp.Data.AbpDbConcurrencyException)
-            {
-                return true;
-            }
-
-            var typeName = current.GetType().Name;
-            if (typeName == "DbUpdateException" || typeName == "UniqueConstraintException")
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static string ImageExtensionForContentType(string contentType)

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Ai;
+using Dignite.DocumentAI.Documents.DocumentTypes;
+using Dignite.DocumentAI.Documents.Pipelines.Classification;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Threading;
+using Volo.Abp.Timing;
+using Volo.Abp.Uow;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Routing;
+
+/// <summary>
+/// Scenario B sub-document routing (#306). Consumes the <see cref="DocumentFigure"/> candidates that the
+/// text-extraction job persisted for a source document and decides, per figure, whether the figure is itself
+/// a document — by classifying its OCR transcription against the source's tenant document-type layer and
+/// comparing against the matched type's <c>ConfidenceThreshold</c> (the same per-type Ready-gate bar). A figure
+/// that clears the bar is spawned as its own derived <see cref="Document"/> (its crop copied to an independent
+/// blob, back-reference <c>OriginDocumentId</c> / <c>OriginFigureKey</c> set), which then runs the full normal
+/// pipeline; a figure that does not is marked <see cref="DocumentFigureStatus.NotADocument"/> and its candidate
+/// crop is deleted. Figures that remain inline in the source Markdown either way (#301).
+/// <para>
+/// <b>Resumable + idempotent.</b> Only <see cref="DocumentFigureStatus.Pending"/> candidates are processed, and
+/// each figure's evaluation commits atomically with its status change, so a crash resumes the remaining
+/// candidates without re-paying the gate classification or duplicate-spawning. The unique
+/// <c>(OriginDocumentId, OriginFigureKey)</c> index on <see cref="Document"/> is the final backstop against a
+/// concurrent double-route. Per-figure failures are isolated: one bad figure is logged and left
+/// <see cref="DocumentFigureStatus.Pending"/> for a later retry without blocking the others.
+/// </para>
+/// <para>
+/// <b>UoW discipline</b> (background-jobs.md): the gate LLM call and blob IO run outside any UoW; only the
+/// derived-document insert + figure status change + derived-pipeline enqueue run inside a short UoW.
+/// </para>
+/// </summary>
+[BackgroundJobName("DocumentAI.DocumentFigureRouting")]
+public class DocumentFigureRoutingJob
+    : AsyncBackgroundJob<DocumentFigureRoutingJobArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentFigure, Guid> _figureRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly DocumentClassificationWorkflow _classificationWorkflow;
+    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
+    private readonly IDistributedEventBus _distributedEventBus;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly IClock _clock;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly DocumentAIBehaviorOptions _behaviorOptions;
+    private readonly ICancellationTokenProvider _cancellationTokenProvider;
+
+    public DocumentFigureRoutingJob(
+        IDocumentRepository documentRepository,
+        IRepository<DocumentFigure, Guid> figureRepository,
+        IDocumentTypeRepository documentTypeRepository,
+        DocumentClassificationWorkflow classificationWorkflow,
+        DocumentPipelineJobScheduler pipelineJobScheduler,
+        IBlobContainer<DocumentAIDocumentContainer> blobContainer,
+        IDistributedEventBus distributedEventBus,
+        ICurrentTenant currentTenant,
+        IClock clock,
+        IGuidGenerator guidGenerator,
+        IUnitOfWorkManager unitOfWorkManager,
+        IOptions<DocumentAIBehaviorOptions> behaviorOptions,
+        ICancellationTokenProvider cancellationTokenProvider)
+    {
+        _documentRepository = documentRepository;
+        _figureRepository = figureRepository;
+        _documentTypeRepository = documentTypeRepository;
+        _classificationWorkflow = classificationWorkflow;
+        _pipelineJobScheduler = pipelineJobScheduler;
+        _blobContainer = blobContainer;
+        _distributedEventBus = distributedEventBus;
+        _currentTenant = currentTenant;
+        _clock = clock;
+        _guidGenerator = guidGenerator;
+        _unitOfWorkManager = unitOfWorkManager;
+        _behaviorOptions = behaviorOptions.Value;
+        _cancellationTokenProvider = cancellationTokenProvider;
+    }
+
+    public override async Task ExecuteAsync(DocumentFigureRoutingJobArgs args)
+    {
+        var cancellationToken = _cancellationTokenProvider.Token;
+
+        var workItem = await LoadAsync(args.SourceDocumentId);
+        if (workItem is null || workItem.PendingFigures.Count == 0)
+        {
+            return;
+        }
+
+        if (workItem.CandidateTypes.Count == 0)
+        {
+            // No document types in the source's layer -> nothing can be classified as a document. Mark every
+            // candidate NotADocument (and reclaim its crop) so the job does not re-run them forever.
+            Logger.LogDebug(
+                "Figure routing for source {SourceDocumentId}: no candidate document types; rejecting {Count} figure(s).",
+                args.SourceDocumentId, workItem.PendingFigures.Count);
+            foreach (var figure in workItem.PendingFigures)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await SafeRejectAsync(workItem, figure);
+            }
+
+            return;
+        }
+
+        foreach (var figure in workItem.PendingFigures)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await RouteFigureAsync(workItem, figure, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Per-figure isolation: a single bad figure (gate error, blob fault, transient DB error) must
+                // not block the rest. Leave it Pending so a later job retry re-attempts it.
+                Logger.LogWarning(ex,
+                    "Routing figure {FigureId} of source {SourceDocumentId} failed; leaving it Pending for retry.",
+                    figure.FigureId, args.SourceDocumentId);
+            }
+        }
+    }
+
+    /// <summary>Load phase (short UoW): snapshot the source's tenant + uploader, candidate types, and pending figures.</summary>
+    protected virtual async Task<RoutingWorkItem?> LoadAsync(Guid sourceDocumentId)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var source = await _documentRepository.FindAsync(sourceDocumentId, includeDetails: false);
+        if (source is null)
+        {
+            return null;
+        }
+
+        List<DocumentType> candidateTypes;
+        using (_currentTenant.Change(source.TenantId))
+        {
+            var visible = await _documentTypeRepository.GetListAsync();
+            candidateTypes = visible
+                .OrderByDescending(t => t.Priority)
+                .ThenBy(t => t.TypeCode)
+                .Take(_behaviorOptions.MaxDocumentTypesInClassificationPrompt)
+                .ToList();
+        }
+
+        var pending = await _figureRepository.GetListAsync(
+            f => f.SourceDocumentId == sourceDocumentId && f.Status == DocumentFigureStatus.Pending);
+
+        var figures = pending
+            .Select(f => new FigureSnapshot(f.Id, f.ContentHash, f.CropBlobName, f.ContentType, f.PageNumber, f.Transcription))
+            .ToList();
+
+        await uow.CompleteAsync();
+
+        return new RoutingWorkItem(
+            sourceDocumentId, source.TenantId, source.FileOrigin.UploadedByUserName, candidateTypes, figures);
+    }
+
+    protected virtual async Task RouteFigureAsync(
+        RoutingWorkItem workItem, FigureSnapshot figure, CancellationToken cancellationToken)
+    {
+        // Gate (external, no UoW): classify the figure transcription against the source's tenant type layer.
+        DocumentClassificationOutcome outcome;
+        using (_currentTenant.Change(workItem.TenantId))
+        {
+            outcome = await _classificationWorkflow.RunAsync(workItem.CandidateTypes, figure.Transcription, cancellationToken);
+        }
+
+        // Match the winning type from the already-loaded candidates (same set the classifier chose from), and
+        // gate on that type's own ConfidenceThreshold — the figure must read as a confident document of a known
+        // type to become one, otherwise it stays inline-only.
+        var matched = string.IsNullOrEmpty(outcome.TypeCode)
+            ? null
+            : workItem.CandidateTypes.FirstOrDefault(t => t.TypeCode == outcome.TypeCode);
+        var isDocument = matched != null && outcome.ConfidenceScore >= matched.ConfidenceThreshold;
+
+        if (!isDocument)
+        {
+            await SafeRejectAsync(workItem, figure);
+            return;
+        }
+
+        await SpawnDerivedDocumentAsync(workItem, figure, cancellationToken);
+    }
+
+    /// <summary>Reject path: mark the candidate NotADocument (short UoW), then reclaim its crop blob (external, fail-open).</summary>
+    private async Task SafeRejectAsync(RoutingWorkItem workItem, FigureSnapshot figure)
+    {
+        using (_currentTenant.Change(workItem.TenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var entity = await _figureRepository.FindAsync(figure.FigureId);
+            if (entity is null || entity.Status != DocumentFigureStatus.Pending)
+            {
+                return;
+            }
+
+            entity.MarkNotADocument();
+            await _figureRepository.UpdateAsync(entity);
+            await uow.CompleteAsync();
+        }
+
+        await TryDeleteBlobAsync(figure.CropBlobName);
+    }
+
+    private async Task SpawnDerivedDocumentAsync(
+        RoutingWorkItem workItem, FigureSnapshot figure, CancellationToken cancellationToken)
+    {
+        // External: copy the candidate crop into an independent, derived-document-owned blob so the derived
+        // document outlives the source (the source's permanent delete reclaims the candidate crop, not this copy).
+        byte[] cropBytes;
+        await using (var cropStream = await _blobContainer.GetAsync(figure.CropBlobName))
+        using (var buffer = new MemoryStream())
+        {
+            await cropStream.CopyToAsync(buffer, cancellationToken);
+            cropBytes = buffer.ToArray();
+        }
+
+        var extension = ImageExtensionForContentType(figure.ContentType);
+        var derivedBlobName = _guidGenerator.Create().ToString("N") + extension;
+        using (var saveStream = new MemoryStream(cropBytes, writable: false))
+        {
+            await _blobContainer.SaveAsync(derivedBlobName, saveStream, overrideExisting: true, cancellationToken);
+        }
+
+        var derivedDocumentId = _guidGenerator.Create();
+
+        try
+        {
+            await CommitSpawnAsync(workItem, figure, derivedBlobName, derivedDocumentId, extension, cropBytes.LongLength);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The spawn UoW failed and rolled back, so the copied blob references no committed document — reclaim
+            // it, then rethrow so the per-figure handler leaves the figure Pending for a later retry (which writes
+            // a fresh copy). Mirrors the text-extraction job's failed-completion crop cleanup. The
+            // already-routed / concurrent-double-spawn paths inside CommitSpawnAsync delete the blob themselves
+            // and return without throwing, so they are not double-deleted here.
+            await TryDeleteBlobAsync(derivedBlobName);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Complete phase (short UoW): inserts the derived document, marks the figure Spawned, publishes
+    /// <c>DocumentUploadedEto</c>, and queues the derived document's pipeline — all atomically. Returns early
+    /// (deleting the orphan copied blob) when the candidate is no longer Pending or a concurrent route already
+    /// spawned it; any other failure rolls back and propagates to the caller's orphan-blob cleanup.
+    /// </summary>
+    private async Task CommitSpawnAsync(
+        RoutingWorkItem workItem, FigureSnapshot figure, string derivedBlobName, Guid derivedDocumentId,
+        string extension, long fileSize)
+    {
+        using (_currentTenant.Change(workItem.TenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var entity = await _figureRepository.FindAsync(figure.FigureId);
+            if (entity is null || entity.Status != DocumentFigureStatus.Pending)
+            {
+                // Another run already routed it (or it was removed). Drop our orphan copied blob and stop.
+                await TryDeleteBlobAsync(derivedBlobName);
+                return;
+            }
+
+            var shortHash = figure.ContentHash.Length > 8 ? figure.ContentHash[..8] : figure.ContentHash;
+            var fileOrigin = new FileOrigin(
+                blobName: derivedBlobName,
+                uploadedByUserName: workItem.SourceUploadedByUserName,
+                contentType: figure.ContentType,
+                contentHash: figure.ContentHash,
+                fileSize: fileSize,
+                originalFileName: $"figure-{shortHash}{extension}");
+
+            var derived = Document.CreateDerived(
+                derivedDocumentId, workItem.TenantId, fileOrigin, workItem.SourceDocumentId, figure.ContentHash);
+
+            try
+            {
+                await _documentRepository.InsertAsync(derived, autoSave: true);
+            }
+            catch (Exception ex) when (IsUniqueConstraintViolation(ex))
+            {
+                // A concurrent route already spawned this figure's derived document (the unique
+                // (OriginDocumentId, OriginFigureKey) index fired). Roll back, drop our orphan blob, and stop;
+                // the winning run owns the figure's status.
+                Logger.LogInformation(
+                    "Figure {FigureId} of source {SourceDocumentId} was already spawned concurrently; skipping.",
+                    figure.FigureId, workItem.SourceDocumentId);
+                await TryDeleteBlobAsync(derivedBlobName);
+                return;
+            }
+
+            entity.MarkSpawned(derivedDocumentId);
+            await _figureRepository.UpdateAsync(entity);
+
+            await _distributedEventBus.PublishAsync(
+                new DocumentUploadedEto
+                {
+                    DocumentId = derived.Id,
+                    TenantId = derived.TenantId,
+                    EventTime = _clock.Now,
+                    FileName = fileOrigin.OriginalFileName,
+                    FileSize = fileOrigin.FileSize,
+                    ContentType = fileOrigin.ContentType
+                });
+
+            // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown
+            // from this figure's transcription instead of re-OCR'ing the crop (see DocumentTextExtractionBackgroundJob).
+            await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    private async Task TryDeleteBlobAsync(string blobName)
+    {
+        try
+        {
+            await _blobContainer.DeleteAsync(blobName);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to delete blob {BlobName} during figure routing cleanup.", blobName);
+        }
+    }
+
+    /// <summary>Whether the exception is (or wraps) a DB unique-constraint violation, used to detect a concurrent double-spawn.</summary>
+    protected virtual bool IsUniqueConstraintViolation(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException)
+        {
+            if (current is Volo.Abp.Data.AbpDbConcurrencyException)
+            {
+                return true;
+            }
+
+            var typeName = current.GetType().Name;
+            if (typeName == "DbUpdateException" || typeName == "UniqueConstraintException")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ImageExtensionForContentType(string contentType)
+        => contentType?.ToLowerInvariant() switch
+        {
+            "image/png" => ".png",
+            "image/jpeg" => ".jpg",
+            "image/jpg" => ".jpg",
+            "image/gif" => ".gif",
+            "image/webp" => ".webp",
+            "image/bmp" => ".bmp",
+            "image/tiff" => ".tiff",
+            _ => ".bin"
+        };
+
+    /// <summary>Detached snapshot of one pending candidate figure, carried across the per-figure external + UoW phases.</summary>
+    protected sealed record FigureSnapshot(
+        Guid FigureId, string ContentHash, string CropBlobName, string ContentType, int? PageNumber, string Transcription);
+
+    /// <summary>Per-source routing context loaded once up front: tenant + uploader provenance, candidate types, and pending figures.</summary>
+    protected sealed record RoutingWorkItem(
+        Guid SourceDocumentId,
+        Guid? TenantId,
+        string SourceUploadedByUserName,
+        IReadOnlyList<DocumentType> CandidateTypes,
+        IReadOnlyList<FigureSnapshot> PendingFigures);
+}
+
+public class DocumentFigureRoutingJobArgs
+{
+    /// <summary>The source document whose pending candidate figures should be routed.</summary>
+    public Guid SourceDocumentId { get; set; }
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -8,6 +8,7 @@ using Dignite.DocumentAI.Abstractions.TextExtraction;
 using Dignite.DocumentAI.Ai;
 using Dignite.DocumentAI.Documents;
 using Dignite.DocumentAI.Documents.Cabinets;
+using Dignite.DocumentAI.Documents.Pipelines.Routing;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -28,6 +29,9 @@ namespace Dignite.DocumentAI.Documents.Pipelines.TextExtraction;
 public class DocumentTextExtractionBackgroundJob
     : DocumentPipelineBackgroundJobBase<DocumentTextExtractionJobArgs>, ITransientDependency
 {
+    /// <summary>Provider name recorded for a derived sub-document whose Markdown is seeded from the source figure's transcription (#306), instead of re-OCR'ing the crop.</summary>
+    private const string ScenarioBSeedProviderName = "ScenarioB-FigureSeed";
+
     private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
     private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly ITextExtractor _textExtractor;
@@ -95,18 +99,37 @@ public class DocumentTextExtractionBackgroundJob
         IReadOnlyList<FigureCandidate> figureCandidates = Array.Empty<FigureCandidate>();
         try
         {
-            // The caller owns the blob stream. With the FileSystem provider this is a FileStream holding an OS file handle,
-            // so it must be disposed, consistent with DocumentAppService.GetBlobAsync disposeStream:true.
-            // Use await using so it is released when this try block (External phase) ends; CompleteRunAsync no longer needs it.
-            await using var blobStream = await _blobContainer.GetAsync(workItem.BlobName);
-            var ctx = new TextExtractionContext
+            TextExtractionResult result;
+            if (workItem.SeedMarkdown != null)
             {
-                ContentType = workItem.ContentType,
-                FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty),
-                LanguageHints = { "ja", "en" }
-            };
+                // #306 derived sub-document: seed Markdown from the source figure's transcription instead of
+                // re-OCR'ing the crop. The crop is the exact bytes the figure OCR already transcribed via the
+                // same IOcrProvider, so re-OCR would reproduce the same text — seeding is equivalent and saves
+                // one OCR call. A crop is a single image, so no embedded figures are surfaced and no recursive
+                // sub-document routing occurs.
+                result = new TextExtractionResult
+                {
+                    Markdown = workItem.SeedMarkdown,
+                    UsedOcr = false,
+                    ProviderName = ScenarioBSeedProviderName,
+                    IsComplete = true
+                };
+            }
+            else
+            {
+                // The caller owns the blob stream. With the FileSystem provider this is a FileStream holding an OS file handle,
+                // so it must be disposed, consistent with DocumentAppService.GetBlobAsync disposeStream:true.
+                // Use await using so it is released when this try block (External phase) ends; CompleteRunAsync no longer needs it.
+                await using var blobStream = await _blobContainer.GetAsync(workItem.BlobName);
+                var ctx = new TextExtractionContext
+                {
+                    ContentType = workItem.ContentType,
+                    FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty),
+                    LanguageHints = { "ja", "en" }
+                };
 
-            var result = await _textExtractor.ExtractAsync(blobStream, ctx, _cancellationTokenProvider.Token);
+                result = await _textExtractor.ExtractAsync(blobStream, ctx, _cancellationTokenProvider.Token);
+            }
 
             var title = await TryGenerateTitleAsync(result.Markdown, _cancellationTokenProvider.Token)
                 ?? MarkdownTitleExtractor.ExtractTitle(result.Markdown)
@@ -152,13 +175,26 @@ public class DocumentTextExtractionBackgroundJob
             document, args.PipelineRunId, DocumentAIPipelines.TextExtraction);
         await DocumentRepository.UpdateAsync(document, autoSave: true);
 
+        // #306: a derived sub-document (OriginDocumentId set) seeds its Markdown from the source figure's
+        // transcription rather than re-OCR'ing the crop. Load it inside this UoW; null (not derived, or the
+        // candidate is missing/empty) falls back to the normal OCR path in ExecuteAsync.
+        string? seedMarkdown = null;
+        if (document.OriginDocumentId.HasValue && !string.IsNullOrEmpty(document.OriginFigureKey))
+        {
+            var figure = await _documentFigureRepository.FirstOrDefaultAsync(
+                f => f.SourceDocumentId == document.OriginDocumentId.Value && f.ContentHash == document.OriginFigureKey);
+            var transcription = figure?.Transcription;
+            seedMarkdown = string.IsNullOrEmpty(transcription) ? null : transcription;
+        }
+
         await uow.CompleteAsync();
 
         return new TextExtractionWorkItem(
             run.Id,
             document.FileOrigin.BlobName,
             document.FileOrigin.ContentType,
-            document.FileOrigin.OriginalFileName);
+            document.FileOrigin.OriginalFileName,
+            seedMarkdown);
     }
 
     private async Task CompleteRunAsync(
@@ -196,6 +232,15 @@ public class DocumentTextExtractionBackgroundJob
                 candidate.ContentType,
                 candidate.Transcription,
                 candidate.PageNumber));
+        }
+
+        // #306: hand the persisted candidates to sub-document routing (a separate, independently-retried job).
+        // Enqueued in this same UoW so the candidates and the routing job commit atomically; no candidates -> no
+        // routing job. A derived sub-document is itself seeded (no figures), so it never re-enqueues routing.
+        if (figureCandidates.Count > 0)
+        {
+            await _backgroundJobManager.EnqueueAsync(
+                new DocumentFigureRoutingJobArgs { SourceDocumentId = document.Id });
         }
 
         // Publish OCRCompletedEto with a thin payload; downstream consumers pull Markdown back through REST.
@@ -453,7 +498,8 @@ public class DocumentTextExtractionBackgroundJob
         Guid RunId,
         string BlobName,
         string ContentType,
-        string? OriginalFileName);
+        string? OriginalFileName,
+        string? SeedMarkdown);
 
     /// <summary>
     /// Descriptor of a persisted candidate figure crop (#306). <c>protected</c> because it appears in the

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentConsts.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentConsts.cs
@@ -45,6 +45,13 @@ public static class DocumentConsts
     public static int MaxLanguageLength { get; set; } = 16;
 
     /// <summary>
+    /// Length of <see cref="Document.OriginFigureKey"/> (#306): the SHA-256 (lowercase hex) of the source
+    /// figure's bytes, which equals the derived document's <c>FileOrigin.ContentHash</c>. Matches
+    /// <see cref="FileOriginConsts.MaxContentHashLength"/>.
+    /// </summary>
+    public static int MaxOriginFigureKeyLength { get; set; } = 64;
+
+    /// <summary>
     /// Native payload archive size limit in bytes, default 16 MiB (#210).
     /// Over limit -> log warning, set manifest null, and text extraction still succeeds (archive fails open).
     /// May be overridden by tests or host, same static mutable pattern as MaxTitleLength.

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -101,6 +101,24 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// </summary>
     public virtual DocumentTextExtractionMetadata? ExtractionMetadata { get; private set; }
 
+    // === Scenario B sub-document back-reference (#306) ===
+
+    /// <summary>
+    /// When this document was derived from an embedded figure of another document (#306, Scenario B), the id of
+    /// that <b>source</b> document; <c>null</c> for normally-uploaded documents. A peer back-reference
+    /// (reference-by-id, no navigation property, no FK cascade): the derived document has a fully independent
+    /// lifecycle and outlives the source. Exposed at the egress so downstream can follow it for provenance.
+    /// </summary>
+    public virtual Guid? OriginDocumentId { get; private set; }
+
+    /// <summary>
+    /// Content-derived stable key of the source figure this document was derived from (#306): the SHA-256 of the
+    /// figure bytes, equal to this document's <c>FileOrigin.ContentHash</c>. NOT bbox (which drifts, #210). Unique
+    /// together with <see cref="OriginDocumentId"/> so re-extraction / routing retry never duplicate-spawn.
+    /// <c>null</c> for normally-uploaded documents.
+    /// </summary>
+    public virtual string? OriginFigureKey { get; private set; }
+
     // --- Aggregate-internal field value collection (field architecture v2 / Issue #206) ---
 
     private readonly List<DocumentExtractedField> _extractedFieldValues = new();
@@ -130,6 +148,29 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         FileOrigin = Check.NotNull(fileOrigin, nameof(fileOrigin));
         CabinetId = cabinetId;
         LifecycleStatus = DocumentLifecycleStatus.Uploaded;
+    }
+
+    /// <summary>
+    /// Creates a <b>derived</b> document spawned from an embedded figure of <paramref name="originDocumentId"/>
+    /// (#306, Scenario B). It is a normal peer <see cref="Document"/> that runs the full pipeline + egress; the
+    /// only difference is the back-reference (<see cref="OriginDocumentId"/> / <see cref="OriginFigureKey"/>).
+    /// <paramref name="originFigureKey"/> equals <paramref name="fileOrigin"/>'s <c>ContentHash</c> (the figure
+    /// content hash), tying storage and routing idempotency together.
+    /// </summary>
+    public static Document CreateDerived(
+        Guid id,
+        Guid? tenantId,
+        FileOrigin fileOrigin,
+        Guid originDocumentId,
+        string originFigureKey)
+    {
+        var document = new Document(id, tenantId, fileOrigin)
+        {
+            OriginDocumentId = Check.NotDefaultOrNull<Guid>(originDocumentId, nameof(originDocumentId)),
+            OriginFigureKey = Check.NotNullOrWhiteSpace(
+                originFigureKey, nameof(originFigureKey), DocumentConsts.MaxOriginFigureKeyLength)
+        };
+        return document;
     }
 
     // --- Write methods (called by DocumentPipelineRunManager when a pipeline completes) ---

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Figures/DocumentFigure.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Figures/DocumentFigure.cs
@@ -100,4 +100,27 @@ public class DocumentFigure : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         PageNumber = pageNumber;
         Status = DocumentFigureStatus.Pending;
     }
+
+    /// <summary>
+    /// Records that sub-document routing spawned a derived <see cref="Document"/> from this candidate (#306):
+    /// links the derived document and moves <see cref="Status"/> to <see cref="DocumentFigureStatus.Spawned"/>.
+    /// Idempotent re-routing is guarded upstream by the unique <c>(OriginDocumentId, OriginFigureKey)</c> index
+    /// on the derived document.
+    /// </summary>
+    public void MarkSpawned(Guid routedDocumentId)
+    {
+        RoutedDocumentId = Check.NotDefaultOrNull<Guid>(routedDocumentId, nameof(routedDocumentId));
+        Status = DocumentFigureStatus.Spawned;
+    }
+
+    /// <summary>
+    /// Records that the routing gate judged this figure not itself a document of any candidate type (#306):
+    /// moves <see cref="Status"/> to <see cref="DocumentFigureStatus.NotADocument"/>. The caller deletes the
+    /// candidate crop blob separately; the row is kept as an audit + idempotency marker so a re-run does not
+    /// re-evaluate it.
+    /// </summary>
+    public void MarkNotADocument()
+    {
+        Status = DocumentFigureStatus.NotADocument;
+    }
 }

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -71,6 +71,9 @@ public static class DocumentAIDbContextModelCreatingExtensions
             // Field architecture v2: system common fields are flattened as top-level typed columns: real automatic pipeline outputs.
             b.Property(x => x.Language).HasMaxLength(DocumentConsts.MaxLanguageLength);
 
+            // #306 Scenario B back-reference: content-derived key of the source figure (= FileOrigin.ContentHash).
+            b.Property(x => x.OriginFigureKey).HasMaxLength(DocumentConsts.MaxOriginFigureKeyLength);
+
             // Text extraction provenance (#210): provider name + archived manifest, serialized as a whole into a typed JSON column (#206 cross-DB principle).
             b.Property(x => x.ExtractionMetadata)
                 .HasConversion(ExtractionMetadataConverter, ExtractionMetadataComparer);
@@ -127,6 +130,18 @@ public static class DocumentAIDbContextModelCreatingExtensions
             // High-traffic list-page path: filter by (tenant layer, document type). The FK also automatically creates a single-column DocumentTypeId index for hard-delete RESTRICT checks.
             b.HasIndex(x => new { x.TenantId, x.DocumentTypeId });
             b.HasIndex(x => x.CreationTime);
+
+            // #306 Scenario B back-reference: derived documents only. A filtered UNIQUE index on
+            // (OriginDocumentId, OriginFigureKey) makes sub-document routing idempotent (one derived document
+            // per source figure; re-routing / retry never duplicate-spawn) and also serves "list a source's
+            // derived documents" (OriginDocumentId is the leading column). Filtered to non-null so
+            // normally-uploaded documents (both columns null) are exempt. The HasFilter clause is
+            // SQL-Server-specific; the SQL-Server-only filtered-index portability limitation is intentionally
+            // accepted for v0.2.0. No FK on OriginDocumentId: it is a soft provenance pointer, not a constraint,
+            // so the derived document outlives the source (the source may be hard-deleted while derived ones remain).
+            b.HasIndex(x => new { x.OriginDocumentId, x.OriginFigureKey })
+                .IsUnique()
+                .HasFilter("[OriginDocumentId] IS NOT NULL");
         });
 
         builder.Entity<DocumentExtractedField>(b =>

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
@@ -111,18 +111,22 @@ public class EtoContract_Tests
     [Fact]
     public void DocumentReadyEto_RoundTrips_Through_SystemTextJson()
     {
+        var originDocumentId = Guid.NewGuid();
         var eto = new DocumentReadyEto
         {
             DocumentId = Guid.NewGuid(),
             TenantId = null,
             EventTime = SampleEventTime,
-            DocumentTypeCode = "contract.general"
+            DocumentTypeCode = "contract.general",
+            // #306: provenance link for a Scenario B sub-document. Non-null so a serialization regression is caught.
+            OriginDocumentId = originDocumentId
         };
 
         var roundTrip = RoundTrip(eto);
 
         roundTrip.DocumentTypeCode.ShouldBe("contract.general");
         roundTrip.EventTime.ShouldBe(eto.EventTime);
+        roundTrip.OriginDocumentId.ShouldBe(originDocumentId);
     }
 
     [Fact]

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFigureRoutingJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFigureRoutingJob_Tests.cs
@@ -168,7 +168,64 @@ public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureR
             (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).ShouldBeEmpty());
     }
 
-    private async Task<(Guid FigureId, string ContentHash, string CropBlobName)> ArrangeAsync(Guid sourceId, bool withType)
+    [Fact]
+    public async Task Figure_Fault_Rethrows_To_Trigger_Job_Retry_And_Leaves_It_Pending()
+    {
+        var sourceId = _guidGenerator.Create();
+        var (figureId, _, cropBlobName) = await ArrangeAsync(sourceId, withType: true);
+        StubGate(TypeCode, 0.92);          // confident -> proceeds to spawn, which reads the crop
+        StubCropBlobThrows(cropBlobName);  // the crop read faults on every run (e.g. transient blob loss)
+
+        // The fault must NOT be swallowed: ExecuteAsync rethrows so ABP reschedules the job. Routing is enqueued
+        // only once, so swallowing would strand the figure Pending forever.
+        await Should.ThrowAsync<AggregateException>(
+            () => _job.ExecuteAsync(new DocumentFigureRoutingJobArgs { SourceDocumentId = sourceId }));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _figureRepository.GetAsync(figureId)).Status.ShouldBe(DocumentFigureStatus.Pending);
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Blank_Transcription_Figure_Is_Rejected_Without_Calling_The_Gate()
+    {
+        var sourceId = _guidGenerator.Create();
+        var (figureId, _, cropBlobName) = await ArrangeAsync(sourceId, withType: true, transcription: "   ");
+        StubCropBlob(cropBlobName);
+
+        await _job.ExecuteAsync(new DocumentFigureRoutingJobArgs { SourceDocumentId = sourceId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).ShouldBeEmpty();
+            (await _figureRepository.GetAsync(figureId)).Status.ShouldBe(DocumentFigureStatus.NotADocument);
+        });
+
+        await _blobContainer.Received(1).DeleteAsync(cropBlobName, Arg.Any<CancellationToken>());
+        // An empty/whitespace transcription is short-circuited to reject; the gate LLM is never called.
+        await _workflow.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Duplicate_Derived_Document_For_Same_Source_Figure_Is_Rejected_By_Unique_Index()
+    {
+        var sourceId = _guidGenerator.Create();
+        var figureKey = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64];
+
+        await WithUnitOfWorkAsync(async () =>
+            await _documentRepository.InsertAsync(NewDerived(sourceId, figureKey), autoSave: true));
+
+        // The filtered unique index on (OriginDocumentId, OriginFigureKey) is routing's concurrency backstop: a
+        // second derived document for the same source figure must be rejected by the database.
+        await Should.ThrowAsync<Exception>(() => WithUnitOfWorkAsync(async () =>
+            await _documentRepository.InsertAsync(NewDerived(sourceId, figureKey), autoSave: true)));
+    }
+
+    private async Task<(Guid FigureId, string ContentHash, string CropBlobName)> ArrangeAsync(
+        Guid sourceId, bool withType, string transcription = "INVOICE No. 42 Total 100.00")
     {
         var contentHash = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64];
         var cropBlobName = $"figures/{sourceId}/{contentHash}";
@@ -197,7 +254,7 @@ public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureR
             await _figureRepository.InsertAsync(new DocumentFigure(
                 figureId, tenantId: null, sourceDocumentId: sourceId,
                 contentHash: contentHash, cropBlobName: cropBlobName, contentType: "image/png",
-                transcription: "INVOICE No. 42 Total 100.00", pageNumber: 2), autoSave: true);
+                transcription: transcription, pageNumber: 2), autoSave: true);
         });
 
         return (figureId, contentHash, cropBlobName);
@@ -209,4 +266,18 @@ public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureR
     private void StubGate(string typeCode, double confidence)
         => _workflow.RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new DocumentClassificationOutcome { TypeCode = typeCode, ConfidenceScore = confidence });
+
+    private void StubCropBlobThrows(string cropBlobName)
+        => _blobContainer.GetAsync(cropBlobName).Returns<Stream>(_ => throw new InvalidOperationException("blob unavailable"));
+
+    private Document NewDerived(Guid sourceId, string figureKey)
+    {
+        var id = _guidGenerator.Create();
+        return Document.CreateDerived(
+            id, tenantId: null,
+            fileOrigin: new FileOrigin(
+                blobName: $"{id:N}.png", uploadedByUserName: "test-user", contentType: "image/png",
+                contentHash: figureKey, fileSize: 4, originalFileName: "figure.png"),
+            originDocumentId: sourceId, originFigureKey: figureKey);
+    }
 }

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFigureRoutingJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFigureRoutingJob_Tests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Ai;
+using Dignite.DocumentAI.Documents;
+using Dignite.DocumentAI.Documents.DocumentTypes;
+using Dignite.DocumentAI.Documents.Figures;
+using Dignite.DocumentAI.Documents.Pipelines;
+using Dignite.DocumentAI.Documents.Pipelines.Classification;
+using Dignite.DocumentAI.Documents.Pipelines.Routing;
+using Dignite.DocumentAI.Documents.Pipelines.TextExtraction;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Dignite.DocumentAI.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(DocumentAIEntityFrameworkCoreTestModule))]
+public class DocumentFigureRoutingJobTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<DocumentAIDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+
+        // Gate seam: a partial substitute of the classification workflow whose RunAsync each test stubs to a
+        // chosen outcome — no real LLM call (mirrors DocumentClassificationBackgroundJob_Tests).
+        var workflow = Substitute.ForPartsOf<DocumentClassificationWorkflow>(
+            Substitute.For<IChatClient>(),
+            Options.Create(new DocumentAIBehaviorOptions()),
+            new DefaultPromptProvider());
+        context.Services.AddSingleton(workflow);
+    }
+}
+
+public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureRoutingJobTestModule>
+{
+    private const string TypeCode = "invoice.general";
+    private const double Threshold = 0.75;
+
+    private readonly DocumentFigureRoutingJob _job;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentFigure, Guid> _figureRepository;
+    private readonly IRepository<DocumentType, Guid> _typeRepository;
+    private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
+    private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly IDistributedEventBus _eventBus;
+    private readonly DocumentClassificationWorkflow _workflow;
+    private readonly IGuidGenerator _guidGenerator;
+
+    public DocumentFigureRoutingJob_Tests()
+    {
+        _job = GetRequiredService<DocumentFigureRoutingJob>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _figureRepository = GetRequiredService<IRepository<DocumentFigure, Guid>>();
+        _typeRepository = GetRequiredService<IRepository<DocumentType, Guid>>();
+        _blobContainer = GetRequiredService<IBlobContainer<DocumentAIDocumentContainer>>();
+        _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
+        _eventBus = GetRequiredService<IDistributedEventBus>();
+        _workflow = GetRequiredService<DocumentClassificationWorkflow>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+    }
+
+    [Fact]
+    public async Task Confident_Figure_Spawns_Derived_Document()
+    {
+        var sourceId = _guidGenerator.Create();
+        var (figureId, contentHash, cropBlobName) = await ArrangeAsync(sourceId, withType: true);
+        StubCropBlob(cropBlobName);
+        StubGate(TypeCode, 0.92);
+
+        await _job.ExecuteAsync(new DocumentFigureRoutingJobArgs { SourceDocumentId = sourceId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var derived = (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).SingleOrDefault();
+            derived.ShouldNotBeNull();
+            derived!.OriginFigureKey.ShouldBe(contentHash);
+            derived.FileOrigin.ContentHash.ShouldBe(contentHash);
+            derived.FileOrigin.BlobName.ShouldNotBe(cropBlobName); // copied to an independent blob
+            derived.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.Processing); // text-extraction queued
+
+            var figure = await _figureRepository.GetAsync(figureId);
+            figure.Status.ShouldBe(DocumentFigureStatus.Spawned);
+            figure.RoutedDocumentId.ShouldBe(derived.Id);
+
+            // The crop was copied to the derived document's own blob, and its text-extraction pipeline was queued.
+            await _blobContainer.Received(1).SaveAsync(
+                derived.FileOrigin.BlobName, Arg.Any<Stream>(), overrideExisting: true, Arg.Any<CancellationToken>());
+            await _backgroundJobManager.Received(1).EnqueueAsync(
+                Arg.Is<DocumentTextExtractionJobArgs>(a => a.DocumentId == derived.Id),
+                Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+            await _eventBus.Received(1).PublishAsync(
+                Arg.Is<DocumentUploadedEto>(e => e.DocumentId == derived.Id));
+        });
+    }
+
+    [Fact]
+    public async Task LowConfidence_Figure_Is_Rejected_And_Crop_Deleted()
+    {
+        var sourceId = _guidGenerator.Create();
+        var (figureId, _, cropBlobName) = await ArrangeAsync(sourceId, withType: true);
+        StubCropBlob(cropBlobName);
+        StubGate(TypeCode, 0.50); // below the type's 0.75 threshold
+
+        await _job.ExecuteAsync(new DocumentFigureRoutingJobArgs { SourceDocumentId = sourceId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).ShouldBeEmpty();
+            (await _figureRepository.GetAsync(figureId)).Status.ShouldBe(DocumentFigureStatus.NotADocument);
+        });
+
+        await _blobContainer.Received(1).DeleteAsync(cropBlobName, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task No_Candidate_Types_Rejects_All_Without_Classifying()
+    {
+        var sourceId = _guidGenerator.Create();
+        var (figureId, _, cropBlobName) = await ArrangeAsync(sourceId, withType: false);
+
+        await _job.ExecuteAsync(new DocumentFigureRoutingJobArgs { SourceDocumentId = sourceId });
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _figureRepository.GetAsync(figureId)).Status.ShouldBe(DocumentFigureStatus.NotADocument));
+
+        await _blobContainer.Received(1).DeleteAsync(cropBlobName, Arg.Any<CancellationToken>());
+        // The no-types early path never calls the gate.
+        await _workflow.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Already_Routed_Figures_Are_Skipped()
+    {
+        var sourceId = _guidGenerator.Create();
+        var (figureId, _, _) = await ArrangeAsync(sourceId, withType: true);
+
+        // Pre-mark the only candidate as already spawned, then run: routing must process nothing.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var figure = await _figureRepository.GetAsync(figureId);
+            figure.MarkSpawned(_guidGenerator.Create());
+            await _figureRepository.UpdateAsync(figure);
+        });
+
+        await _job.ExecuteAsync(new DocumentFigureRoutingJobArgs { SourceDocumentId = sourceId });
+
+        await _workflow.DidNotReceive().RunAsync(
+            Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).ShouldBeEmpty());
+    }
+
+    private async Task<(Guid FigureId, string ContentHash, string CropBlobName)> ArrangeAsync(Guid sourceId, bool withType)
+    {
+        var contentHash = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64];
+        var cropBlobName = $"figures/{sourceId}/{contentHash}";
+        var figureId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _documentRepository.InsertAsync(new Document(
+                sourceId,
+                tenantId: null,
+                fileOrigin: new FileOrigin(
+                    blobName: $"blobs/{sourceId:N}.pdf",
+                    uploadedByUserName: "test-user",
+                    contentType: "application/pdf",
+                    contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                    fileSize: 1024,
+                    originalFileName: "contract.pdf")), autoSave: true);
+
+            if (withType)
+            {
+                await _typeRepository.InsertAsync(new DocumentType(
+                    _guidGenerator.Create(), tenantId: null, typeCode: TypeCode, displayName: "Invoice",
+                    confidenceThreshold: Threshold, priority: 0), autoSave: true);
+            }
+
+            await _figureRepository.InsertAsync(new DocumentFigure(
+                figureId, tenantId: null, sourceDocumentId: sourceId,
+                contentHash: contentHash, cropBlobName: cropBlobName, contentType: "image/png",
+                transcription: "INVOICE No. 42 Total 100.00", pageNumber: 2), autoSave: true);
+        });
+
+        return (figureId, contentHash, cropBlobName);
+    }
+
+    private void StubCropBlob(string cropBlobName)
+        => _blobContainer.GetAsync(cropBlobName).Returns(_ => (Stream)new MemoryStream(new byte[] { 1, 2, 3, 4 }));
+
+    private void StubGate(string typeCode, double confidence)
+        => _workflow.RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome { TypeCode = typeCode, ConfidenceScore = confidence });
+}

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -460,6 +460,51 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
             $"figures/{documentId}/{Sha256Hex(figureBytes)}", Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task Text_Extraction_Seeds_Derived_Document_From_Figure_Transcription()
+    {
+        var sourceId = _guidGenerator.Create();
+        var derivedId = _guidGenerator.Create();
+        var figureKey = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64];
+        const string seed = "# Invoice\n\nTotal 100.00";
+
+        Guid runId = default;
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // The source document the figure belongs to (the figure FK requires it to exist).
+            await _documentRepository.InsertAsync(CreateDocument(sourceId), autoSave: true);
+
+            // The source figure whose transcription the derived document seeds from.
+            await _figureRepository.InsertAsync(new DocumentFigure(
+                _guidGenerator.Create(), tenantId: null, sourceDocumentId: sourceId,
+                contentHash: figureKey, cropBlobName: $"figures/{sourceId}/{figureKey}",
+                contentType: "image/png", transcription: seed, pageNumber: 1), autoSave: true);
+
+            var derived = Document.CreateDerived(
+                derivedId, tenantId: null,
+                fileOrigin: new FileOrigin(
+                    blobName: $"blobs/{derivedId:N}.png", uploadedByUserName: "test-user",
+                    contentType: "image/png", contentHash: figureKey, fileSize: 4, originalFileName: "figure.png"),
+                originDocumentId: sourceId, originFigureKey: figureKey);
+            await _documentRepository.InsertAsync(derived, autoSave: true);
+
+            var run = await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);
+            runId = run.Id;
+        });
+
+        // Intentionally do NOT stub the extractor: the seeded path must not call it.
+        await _textExtractionJob.ExecuteAsync(new DocumentTextExtractionJobArgs { DocumentId = derivedId, PipelineRunId = runId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var derived = await _documentRepository.GetAsync(derivedId, includeDetails: false);
+            derived.Markdown.ShouldBe(seed); // seeded from the figure transcription, no OCR
+        });
+
+        await _textExtractor.DidNotReceive().ExtractAsync(
+            Arg.Any<Stream>(), Arg.Any<TextExtractionContext>(), Arg.Any<CancellationToken>());
+    }
+
     private async Task<Guid> ArrangeQueuedTextExtractionAsync(Guid documentId)
     {
         Guid textExtractionRunId = default;

--- a/host/src/Migrations/20260616065141_Added_DocumentOriginBackReference.Designer.cs
+++ b/host/src/Migrations/20260616065141_Added_DocumentOriginBackReference.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.DocumentAI.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.DocumentAI.Host.Migrations
 {
     [DbContext(typeof(DocumentAIHostDbContext))]
-    partial class DocumentAIHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616065141_Added_DocumentOriginBackReference")]
+    partial class Added_DocumentOriginBackReference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260616065141_Added_DocumentOriginBackReference.cs
+++ b/host/src/Migrations/20260616065141_Added_DocumentOriginBackReference.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.DocumentAI.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Added_DocumentOriginBackReference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "OriginDocumentId",
+                table: "DocAIDocuments",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OriginFigureKey",
+                table: "DocAIDocuments",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAIDocuments_OriginDocumentId_OriginFigureKey",
+                table: "DocAIDocuments",
+                columns: new[] { "OriginDocumentId", "OriginFigureKey" },
+                unique: true,
+                filter: "[OriginDocumentId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DocAIDocuments_OriginDocumentId_OriginFigureKey",
+                table: "DocAIDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "OriginDocumentId",
+                table: "DocAIDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "OriginFigureKey",
+                table: "DocAIDocuments");
+        }
+    }
+}


### PR DESCRIPTION
## Scenario B sub-document routing (#306, PR2)

Second of two stacked PRs for #306. **Stacked on #344** (PR1: `Figure` transport contract + `DocumentFigure` candidate persistence) — review/merge #344 first, then this retargets to `main`.

PR1 persists each embedded figure as a `DocumentFigure` candidate (`Pending`) with its OCR transcription and a candidate crop blob. **This PR consumes those candidates and decides, per figure, whether the figure is itself a document** — and if so, spawns it as its own derived `Document`.

### What it does

- **`Document` back-reference**: adds `OriginDocumentId` (Guid?, soft pointer — no FK, derived docs outlive their source) + `OriginFigureKey` (string, = figure `ContentHash`) via a `Document.CreateDerived(...)` factory. Filtered unique index `(OriginDocumentId, OriginFigureKey) WHERE OriginDocumentId IS NOT NULL` is the final backstop against a concurrent double-route.
- **`DocumentFigureRoutingJob`** (`AsyncBackgroundJob`, enqueued by the text-extraction job when a source yields figure candidates): for each `Pending` figure, classifies its transcription against the **source's tenant** document-type layer (reusing `DocumentClassificationWorkflow`, which already applies `PromptBoundary`), and gates on the matched type's own `ConfidenceThreshold` (same per-type Ready-gate bar). Clears the bar → spawn a derived `Document` (crop copied to an independent derived-owned blob, back-reference set, `Spawned`); fails the bar → `NotADocument` + reclaim crop.
- **Derived-document seeding optimization**: the derived doc's text-extraction job seeds `Markdown` directly from the figure's stored transcription instead of re-OCR'ing the crop (lossless — same bytes/provider → same output), then continues the normal pipeline (classification, field extraction, Ready gate).
- **Egress provenance**: `DocumentReadyEto.OriginDocumentId` + `DocumentDto.OriginDocumentId` so downstream consumers can link a derived document back to its source.

### Reliability / correctness

- **Resumable + idempotent**: only `Pending` candidates are processed; each figure's evaluation commits atomically with its status change. A crash resumes the remaining candidates without re-paying the gate classification or duplicate-spawning.
- **Per-figure isolation**: one bad figure (gate error, blob fault, transient DB error) is logged and left `Pending` for retry without blocking the others.
- **UoW discipline** (background-jobs.md): the gate LLM call and blob IO run outside any UoW; only the derived-document insert + figure status change + derived-pipeline enqueue run inside a short UoW.
- **No orphan blobs**: a spawn-UoW failure *after* the crop copy reclaims the copied derived blob (then rethrows, leaving the figure `Pending`); the reject path reclaims the candidate crop fail-open; source permanent-delete reclaims candidate crops across **all** figure statuses (spawned figures retain their candidate crop, derived docs own independent copies and are untouched).

### Security

LLM-triggered gate path complies with the repo's LLM-call conventions: reuses `DocumentClassificationWorkflow` (PromptBoundary on the figure transcription), candidate types loaded through the `IMultiTenant` global filter via `GetListAsync` (no hand-written tenant predicate, no `Disable<IMultiTenant>()`), hard cap `Take(MaxDocumentTypesInClassificationPrompt)`, classification instructions are compile-time constants.

### Migration

`Added_DocumentOriginBackReference` — additive only: two nullable columns (`OriginDocumentId uniqueidentifier NULL`, `OriginFigureKey nvarchar(64) NULL`) + filtered unique index. No data backfill, no NOT NULL on a populated table.

### Tests

- `DocumentFigureRoutingJob_Tests` (new, 4): confident figure spawns a derived document; low-confidence figure rejected + crop deleted; no candidate types rejects all without classifying; already-routed figures skipped.
- Seeding: `Text_Extraction_Seeds_Derived_Document_From_Figure_Transcription` — derived doc Markdown == seed, OCR `ExtractAsync` not called.
- `DocumentReadyEto` round-trip extended with `OriginDocumentId`.
- Full suites green: EF.Tests **79**, App.Tests **250**, Pdf.Tests **59**; host builds 0 errors.