### PR TITLE
feat(documents): container document concept (#346, PR3a)

### DIFF
--- a/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReadyEto.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReadyEto.cs
@@ -36,11 +36,25 @@ public class DocumentReadyEto
     /// </summary>
     public required DateTime EventTime { get; init; }
 
+    /// <summary>
+    /// Confirmed document type, or <c>null</c>. Since #346, <c>null</c> together with <see cref="IsContainer"/> =
+    /// <c>true</c> is a valid Ready outcome: a container has no single type. Downstream must tolerate this pairing
+    /// and skip building a record from the container.
+    /// </summary>
     public string? DocumentTypeCode { get; init; }
 
     /// <summary>
-    /// Provenance link for a Scenario B sub-document (#306): when this document was derived from an embedded
-    /// figure of another document, the id of that source document; <c>null</c> for normally-uploaded documents.
+    /// Whether this document is a <b>container</b> (#346): a parent bundling several independent documents that
+    /// ran no type-bound field extraction itself. When <c>true</c>, <see cref="DocumentTypeCode"/> is <c>null</c>
+    /// and downstream must <b>not</b> build a business record from this document — the real records are its
+    /// sub-documents (each fires its own <c>DocumentReadyEto</c> carrying <see cref="OriginDocumentId"/>). New
+    /// optional field; defaults to <c>false</c> for producers / consumers that predate it.
+    /// </summary>
+    public bool IsContainer { get; init; }
+
+    /// <summary>
+    /// Provenance link for a Scenario B sub-document (#306): when this document was derived from a constituent
+    /// of another document, the id of that source document; <c>null</c> for normally-uploaded documents.
     /// Downstream may follow it to associate the derived document with its source. New optional field; defaults
     /// to <c>null</c> for producers / consumers that predate it.
     /// </summary>

--- a/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/Figure.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/Figure.cs
@@ -9,7 +9,7 @@ namespace Dignite.DocumentAI.Abstractions.TextExtraction;
 /// <para>
 /// <b>Identity is content, not position.</b> A figure is keyed downstream by the SHA-256 of
 /// <see cref="Content"/> (which doubles as the derived document's <c>FileOrigin.ContentHash</c> /
-/// <c>OriginFigureKey</c>), never by bbox — bbox drifts across provider / re-extraction (#210). The
+/// <c>OriginConstituentKey</c>), never by bbox — bbox drifts across provider / re-extraction (#210). The
 /// transient <see cref="PageNumber"/> is provenance only.
 /// </para>
 /// </summary>

--- a/core/src/Dignite.DocumentAI.Application.Contracts/Documents/DocumentDto.cs
+++ b/core/src/Dignite.DocumentAI.Application.Contracts/Documents/DocumentDto.cs
@@ -16,10 +16,18 @@ public class DocumentDto : EntityDto<Guid>
     public Guid? CabinetId { get; set; }
 
     /// <summary>
-    /// Provenance link for a Scenario B sub-document (#306): when this document was derived from an embedded
-    /// figure of another document, the id of that source document; <c>null</c> for normally-uploaded documents.
+    /// Provenance link for a Scenario B sub-document (#306): when this document was derived from a constituent
+    /// of another document, the id of that source document; <c>null</c> for normally-uploaded documents.
     /// </summary>
     public Guid? OriginDocumentId { get; set; }
+
+    /// <summary>
+    /// Whether this document is a <b>container</b> (#346): a parent bundling several independent documents that
+    /// runs no type-bound field extraction itself. <c>true</c> means downstream must <b>not</b> build a business
+    /// record from this document — its real records are its sub-documents (query <c>OriginDocumentId == this.Id</c>).
+    /// A container has no <see cref="DocumentTypeCode"/> and no <see cref="ExtractedFields"/>.
+    /// </summary>
+    public bool IsContainer { get; set; }
 
     public string? DocumentTypeCode { get; set; }
     public DocumentLifecycleStatus LifecycleStatus { get; set; }

--- a/core/src/Dignite.DocumentAI.Application/Ai/DefaultPromptProvider.cs
+++ b/core/src/Dignite.DocumentAI.Application/Ai/DefaultPromptProvider.cs
@@ -26,6 +26,17 @@ public class DefaultPromptProvider : IPromptProvider, ITransientDependency
         "structure signals (e.g. an invoice usually has a table of line items; a contract has numbered clauses). " +
         "Return JSON only. Confidence values must be decimal scores from 0.0 to 1.0; never return percentages. " +
         "If you are not confident, set confidence low and typeCode to null. " +
+        // #346: container detection rides this same classification call. Keep it CONSERVATIVE — only a clear
+        // bundle of several independent documents qualifies; attachments / annexes / continuation pages / a
+        // single ledger must never be flagged, or normal documents would stop extracting.
+        "Set isContainer to true ONLY when the content is clearly several independent, complete documents bundled " +
+        "into one file — for example many separate invoices in one file, or a pack mixing a contract plus an " +
+        "invoice plus a receipt. When isContainer is true the type guess is not used, so still fill typeCode and " +
+        "confidence with your best guess but they will be ignored. " +
+        "Do NOT set isContainer for any of these (they are each a single document): a document with attachments, " +
+        "annexes, 別紙, appendices, or exhibits; a multi-page single document such as a continuation page or " +
+        "line-item overflow of one invoice or contract (the same document identity / header repeats); or a single " +
+        "register, ledger, or itemized table that merely lists many rows. When in doubt, set isContainer to false. " +
         // Defensive validation: language comes from host trust-domain configuration
         // (DocumentAIBehaviorOptions.DefaultLanguage), so it does not violate the "compile-time
         // constants for instructions" safety rule. Still, before interpolation into the system prompt,

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
@@ -145,6 +145,18 @@ public class DocumentClassificationBackgroundJob
         DocumentPipelineRun run,
         DocumentClassificationOutcome outcome)
     {
+        // #346: a container dominates the type guess. A parent that bundles several independent documents runs no
+        // field extraction itself: mark it a container, complete the run as succeeded, and — crucially — do NOT
+        // publish DocumentClassifiedEto, so FieldExtractionEventHandler never cascades (the race-free suppression
+        // is simply never emitting the trigger event). MarkAsContainer leaves DocumentTypeId null and sets no
+        // UnresolvedClassification reason, so the container is not sent to the operator review queue and — with
+        // both key pipelines succeeded and no blocking reason — derives straight to Ready (Design A).
+        if (outcome.IsContainer)
+        {
+            await PipelineRunManager.CompleteClassificationAsContainerAsync(document, run);
+            return;
+        }
+
         // Field architecture v2: look up the type definition from DB, exactly matching the single
         // layer selected by Document.TenantId.
         DocumentType? typeDef = null;

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationWorkflow.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationWorkflow.cs
@@ -155,7 +155,10 @@ public class DocumentClassificationWorkflow : ITransientDependency
         {
             TypeCode = typeCode,
             ConfidenceScore = confidenceScore,
-            Reason = parsed?.Reason
+            Reason = parsed?.Reason,
+            // #346: container detection rides the same classification call (zero extra LLM cost). When set, it
+            // dominates the type guess downstream — the BackgroundJob takes the container branch and ignores typeCode.
+            IsContainer = parsed?.IsContainer ?? false
         };
 
         if (parsed?.Candidates != null)
@@ -230,6 +233,15 @@ public class DocumentClassificationWorkflow : ITransientDependency
         public string? TypeCode { get; set; }
         public double Confidence { get; set; }
         public string? Reason { get; set; }
+
+        /// <summary>
+        /// #346: <c>true</c> when the content is clearly several independent documents (a multi-type bundle or
+        /// multiple instances of one type), so the document is a container that must not run field extraction on
+        /// itself. Conservative by design (see the classification prompt); dominates <see cref="TypeCode"/> /
+        /// <see cref="Confidence"/> when set.
+        /// </summary>
+        public bool IsContainer { get; set; }
+
         public List<CandidateItem> Candidates { get; set; } = new();
 
         public sealed class CandidateItem
@@ -245,5 +257,13 @@ public class DocumentClassificationOutcome
     public string? TypeCode { get; set; }
     public double ConfidenceScore { get; set; }
     public string? Reason { get; set; }
+
+    /// <summary>
+    /// #346: the document is a <b>container</b> (several independent documents bundled together). When <c>true</c>
+    /// the BackgroundJob marks the document a container and suppresses field extraction; <see cref="TypeCode"/> /
+    /// <see cref="ConfidenceScore"/> are ignored.
+    /// </summary>
+    public bool IsContainer { get; set; }
+
     public List<PipelineRunCandidate> Candidates { get; } = new();
 }

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler.cs
@@ -16,9 +16,10 @@ namespace Dignite.DocumentAI.Documents.Pipelines.Lifecycle;
 /// <para>
 /// The Ready gate is enforced by the classification stage: documents with insufficient automatic
 /// classification confidence / no suitable type receive the blocking UnresolvedClassification reason
-/// and enter the manual review queue; when <c>DocumentTypeCode</c> is empty,
-/// <c>DeriveLifecycle</c> does not transition to Ready. Therefore this handler needs no extra check:
-/// <c>NewStatus == Ready</c> implicitly means the classification / manual-review gate passed.
+/// and enter the manual review queue, which keeps them out of Ready. Therefore this handler needs no
+/// extra check: <c>NewStatus == Ready</c> implicitly means the gate passed. #346: a <b>container</b> is a
+/// valid Ready outcome with <b>no</b> type — it reaches Ready with <c>DocumentTypeCode == null</c> and
+/// <c>IsContainer == true</c> (it sets no blocking reason), so the published ETO carries that pairing.
 /// </para>
 /// </summary>
 public class DocumentReadyEventHandler
@@ -61,9 +62,10 @@ public class DocumentReadyEventHandler
         }
 
         // ETO still carries the DocumentTypeCode string to preserve the outbound contract, resolving
-        // it from internal DocumentTypeId (#207). Ready documents must have a confirmed type because
-        // of the DeriveLifecycle gate, and DeleteAsync prevents deleting in-use types, so the type
-        // should be active.
+        // it from internal DocumentTypeId (#207). A non-container Ready document has a confirmed type
+        // because of the DeriveLifecycle gate, and DeleteAsync prevents deleting in-use types, so the
+        // type should be active. #346: a container reaches Ready with DocumentTypeId null, so
+        // documentTypeCode stays null — that null + IsContainer=true is the valid container outcome.
         string? documentTypeCode = null;
         if (document.DocumentTypeId.HasValue)
         {
@@ -78,6 +80,8 @@ public class DocumentReadyEventHandler
                 TenantId = document.TenantId,
                 EventTime = _clock.Now,
                 DocumentTypeCode = documentTypeCode,
+                // #346: container marker; downstream skips building a record from a container (DocumentTypeCode null).
+                IsContainer = document.IsContainer,
                 // #306: provenance link for a Scenario B sub-document (null for normally-uploaded documents).
                 OriginDocumentId = document.OriginDocumentId
             });

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
@@ -29,14 +29,14 @@ namespace Dignite.DocumentAI.Documents.Pipelines.Routing;
 /// a document — by classifying its OCR transcription against the source's tenant document-type layer and
 /// comparing against the matched type's <c>ConfidenceThreshold</c> (the same per-type Ready-gate bar). A figure
 /// that clears the bar is spawned as its own derived <see cref="Document"/> (its crop copied to an independent
-/// blob, back-reference <c>OriginDocumentId</c> / <c>OriginFigureKey</c> set), which then runs the full normal
+/// blob, back-reference <c>OriginDocumentId</c> / <c>OriginConstituentKey</c> set), which then runs the full normal
 /// pipeline; a figure that does not is marked <see cref="DocumentFigureStatus.NotADocument"/> and its candidate
 /// crop is deleted. Figures that remain inline in the source Markdown either way (#301).
 /// <para>
 /// <b>Resumable + idempotent.</b> Only <see cref="DocumentFigureStatus.Pending"/> candidates are processed, and
 /// each figure's evaluation commits atomically with its status change, so a crash resumes the remaining
 /// candidates without re-paying the gate classification or duplicate-spawning. The unique
-/// <c>(OriginDocumentId, OriginFigureKey)</c> index on <see cref="Document"/> is the final backstop against a
+/// <c>(OriginDocumentId, OriginConstituentKey)</c> index on <see cref="Document"/> is the final backstop against a
 /// concurrent double-route. Per-figure failures are isolated (one bad figure does not block the others) and
 /// surfaced: a figure left <see cref="DocumentFigureStatus.Pending"/> by a fault makes the job rethrow so ABP
 /// retries it, re-loading only the still-Pending candidates.
@@ -331,7 +331,7 @@ public class DocumentFigureRoutingJob
                 derivedDocumentId, workItem.TenantId, fileOrigin, workItem.SourceDocumentId, figure.ContentHash);
 
             // A concurrent route that already committed this figure's derived document trips the unique
-            // (OriginDocumentId, OriginFigureKey) index here. The failure propagates to SpawnDerivedDocumentAsync,
+            // (OriginDocumentId, OriginConstituentKey) index here. The failure propagates to SpawnDerivedDocumentAsync,
             // which reclaims this run's orphan blob and rethrows so the job retries; on retry LoadAsync sees the
             // figure as Spawned (the winner committed it) and skips it — self-healing, no duplicate. Not narrowing
             // to a specific exception type is deliberate: any non-unique DB failure also surfaces (job retry)

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -179,10 +179,10 @@ public class DocumentTextExtractionBackgroundJob
         // transcription rather than re-OCR'ing the crop. Load it inside this UoW; null (not derived, or the
         // candidate is missing/empty) falls back to the normal OCR path in ExecuteAsync.
         string? seedMarkdown = null;
-        if (document.OriginDocumentId.HasValue && !string.IsNullOrEmpty(document.OriginFigureKey))
+        if (document.OriginDocumentId.HasValue && !string.IsNullOrEmpty(document.OriginConstituentKey))
         {
             var figure = await _documentFigureRepository.FirstOrDefaultAsync(
-                f => f.SourceDocumentId == document.OriginDocumentId.Value && f.ContentHash == document.OriginFigureKey);
+                f => f.SourceDocumentId == document.OriginDocumentId.Value && f.ContentHash == document.OriginConstituentKey);
             var transcription = figure?.Transcription;
             seedMarkdown = string.IsNullOrEmpty(transcription) ? null : transcription;
         }
@@ -298,7 +298,7 @@ public class DocumentTextExtractionBackgroundJob
     /// External phase (no UoW): persists each de-duplicated embedded figure crop (#306) to blob storage as a
     /// Scenario B routing candidate, keyed by content hash (<c>figures/{documentId}/{contentHash}</c>), and
     /// returns the descriptors the Complete phase turns into <see cref="DocumentFigure"/> rows. The content
-    /// hash doubles as the derived document's <c>OriginFigureKey</c> / <c>FileOrigin.ContentHash</c>, tying
+    /// hash doubles as the derived document's <c>OriginConstituentKey</c> / <c>FileOrigin.ContentHash</c>, tying
     /// storage and routing idempotency together.
     /// <para>
     /// <b>Fails open per figure</b>: a crop is an auxiliary routing input, so empty bytes or a blob-write

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentConsts.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentConsts.cs
@@ -45,11 +45,12 @@ public static class DocumentConsts
     public static int MaxLanguageLength { get; set; } = 16;
 
     /// <summary>
-    /// Length of <see cref="Document.OriginFigureKey"/> (#306): the SHA-256 (lowercase hex) of the source
-    /// figure's bytes, which equals the derived document's <c>FileOrigin.ContentHash</c>. Matches
+    /// Length of <see cref="Document.OriginConstituentKey"/> (#306 / #346): the SHA-256 (lowercase hex) of the
+    /// source constituent — the figure's bytes (image path) or the Markdown slice (born-digital path) — which
+    /// equals the derived document's <c>FileOrigin.ContentHash</c>. Matches
     /// <see cref="FileOriginConsts.MaxContentHashLength"/>.
     /// </summary>
-    public static int MaxOriginFigureKeyLength { get; set; } = 64;
+    public static int MaxOriginConstituentKeyLength { get; set; } = 64;
 
     /// <summary>
     /// Native payload archive size limit in bytes, default 16 MiB (#210).

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -101,10 +101,22 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// </summary>
     public virtual DocumentTextExtractionMetadata? ExtractionMetadata { get; private set; }
 
-    // === Scenario B sub-document back-reference (#306) ===
+    // === Container marker (#346) ===
 
     /// <summary>
-    /// When this document was derived from an embedded figure of another document (#306, Scenario B), the id of
+    /// Whether this document is a <b>container</b> (#346): a parent whose content is several independent documents
+    /// (a multi-type bundle, or multiple instances of one type), so it runs <b>no</b> type-bound field extraction
+    /// itself — each constituent is delegated to a sub-document. Set by <see cref="MarkAsContainer"/> when the
+    /// classification stage reports a container; <c>false</c> for normal single documents. A generic, strongly-typed
+    /// truth-source marker (not a business field, not a generic extension bag), exposed at the egress so downstream
+    /// skips building a record from a container and follows its sub-documents instead.
+    /// </summary>
+    public virtual bool IsContainer { get; private set; }
+
+    // === Scenario B sub-document back-reference (#306 / generalized in #346) ===
+
+    /// <summary>
+    /// When this document was derived from a constituent of another document (#306 / #346, Scenario B), the id of
     /// that <b>source</b> document; <c>null</c> for normally-uploaded documents. A peer back-reference
     /// (reference-by-id, no navigation property, no FK cascade): the derived document has a fully independent
     /// lifecycle and outlives the source. Exposed at the egress so downstream can follow it for provenance.
@@ -112,12 +124,13 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     public virtual Guid? OriginDocumentId { get; private set; }
 
     /// <summary>
-    /// Content-derived stable key of the source figure this document was derived from (#306): the SHA-256 of the
-    /// figure bytes, equal to this document's <c>FileOrigin.ContentHash</c>. NOT bbox (which drifts, #210). Unique
-    /// together with <see cref="OriginDocumentId"/> so re-extraction / routing retry never duplicate-spawn.
+    /// Content-derived stable key of the source constituent this document was derived from (#306 figure path /
+    /// #346 born-digital path): the SHA-256 of the figure bytes <b>or</b> of the Markdown slice, equal to this
+    /// document's <c>FileOrigin.ContentHash</c>. NOT bbox (which drifts, #210). Unique together with
+    /// <see cref="OriginDocumentId"/> so re-extraction / routing retry never duplicate-spawn.
     /// <c>null</c> for normally-uploaded documents.
     /// </summary>
-    public virtual string? OriginFigureKey { get; private set; }
+    public virtual string? OriginConstituentKey { get; private set; }
 
     // --- Aggregate-internal field value collection (field architecture v2 / Issue #206) ---
 
@@ -151,24 +164,25 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     }
 
     /// <summary>
-    /// Creates a <b>derived</b> document spawned from an embedded figure of <paramref name="originDocumentId"/>
-    /// (#306, Scenario B). It is a normal peer <see cref="Document"/> that runs the full pipeline + egress; the
-    /// only difference is the back-reference (<see cref="OriginDocumentId"/> / <see cref="OriginFigureKey"/>).
-    /// <paramref name="originFigureKey"/> equals <paramref name="fileOrigin"/>'s <c>ContentHash</c> (the figure
-    /// content hash), tying storage and routing idempotency together.
+    /// Creates a <b>derived</b> document spawned from a constituent of <paramref name="originDocumentId"/>
+    /// (#306 / #346, Scenario B): an embedded figure (image path) or a Markdown slice (born-digital path). It is a
+    /// normal peer <see cref="Document"/> that runs the full pipeline + egress; the only difference is the
+    /// back-reference (<see cref="OriginDocumentId"/> / <see cref="OriginConstituentKey"/>).
+    /// <paramref name="originConstituentKey"/> equals <paramref name="fileOrigin"/>'s <c>ContentHash</c> (the
+    /// constituent content hash), tying storage and routing idempotency together.
     /// </summary>
     public static Document CreateDerived(
         Guid id,
         Guid? tenantId,
         FileOrigin fileOrigin,
         Guid originDocumentId,
-        string originFigureKey)
+        string originConstituentKey)
     {
         var document = new Document(id, tenantId, fileOrigin)
         {
             OriginDocumentId = Check.NotDefaultOrNull<Guid>(originDocumentId, nameof(originDocumentId)),
-            OriginFigureKey = Check.NotNullOrWhiteSpace(
-                originFigureKey, nameof(originFigureKey), DocumentConsts.MaxOriginFigureKeyLength)
+            OriginConstituentKey = Check.NotNullOrWhiteSpace(
+                originConstituentKey, nameof(originConstituentKey), DocumentConsts.MaxOriginConstituentKeyLength)
         };
         return document;
     }
@@ -343,6 +357,36 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: false);
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null; // #284 review-fix: leaving Rejected disposition -> clear stale rejection reason.
+        _extractedFieldValues.Clear();
+    }
+
+    /// <summary>
+    /// Marks this document as a <b>container</b> (#346): a parent whose content is several independent documents
+    /// (a multi-type bundle, or multiple instances of one type), so it runs <b>no</b> type-bound field extraction
+    /// itself — each constituent is delegated to a sub-document. Detected at classification
+    /// (<c>ClassificationResponse.IsContainer</c>), where the marker dominates the incidental type guess.
+    /// <para>
+    /// Unlike <see cref="RequestClassificationReview"/>, a container is a <b>correct</b> outcome, not an error: it
+    /// does <b>not</b> set <see cref="DocumentReviewReasons.UnresolvedClassification"/>, so it never enters the
+    /// operator review queue, and — with both key pipelines succeeded and no blocking reason — derives straight to
+    /// <c>Ready</c> (Design A). <see cref="DocumentTypeId"/> stays null, confidence is reset to 0, and any existing
+    /// field values are cleared (a container holds no single type's fields). <see cref="Markdown"/> /
+    /// <see cref="Title"/> are kept as the original-file / provenance anchor; only type-bound extraction is
+    /// suppressed. The classification caller deliberately does <b>not</b> publish <c>DocumentClassifiedEto</c> for a
+    /// container, so <c>FieldExtractionEventHandler</c> never cascades.
+    /// </para>
+    /// </summary>
+    internal void MarkAsContainer()
+    {
+        IsContainer = true;
+        DocumentTypeId = null;
+        ClassificationConfidence = 0;
+        // A container is a correct outcome: clear the classification / field review reasons rather than setting them,
+        // so it is not routed to the operator review queue and is not blocked from deriving to Ready.
+        SetReviewReason(DocumentReviewReasons.UnresolvedClassification, present: false);
+        SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: false);
+        ReviewDisposition = DocumentReviewDisposition.NotReviewed;
+        RejectionReason = null;
         _extractedFieldValues.Clear();
     }
 

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Figures/DocumentFigure.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Figures/DocumentFigure.cs
@@ -22,7 +22,7 @@ namespace Dignite.DocumentAI.Documents.Figures;
 /// </para>
 /// <para>
 /// <b>Identity is content, not position.</b> <see cref="ContentHash"/> is the SHA-256 of the figure
-/// bytes and doubles as the derived document's <c>FileOrigin.ContentHash</c> / <c>OriginFigureKey</c>,
+/// bytes and doubles as the derived document's <c>FileOrigin.ContentHash</c> / <c>OriginConstituentKey</c>,
 /// giving idempotent routing (unique <c>(SourceDocumentId, ContentHash)</c>); bbox is deliberately not
 /// persisted as identity because it drifts across provider / re-extraction (#210). <see cref="PageNumber"/>
 /// is provenance only.
@@ -37,7 +37,7 @@ public class DocumentFigure : CreationAuditedAggregateRoot<Guid>, IMultiTenant
 
     /// <summary>
     /// SHA-256 (lowercase hex) of the figure bytes. Doubles as the derived document's
-    /// <c>OriginFigureKey</c> / <c>FileOrigin.ContentHash</c> and is unique per source
+    /// <c>OriginConstituentKey</c> / <c>FileOrigin.ContentHash</c> and is unique per source
     /// (<c>(SourceDocumentId, ContentHash)</c>), so re-extraction / job retry never duplicate-spawn.
     /// </summary>
     public virtual string ContentHash { get; private set; } = default!;
@@ -104,7 +104,7 @@ public class DocumentFigure : CreationAuditedAggregateRoot<Guid>, IMultiTenant
     /// <summary>
     /// Records that sub-document routing spawned a derived <see cref="Document"/> from this candidate (#306):
     /// links the derived document and moves <see cref="Status"/> to <see cref="DocumentFigureStatus.Spawned"/>.
-    /// Idempotent re-routing is guarded upstream by the unique <c>(OriginDocumentId, OriginFigureKey)</c> index
+    /// Idempotent re-routing is guarded upstream by the unique <c>(OriginDocumentId, OriginConstituentKey)</c> index
     /// on the derived document.
     /// </summary>
     public void MarkSpawned(Guid routedDocumentId)

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Pipelines/DocumentPipelineRunManager.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Pipelines/DocumentPipelineRunManager.cs
@@ -188,6 +188,28 @@ public class DocumentPipelineRunManager : DomainService
     }
 
     /// <summary>
+    /// Records a <b>container</b> classification outcome (#346) and completes the run as succeeded. A container
+    /// (a parent bundling several independent documents) runs no type-bound field extraction itself, so
+    /// <see cref="Document.MarkAsContainer"/> leaves <see cref="Document.DocumentTypeId"/> null, clears any field
+    /// values, and — unlike <see cref="CompleteClassificationWithLowConfidenceAsync"/> — does <b>not</b> set the
+    /// blocking <see cref="DocumentReviewReasons.UnresolvedClassification"/> reason. The container is therefore not
+    /// sent to the operator review queue and, with both key pipelines succeeded and no blocking reason, derives
+    /// straight to <c>Ready</c> (Design A).
+    /// <para>
+    /// The caller (<c>DocumentClassificationBackgroundJob</c>) must <b>not</b> publish <c>DocumentClassifiedEto</c>
+    /// for a container, so <c>FieldExtractionEventHandler</c> never cascades — the race-free way to suppress
+    /// extraction is simply never emitting its trigger event.
+    /// </para>
+    /// </summary>
+    public virtual Task CompleteClassificationAsContainerAsync(
+        Document document,
+        DocumentPipelineRun run)
+    {
+        document.MarkAsContainer();
+        return CompleteAsync(document, run);
+    }
+
+    /// <summary>
     /// Operator confirms document type: writes classification result, marks it reviewed, and completes the run. Confidence is fixed at 1.0.
     /// The manual override signal is expressed by <see cref="Document.ReviewDisposition"/> = Confirmed.
     /// This literal is maintained in sync with <c>ClassificationDefaults.ManualClassificationConfidence</c> in Domain.Shared.

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -71,8 +71,11 @@ public static class DocumentAIDbContextModelCreatingExtensions
             // Field architecture v2: system common fields are flattened as top-level typed columns: real automatic pipeline outputs.
             b.Property(x => x.Language).HasMaxLength(DocumentConsts.MaxLanguageLength);
 
-            // #306 Scenario B back-reference: content-derived key of the source figure (= FileOrigin.ContentHash).
-            b.Property(x => x.OriginFigureKey).HasMaxLength(DocumentConsts.MaxOriginFigureKeyLength);
+            // #346 container marker: non-null bool, default false (generic truth-source column, not a business field).
+            b.Property(x => x.IsContainer).IsRequired();
+
+            // #306 / #346 Scenario B back-reference: content-derived key of the source constituent (= FileOrigin.ContentHash).
+            b.Property(x => x.OriginConstituentKey).HasMaxLength(DocumentConsts.MaxOriginConstituentKeyLength);
 
             // Text extraction provenance (#210): provider name + archived manifest, serialized as a whole into a typed JSON column (#206 cross-DB principle).
             b.Property(x => x.ExtractionMetadata)
@@ -131,15 +134,15 @@ public static class DocumentAIDbContextModelCreatingExtensions
             b.HasIndex(x => new { x.TenantId, x.DocumentTypeId });
             b.HasIndex(x => x.CreationTime);
 
-            // #306 Scenario B back-reference: derived documents only. A filtered UNIQUE index on
-            // (OriginDocumentId, OriginFigureKey) makes sub-document routing idempotent (one derived document
-            // per source figure; re-routing / retry never duplicate-spawn) and also serves "list a source's
-            // derived documents" (OriginDocumentId is the leading column). Filtered to non-null so
-            // normally-uploaded documents (both columns null) are exempt. The HasFilter clause is
+            // #306 / #346 Scenario B back-reference: derived documents only. A filtered UNIQUE index on
+            // (OriginDocumentId, OriginConstituentKey) makes sub-document routing idempotent (one derived document
+            // per source constituent — figure or Markdown slice; re-routing / retry never duplicate-spawn) and also
+            // serves "list a source's derived documents" (OriginDocumentId is the leading column). Filtered to
+            // non-null so normally-uploaded documents (both columns null) are exempt. The HasFilter clause is
             // SQL-Server-specific; the SQL-Server-only filtered-index portability limitation is intentionally
             // accepted for v0.2.0. No FK on OriginDocumentId: it is a soft provenance pointer, not a constraint,
             // so the derived document outlives the source (the source may be hard-deleted while derived ones remain).
-            b.HasIndex(x => new { x.OriginDocumentId, x.OriginFigureKey })
+            b.HasIndex(x => new { x.OriginDocumentId, x.OriginConstituentKey })
                 .IsUnique()
                 .HasFilter("[OriginDocumentId] IS NOT NULL");
         });

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentDtoExposure_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/DocumentDtoExposure_Tests.cs
@@ -32,6 +32,14 @@ public class DocumentDtoExposure_Tests
     }
 
     [Fact]
+    public void Exposes_Container_Marker()
+    {
+        // #346: the container marker is an intentional egress field — downstream must see it to skip building a
+        // record from a container. Positive lock to prevent accidental future removal.
+        PropertyNames.ShouldContain(nameof(DocumentDto.IsContainer));
+    }
+
+    [Fact]
     public void Exposes_Extraction_Completeness_Quality_Signal()
     {
         // #268: extraction completeness is an actionable downstream quality signal, unlike the hidden internal

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
@@ -118,6 +118,8 @@ public class EtoContract_Tests
             TenantId = null,
             EventTime = SampleEventTime,
             DocumentTypeCode = "contract.general",
+            // #346: container marker. Non-default so a serialization regression (getter-only / rename) is caught.
+            IsContainer = true,
             // #306: provenance link for a Scenario B sub-document. Non-null so a serialization regression is caught.
             OriginDocumentId = originDocumentId
         };
@@ -126,6 +128,7 @@ public class EtoContract_Tests
 
         roundTrip.DocumentTypeCode.ShouldBe("contract.general");
         roundTrip.EventTime.ShouldBe(eto.EventTime);
+        roundTrip.IsContainer.ShouldBeTrue();
         roundTrip.OriginDocumentId.ShouldBe(originDocumentId);
     }
 

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
@@ -123,6 +123,46 @@ public class DocumentClassificationBackgroundJob_Tests
     }
 
     [Fact]
+    public async Task Container_Marks_Document_And_Does_Not_Publish_ClassifiedEto()
+    {
+        var doc = CreateDocument("Invoice 1 ... Invoice 2 ... Invoice 3 ... (a bundle of independent invoices)");
+        SetupDocumentRepository(doc);
+
+        // #346: the classifier reports a container. Even with an incidental high-confidence type guess, the
+        // container branch dominates: it must not be classified to that type and must not cascade extraction.
+        _workflow
+            .RunAsync(
+                Arg.Any<IReadOnlyList<DocumentType>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                IsContainer = true,
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.95,
+                Reason = "Several independent documents bundled together"
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        var run = await _runRepository.FindLatestByDocumentAndCodeAsync(doc.Id, DocumentAIPipelines.Classification);
+        run.ShouldNotBeNull();
+        run.Status.ShouldBe(PipelineRunStatus.Succeeded);
+
+        doc.IsContainer.ShouldBeTrue();
+        doc.DocumentTypeId.ShouldBeNull();
+        doc.ClassificationConfidence.ShouldBe(0);
+        // A container is a correct outcome, not low confidence: it must not enter the operator review queue.
+        doc.ReviewReasons.ShouldBe(DocumentReviewReasons.None);
+        doc.ReviewDisposition.ShouldBe(DocumentReviewDisposition.NotReviewed);
+
+        // The crux of Design A: never publishing DocumentClassifiedEto is what stops FieldExtractionEventHandler
+        // from cascading field extraction onto the container.
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Any<DocumentClassifiedEto>(), Arg.Any<bool>());
+    }
+
+    [Fact]
     public async Task LowConfidence_Marks_PendingReview_No_Event()
     {
         var doc = CreateDocument("Some document text.");

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler_Tests.cs
@@ -68,6 +68,31 @@ public class DocumentReadyEventHandler_Tests
     }
 
     [Fact]
+    public async Task Container_Ready_Publishes_Eto_With_Marker_And_Null_Type()
+    {
+        // #346: a container reaches Ready with no type. The ETO must carry IsContainer=true and
+        // DocumentTypeCode=null so downstream skips building a record from the container.
+        var doc = CreateContainerDocument();
+        SetupDocumentRepository(doc);
+
+        var evt = new DocumentLifecycleStatusChangedEvent(
+            doc.Id, DocumentLifecycleStatus.Processing, DocumentLifecycleStatus.Ready);
+
+        await _handler.HandleEventAsync(evt);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentReadyEto>(e =>
+                e.DocumentId == doc.Id &&
+                e.IsContainer &&
+                e.DocumentTypeCode == null),
+            Arg.Any<bool>());
+
+        // A container has no DocumentTypeId, so the handler must not even attempt a type lookup.
+        await _documentTypeRepository.DidNotReceive().FindAsync(
+            Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Non_Ready_Transition_Does_Not_Publish()
     {
         var doc = CreateDocument(documentTypeCode: null);
@@ -128,6 +153,16 @@ public class DocumentReadyEventHandler_Tests
                 .Invoke(doc, [TypeId(documentTypeCode), 0.99]);
         }
 
+        return doc;
+    }
+
+    private static Document CreateContainerDocument()
+    {
+        var doc = CreateDocument(documentTypeCode: null);
+        typeof(Document)
+            .GetMethod("MarkAsContainer",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(doc, null);
         return doc;
     }
 

--- a/core/test/Dignite.DocumentAI.Domain.Tests/Documents/DocumentPipelineRunManagerTests.cs
+++ b/core/test/Dignite.DocumentAI.Domain.Tests/Documents/DocumentPipelineRunManagerTests.cs
@@ -109,6 +109,52 @@ public class DocumentPipelineRunManagerTests : DocumentAIDomainTestBase<Document
         doc.ReviewReasons.ShouldBe(DocumentReviewReasons.MissingRequiredFields);
     }
 
+    // #346: a container is a correct outcome with no type. Completing classification as a container marks the
+    // document, leaves the type null, sets NO blocking review reason, and — with both key pipelines succeeded —
+    // derives straight to Ready (Design A), so the container is never parked in the operator review queue.
+    [Fact]
+    public async Task Container_Classification_Derives_To_Ready_Without_Review_Reason()
+    {
+        var doc = CreateDocument();
+
+        var textRun = await _manager.StartAsync(doc, DocumentAIPipelines.TextExtraction);
+        await _manager.CompleteAsync(doc, textRun);
+
+        var classRun = await _manager.StartAsync(doc, DocumentAIPipelines.Classification);
+        await _manager.CompleteClassificationAsContainerAsync(doc, classRun);
+
+        doc.IsContainer.ShouldBeTrue();
+        doc.DocumentTypeId.ShouldBeNull();
+        doc.ClassificationConfidence.ShouldBe(0);
+        // Distinct from the low-confidence path: NO UnresolvedClassification, so it does not enter the review queue.
+        doc.ReviewReasons.ShouldBe(DocumentReviewReasons.None);
+        doc.ReviewDisposition.ShouldBe(DocumentReviewDisposition.NotReviewed);
+        doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.Ready);
+
+        var latestRun = await _runRepo.FindLatestByDocumentAndCodeAsync(doc.Id, DocumentAIPipelines.Classification);
+        latestRun!.Status.ShouldBe(PipelineRunStatus.Succeeded);
+    }
+
+    // #346: marking a container clears any field values already extracted (a container holds no single type's
+    // fields), mirroring the #267 "no confirmed type implies no field values" invariant.
+    [Fact]
+    public async Task Container_Classification_Clears_ExtractedFieldValues()
+    {
+        var doc = CreateDocument();
+        doc.SetFields(new[]
+        {
+            new DocumentFieldValue(Guid.NewGuid(), FieldDataType.Text, JsonSerializer.SerializeToElement("Acme")),
+        });
+        doc.ExtractedFieldValues.ShouldNotBeEmpty();
+
+        var run = await _manager.StartAsync(doc, DocumentAIPipelines.Classification);
+        await _manager.CompleteClassificationAsContainerAsync(doc, run);
+
+        doc.IsContainer.ShouldBeTrue();
+        doc.DocumentTypeId.ShouldBeNull();
+        doc.ExtractedFieldValues.ShouldBeEmpty();
+    }
+
     // ────────────────────────────────────────────────────────────────────────────
     // Scenario 2: key pipeline (TextExtraction) fails → Failed
     // ────────────────────────────────────────────────────────────────────────────

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFigureRoutingJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFigureRoutingJob_Tests.cs
@@ -90,7 +90,7 @@ public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureR
         {
             var derived = (await _documentRepository.GetListAsync(d => d.OriginDocumentId == sourceId)).SingleOrDefault();
             derived.ShouldNotBeNull();
-            derived!.OriginFigureKey.ShouldBe(contentHash);
+            derived!.OriginConstituentKey.ShouldBe(contentHash);
             derived.FileOrigin.ContentHash.ShouldBe(contentHash);
             derived.FileOrigin.BlobName.ShouldNotBe(cropBlobName); // copied to an independent blob
             derived.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.Processing); // text-extraction queued
@@ -218,7 +218,7 @@ public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureR
         await WithUnitOfWorkAsync(async () =>
             await _documentRepository.InsertAsync(NewDerived(sourceId, figureKey), autoSave: true));
 
-        // The filtered unique index on (OriginDocumentId, OriginFigureKey) is routing's concurrency backstop: a
+        // The filtered unique index on (OriginDocumentId, OriginConstituentKey) is routing's concurrency backstop: a
         // second derived document for the same source figure must be rejected by the database.
         await Should.ThrowAsync<Exception>(() => WithUnitOfWorkAsync(async () =>
             await _documentRepository.InsertAsync(NewDerived(sourceId, figureKey), autoSave: true)));
@@ -278,6 +278,6 @@ public class DocumentFigureRoutingJob_Tests : DocumentAITestBase<DocumentFigureR
             fileOrigin: new FileOrigin(
                 blobName: $"{id:N}.png", uploadedByUserName: "test-user", contentType: "image/png",
                 contentHash: figureKey, fileSize: 4, originalFileName: "figure.png"),
-            originDocumentId: sourceId, originFigureKey: figureKey);
+            originDocumentId: sourceId, originConstituentKey: figureKey);
     }
 }

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -362,7 +362,7 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
         await _blobContainer.Received(1).SaveAsync(
             $"figures/{documentId}/{contentHash}", Arg.Any<Stream>(), overrideExisting: true, Arg.Any<CancellationToken>());
 
-        // One DocumentFigure candidate row carrying provenance + the content hash that doubles as OriginFigureKey.
+        // One DocumentFigure candidate row carrying provenance + the content hash that doubles as OriginConstituentKey.
         await WithUnitOfWorkAsync(async () =>
         {
             var figures = await _figureRepository.GetListAsync(f => f.SourceDocumentId == documentId);
@@ -485,7 +485,7 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
                 fileOrigin: new FileOrigin(
                     blobName: $"blobs/{derivedId:N}.png", uploadedByUserName: "test-user",
                     contentType: "image/png", contentHash: figureKey, fileSize: 4, originalFileName: "figure.png"),
-                originDocumentId: sourceId, originFigureKey: figureKey);
+                originDocumentId: sourceId, originConstituentKey: figureKey);
             await _documentRepository.InsertAsync(derived, autoSave: true);
 
             var run = await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);

--- a/host/src/Migrations/20260617044331_Added_DocumentContainerMarkerAndConstituentKeyRename.Designer.cs
+++ b/host/src/Migrations/20260617044331_Added_DocumentContainerMarkerAndConstituentKeyRename.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.DocumentAI.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.DocumentAI.Host.Migrations
 {
     [DbContext(typeof(DocumentAIHostDbContext))]
-    partial class DocumentAIHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617044331_Added_DocumentContainerMarkerAndConstituentKeyRename")]
+    partial class Added_DocumentContainerMarkerAndConstituentKeyRename
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260617044331_Added_DocumentContainerMarkerAndConstituentKeyRename.cs
+++ b/host/src/Migrations/20260617044331_Added_DocumentContainerMarkerAndConstituentKeyRename.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.DocumentAI.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Added_DocumentContainerMarkerAndConstituentKeyRename : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "OriginFigureKey",
+                table: "DocAIDocuments",
+                newName: "OriginConstituentKey");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_DocAIDocuments_OriginDocumentId_OriginFigureKey",
+                table: "DocAIDocuments",
+                newName: "IX_DocAIDocuments_OriginDocumentId_OriginConstituentKey");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsContainer",
+                table: "DocAIDocuments",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsContainer",
+                table: "DocAIDocuments");
+
+            migrationBuilder.RenameColumn(
+                name: "OriginConstituentKey",
+                table: "DocAIDocuments",
+                newName: "OriginFigureKey");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_DocAIDocuments_OriginDocumentId_OriginConstituentKey",
+                table: "DocAIDocuments",
+                newName: "IX_DocAIDocuments_OriginDocumentId_OriginFigureKey");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR3a of #346 — the **container concept** (Milestone v0.2.0). A source that is really a *bundle* of N independent documents but classifies as a single high-confidence type used to run mechanism-B field extraction on itself and fire a `DocumentReadyEto`, producing an ambiguous/garbage downstream record; a bundle that classified low sat in the operator review queue forever. This PR makes "is the parent a container?" an explicit, first-class outcome.

Closes the parked #306 container-marker item. It stops the garbage-record defect **on its own**, before born-digital segmentation exists.

## What changed

- **Detection (zero extra LLM cost).** `ClassificationResponse` / `DocumentClassificationOutcome` gain a binary `IsContainer`, riding the existing classification call. The classification prompt gains **conservative** container guidance: flag only a clear bundle of several independent documents; attachments / annexes / 別紙 / continuation pages / a single register/ledger are explicitly **not** containers; when in doubt, false.
- **Aggregate.** `Document` gains a `bool IsContainer` column + `MarkAsContainer()` — sets the marker, leaves `DocumentTypeId` null, clears field values, and (unlike the low-confidence path) sets **no** `UnresolvedClassification`, so a container is a *correct* outcome, not a review-queue item.
- **Suppression (Design A).** `DocumentClassificationBackgroundJob` takes a container branch (`DocumentPipelineRunManager.CompleteClassificationAsContainerAsync`) that completes the run and **does not publish `DocumentClassifiedEto`**, so `FieldExtractionEventHandler` never cascades — race-free suppression by never emitting the trigger. With both key pipelines succeeded and no blocking reason, the container derives straight to **Ready**.
- **Egress.** `IsContainer` on `DocumentDto` (REST/MCP) and `DocumentReadyEto` (push). For a container the ETO's `DocumentTypeCode` is `null`; downstream tolerates `DocumentTypeCode == null && IsContainer == true` and skips building a record from the container.
- **Generalized back-reference.** `Document.OriginFigureKey` → `OriginConstituentKey` across the whole chain (column + filtered unique index + `CreateDerived` param + `DocumentDto` / `DocumentReadyEto` + figure-routing / text-extraction usage), since the key now also covers born-digital constituents.
- **Migration.** Data-preserving `RenameColumn` / `RenameIndex` + `IsContainer bit NOT NULL default false`. **Generated, not applied.**

## Out of scope (PR3b)

Born-digital segmentation (`DocumentSegment` ledger + `DocumentSegmentationJob`, `MaxSegmentsPerDocument`, recursion guard, container-aware stats) lands in PR3b. In this PR a born-digital container becomes a marked, Ready container with **no** sub-documents — i.e. zero records instead of one wrong record.

## Tests

- Container classification marks the document, completes the run, and **does not** publish `DocumentClassifiedEto`.
- Container derives to **Ready** with no review reason (not parked in the queue); field values cleared.
- `DocumentReadyEto` for a container carries `IsContainer = true`, `DocumentTypeCode = null` (no type lookup).
- `DocumentDto` exposes `IsContainer`; `DocumentReadyEto` round-trips it through System.Text.Json.
- `OriginConstituentKey` rename keeps figure-routing idempotency (unique-index backstop) green.

Build: 0 warnings / 0 errors. Domain 173 / Application 253 / EFCore 82 tests pass. Reviewed by `abp-architecture-reviewer` (no blocking issues) and `ef-migration-safety-reviewer` (safe to apply).

Part of #346
