### PR TITLE
feat(documents): born-digital container segmentation (#346, PR3b)

### DIFF
--- a/angular/packages/document-ai/documents/src/lib/documents/document-detail/document-detail.component.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-detail/document-detail.component.ts
@@ -600,6 +600,8 @@ export class DocumentDetailComponent implements OnInit {
         return '::Document:ReviewReason:UnresolvedClassification';
       case DocumentReviewReasons.MissingRequiredFields:
         return '::Document:ReviewReason:MissingRequiredFields';
+      case DocumentReviewReasons.SegmentationIncomplete:
+        return '::Document:ReviewReason:SegmentationIncomplete';
       default:
         return '::Document:NeedsReview';
     }

--- a/angular/packages/document-ai/documents/src/lib/documents/document-list/document-list.component.ts
+++ b/angular/packages/document-ai/documents/src/lib/documents/document-list/document-list.component.ts
@@ -537,6 +537,9 @@ export class DocumentListComponent implements OnInit {
     if ((reasons & DocumentReviewReasons.MissingRequiredFields) !== DocumentReviewReasons.None) {
       return '::Document:ReviewReason:MissingRequiredFields';
     }
+    if ((reasons & DocumentReviewReasons.SegmentationIncomplete) !== DocumentReviewReasons.None) {
+      return '::Document:ReviewReason:SegmentationIncomplete';
+    }
     return '::Document:NeedsReview';
   }
 

--- a/angular/packages/document-ai/src/lib/proxy-contract.spec.ts
+++ b/angular/packages/document-ai/src/lib/proxy-contract.spec.ts
@@ -32,7 +32,8 @@ describe('proxy enum contract (smoke)', () => {
     expect(DocumentReviewReasons.None).toBe(0);
     expect(DocumentReviewReasons.UnresolvedClassification).toBe(1);
     expect(DocumentReviewReasons.MissingRequiredFields).toBe(2);
-    expect(documentReviewReasonsOptions).toHaveLength(3);
+    expect(DocumentReviewReasons.SegmentationIncomplete).toBe(4);
+    expect(documentReviewReasonsOptions).toHaveLength(4);
   });
 
   it('DocumentLifecycleStatus matches backend values', () => {

--- a/angular/packages/document-ai/src/lib/proxy/documents/document-review-reasons.enum.ts
+++ b/angular/packages/document-ai/src/lib/proxy/documents/document-review-reasons.enum.ts
@@ -4,6 +4,7 @@ export enum DocumentReviewReasons {
   None = 0,
   UnresolvedClassification = 1,
   MissingRequiredFields = 2,
+  SegmentationIncomplete = 4,
 }
 
 export const documentReviewReasonsOptions = mapEnumToOptions(DocumentReviewReasons);

--- a/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReadyEto.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReadyEto.cs
@@ -36,21 +36,7 @@ public class DocumentReadyEto
     /// </summary>
     public required DateTime EventTime { get; init; }
 
-    /// <summary>
-    /// Confirmed document type, or <c>null</c>. Since #346, <c>null</c> together with <see cref="IsContainer"/> =
-    /// <c>true</c> is a valid Ready outcome: a container has no single type. Downstream must tolerate this pairing
-    /// and skip building a record from the container.
-    /// </summary>
     public string? DocumentTypeCode { get; init; }
-
-    /// <summary>
-    /// Whether this document is a <b>container</b> (#346): a parent bundling several independent documents that
-    /// ran no type-bound field extraction itself. When <c>true</c>, <see cref="DocumentTypeCode"/> is <c>null</c>
-    /// and downstream must <b>not</b> build a business record from this document — the real records are its
-    /// sub-documents (each fires its own <c>DocumentReadyEto</c> carrying <see cref="OriginDocumentId"/>). New
-    /// optional field; defaults to <c>false</c> for producers / consumers that predate it.
-    /// </summary>
-    public bool IsContainer { get; init; }
 
     /// <summary>
     /// Provenance link for a Scenario B sub-document (#306): when this document was derived from a constituent

--- a/core/src/Dignite.DocumentAI.Application/Ai/DefaultPromptProvider.cs
+++ b/core/src/Dignite.DocumentAI.Application/Ai/DefaultPromptProvider.cs
@@ -46,6 +46,25 @@ public class DefaultPromptProvider : IPromptProvider, ITransientDependency
         $"Respond in: {LanguageTagValidator.Normalize(language) ?? FallbackLanguage}."
     );
 
+    public virtual PromptTemplate GetSegmentationPrompt(string language) => new(
+        "You split a bundle of several independent documents into its constituent documents. " +
+        "The content is provided as Markdown. Identify each separate document in reading order. " +
+        // #346 decision (Decision Log): the model returns BOUNDARIES, not regenerated text. It copies a short
+        // verbatim marker for each constituent; code does the actual cutting, so there is no content drift.
+        "For each constituent, return its startMarker — the FIRST line (or first ~60 characters) of that " +
+        "constituent, copied EXACTLY and verbatim from the Markdown, character for character, with no edits, " +
+        "no summarizing, and no added punctuation — and isDocument. " +
+        "Set isDocument to false for a cover sheet, table of contents, index, or transmittal page, and true for " +
+        "an actual document (invoice, contract, receipt, etc.). List the segments in the order they appear. " +
+        // Conservative boundaries: the same false-positive traps as container detection.
+        "Do NOT split a single multi-page document (a continuation page or line-item overflow of one invoice or " +
+        "contract is the SAME document, one segment). Do NOT split attachments, annexes, 別紙, appendices, or " +
+        "exhibits away from the document they belong to. Do NOT split a figure or image transcription that is " +
+        "already inlined inside another document's text. When unsure whether two parts are separate documents, " +
+        "keep them as one segment. " +
+        $"Respond in: {LanguageTagValidator.Normalize(language) ?? FallbackLanguage}."
+    );
+
     public virtual PromptTemplate GetTitleGenerationPrompt() => new(
         "You generate concise document titles. " +
         "Given a document in Markdown format, return one short descriptive title only — " +

--- a/core/src/Dignite.DocumentAI.Application/Ai/DocumentAIBehaviorOptions.cs
+++ b/core/src/Dignite.DocumentAI.Application/Ai/DocumentAIBehaviorOptions.cs
@@ -69,12 +69,22 @@ public class DocumentAIBehaviorOptions
     public double MinCabinetSuggestionConfidence { get; set; } = 0.6;
 
     /// <summary>
-    /// Maximum number of born-digital sub-documents a single container may be split into (#346). A hard cost +
-    /// blast-radius bound: each spawned slice runs its own classification + extraction + Ready, so an
-    /// adversarial or pathological container could otherwise fan out unbounded work. When the LLM segmentation
-    /// pass proposes more document-slices than this, the container is left with a review signal instead of
-    /// spawning them (mirrors the figure path's per-source cap). Does not count non-document slices
-    /// (cover / index).
+    /// Maximum number of slices a single container may be split into (#346). A hard cost + blast-radius bound:
+    /// each spawned document slice runs its own classification + extraction + Ready, so an adversarial or
+    /// pathological container could otherwise fan out unbounded work — and the rows themselves are bounded too.
+    /// When the LLM segmentation pass proposes more <b>total</b> slices than this (document <b>and</b>
+    /// cover / index slices, after de-duplication), the container is left with a review signal instead of being
+    /// split (mirrors the figure path's per-source cap). At least two distinct document slices are also required.
     /// </summary>
     public int MaxSegmentsPerDocument { get; set; } = 50;
+
+    /// <summary>
+    /// Maximum Markdown length (characters) a container may have for born-digital segmentation (#346). Segmentation
+    /// feeds the <b>whole</b> Markdown to the LLM (constituent boundaries can be anywhere; truncating would silently
+    /// lose the tail documents), so this is the hard upper bound on that single call's prompt-token cost. Above it
+    /// the container is left with a review signal for manual handling rather than paying for an enormous,
+    /// low-confidence call. Default 200k chars (≈ a large multi-document bundle, comfortably within modern context
+    /// windows); hosts may raise it for bigger bundles or lower it to cap spend.
+    /// </summary>
+    public int MaxSegmentationMarkdownLength { get; set; } = 200_000;
 }

--- a/core/src/Dignite.DocumentAI.Application/Ai/DocumentAIBehaviorOptions.cs
+++ b/core/src/Dignite.DocumentAI.Application/Ai/DocumentAIBehaviorOptions.cs
@@ -67,4 +67,14 @@ public class DocumentAIBehaviorOptions
     /// needs the leading document semantics.
     /// </summary>
     public double MinCabinetSuggestionConfidence { get; set; } = 0.6;
+
+    /// <summary>
+    /// Maximum number of born-digital sub-documents a single container may be split into (#346). A hard cost +
+    /// blast-radius bound: each spawned slice runs its own classification + extraction + Ready, so an
+    /// adversarial or pathological container could otherwise fan out unbounded work. When the LLM segmentation
+    /// pass proposes more document-slices than this, the container is left with a review signal instead of
+    /// spawning them (mirrors the figure path's per-source cap). Does not count non-document slices
+    /// (cover / index).
+    /// </summary>
+    public int MaxSegmentsPerDocument { get; set; } = 50;
 }

--- a/core/src/Dignite.DocumentAI.Application/Ai/IPromptProvider.cs
+++ b/core/src/Dignite.DocumentAI.Application/Ai/IPromptProvider.cs
@@ -10,6 +10,14 @@ public interface IPromptProvider
     PromptTemplate GetClassificationPrompt(string language);
 
     /// <summary>
+    /// Born-digital container segmentation prompt (#346). Asks the LLM to return, for each constituent document,
+    /// a <b>verbatim</b> start marker plus whether the slice is itself a document — never regenerated content.
+    /// The <paramref name="language"/> only governs any incidental wording; the markers must be copied exactly
+    /// from the document regardless of language.
+    /// </summary>
+    PromptTemplate GetSegmentationPrompt(string language);
+
+    /// <summary>
     /// Title generation prompt. It <b>does not</b> accept a language parameter because the title
     /// strategy is "follow the document language"; the prompt includes "Respond in the same language
     /// as the document." It is not affected by <c>DocumentAIBehaviorOptions.DefaultLanguage</c>.

--- a/core/src/Dignite.DocumentAI.Application/DocumentAIApplicationGlobalUsings.cs
+++ b/core/src/Dignite.DocumentAI.Application/DocumentAIApplicationGlobalUsings.cs
@@ -4,4 +4,5 @@ global using Dignite.DocumentAI.Documents.Exports;
 global using Dignite.DocumentAI.Documents.Fields;
 global using Dignite.DocumentAI.Documents.Figures;
 global using Dignite.DocumentAI.Documents.Pipelines;
+global using Dignite.DocumentAI.Documents.Segments;
 global using Dignite.DocumentAI.Slugging;

--- a/core/src/Dignite.DocumentAI.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/DocumentAppService.cs
@@ -869,6 +869,18 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
             }
         }
 
+        // #346: a container whose born-digital segmentation could not complete carries this non-blocking reason.
+        // Project it so the detail page shows WHY the container needs attention (the client localizes by the Reason
+        // enum); otherwise RequiresReview would be true with no explanation. No extra data — the reason bit is enough.
+        if ((document.ReviewReasons & DocumentReviewReasons.SegmentationIncomplete) != DocumentReviewReasons.None)
+        {
+            details.Add(new ReviewReasonDetailDto
+            {
+                Reason = DocumentReviewReasons.SegmentationIncomplete,
+                IsBlocking = ReviewReasonPolicy.IsBlocking(DocumentReviewReasons.SegmentationIncomplete)
+            });
+        }
+
         // If all reason-bit details were skipped (for example MRF is the only reason but field names are temporarily empty),
         // return null rather than an empty array. This keeps "no details" semantics consistent with frontend reviewReasonDetails?.length checks.
         // RequiresReview is still determined independently by the upstream predicate.

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
 using Dignite.DocumentAI.Ai;
+using Dignite.DocumentAI.Documents.Pipelines.Segmentation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.BackgroundJobs;
@@ -26,6 +27,7 @@ public class DocumentClassificationBackgroundJob
     private readonly IClock _clock;
     private readonly DocumentAIBehaviorOptions _aiOptions;
     private readonly ICurrentTenant _currentTenant;
+    private readonly IBackgroundJobManager _backgroundJobManager;
 
     public DocumentClassificationBackgroundJob(
         IDocumentRepository documentRepository,
@@ -38,7 +40,8 @@ public class DocumentClassificationBackgroundJob
         IDistributedEventBus distributedEventBus,
         IClock clock,
         IOptions<DocumentAIBehaviorOptions> aiOptions,
-        ICurrentTenant currentTenant)
+        ICurrentTenant currentTenant,
+        IBackgroundJobManager backgroundJobManager)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _documentTypeRepository = documentTypeRepository;
@@ -47,6 +50,7 @@ public class DocumentClassificationBackgroundJob
         _clock = clock;
         _aiOptions = aiOptions.Value;
         _currentTenant = currentTenant;
+        _backgroundJobManager = backgroundJobManager;
     }
 
     public override async Task ExecuteAsync(DocumentClassificationJobArgs args)
@@ -151,10 +155,30 @@ public class DocumentClassificationBackgroundJob
         // is simply never emitting the trigger event). MarkAsContainer leaves DocumentTypeId null and sets no
         // UnresolvedClassification reason, so the container is not sent to the operator review queue and — with
         // both key pipelines succeeded and no blocking reason — derives straight to Ready (Design A).
-        if (outcome.IsContainer)
+        //
+        // Recursion guard (#346): a derived sub-document (OriginDocumentId set) must NOT be re-detected as a
+        // container — that would recurse the split one level deeper. v1 bars recursion at depth one: a derived
+        // document never takes the container branch, so a slice the LLM mistakes for a bundle is simply classified
+        // normally (a real type, or low-confidence review) like any other document.
+        if (outcome.IsContainer && !document.OriginDocumentId.HasValue)
         {
             await PipelineRunManager.CompleteClassificationAsContainerAsync(document, run);
+
+            // Born-digital path: enqueue the LLM segmentation that splits the container's Markdown into
+            // sub-documents. Enqueued in the SAME UoW as the completion so the container marker and the
+            // segmentation job commit atomically (no committed container without its segmentation job, and vice
+            // versa). The image path needs no enqueue here — its figures were already routed during text
+            // extraction; the segmentation prompt is told not to re-split inlined figure transcriptions.
+            await _backgroundJobManager.EnqueueAsync(
+                new DocumentSegmentationJobArgs { ContainerDocumentId = document.Id });
             return;
+        }
+
+        if (outcome.IsContainer)
+        {
+            Logger.LogDebug(
+                "Document {DocumentId} is a derived sub-document; ignoring the container signal (recursion guard) and classifying normally.",
+                document.Id);
         }
 
         // Field architecture v2: look up the type definition from DB, exactly matching the single

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler.cs
@@ -17,9 +17,10 @@ namespace Dignite.DocumentAI.Documents.Pipelines.Lifecycle;
 /// The Ready gate is enforced by the classification stage: documents with insufficient automatic
 /// classification confidence / no suitable type receive the blocking UnresolvedClassification reason
 /// and enter the manual review queue, which keeps them out of Ready. Therefore this handler needs no
-/// extra check: <c>NewStatus == Ready</c> implicitly means the gate passed. #346: a <b>container</b> is a
-/// valid Ready outcome with <b>no</b> type — it reaches Ready with <c>DocumentTypeCode == null</c> and
-/// <c>IsContainer == true</c> (it sets no blocking reason), so the published ETO carries that pairing.
+/// extra check: <c>NewStatus == Ready</c> implicitly means the gate passed. #346: a <b>container</b> also
+/// reaches Ready lifecycle but has <b>no</b> confirmed type, so it is <b>not</b> a consumable document — this
+/// handler suppresses its <c>DocumentReadyEto</c>; downstream consumes only the container's sub-documents,
+/// each emitting its own Ready event. This keeps the contract "<c>DocumentReadyEto</c> ⟺ a confirmed type".
 /// </para>
 /// </summary>
 public class DocumentReadyEventHandler
@@ -61,11 +62,25 @@ public class DocumentReadyEventHandler
             return;
         }
 
-        // ETO still carries the DocumentTypeCode string to preserve the outbound contract, resolving
-        // it from internal DocumentTypeId (#207). A non-container Ready document has a confirmed type
-        // because of the DeriveLifecycle gate, and DeleteAsync prevents deleting in-use types, so the
-        // type should be active. #346: a container reaches Ready with DocumentTypeId null, so
-        // documentTypeCode stays null — that null + IsContainer=true is the valid container outcome.
+        // #346: a container has no confirmed type, so it is NOT a consumable business document — it does not emit the
+        // type-confirmed DocumentReadyEto. (Doing so would be a type-less "ready" fired before its sub-documents even
+        // exist, with no later way to signal a segmentation failure — the contract break Codex's adversarial review
+        // flagged.) The container still reaches Ready *lifecycle* for the operator UI; downstream consumes only the
+        // sub-documents' own DocumentReadyEto, each carrying OriginDocumentId back to this container. A container the
+        // segmenter cannot split surfaces in the operator review queue (SegmentationIncomplete), exactly like a
+        // low-confidence document waits in review without emitting Ready. This keeps the documented contract
+        // "DocumentReadyEto ⟺ a confirmed type" intact.
+        if (document.IsContainer)
+        {
+            _logger.LogInformation(
+                "Document {DocumentId} reached Ready lifecycle as a container; suppressing DocumentReadyEto (its sub-documents emit their own).",
+                document.Id);
+            return;
+        }
+
+        // The ETO carries the DocumentTypeCode string (resolved from the internal DocumentTypeId, #207). A Ready
+        // document always has a confirmed type because of the DeriveLifecycle gate (and the container case is handled
+        // above), and DeleteAsync prevents deleting in-use types, so the type should be active.
         string? documentTypeCode = null;
         if (document.DocumentTypeId.HasValue)
         {
@@ -80,8 +95,6 @@ public class DocumentReadyEventHandler
                 TenantId = document.TenantId,
                 EventTime = _clock.Now,
                 DocumentTypeCode = documentTypeCode,
-                // #346: container marker; downstream skips building a record from a container (DocumentTypeCode null).
-                IsContainer = document.IsContainer,
                 // #306: provenance link for a Scenario B sub-document (null for normally-uploaded documents).
                 OriginDocumentId = document.OriginDocumentId
             });

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
@@ -108,13 +109,11 @@ public class DocumentSegmentationJob
             await SplitAndPersistAsync(context, cancellationToken);
         }
 
-        // Phase B: spawn a derived document per still-Pending segment. Re-loaded each run, so a retry processes
-        // only the slices not yet spawned.
+        // Phase B: spawn a derived document per still-Pending segment. Re-loaded each run, so a retry processes only
+        // the slices not yet spawned. NOTE: no early return on an empty list — a resume/retry that finds nothing
+        // Pending must still run FinalizeSegmentationFlagAsync below, so a container whose last slice was spawned by
+        // a concurrent worker still gets its stale flag cleared.
         var pending = await LoadPendingSegmentsAsync(args.ContainerDocumentId);
-        if (pending.Count == 0)
-        {
-            return;
-        }
 
         var failures = new List<Exception>();
         foreach (var segment in pending)
@@ -123,12 +122,21 @@ public class DocumentSegmentationJob
             await SpawnWithIsolationAsync(failures, segment, context, cancellationToken);
         }
 
-        if (failures.Count > 0)
+        // #346 fix: decide the container's terminal SegmentationIncomplete flag from the DB's remaining-Pending count,
+        // NOT from this run's per-segment failures. Two concurrent workers can each collide on the other's
+        // just-spawned segment (the unique (OriginDocumentId, OriginConstituentKey) backstop) and so each end with
+        // failures > 0 even though every slice is now Spawned; keying off the actual remaining count means whichever
+        // run observes zero remaining clears the flag, so a fully-segmented container never lingers in the review
+        // queue, and a genuinely incomplete one stays flagged ("failure is never silent").
+        var remainingPending = await FinalizeSegmentationFlagAsync(context);
+
+        if (failures.Count > 0 && remainingPending > 0)
         {
-            // Surface the faults so ABP reschedules the job; already-spawned segments are terminal and skipped on
-            // retry (LoadPendingSegmentsAsync re-reads only the still-Pending ones), so retries never duplicate.
+            // Real faults this run AND slices still Pending -> surface so ABP reschedules; already-spawned segments
+            // are terminal and skipped on retry (LoadPendingSegmentsAsync re-reads only the still-Pending ones), so
+            // retries never duplicate.
             throw new AggregateException(
-                $"Segmentation left {failures.Count} slice(s) of container {args.ContainerDocumentId} Pending; the job will be retried.",
+                $"Segmentation left {remainingPending} slice(s) of container {args.ContainerDocumentId} Pending; the job will be retried.",
                 failures);
         }
     }
@@ -171,10 +179,28 @@ public class DocumentSegmentationJob
         }
 
         // Gate (external, no UoW): the LLM proposes boundaries; keep the ambient tenant aligned as classification does.
-        DocumentSegmentationOutcome outcome;
+        // A schema-drift / non-JSON structured response is a recoverable bad-output case (mirrors
+        // DocumentClassificationBackgroundJob): flag the container for review rather than letting the exception fault
+        // the job into an endless ABP retry loop that never reaches a terminal state.
+        DocumentSegmentationOutcome? outcome = null;
         using (_currentTenant.Change(context.TenantId))
         {
-            outcome = await _segmentationWorkflow.RunAsync(context.Markdown, cancellationToken);
+            try
+            {
+                outcome = await _segmentationWorkflow.RunAsync(context.Markdown, cancellationToken);
+            }
+            catch (Exception ex) when (IsSchemaDeserializationError(ex))
+            {
+                Logger.LogWarning(ex,
+                    "AI segmentation response failed JSON deserialization for container {ContainerId}; flagging for review.",
+                    context.ContainerId);
+            }
+        }
+
+        if (outcome is null)
+        {
+            await MarkSegmentationIncompleteAsync(context, "the AI segmentation response could not be parsed (schema drift)");
+            return;
         }
 
         if (!MarkdownSlicer.TrySlice(context.Markdown, outcome.Boundaries, out var slices))
@@ -183,12 +209,35 @@ public class DocumentSegmentationJob
             return;
         }
 
-        var documentSliceCount = slices.Count(s => s.IsDocument);
+        // De-duplicate byte-identical slices up front (same content -> same content hash). A born-digital duplicate
+        // is almost certainly an accidental repeat — the figure path makes the same choice for identical embedded
+        // images — but unlike a silent drop we LOG it, and we count AFTER de-dup so the validation below reflects the
+        // number of DISTINCT documents actually persisted. Hashing the content (no positional salt) keeps SegmentKey
+        // == the derived FileOrigin.ContentHash == OriginConstituentKey: one pure content fingerprint, consistent
+        // with the upload + #306 figure paths.
+        var deduped = new List<(MarkdownSlice Slice, string Key)>();
+        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var slice in slices)
+        {
+            var key = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(slice.Text));
+            if (seenKeys.Add(key))
+            {
+                deduped.Add((slice, key));
+            }
+            else
+            {
+                Logger.LogWarning(
+                    "Container {ContainerId} produced a byte-identical slice at ordinal {Ordinal}; de-duplicated to one sub-document (mirrors the figure path's identical-image de-dup).",
+                    context.ContainerId, slice.Ordinal);
+            }
+        }
+
+        var documentSliceCount = deduped.Count(p => p.Slice.IsDocument);
         if (documentSliceCount < 2)
         {
-            // Fewer than two document slices means this was not really a multi-document bundle; do not spawn a lone
-            // duplicate of the container — let an operator reclassify it to a concrete type.
-            await MarkSegmentationIncompleteAsync(context, "fewer than two document slices were identified");
+            // Fewer than two DISTINCT document slices means this was not really a multi-document bundle; do not spawn
+            // a lone duplicate of the container — let an operator reclassify it to a concrete type.
+            await MarkSegmentationIncompleteAsync(context, "fewer than two distinct document slices were identified");
             return;
         }
 
@@ -211,22 +260,13 @@ public class DocumentSegmentationJob
                 return;
             }
 
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var slice in slices)
+            foreach (var (slice, key) in deduped)
             {
-                var segmentKey = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(slice.Text));
-                // De-dupe identical slices within one container: same text -> same key -> one row (the unique
-                // (SourceDocumentId, SegmentKey) index is the final guard).
-                if (!seen.Add(segmentKey))
-                {
-                    continue;
-                }
-
                 await _segmentRepository.InsertAsync(new DocumentSegment(
                     _guidGenerator.Create(),
                     context.TenantId,
                     context.ContainerId,
-                    segmentKey,
+                    key,
                     slice.Text,
                     slice.Ordinal,
                     // Cover / index / transmittal slices are recorded for audit but never spawned.
@@ -385,6 +425,51 @@ public class DocumentSegmentationJob
             await uow.CompleteAsync();
         }
     }
+
+    /// <summary>
+    /// Sets or clears <see cref="DocumentReviewReasons.SegmentationIncomplete"/> on the container from the DB's
+    /// remaining-Pending segment count (short UoW; writes only when the flag must change), and returns that count.
+    /// When no segment rows exist at all, Phase A already owns the flag (untrusted / &lt;2 / &gt;max / unparseable
+    /// split), so it is left untouched. Driving the flag off the persisted state — not a single run's failures —
+    /// makes the flag converge correctly even when concurrent workers collide on each other's spawned segments.
+    /// </summary>
+    private async Task<int> FinalizeSegmentationFlagAsync(SegmentationContext context)
+    {
+        using (_currentTenant.Change(context.TenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == context.ContainerId);
+            if (segments.Count == 0)
+            {
+                // Nothing persisted -> Phase A already decided the flag (or there was nothing to do); don't override it.
+                await uow.CompleteAsync();
+                return 0;
+            }
+
+            var remainingPending = segments.Count(s => s.Status == DocumentSegmentStatus.Pending);
+
+            var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
+            if (container is not null)
+            {
+                var hasFlag = (container.ReviewReasons & DocumentReviewReasons.SegmentationIncomplete)
+                    != DocumentReviewReasons.None;
+                var shouldHaveFlag = remainingPending > 0;
+                if (hasFlag != shouldHaveFlag)
+                {
+                    container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: shouldHaveFlag);
+                    await _documentRepository.UpdateAsync(container);
+                }
+            }
+
+            await uow.CompleteAsync();
+            return remainingPending;
+        }
+    }
+
+    // Mirrors DocumentClassificationBackgroundJob: a structured-output schema drift surfaces as a JsonException
+    // (sometimes wrapped); treat it as a recoverable bad-output case, not a job fault.
+    private static bool IsSchemaDeserializationError(Exception ex)
+        => ex is JsonException || ex.GetBaseException() is JsonException;
 
     private async Task TryDeleteBlobAsync(string blobName)
     {

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -146,20 +146,13 @@ public class DocumentSegmentationJob
     {
         using var uow = _unitOfWorkManager.Begin(requiresNew: true);
 
-        var container = await _documentRepository.FindAsync(containerDocumentId, includeDetails: false);
+        // A stale job may have been enqueued for a document that was since removed, or reclassified away from a
+        // container (see FindActiveContainerAsync); in either case there is nothing to segment.
+        var container = await FindActiveContainerAsync(containerDocumentId);
         if (container is null)
         {
-            return null;
-        }
-
-        // #346: this job may have been enqueued for a container that an operator (or a high-confidence
-        // re-recognition) has since reclassified to a concrete type — which clears IsContainer. A stale job must
-        // NOT split/spawn a document that is no longer a container, or it would inject spurious sub-documents
-        // downstream alongside the now-typed document's own fields. Abort if the container marker is gone.
-        if (!container.IsContainer)
-        {
             Logger.LogInformation(
-                "Document {ContainerId} is no longer a container (reclassified after this job was enqueued); skipping segmentation.",
+                "Document {ContainerId} is missing or no longer a container (removed/reclassified after this job was enqueued); skipping segmentation.",
                 containerDocumentId);
             return null;
         }
@@ -175,6 +168,21 @@ public class DocumentSegmentationJob
             container.FileOrigin.UploadedByUserName,
             container.Markdown ?? string.Empty,
             hasExistingSegments);
+    }
+
+    /// <summary>
+    /// Loads the container by id, returning it only while it is still an <b>active container</b>. Returns null when
+    /// the document was removed, or was reclassified to a concrete type after this job was enqueued (an operator
+    /// correction or a high-confidence re-recognition clears <see cref="Document.IsContainer"/>). A stale job must
+    /// never split, spawn, or re-flag a document that is no longer a container — doing so would inject spurious
+    /// sub-documents downstream, or push the operator's reclassification back into the review queue. This is the
+    /// single guard every phase consults (LoadAsync / CommitSpawnAsync / FinalizeSegmentationFlagAsync /
+    /// MarkSegmentationIncompleteAsync); it runs in the caller's ambient UoW and opens none.
+    /// </summary>
+    private async Task<Document?> FindActiveContainerAsync(Guid containerId)
+    {
+        var container = await _documentRepository.FindAsync(containerId, includeDetails: false);
+        return container is { IsContainer: true } ? container : null;
     }
 
     /// <summary>
@@ -238,13 +246,15 @@ public class DocumentSegmentationJob
         // OriginConstituentKey idempotency identity (positional salt would diverge from the upload + #306 figure
         // paths). So rather than silently collapsing them (and risking dropping a real document instance), flag the
         // whole container for human review. Byte-identical document slices are rare, so the false-trigger cost is low.
-        var dedupedKeys = new HashSet<string>(StringComparer.Ordinal);
+        // NB: a duplicate here ABORTS the whole split (it is not silently collapsed) — `seenKeys` only detects the
+        // collision; `keyed` is consumed only when there are zero duplicates.
+        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
         var keyed = new List<(MarkdownSlice Slice, string Key)>(slices.Count);
         var hasDuplicateSlice = false;
         foreach (var slice in slices)
         {
             var key = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(slice.Text));
-            if (dedupedKeys.Add(key))
+            if (seenKeys.Add(key))
             {
                 keyed.Add((slice, key));
             }
@@ -402,8 +412,7 @@ public class DocumentSegmentationJob
             // #346: re-check the container is still a container in THIS UoW — it may have been reclassified between
             // LoadAsync and now (the per-segment spawns span time). If the marker is gone, do not spawn; the
             // document is being handled as a concrete type.
-            var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
-            if (container is null || !container.IsContainer)
+            if (await FindActiveContainerAsync(context.ContainerId) is null)
             {
                 await TryDeleteBlobAsync(derivedBlobName);
                 return;
@@ -459,7 +468,12 @@ public class DocumentSegmentationJob
         using (_currentTenant.Change(context.TenantId))
         using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
         {
-            var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
+            // #346: re-check the container is still a container in THIS UoW. It may have been reclassified to a
+            // concrete type during the slow LLM split (the window between LoadAsync and here); flagging the now-typed
+            // document would push the operator's reclassification back into the review queue with no path to clear it
+            // — this Phase A path persists no segment rows, so FinalizeSegmentationFlagAsync's count-driven clear
+            // never runs. Mirrors the guard CommitSpawnAsync / FinalizeSegmentationFlagAsync already apply.
+            var container = await FindActiveContainerAsync(context.ContainerId);
             if (container is null)
             {
                 return;
@@ -493,12 +507,11 @@ public class DocumentSegmentationJob
 
             var remainingPending = segments.Count(s => s.Status == DocumentSegmentStatus.Pending);
 
-            var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
-
             // #346: if the document was reclassified to a concrete type mid-job (IsContainer cleared), do NOT touch
             // its review flag — its leftover Pending segments are inert (CommitSpawnAsync skips them) and re-flagging
             // a now-typed document would wrongly push the operator's reclassification back into the review queue.
-            if (container is null || !container.IsContainer)
+            var container = await FindActiveContainerAsync(context.ContainerId);
+            if (container is null)
             {
                 await uow.CompleteAsync();
                 return 0;

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -178,6 +178,17 @@ public class DocumentSegmentationJob
             return;
         }
 
+        // Segmentation feeds the WHOLE Markdown to the LLM (boundaries can be anywhere; truncating would lose tail
+        // documents), so an unbounded container is an unbounded prompt-token cost. Above the cap, degrade to a review
+        // signal (a human splits / reclassifies it) instead of paying for an enormous, low-confidence single call.
+        if (context.Markdown.Length > _behaviorOptions.MaxSegmentationMarkdownLength)
+        {
+            await MarkSegmentationIncompleteAsync(
+                context,
+                $"the container Markdown ({context.Markdown.Length} chars) exceeds the segmentation limit of {_behaviorOptions.MaxSegmentationMarkdownLength}");
+            return;
+        }
+
         // Gate (external, no UoW): the LLM proposes boundaries; keep the ambient tenant aligned as classification does.
         // A schema-drift / non-JSON structured response is a recoverable bad-output case (mirrors
         // DocumentClassificationBackgroundJob): flag the container for review rather than letting the exception fault
@@ -241,11 +252,14 @@ public class DocumentSegmentationJob
             return;
         }
 
-        if (documentSliceCount > _behaviorOptions.MaxSegmentsPerDocument)
+        // Cap the TOTAL number of slices (document + cover/index), not just the document ones, so a flood of
+        // non-document slices cannot insert an unbounded number of rows in one UoW — the blast-radius bound the
+        // option promises.
+        if (deduped.Count > _behaviorOptions.MaxSegmentsPerDocument)
         {
             await MarkSegmentationIncompleteAsync(
                 context,
-                $"the split produced {documentSliceCount} document slices, over the MaxSegmentsPerDocument limit of {_behaviorOptions.MaxSegmentsPerDocument}");
+                $"the split produced {deduped.Count} slices, over the MaxSegmentsPerDocument limit of {_behaviorOptions.MaxSegmentsPerDocument}");
             return;
         }
 

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -152,6 +152,18 @@ public class DocumentSegmentationJob
             return null;
         }
 
+        // #346: this job may have been enqueued for a container that an operator (or a high-confidence
+        // re-recognition) has since reclassified to a concrete type — which clears IsContainer. A stale job must
+        // NOT split/spawn a document that is no longer a container, or it would inject spurious sub-documents
+        // downstream alongside the now-typed document's own fields. Abort if the container marker is gone.
+        if (!container.IsContainer)
+        {
+            Logger.LogInformation(
+                "Document {ContainerId} is no longer a container (reclassified after this job was enqueued); skipping segmentation.",
+                containerDocumentId);
+            return null;
+        }
+
         var hasExistingSegments =
             await _segmentRepository.FirstOrDefaultAsync(s => s.SourceDocumentId == containerDocumentId) is not null;
 
@@ -220,30 +232,39 @@ public class DocumentSegmentationJob
             return;
         }
 
-        // De-duplicate byte-identical slices up front (same content -> same content hash). A born-digital duplicate
-        // is almost certainly an accidental repeat — the figure path makes the same choice for identical embedded
-        // images — but unlike a silent drop we LOG it, and we count AFTER de-dup so the validation below reflects the
-        // number of DISTINCT documents actually persisted. Hashing the content (no positional salt) keeps SegmentKey
-        // == the derived FileOrigin.ContentHash == OriginConstituentKey: one pure content fingerprint, consistent
-        // with the upload + #306 figure paths.
-        var deduped = new List<(MarkdownSlice Slice, string Key)>();
-        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+        // Detect byte-identical slices (same content -> same content hash). Content alone cannot decide whether two
+        // identical slices are an accidental duplicate (one real document copied/paged twice) or two genuinely
+        // distinct instances — and the pure content hash is needed as the SegmentKey / FileOrigin.ContentHash /
+        // OriginConstituentKey idempotency identity (positional salt would diverge from the upload + #306 figure
+        // paths). So rather than silently collapsing them (and risking dropping a real document instance), flag the
+        // whole container for human review. Byte-identical document slices are rare, so the false-trigger cost is low.
+        var dedupedKeys = new HashSet<string>(StringComparer.Ordinal);
+        var keyed = new List<(MarkdownSlice Slice, string Key)>(slices.Count);
+        var hasDuplicateSlice = false;
         foreach (var slice in slices)
         {
             var key = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(slice.Text));
-            if (seenKeys.Add(key))
+            if (dedupedKeys.Add(key))
             {
-                deduped.Add((slice, key));
+                keyed.Add((slice, key));
             }
             else
             {
+                hasDuplicateSlice = true;
                 Logger.LogWarning(
-                    "Container {ContainerId} produced a byte-identical slice at ordinal {Ordinal}; de-duplicated to one sub-document (mirrors the figure path's identical-image de-dup).",
+                    "Container {ContainerId} produced a byte-identical slice at ordinal {Ordinal}; flagging for review (cannot tell an accidental duplicate from a genuine repeated instance).",
                     context.ContainerId, slice.Ordinal);
             }
         }
 
-        var documentSliceCount = deduped.Count(p => p.Slice.IsDocument);
+        if (hasDuplicateSlice)
+        {
+            await MarkSegmentationIncompleteAsync(
+                context, "byte-identical duplicate slices detected; manual review required to avoid dropping a document");
+            return;
+        }
+
+        var documentSliceCount = keyed.Count(p => p.Slice.IsDocument);
         if (documentSliceCount < 2)
         {
             // Fewer than two DISTINCT document slices means this was not really a multi-document bundle; do not spawn
@@ -255,11 +276,11 @@ public class DocumentSegmentationJob
         // Cap the TOTAL number of slices (document + cover/index), not just the document ones, so a flood of
         // non-document slices cannot insert an unbounded number of rows in one UoW — the blast-radius bound the
         // option promises.
-        if (deduped.Count > _behaviorOptions.MaxSegmentsPerDocument)
+        if (keyed.Count > _behaviorOptions.MaxSegmentsPerDocument)
         {
             await MarkSegmentationIncompleteAsync(
                 context,
-                $"the split produced {deduped.Count} slices, over the MaxSegmentsPerDocument limit of {_behaviorOptions.MaxSegmentsPerDocument}");
+                $"the split produced {keyed.Count} slices, over the MaxSegmentsPerDocument limit of {_behaviorOptions.MaxSegmentsPerDocument}");
             return;
         }
 
@@ -274,7 +295,7 @@ public class DocumentSegmentationJob
                 return;
             }
 
-            foreach (var (slice, key) in deduped)
+            foreach (var (slice, key) in keyed)
             {
                 await _segmentRepository.InsertAsync(new DocumentSegment(
                     _guidGenerator.Create(),
@@ -378,6 +399,16 @@ public class DocumentSegmentationJob
                 return;
             }
 
+            // #346: re-check the container is still a container in THIS UoW — it may have been reclassified between
+            // LoadAsync and now (the per-segment spawns span time). If the marker is gone, do not spawn; the
+            // document is being handled as a concrete type.
+            var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
+            if (container is null || !container.IsContainer)
+            {
+                await TryDeleteBlobAsync(derivedBlobName);
+                return;
+            }
+
             var shortKey = segment.SegmentKey.Length > 8 ? segment.SegmentKey[..8] : segment.SegmentKey;
             var fileOrigin = new FileOrigin(
                 blobName: derivedBlobName,
@@ -463,16 +494,23 @@ public class DocumentSegmentationJob
             var remainingPending = segments.Count(s => s.Status == DocumentSegmentStatus.Pending);
 
             var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
-            if (container is not null)
+
+            // #346: if the document was reclassified to a concrete type mid-job (IsContainer cleared), do NOT touch
+            // its review flag — its leftover Pending segments are inert (CommitSpawnAsync skips them) and re-flagging
+            // a now-typed document would wrongly push the operator's reclassification back into the review queue.
+            if (container is null || !container.IsContainer)
             {
-                var hasFlag = (container.ReviewReasons & DocumentReviewReasons.SegmentationIncomplete)
-                    != DocumentReviewReasons.None;
-                var shouldHaveFlag = remainingPending > 0;
-                if (hasFlag != shouldHaveFlag)
-                {
-                    container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: shouldHaveFlag);
-                    await _documentRepository.UpdateAsync(container);
-                }
+                await uow.CompleteAsync();
+                return 0;
+            }
+
+            var hasFlag = (container.ReviewReasons & DocumentReviewReasons.SegmentationIncomplete)
+                != DocumentReviewReasons.None;
+            var shouldHaveFlag = remainingPending > 0;
+            if (hasFlag != shouldHaveFlag)
+            {
+                container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: shouldHaveFlag);
+                await _documentRepository.UpdateAsync(container);
             }
 
             await uow.CompleteAsync();

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Ai;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Threading;
+using Volo.Abp.Timing;
+using Volo.Abp.Uow;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Segmentation;
+
+/// <summary>
+/// Born-digital container segmentation (#346): the generalization of #306 figure routing to text bundles. Enqueued
+/// from the classification complete-phase when a container is detected, it splits the container's Markdown into its
+/// constituent documents and spawns each as a derived <see cref="Document"/> seeded from its slice — reusing the
+/// same derived-document sink as figure routing.
+/// <para>
+/// <b>Two phases, both resumable + idempotent.</b> Phase A runs the one-shot LLM split (skipped if segment rows
+/// already exist, so a retry never re-splits and never produces drifting boundaries); per the locked #346 decision
+/// the LLM returns only verbatim markers and <see cref="MarkdownSlicer"/> does the deterministic, verifiable
+/// cutting. Phase B spawns a derived document per still-<see cref="DocumentSegmentStatus.Pending"/> segment; a crash
+/// resumes only the unfinished ones, and the unique <c>(OriginDocumentId, OriginConstituentKey)</c> index on
+/// <see cref="Document"/> is the duplicate-spawn backstop. Per-segment faults are isolated (one bad slice does not
+/// block the rest) and surfaced (the job rethrows so ABP retries the remaining Pending slices).
+/// </para>
+/// <para>
+/// <b>Failure is never silent.</b> If the split cannot be trusted (untrusted markers, fewer than two document
+/// slices, or more than <see cref="DocumentAIBehaviorOptions.MaxSegmentsPerDocument"/>), the container is flagged
+/// <see cref="DocumentReviewReasons.SegmentationIncomplete"/> (non-blocking — it stays Ready) so an operator can
+/// split / reclassify it instead of it quietly producing zero sub-documents.
+/// </para>
+/// <para>
+/// <b>UoW discipline</b> (background-jobs.md): the LLM split and blob IO run outside any UoW; only the
+/// segment-row inserts and each derived-document insert + status change + pipeline enqueue run inside short UoWs.
+/// </para>
+/// </summary>
+[BackgroundJobName("DocumentAI.DocumentSegmentation")]
+public class DocumentSegmentationJob
+    : AsyncBackgroundJob<DocumentSegmentationJobArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly DocumentSegmentationWorkflow _segmentationWorkflow;
+    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
+    private readonly IDistributedEventBus _distributedEventBus;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly IClock _clock;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly DocumentAIBehaviorOptions _behaviorOptions;
+    private readonly ICancellationTokenProvider _cancellationTokenProvider;
+
+    public DocumentSegmentationJob(
+        IDocumentRepository documentRepository,
+        IRepository<DocumentSegment, Guid> segmentRepository,
+        DocumentSegmentationWorkflow segmentationWorkflow,
+        DocumentPipelineJobScheduler pipelineJobScheduler,
+        IBlobContainer<DocumentAIDocumentContainer> blobContainer,
+        IDistributedEventBus distributedEventBus,
+        ICurrentTenant currentTenant,
+        IClock clock,
+        IGuidGenerator guidGenerator,
+        IUnitOfWorkManager unitOfWorkManager,
+        IOptions<DocumentAIBehaviorOptions> behaviorOptions,
+        ICancellationTokenProvider cancellationTokenProvider)
+    {
+        _documentRepository = documentRepository;
+        _segmentRepository = segmentRepository;
+        _segmentationWorkflow = segmentationWorkflow;
+        _pipelineJobScheduler = pipelineJobScheduler;
+        _blobContainer = blobContainer;
+        _distributedEventBus = distributedEventBus;
+        _currentTenant = currentTenant;
+        _clock = clock;
+        _guidGenerator = guidGenerator;
+        _unitOfWorkManager = unitOfWorkManager;
+        _behaviorOptions = behaviorOptions.Value;
+        _cancellationTokenProvider = cancellationTokenProvider;
+    }
+
+    public override async Task ExecuteAsync(DocumentSegmentationJobArgs args)
+    {
+        var cancellationToken = _cancellationTokenProvider.Token;
+
+        var context = await LoadAsync(args.ContainerDocumentId);
+        if (context is null)
+        {
+            return; // container removed before segmentation ran
+        }
+
+        // Phase A: split once. If a prior run already persisted segment rows, skip the LLM (resumable, no re-split).
+        if (!context.HasExistingSegments)
+        {
+            await SplitAndPersistAsync(context, cancellationToken);
+        }
+
+        // Phase B: spawn a derived document per still-Pending segment. Re-loaded each run, so a retry processes
+        // only the slices not yet spawned.
+        var pending = await LoadPendingSegmentsAsync(args.ContainerDocumentId);
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        var failures = new List<Exception>();
+        foreach (var segment in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await SpawnWithIsolationAsync(failures, segment, context, cancellationToken);
+        }
+
+        if (failures.Count > 0)
+        {
+            // Surface the faults so ABP reschedules the job; already-spawned segments are terminal and skipped on
+            // retry (LoadPendingSegmentsAsync re-reads only the still-Pending ones), so retries never duplicate.
+            throw new AggregateException(
+                $"Segmentation left {failures.Count} slice(s) of container {args.ContainerDocumentId} Pending; the job will be retried.",
+                failures);
+        }
+    }
+
+    /// <summary>Load phase (short UoW): snapshot the container's tenant + uploader + Markdown, and whether segment rows already exist.</summary>
+    protected virtual async Task<SegmentationContext?> LoadAsync(Guid containerDocumentId)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var container = await _documentRepository.FindAsync(containerDocumentId, includeDetails: false);
+        if (container is null)
+        {
+            return null;
+        }
+
+        var hasExistingSegments =
+            await _segmentRepository.FirstOrDefaultAsync(s => s.SourceDocumentId == containerDocumentId) is not null;
+
+        await uow.CompleteAsync();
+
+        return new SegmentationContext(
+            containerDocumentId,
+            container.TenantId,
+            container.FileOrigin.UploadedByUserName,
+            container.Markdown ?? string.Empty,
+            hasExistingSegments);
+    }
+
+    /// <summary>
+    /// Phase A: one LLM split (external, no UoW) → deterministic slicing → validation → a short UoW that inserts
+    /// the segment rows. On any untrusted / out-of-bounds result the container is flagged
+    /// <see cref="DocumentReviewReasons.SegmentationIncomplete"/> and no rows are written (so Phase B spawns nothing).
+    /// </summary>
+    protected virtual async Task SplitAndPersistAsync(SegmentationContext context, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(context.Markdown))
+        {
+            await MarkSegmentationIncompleteAsync(context, "container has no Markdown to segment");
+            return;
+        }
+
+        // Gate (external, no UoW): the LLM proposes boundaries; keep the ambient tenant aligned as classification does.
+        DocumentSegmentationOutcome outcome;
+        using (_currentTenant.Change(context.TenantId))
+        {
+            outcome = await _segmentationWorkflow.RunAsync(context.Markdown, cancellationToken);
+        }
+
+        if (!MarkdownSlicer.TrySlice(context.Markdown, outcome.Boundaries, out var slices))
+        {
+            await MarkSegmentationIncompleteAsync(context, "the LLM split could not be verified against the Markdown");
+            return;
+        }
+
+        var documentSliceCount = slices.Count(s => s.IsDocument);
+        if (documentSliceCount < 2)
+        {
+            // Fewer than two document slices means this was not really a multi-document bundle; do not spawn a lone
+            // duplicate of the container — let an operator reclassify it to a concrete type.
+            await MarkSegmentationIncompleteAsync(context, "fewer than two document slices were identified");
+            return;
+        }
+
+        if (documentSliceCount > _behaviorOptions.MaxSegmentsPerDocument)
+        {
+            await MarkSegmentationIncompleteAsync(
+                context,
+                $"the split produced {documentSliceCount} document slices, over the MaxSegmentsPerDocument limit of {_behaviorOptions.MaxSegmentsPerDocument}");
+            return;
+        }
+
+        using (_currentTenant.Change(context.TenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            // Concurrency guard: another run may have committed segments between LoadAsync and here. Re-check inside
+            // the UoW; if so, drop this split and let Phase B spawn from the committed rows (no double-split).
+            if (await _segmentRepository.FirstOrDefaultAsync(s => s.SourceDocumentId == context.ContainerId) is not null)
+            {
+                await uow.CompleteAsync();
+                return;
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var slice in slices)
+            {
+                var segmentKey = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(slice.Text));
+                // De-dupe identical slices within one container: same text -> same key -> one row (the unique
+                // (SourceDocumentId, SegmentKey) index is the final guard).
+                if (!seen.Add(segmentKey))
+                {
+                    continue;
+                }
+
+                await _segmentRepository.InsertAsync(new DocumentSegment(
+                    _guidGenerator.Create(),
+                    context.TenantId,
+                    context.ContainerId,
+                    segmentKey,
+                    slice.Text,
+                    slice.Ordinal,
+                    // Cover / index / transmittal slices are recorded for audit but never spawned.
+                    slice.IsDocument ? DocumentSegmentStatus.Pending : DocumentSegmentStatus.NotADocument));
+            }
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    /// <summary>Phase B reload (short UoW): snapshot the still-Pending segments to spawn.</summary>
+    protected virtual async Task<List<PendingSegment>> LoadPendingSegmentsAsync(Guid containerDocumentId)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+
+        var pending = await _segmentRepository.GetListAsync(
+            s => s.SourceDocumentId == containerDocumentId && s.Status == DocumentSegmentStatus.Pending);
+
+        var snapshot = pending
+            .OrderBy(s => s.Ordinal)
+            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.SliceText, s.Ordinal))
+            .ToList();
+
+        await uow.CompleteAsync();
+
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Runs one segment's spawn with per-segment isolation: a fault is logged and collected (so
+    /// <see cref="ExecuteAsync"/> can rethrow and trigger a job retry) instead of aborting the remaining segments.
+    /// Cancellation is never collected — it propagates so the job is treated as cancelled, not failed.
+    /// </summary>
+    private async Task SpawnWithIsolationAsync(
+        List<Exception> failures, PendingSegment segment, SegmentationContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await SpawnDerivedDocumentAsync(segment, context, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logger.LogWarning(ex,
+                "Spawning segment {SegmentId} of container {ContainerId} failed; left Pending for job retry.",
+                segment.SegmentId, context.ContainerId);
+            failures.Add(ex);
+        }
+    }
+
+    private async Task SpawnDerivedDocumentAsync(
+        PendingSegment segment, SegmentationContext context, CancellationToken cancellationToken)
+    {
+        // External: write the slice to an independent, derived-document-owned blob so the derived document outlives
+        // the container (the container's permanent delete reclaims the container/segment rows, not this blob).
+        var sliceBytes = Encoding.UTF8.GetBytes(segment.SliceText);
+        var derivedBlobName = _guidGenerator.Create().ToString("N") + ".md";
+        using (var saveStream = new MemoryStream(sliceBytes, writable: false))
+        {
+            await _blobContainer.SaveAsync(derivedBlobName, saveStream, overrideExisting: true, cancellationToken);
+        }
+
+        var derivedDocumentId = _guidGenerator.Create();
+
+        try
+        {
+            await CommitSpawnAsync(segment, context, derivedBlobName, derivedDocumentId, sliceBytes.LongLength);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The spawn UoW rolled back (a concurrent unique-index collision, or any other fault), so the written
+            // blob references no committed document — reclaim it, then rethrow so the per-segment handler records
+            // the fault and the job is retried (which writes a fresh blob next time). The one CommitSpawnAsync path
+            // that returns without throwing (the segment is already non-Pending) deletes its own orphan blob.
+            await TryDeleteBlobAsync(derivedBlobName);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Complete phase (short UoW): inserts the derived document, marks the segment Spawned, publishes
+    /// <c>DocumentUploadedEto</c>, and queues the derived document's pipeline — all atomically. Returns early
+    /// (deleting the orphan blob) when the segment is no longer Pending or a concurrent run already spawned it.
+    /// </summary>
+    private async Task CommitSpawnAsync(
+        PendingSegment segment, SegmentationContext context, string derivedBlobName, Guid derivedDocumentId, long fileSize)
+    {
+        using (_currentTenant.Change(context.TenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var entity = await _segmentRepository.FindAsync(segment.SegmentId);
+            if (entity is null || entity.Status != DocumentSegmentStatus.Pending)
+            {
+                // Another run already spawned it (or it was removed). Drop our orphan blob and stop.
+                await TryDeleteBlobAsync(derivedBlobName);
+                return;
+            }
+
+            var shortKey = segment.SegmentKey.Length > 8 ? segment.SegmentKey[..8] : segment.SegmentKey;
+            var fileOrigin = new FileOrigin(
+                blobName: derivedBlobName,
+                uploadedByUserName: context.UploadedByUserName,
+                contentType: "text/markdown",
+                contentHash: segment.SegmentKey,
+                fileSize: fileSize,
+                originalFileName: $"segment-{shortKey}.md");
+
+            var derived = Document.CreateDerived(
+                derivedDocumentId, context.TenantId, fileOrigin, context.ContainerId, segment.SegmentKey);
+
+            // A concurrent run that already committed this segment's derived document trips the unique
+            // (OriginDocumentId, OriginConstituentKey) index here. The failure propagates to
+            // SpawnDerivedDocumentAsync, which reclaims this run's orphan blob and rethrows so the job retries; on
+            // retry the segment is Spawned and skipped — self-healing, no duplicate.
+            await _documentRepository.InsertAsync(derived, autoSave: true);
+
+            entity.MarkSpawned(derivedDocumentId);
+            await _segmentRepository.UpdateAsync(entity);
+
+            await _distributedEventBus.PublishAsync(
+                new DocumentUploadedEto
+                {
+                    DocumentId = derived.Id,
+                    TenantId = derived.TenantId,
+                    EventTime = _clock.Now,
+                    FileName = fileOrigin.OriginalFileName,
+                    FileSize = fileOrigin.FileSize,
+                    ContentType = fileOrigin.ContentType
+                });
+
+            // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown from
+            // this segment's SliceText instead of re-extracting the blob (see DocumentTextExtractionBackgroundJob).
+            await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);
+
+            await uow.CompleteAsync();
+        }
+    }
+
+    /// <summary>Flags the container with the non-blocking <see cref="DocumentReviewReasons.SegmentationIncomplete"/> signal (short UoW).</summary>
+    private async Task MarkSegmentationIncompleteAsync(SegmentationContext context, string reason)
+    {
+        Logger.LogWarning(
+            "Container {ContainerId} segmentation incomplete ({Reason}); flagging for operator review.",
+            context.ContainerId, reason);
+
+        using (_currentTenant.Change(context.TenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var container = await _documentRepository.FindAsync(context.ContainerId, includeDetails: false);
+            if (container is null)
+            {
+                return;
+            }
+
+            container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: true);
+            await _documentRepository.UpdateAsync(container);
+            await uow.CompleteAsync();
+        }
+    }
+
+    private async Task TryDeleteBlobAsync(string blobName)
+    {
+        try
+        {
+            await _blobContainer.DeleteAsync(blobName);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to delete blob {BlobName} during segmentation cleanup.", blobName);
+        }
+    }
+
+    /// <summary>Per-container segmentation context loaded once up front: tenant + uploader provenance, the Markdown to split, and whether a prior split exists.</summary>
+    protected sealed record SegmentationContext(
+        Guid ContainerId,
+        Guid? TenantId,
+        string UploadedByUserName,
+        string Markdown,
+        bool HasExistingSegments);
+
+    /// <summary>Detached snapshot of one still-Pending segment, carried across the per-segment external + UoW phases.</summary>
+    protected sealed record PendingSegment(Guid SegmentId, string SegmentKey, string SliceText, int Ordinal);
+}
+
+public class DocumentSegmentationJobArgs
+{
+    /// <summary>The container document whose Markdown should be split into sub-documents.</summary>
+    public Guid ContainerDocumentId { get; set; }
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationWorkflow.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationWorkflow.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Ai;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Segmentation;
+
+/// <summary>
+/// Born-digital container segmentation (#346): one LLM pass over a container's Markdown that proposes where each
+/// constituent document begins. Per the locked design (decision in the #346 Decision Log) the LLM returns only
+/// <b>verbatim start markers</b> + an is-document flag; <see cref="MarkdownSlicer"/> does the deterministic
+/// cutting, so the LLM never regenerates content and the split is verifiable.
+/// <para>
+/// Mirrors <see cref="Classification.DocumentClassificationWorkflow"/>: tool-free, structured-output, routed
+/// through the dedicated keyed <see cref="DocumentAIConsts.StructuredChatClientKey"/> client; no
+/// <c>AIContextProviders</c> (channel layer, not RAG); the container Markdown is wrapped with
+/// <see cref="PromptBoundary.WrapDocument"/> and the boundary rule is appended to the instructions.
+/// </para>
+/// </summary>
+public class DocumentSegmentationWorkflow : ITransientDependency
+{
+    private readonly IChatClient _chatClient;
+    private readonly IPromptProvider _promptProvider;
+    private readonly DocumentAIBehaviorOptions _options;
+
+    public ILogger<DocumentSegmentationWorkflow> Logger { get; set; }
+        = NullLogger<DocumentSegmentationWorkflow>.Instance;
+
+    public DocumentSegmentationWorkflow(
+        [FromKeyedServices(DocumentAIConsts.StructuredChatClientKey)] IChatClient chatClient,
+        IOptions<DocumentAIBehaviorOptions> options,
+        IPromptProvider promptProvider)
+    {
+        _chatClient = chatClient;
+        _promptProvider = promptProvider;
+        _options = options.Value;
+    }
+
+    public virtual async Task<DocumentSegmentationOutcome> RunAsync(
+        string markdown,
+        CancellationToken cancellationToken = default)
+    {
+        var outcome = new DocumentSegmentationOutcome();
+        if (string.IsNullOrWhiteSpace(markdown))
+        {
+            return outcome;
+        }
+
+        // Unlike classification (which truncates to the leading prefix), segmentation feeds the WHOLE Markdown:
+        // constituent boundaries can be anywhere, and a truncated tail would silently lose the last documents.
+        // Output stays small regardless of input size because only short verbatim markers are returned.
+        var userMessage = $$"""
+                ## Document Markdown
+                {{PromptBoundary.WrapDocument(markdown)}}
+                """;
+
+        var template = _promptProvider.GetSegmentationPrompt(_options.DefaultLanguage);
+        AIAgent agent = new ChatClientAgent(
+            _chatClient,
+            new ChatClientAgentOptions
+            {
+                Name = "DocumentAIDocumentSegmenter",
+                ChatOptions = new ChatOptions
+                {
+                    Instructions = template.SystemInstructions + " " + PromptBoundary.BoundaryRule
+                },
+                UseProvidedChatClientAsIs = true
+            })
+            .AsBuilder()
+            .UseOpenTelemetry()
+            .Build();
+
+        var response = await agent.RunAsync<SegmentationResponse>(
+            userMessage,
+            cancellationToken: cancellationToken);
+
+        var parsed = response.Result;
+        var droppedBlankMarkers = 0;
+        if (parsed?.Segments != null)
+        {
+            foreach (var segment in parsed.Segments)
+            {
+                // A blank marker cannot be located in the Markdown, so it would only poison the slice; drop it
+                // here and let MarkdownSlicer's verification decide whether the remaining set is trustworthy.
+                if (!string.IsNullOrWhiteSpace(segment.StartMarker))
+                {
+                    outcome.Boundaries.Add(new SegmentBoundary(segment.StartMarker, segment.IsDocument));
+                }
+                else
+                {
+                    droppedBlankMarkers++;
+                }
+            }
+        }
+
+        // Drift visibility (same discipline as the other structured paths): surface what the LLM returned so a
+        // systematic regression — empty output, or all-blank / unmatchable markers — is diagnosable at the call
+        // site, not only as a downstream SegmentationIncomplete review flag. MarkdownSlicer then verifies each
+        // marker verbatim against the Markdown.
+        Logger.LogInformation(
+            "Segmentation proposed {BoundaryCount} boundaries ({DroppedBlankMarkers} blank markers dropped) for a {Length}-character container.",
+            outcome.Boundaries.Count, droppedBlankMarkers, markdown.Length);
+
+        return outcome;
+    }
+
+    private sealed class SegmentationResponse
+    {
+        public List<SegmentItem> Segments { get; set; } = new();
+
+        public sealed class SegmentItem
+        {
+            /// <summary>The verbatim first line / opening snippet of the constituent, copied exactly from the Markdown.</summary>
+            public string StartMarker { get; set; } = default!;
+
+            /// <summary><c>true</c> if the slice is itself a document; <c>false</c> for a cover / index / transmittal page.</summary>
+            public bool IsDocument { get; set; }
+        }
+    }
+}
+
+public class DocumentSegmentationOutcome
+{
+    /// <summary>Ordered constituent boundaries proposed by the LLM; fed to <see cref="MarkdownSlicer.TrySlice"/>.</summary>
+    public List<SegmentBoundary> Boundaries { get; } = new();
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
@@ -28,8 +28,10 @@ public static class MarkdownSlicer
     /// preamble before the first marker is folded into the first slice so no content is dropped.
     /// <para>
     /// Returns <c>false</c> (with an empty <paramref name="slices"/>) when the boundaries cannot be trusted —
-    /// empty input, a marker not found verbatim, or markers out of order — so the caller raises a review signal
-    /// instead of spawning garbage. A marker is matched against the raw Markdown first, then against a copy with
+    /// empty input, or a marker not found verbatim at or after the previous marker's position — so the caller raises
+    /// a review signal instead of spawning garbage. (Out-of-order markers are rejected by that same forward search,
+    /// not a separate ordering pass: a marker that appears only before its predecessor is not found from the
+    /// advancing cursor and yields <c>false</c>.) A marker is matched against the raw Markdown first, then against a copy with
     /// <c>&amp;lt;</c> decoded back to <c>&lt;</c>, because the LLM reads the Markdown after
     /// <see cref="Dignite.DocumentAI.Ai.PromptBoundary.WrapDocument"/> has encoded <c>&lt;</c>.
     /// </para>

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
@@ -85,7 +85,7 @@ public static class MarkdownSlicer
             return -1;
         }
 
-        var pos = markdown.IndexOf(marker, cursor, StringComparison.Ordinal);
+        var pos = FindLineStart(markdown, marker, cursor);
         if (pos >= 0)
         {
             return pos;
@@ -95,10 +95,33 @@ public static class MarkdownSlicer
         // came back carrying that encoding, decode it before retrying against the raw Markdown.
         if (marker.Contains("&lt;", StringComparison.Ordinal))
         {
-            var decoded = marker.Replace("&lt;", "<", StringComparison.Ordinal);
-            return markdown.IndexOf(decoded, cursor, StringComparison.Ordinal);
+            return FindLineStart(markdown, marker.Replace("&lt;", "<", StringComparison.Ordinal), cursor);
         }
 
         return -1;
+    }
+
+    // The LLM is asked to return each constituent's FIRST LINE as the marker, so a marker is only a valid cut point
+    // at the START of a line (offset 0 or immediately after a newline). Anchoring to a line start prevents a short
+    // marker (e.g. "Total") from binding to an earlier mid-line occurrence inside the previous slice's body, which
+    // would silently mis-cut the document while still "finding" the marker verbatim.
+    private static int FindLineStart(string markdown, string marker, int cursor)
+    {
+        var from = cursor;
+        while (true)
+        {
+            var pos = markdown.IndexOf(marker, from, StringComparison.Ordinal);
+            if (pos < 0)
+            {
+                return -1;
+            }
+
+            if (pos == 0 || markdown[pos - 1] == '\n')
+            {
+                return pos;
+            }
+
+            from = pos + 1; // this occurrence is mid-line; keep looking for a line-anchored one
+        }
     }
 }

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Segmentation;
+
+/// <summary>
+/// A constituent boundary proposed by the segmentation LLM (#346): a <b>verbatim</b> start marker copied from
+/// the container Markdown plus whether the slice it opens is itself a document (vs a cover / index / transmittal).
+/// </summary>
+public sealed record SegmentBoundary(string StartMarker, bool IsDocument);
+
+/// <summary>A deterministically-cut constituent slice of a container's Markdown (#346).</summary>
+public sealed record MarkdownSlice(string Text, bool IsDocument, int Ordinal);
+
+/// <summary>
+/// Deterministically cuts a container's Markdown at LLM-proposed boundaries (#346 decision: the LLM returns
+/// <b>verbatim start markers</b>, never regenerated slice text; the code does the cutting, so there is no content
+/// drift and the result is machine-verifiable). This is the highest-leverage stability lever of the born-digital
+/// path: the LLM's unreliable job (boundary judgment) is bounded to short markers, while exact content is owned by
+/// code.
+/// </summary>
+public static class MarkdownSlicer
+{
+    /// <summary>
+    /// Cuts <paramref name="markdown"/> at <paramref name="boundaries"/>. Each marker is located by an ordinal
+    /// forward search with an advancing cursor, so repeated markers (e.g. two invoices both starting "Invoice")
+    /// map to successive occurrences in document order. Slices run marker-to-marker (last to end); any leading
+    /// preamble before the first marker is folded into the first slice so no content is dropped.
+    /// <para>
+    /// Returns <c>false</c> (with an empty <paramref name="slices"/>) when the boundaries cannot be trusted —
+    /// empty input, a marker not found verbatim, or markers out of order — so the caller raises a review signal
+    /// instead of spawning garbage. A marker is matched against the raw Markdown first, then against a copy with
+    /// <c>&amp;lt;</c> decoded back to <c>&lt;</c>, because the LLM reads the Markdown after
+    /// <see cref="Dignite.DocumentAI.Ai.PromptBoundary.WrapDocument"/> has encoded <c>&lt;</c>.
+    /// </para>
+    /// </summary>
+    public static bool TrySlice(
+        string? markdown,
+        IReadOnlyList<SegmentBoundary>? boundaries,
+        out List<MarkdownSlice> slices)
+    {
+        slices = new List<MarkdownSlice>();
+
+        if (string.IsNullOrEmpty(markdown) || boundaries is not { Count: > 0 })
+        {
+            return false;
+        }
+
+        var positions = new int[boundaries.Count];
+        var cursor = 0;
+        for (var i = 0; i < boundaries.Count; i++)
+        {
+            var pos = FindMarker(markdown, boundaries[i].StartMarker, cursor);
+            if (pos < 0)
+            {
+                return false; // marker not found verbatim -> untrusted split
+            }
+
+            positions[i] = pos;
+            cursor = pos + 1; // advance so a repeated marker maps to the next occurrence
+        }
+
+        for (var i = 0; i < boundaries.Count; i++)
+        {
+            // The first slice folds in any leading preamble (content before the first marker) so nothing is lost.
+            var start = i == 0 ? 0 : positions[i];
+            var end = i == boundaries.Count - 1 ? markdown.Length : positions[i + 1];
+
+            var text = markdown[start..end].Trim();
+            if (text.Length == 0)
+            {
+                continue; // defensively skip an empty slice (e.g. adjacent markers)
+            }
+
+            slices.Add(new MarkdownSlice(text, boundaries[i].IsDocument, slices.Count));
+        }
+
+        return slices.Count > 0;
+    }
+
+    private static int FindMarker(string markdown, string? marker, int cursor)
+    {
+        if (string.IsNullOrWhiteSpace(marker))
+        {
+            return -1;
+        }
+
+        var pos = markdown.IndexOf(marker, cursor, StringComparison.Ordinal);
+        if (pos >= 0)
+        {
+            return pos;
+        }
+
+        // The LLM read the Markdown through PromptBoundary.WrapDocument, which encodes '<' as "&lt;". If the marker
+        // came back carrying that encoding, decode it before retrying against the raw Markdown.
+        if (marker.Contains("&lt;", StringComparison.Ordinal))
+        {
+            var decoded = marker.Replace("&lt;", "<", StringComparison.Ordinal);
+            return markdown.IndexOf(decoded, cursor, StringComparison.Ordinal);
+        }
+
+        return -1;
+    }
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/TextExtraction/DocumentTextExtractionBackgroundJob.cs
@@ -32,6 +32,9 @@ public class DocumentTextExtractionBackgroundJob
     /// <summary>Provider name recorded for a derived sub-document whose Markdown is seeded from the source figure's transcription (#306), instead of re-OCR'ing the crop.</summary>
     private const string ScenarioBSeedProviderName = "ScenarioB-FigureSeed";
 
+    /// <summary>Provider name recorded for a derived sub-document whose Markdown is seeded from a born-digital container's Markdown slice (#346), instead of re-extracting the slice blob.</summary>
+    private const string ScenarioBSegmentSeedProviderName = "ScenarioB-SegmentSeed";
+
     private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
     private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly ITextExtractor _textExtractor;
@@ -54,6 +57,8 @@ public class DocumentTextExtractionBackgroundJob
     // #306: Scenario B candidate figures are an independent aggregate (default repository), persisted in
     // this job's Complete phase from the crops written in its External phase.
     private readonly IRepository<DocumentFigure, Guid> _documentFigureRepository;
+    // #346: born-digital container slices; looked up in the Begin phase to seed a derived sub-document's Markdown.
+    private readonly IRepository<DocumentSegment, Guid> _documentSegmentRepository;
     private readonly IGuidGenerator _guidGenerator;
 
     public DocumentTextExtractionBackgroundJob(
@@ -73,6 +78,7 @@ public class DocumentTextExtractionBackgroundJob
         IOptions<DocumentAIBehaviorOptions> behaviorOptions,
         ICancellationTokenProvider cancellationTokenProvider,
         IRepository<DocumentFigure, Guid> documentFigureRepository,
+        IRepository<DocumentSegment, Guid> documentSegmentRepository,
         IGuidGenerator guidGenerator)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
@@ -87,6 +93,7 @@ public class DocumentTextExtractionBackgroundJob
         _behaviorOptions = behaviorOptions.Value;
         _cancellationTokenProvider = cancellationTokenProvider;
         _documentFigureRepository = documentFigureRepository;
+        _documentSegmentRepository = documentSegmentRepository;
         _guidGenerator = guidGenerator;
     }
 
@@ -102,16 +109,17 @@ public class DocumentTextExtractionBackgroundJob
             TextExtractionResult result;
             if (workItem.SeedMarkdown != null)
             {
-                // #306 derived sub-document: seed Markdown from the source figure's transcription instead of
-                // re-OCR'ing the crop. The crop is the exact bytes the figure OCR already transcribed via the
-                // same IOcrProvider, so re-OCR would reproduce the same text — seeding is equivalent and saves
-                // one OCR call. A crop is a single image, so no embedded figures are surfaced and no recursive
-                // sub-document routing occurs.
+                // Derived sub-document: seed Markdown from the source constituent instead of re-extracting it.
+                // #306 figure path — the crop is the exact bytes the figure OCR already transcribed via the same
+                // IOcrProvider, so re-OCR would reproduce the same text; seeding is equivalent and saves one OCR
+                // call. #346 born-digital path — the slice is already Markdown, so seeding preserves the exact
+                // slice text (no re-extraction, no drift). Either way the seed is a single constituent, so no
+                // embedded figures are surfaced and no recursive sub-document routing occurs.
                 result = new TextExtractionResult
                 {
                     Markdown = workItem.SeedMarkdown,
                     UsedOcr = false,
-                    ProviderName = ScenarioBSeedProviderName,
+                    ProviderName = workItem.SeedProviderName ?? ScenarioBSeedProviderName,
                     IsComplete = true
                 };
             }
@@ -175,16 +183,32 @@ public class DocumentTextExtractionBackgroundJob
             document, args.PipelineRunId, DocumentAIPipelines.TextExtraction);
         await DocumentRepository.UpdateAsync(document, autoSave: true);
 
-        // #306: a derived sub-document (OriginDocumentId set) seeds its Markdown from the source figure's
-        // transcription rather than re-OCR'ing the crop. Load it inside this UoW; null (not derived, or the
-        // candidate is missing/empty) falls back to the normal OCR path in ExecuteAsync.
+        // A derived sub-document (OriginDocumentId set) seeds its Markdown from the source constituent rather than
+        // re-extracting it. Two constituent paths, looked up by the shared OriginConstituentKey: the #306 figure
+        // path seeds from the figure's transcription; the #346 born-digital path seeds from the container's
+        // Markdown slice (the exact slice text, so there is no content drift). Loaded inside this UoW; null (not
+        // derived, or the constituent is missing/empty) falls back to the normal extraction path in ExecuteAsync.
         string? seedMarkdown = null;
+        string? seedProviderName = null;
         if (document.OriginDocumentId.HasValue && !string.IsNullOrEmpty(document.OriginConstituentKey))
         {
             var figure = await _documentFigureRepository.FirstOrDefaultAsync(
                 f => f.SourceDocumentId == document.OriginDocumentId.Value && f.ContentHash == document.OriginConstituentKey);
-            var transcription = figure?.Transcription;
-            seedMarkdown = string.IsNullOrEmpty(transcription) ? null : transcription;
+            if (!string.IsNullOrEmpty(figure?.Transcription))
+            {
+                seedMarkdown = figure.Transcription;
+                seedProviderName = ScenarioBSeedProviderName;
+            }
+            else
+            {
+                var segment = await _documentSegmentRepository.FirstOrDefaultAsync(
+                    s => s.SourceDocumentId == document.OriginDocumentId.Value && s.SegmentKey == document.OriginConstituentKey);
+                if (!string.IsNullOrEmpty(segment?.SliceText))
+                {
+                    seedMarkdown = segment.SliceText;
+                    seedProviderName = ScenarioBSegmentSeedProviderName;
+                }
+            }
         }
 
         await uow.CompleteAsync();
@@ -194,7 +218,8 @@ public class DocumentTextExtractionBackgroundJob
             document.FileOrigin.BlobName,
             document.FileOrigin.ContentType,
             document.FileOrigin.OriginalFileName,
-            seedMarkdown);
+            seedMarkdown,
+            seedProviderName);
     }
 
     private async Task CompleteRunAsync(
@@ -499,7 +524,8 @@ public class DocumentTextExtractionBackgroundJob
         string BlobName,
         string ContentType,
         string? OriginalFileName,
-        string? SeedMarkdown);
+        string? SeedMarkdown,
+        string? SeedProviderName);
 
     /// <summary>
     /// Descriptor of a persisted candidate figure crop (#306). <c>protected</c> because it appears in the

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentReviewReasons.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentReviewReasons.cs
@@ -37,5 +37,14 @@ public enum DocumentReviewReasons
     /// <b>non-blocking</b>: the document still becomes Ready and emits <c>DocumentReadyEto</c>; it only
     /// enters the operator "needs completion" queue. Maintained by the field extraction stage.
     /// </summary>
-    MissingRequiredFields = 1 << 1
+    MissingRequiredFields = 1 << 1,
+
+    /// <summary>
+    /// A container (#346) was detected but its born-digital segmentation could not be completed cleanly — the
+    /// LLM produced an untrusted split, fewer than two document slices, or more than
+    /// <c>MaxSegmentsPerDocument</c>. <b>non-blocking</b>: the container itself is already Ready (it carries no
+    /// type to gate), so this only routes it into the operator queue so a human can split / reclassify it instead
+    /// of it silently producing zero sub-documents. Maintained by the segmentation job.
+    /// </summary>
+    SegmentationIncomplete = 1 << 2
 }

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentSegmentConsts.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentSegmentConsts.cs
@@ -1,0 +1,16 @@
+namespace Dignite.DocumentAI.Documents.Segments;
+
+/// <summary>
+/// Length limits for <see cref="DocumentSegment"/> columns (#346, born-digital path). Mirrors
+/// <c>DocumentFigureConsts</c>: the segment key is bounded; the slice text is intentionally unbounded
+/// (nvarchar(max), like <c>Document.Markdown</c> and <c>DocumentFigure.Transcription</c>) because it is a
+/// Markdown slice used to seed the derived document, never indexed.
+/// </summary>
+public static class DocumentSegmentConsts
+{
+    /// <summary>
+    /// Length of <see cref="DocumentSegment.SegmentKey"/>: the SHA-256 (lowercase hex) of the slice text,
+    /// which equals the spawned derived document's <c>FileOrigin.ContentHash</c> / <c>OriginConstituentKey</c>.
+    /// </summary>
+    public static int MaxSegmentKeyLength { get; set; } = 64;
+}

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentSegmentStatus.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentSegmentStatus.cs
@@ -1,0 +1,20 @@
+namespace Dignite.DocumentAI.Documents.Segments;
+
+/// <summary>
+/// Routing lifecycle of a <see cref="DocumentSegment"/> (#346, born-digital path). The segmentation job uses
+/// this as a durable, resumable work-queue marker: it processes <see cref="Pending"/> segments, so a crash
+/// mid-routing resumes only the unfinished ones without duplicate-spawning or re-paying the LLM split.
+/// Mirrors <c>DocumentFigureStatus</c> — the two constituent paths (image figures / born-digital slices) share
+/// the same status model and feed the same derived-document sink.
+/// </summary>
+public enum DocumentSegmentStatus
+{
+    /// <summary>Not yet spawned into a derived <c>Document</c> (the initial state after the LLM split).</summary>
+    Pending = 0,
+
+    /// <summary>Spawned into a derived <c>Document</c> (recorded in <see cref="DocumentSegment.RoutedDocumentId"/>).</summary>
+    Spawned = 1,
+
+    /// <summary>The LLM classified the slice as a non-document segment (cover / index / transmittal); not spawned.</summary>
+    NotADocument = 2
+}

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/en.json
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/en.json
@@ -74,6 +74,7 @@
     "Document:ReviewDisposition:Rejected": "Rejected",
     "Document:ReviewReason:UnresolvedClassification": "Classification unresolved",
     "Document:ReviewReason:MissingRequiredFields": "Missing required fields",
+    "Document:ReviewReason:SegmentationIncomplete": "Couldn't be split into documents",
     "Document:Review:RejectReasonRequired": "Rejection reason is required.",
     "Document:TotalCount": "Total:",
     "Document:AreYouSureToDelete": "Are you sure you want to delete this document?",

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/zh-Hans.json
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Localization/DocumentAI/zh-Hans.json
@@ -223,6 +223,7 @@
     "Document:ReviewDisposition:Rejected": "已拒绝",
     "Document:ReviewReason:UnresolvedClassification": "分类未定",
     "Document:ReviewReason:MissingRequiredFields": "必填字段缺失",
+    "Document:ReviewReason:SegmentationIncomplete": "未能拆分为多个文档",
     "Document:Review:RejectReasonRequired": "拒绝理由为必填。",
     "Document:DocumentTypeCode": "文档类型代码",
     "Document:Type": "文档类型",

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -333,6 +333,10 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         DocumentTypeId = Check.NotDefaultOrNull<Guid>(documentTypeId, nameof(documentTypeId));
         ClassificationConfidence = Check.Range(classificationConfidence, nameof(classificationConfidence), 0d, 1d);
         SetReviewReason(DocumentReviewReasons.UnresolvedClassification, present: false);
+        // #346: a concrete type is now assigned, so this is no longer a container; clear the marker and any stale
+        // segmentation-incomplete signal to avoid the contradictory "has a type AND is a container" state.
+        IsContainer = false;
+        SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null; // #284 review-fix: leaving Rejected disposition -> clear stale rejection reason; only Rejected should have one.
     }
@@ -382,9 +386,11 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         DocumentTypeId = null;
         ClassificationConfidence = 0;
         // A container is a correct outcome: clear the classification / field review reasons rather than setting them,
-        // so it is not routed to the operator review queue and is not blocked from deriving to Ready.
+        // so it is not routed to the operator review queue and is not blocked from deriving to Ready. The
+        // segmentation-incomplete signal (#346) is cleared too — a freshly detected container has not failed yet.
         SetReviewReason(DocumentReviewReasons.UnresolvedClassification, present: false);
         SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: false);
+        SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null;
         _extractedFieldValues.Clear();
@@ -397,6 +403,10 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         // Operator-confirmed type -> clear UC; MRF will be recomputed by subsequent field re-extraction. Clear it here first to avoid stale required-field decisions from the old schema.
         SetReviewReason(DocumentReviewReasons.UnresolvedClassification, present: false);
         SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: false);
+        // #346: operator reclassifying a container to a concrete type clears the container marker (reversibility)
+        // and any stale segmentation-incomplete signal; subsequent DocumentClassifiedEto cascades field extraction.
+        IsContainer = false;
+        SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.Confirmed;
         RejectionReason = null; // #284 review-fix: rejection is recoverable; clear stale rejection reason after Reclassify / Confirm.
     }

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Segments/DocumentSegment.cs
@@ -102,14 +102,4 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         RoutedDocumentId = Check.NotDefaultOrNull<Guid>(routedDocumentId, nameof(routedDocumentId));
         Status = DocumentSegmentStatus.Spawned;
     }
-
-    /// <summary>
-    /// Records that the LLM classified this slice as a non-document segment (cover / index / transmittal, #346):
-    /// moves <see cref="Status"/> to <see cref="DocumentSegmentStatus.NotADocument"/>. The row is retained as an
-    /// audit + idempotency marker so a re-run does not re-evaluate it; it is never spawned.
-    /// </summary>
-    public void MarkNotADocument()
-    {
-        Status = DocumentSegmentStatus.NotADocument;
-    }
 }

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Segments/DocumentSegment.cs
@@ -1,0 +1,115 @@
+using System;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+using Volo.Abp.MultiTenancy;
+
+namespace Dignite.DocumentAI.Documents.Segments;
+
+/// <summary>
+/// A born-digital constituent slice of a <b>container</b> document (#346): the LLM segmentation pass splits the
+/// container's Markdown into per-document slices, and each slice is recorded here as the durable, resumable,
+/// idempotent work-queue row before it is spawned into its own derived <see cref="Document"/>.
+/// <para>
+/// This is the born-digital sibling of <c>DocumentFigure</c> (the image path). The two are kept as parallel
+/// ledgers + jobs feeding the same derived-document sink; unifying them into one "constituent" abstraction is
+/// deferred (#346). It references its source by id through <see cref="SourceDocumentId"/> (DDD reference-by-id,
+/// no navigation property), while the DB keeps an FK + CASCADE so hard-deleting the container also removes its
+/// segment rows. There is no soft delete: a segment is working state, not an independently restorable document
+/// (the derived document it spawns is the first-class, restorable artifact).
+/// </para>
+/// <para>
+/// <b>The slice text lives on the row</b> (<see cref="SliceText"/>), mirroring <c>DocumentFigure.Transcription</c>:
+/// it seeds the spawned derived document's text extraction (no re-extraction, so the exact slice is preserved —
+/// the #346 "never regenerate slice text" decision), and the derived document's own <c>FileOrigin</c> blob is
+/// written fresh from it at spawn time (derived-owned, so it outlives the container). <see cref="SegmentKey"/> is
+/// the SHA-256 of the slice text and doubles as the derived document's <c>FileOrigin.ContentHash</c> /
+/// <c>OriginConstituentKey</c>, giving idempotent routing (unique <c>(SourceDocumentId, SegmentKey)</c>);
+/// <see cref="Ordinal"/> is reading-order provenance only. Re-running segmentation is barred (container status is
+/// sticky, #346), so a key collision only ever comes from a job retry, never a deliberate re-split.
+/// </para>
+/// </summary>
+public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
+{
+    public virtual Guid? TenantId { get; private set; }
+
+    /// <summary>Owning container document id (reference-by-id; DB keeps FK + CASCADE).</summary>
+    public virtual Guid SourceDocumentId { get; private set; }
+
+    /// <summary>
+    /// SHA-256 (lowercase hex) of the slice text. Doubles as the derived document's
+    /// <c>OriginConstituentKey</c> / <c>FileOrigin.ContentHash</c> and is unique per source
+    /// (<c>(SourceDocumentId, SegmentKey)</c>), so a job retry never duplicate-spawns.
+    /// </summary>
+    public virtual string SegmentKey { get; private set; } = default!;
+
+    /// <summary>
+    /// The Markdown slice text. Working state on this aggregate: it seeds the derived document's text extraction
+    /// (skipping re-extraction so the exact slice is preserved) and is written to the derived document's
+    /// <c>FileOrigin</c> blob at spawn time. It is <b>not</b> a channel text egress, so it does not conflict with
+    /// Markdown-first (which governs the <see cref="Document"/> aggregate's text payload). Mirrors
+    /// <c>DocumentFigure.Transcription</c> (nvarchar(max), not indexed).
+    /// </summary>
+    public virtual string SliceText { get; private set; } = default!;
+
+    /// <summary>0-based reading-order position of this slice within the container. Provenance only.</summary>
+    public virtual int Ordinal { get; private set; }
+
+    /// <summary>
+    /// The derived <see cref="Document"/> spawned from this slice, or <c>null</c> when not (yet) spawned /
+    /// classified as a non-document segment.
+    /// </summary>
+    public virtual Guid? RoutedDocumentId { get; private set; }
+
+    /// <summary>
+    /// Routing progress (#346): <see cref="DocumentSegmentStatus.Pending"/> until the job spawns this slice,
+    /// then <see cref="DocumentSegmentStatus.Spawned"/> (see <see cref="RoutedDocumentId"/>) or
+    /// <see cref="DocumentSegmentStatus.NotADocument"/> (the LLM marked the slice a cover / index / transmittal).
+    /// This is the durable, resumable work-queue marker that lets the job crash and resume from the remaining
+    /// <see cref="DocumentSegmentStatus.Pending"/> slices without duplicate-spawning or re-paying the LLM split.
+    /// </summary>
+    public virtual DocumentSegmentStatus Status { get; private set; }
+
+    protected DocumentSegment()
+    {
+    }
+
+    public DocumentSegment(
+        Guid id,
+        Guid? tenantId,
+        Guid sourceDocumentId,
+        string segmentKey,
+        string sliceText,
+        int ordinal,
+        DocumentSegmentStatus status = DocumentSegmentStatus.Pending)
+        : base(id)
+    {
+        TenantId = tenantId;
+        SourceDocumentId = Check.NotDefaultOrNull<Guid>(sourceDocumentId, nameof(sourceDocumentId));
+        SegmentKey = Check.NotNullOrWhiteSpace(segmentKey, nameof(segmentKey), DocumentSegmentConsts.MaxSegmentKeyLength);
+        SliceText = Check.NotNullOrWhiteSpace(sliceText, nameof(sliceText));
+        Ordinal = ordinal;
+        Status = status;
+    }
+
+    /// <summary>
+    /// Records that the job spawned a derived <see cref="Document"/> from this slice (#346): links the derived
+    /// document and moves <see cref="Status"/> to <see cref="DocumentSegmentStatus.Spawned"/>. Idempotent
+    /// re-routing is guarded upstream by the unique <c>(OriginDocumentId, OriginConstituentKey)</c> index on
+    /// the derived document.
+    /// </summary>
+    public void MarkSpawned(Guid routedDocumentId)
+    {
+        RoutedDocumentId = Check.NotDefaultOrNull<Guid>(routedDocumentId, nameof(routedDocumentId));
+        Status = DocumentSegmentStatus.Spawned;
+    }
+
+    /// <summary>
+    /// Records that the LLM classified this slice as a non-document segment (cover / index / transmittal, #346):
+    /// moves <see cref="Status"/> to <see cref="DocumentSegmentStatus.NotADocument"/>. The row is retained as an
+    /// audit + idempotency marker so a re-run does not re-evaluate it; it is never spawned.
+    /// </summary>
+    public void MarkNotADocument()
+    {
+        Status = DocumentSegmentStatus.NotADocument;
+    }
+}

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/DocumentAIEntityFrameworkCoreGlobalUsings.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/DocumentAIEntityFrameworkCoreGlobalUsings.cs
@@ -4,3 +4,4 @@ global using Dignite.DocumentAI.Documents.Exports;
 global using Dignite.DocumentAI.Documents.Fields;
 global using Dignite.DocumentAI.Documents.Figures;
 global using Dignite.DocumentAI.Documents.Pipelines;
+global using Dignite.DocumentAI.Documents.Segments;

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -180,17 +180,17 @@ public class EfCoreDocumentRepository
         // inlined here rather than reusing that Expression because EF Core cannot fold a shared Expression into a
         // grouped projection; keep the two in sync.
         var byStatus = await dbSet
-            // #346: a container is an infrastructure wrapper, not a business document — its sub-documents are the
-            // real records. Exclude containers from the overview so a container + its N sub-documents do not
-            // double-count the totals / storage. A segmentation-incomplete container still surfaces in the operator
-            // review queue list (DocumentAppService.ApplyFilter); only this dashboard summary omits it.
-            .Where(d => !d.IsContainer)
             .GroupBy(d => d.LifecycleStatus)
             .Select(g => new
             {
                 Status = g.Key,
-                Count = g.LongCount(),
-                Bytes = g.Sum(d => d.FileOrigin.FileSize),
+                // #346: a container is an infrastructure wrapper, not a business document — its sub-documents are the
+                // real records. Exclude containers from the document counts / storage so a container + its N
+                // sub-documents do not double-count. But a segmentation-incomplete container DOES need operator
+                // attention, so it is INCLUDED in NeedsReview below — the review-queue list (DocumentAppService.ApplyFilter)
+                // counts it too, so the dashboard count and the queue never drift (#333).
+                Count = g.Sum(d => d.IsContainer ? 0L : 1L),
+                Bytes = g.Sum(d => d.IsContainer ? 0L : d.FileOrigin.FileSize),
                 NeedsReview = g.Sum(d =>
                     d.ReviewReasons != DocumentReviewReasons.None
                     && d.ReviewDisposition != DocumentReviewDisposition.Rejected

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -180,6 +180,11 @@ public class EfCoreDocumentRepository
         // inlined here rather than reusing that Expression because EF Core cannot fold a shared Expression into a
         // grouped projection; keep the two in sync.
         var byStatus = await dbSet
+            // #346: a container is an infrastructure wrapper, not a business document — its sub-documents are the
+            // real records. Exclude containers from the overview so a container + its N sub-documents do not
+            // double-count the totals / storage. A segmentation-incomplete container still surfaces in the operator
+            // review queue list (DocumentAppService.ApplyFilter); only this dashboard summary omits it.
+            .Where(d => !d.IsContainer)
             .GroupBy(d => d.LifecycleStatus)
             .Select(g => new
             {

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContext.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContext.cs
@@ -11,6 +11,7 @@ public class DocumentAIDbContext : AbpDbContext<DocumentAIDbContext>, IDocumentA
     public DbSet<Document> Documents { get; set; }
     public DbSet<DocumentPipelineRun> DocumentPipelineRuns { get; set; }
     public DbSet<DocumentFigure> DocumentFigures { get; set; }
+    public DbSet<DocumentSegment> DocumentSegments { get; set; }
     public DbSet<DocumentType> DocumentTypes { get; set; }
     public DbSet<FieldDefinition> FieldDefinitions { get; set; }
     public DbSet<ExportTemplate> ExportTemplates { get; set; }

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -272,6 +272,14 @@ public static class DocumentAIDbContextModelCreatingExtensions
             // is a plain (portable) unique index, not a filtered one.
             b.HasIndex(x => new { x.SourceDocumentId, x.SegmentKey })
                 .IsUnique();
+
+            // Concurrency guard (#346): one split per container. The LLM split is non-deterministic, so two
+            // concurrent segmentation runs would otherwise produce different SegmentKeys and both commit (a double
+            // split). Every split numbers its slices from Ordinal 0, so this unique index makes the second
+            // committer collide on Ordinal 0 and roll back its whole insert — only one split survives; the loser
+            // retries and resumes from the winner's persisted rows.
+            b.HasIndex(x => new { x.SourceDocumentId, x.Ordinal })
+                .IsUnique();
         });
 
         builder.Entity<DocumentType>(b =>

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -246,6 +246,34 @@ public static class DocumentAIDbContextModelCreatingExtensions
                 .IsUnique();
         });
 
+        builder.Entity<DocumentSegment>(b =>
+        {
+            b.ToTable(DocumentAIDbProperties.DbTablePrefix + "DocumentSegments", DocumentAIDbProperties.DbSchema);
+            b.ConfigureByConvention();
+
+            b.Property(x => x.SegmentKey).IsRequired().HasMaxLength(DocumentSegmentConsts.MaxSegmentKeyLength);
+            // SliceText is a Markdown slice used to seed the derived document (nvarchar(max), like Document.Markdown
+            // and DocumentFigure.Transcription); not indexed.
+            b.Property(x => x.SliceText).IsRequired();
+            b.Property(x => x.Ordinal).IsRequired();
+            b.Property(x => x.Status).IsRequired();
+
+            // #346: born-digital slice -> container Document, FK + CASCADE so hard-deleting the container removes
+            // its segment rows (mirrors the #306 DocumentFigure child-side declaration). RoutedDocumentId is a
+            // soft pointer to the spawned derived Document with NO FK constraint: the derived document is a peer
+            // that must outlive the container, so it must not cascade from / be constrained by this table.
+            b.HasOne<Document>()
+                .WithMany()
+                .HasForeignKey(x => x.SourceDocumentId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Idempotent spawn: one slice per (source, slice-content-hash). A job retry that re-persists the same
+            // slice collides here instead of duplicate-spawning downstream. Both columns are non-nullable, so this
+            // is a plain (portable) unique index, not a filtered one.
+            b.HasIndex(x => new { x.SourceDocumentId, x.SegmentKey })
+                .IsUnique();
+        });
+
         builder.Entity<DocumentType>(b =>
         {
             b.ToTable(DocumentAIDbProperties.DbTablePrefix + "DocumentTypes", DocumentAIDbProperties.DbSchema);

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/IDocumentAIDbContext.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/IDocumentAIDbContext.cs
@@ -11,6 +11,7 @@ public interface IDocumentAIDbContext : IEfCoreDbContext
     DbSet<Document> Documents { get; }
     DbSet<DocumentPipelineRun> DocumentPipelineRuns { get; }
     DbSet<DocumentFigure> DocumentFigures { get; }
+    DbSet<DocumentSegment> DocumentSegments { get; }
     DbSet<DocumentType> DocumentTypes { get; }
     DbSet<FieldDefinition> FieldDefinitions { get; }
     DbSet<ExportTemplate> ExportTemplates { get; }

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
@@ -118,8 +118,6 @@ public class EtoContract_Tests
             TenantId = null,
             EventTime = SampleEventTime,
             DocumentTypeCode = "contract.general",
-            // #346: container marker. Non-default so a serialization regression (getter-only / rename) is caught.
-            IsContainer = true,
             // #306: provenance link for a Scenario B sub-document. Non-null so a serialization regression is caught.
             OriginDocumentId = originDocumentId
         };
@@ -128,7 +126,6 @@ public class EtoContract_Tests
 
         roundTrip.DocumentTypeCode.ShouldBe("contract.general");
         roundTrip.EventTime.ShouldBe(eto.EventTime);
-        roundTrip.IsContainer.ShouldBeTrue();
         roundTrip.OriginDocumentId.ShouldBe(originDocumentId);
     }
 

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
@@ -8,6 +8,7 @@ using Dignite.DocumentAI.Ai;
 using Dignite.DocumentAI.Documents;
 using Dignite.DocumentAI.Documents.Pipelines;
 using Dignite.DocumentAI.Documents.Pipelines.Classification;
+using Dignite.DocumentAI.Documents.Pipelines.Segmentation;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -76,6 +77,7 @@ public class DocumentClassificationBackgroundJob_Tests
     private readonly IDocumentPipelineRunRepository _runRepository;
     private readonly DocumentClassificationWorkflow _workflow;
     private readonly IDistributedEventBus _eventBus;
+    private readonly IBackgroundJobManager _backgroundJobManager;
 
     public DocumentClassificationBackgroundJob_Tests()
     {
@@ -84,6 +86,7 @@ public class DocumentClassificationBackgroundJob_Tests
         _runRepository = GetRequiredService<IDocumentPipelineRunRepository>();
         _workflow = GetRequiredService<DocumentClassificationWorkflow>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
+        _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
     }
 
     [Fact]
@@ -160,6 +163,44 @@ public class DocumentClassificationBackgroundJob_Tests
         // from cascading field extraction onto the container.
         await _eventBus.DidNotReceive().PublishAsync(
             Arg.Any<DocumentClassifiedEto>(), Arg.Any<bool>());
+
+        // #346 PR3b: a detected container enqueues the born-digital segmentation job (same UoW as the completion).
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentSegmentationJobArgs>(a => a.ContainerDocumentId == doc.Id),
+            Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task Derived_SubDocument_Flagged_Container_Is_Classified_Normally_Not_Recursed()
+    {
+        // #346 recursion guard: a derived sub-document must never be re-detected as a container, or the split would
+        // recurse. Even if the LLM flags it a container, it is classified normally (here to a real type) and the
+        // segmentation job is NOT enqueued.
+        var doc = CreateDerivedDocument("A single invoice that the LLM mistook for a bundle.");
+        SetupDocumentRepository(doc);
+
+        _workflow
+            .RunAsync(
+                Arg.Any<IReadOnlyList<DocumentType>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                IsContainer = true,
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.95
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        doc.IsContainer.ShouldBeFalse();
+        doc.DocumentTypeId.ShouldBe(DocumentClassificationJobTestModule.ContractTypeId);
+
+        await _backgroundJobManager.DidNotReceive().EnqueueAsync(
+            Arg.Any<DocumentSegmentationJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+        // It classified to a real type, so the normal field-extraction cascade event still fires.
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentClassifiedEto>(e => e.DocumentId == doc.Id), Arg.Any<bool>());
     }
 
     [Fact]
@@ -357,6 +398,30 @@ public class DocumentClassificationBackgroundJob_Tests
                 contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
                 fileSize: 1024,
                 originalFileName: "test.pdf"));
+
+        typeof(Document)
+            .GetProperty(nameof(Document.Markdown))!
+            .GetSetMethod(nonPublic: true)!
+            .Invoke(doc, [extractedText]);
+
+        return doc;
+    }
+
+    private static Document CreateDerivedDocument(string extractedText)
+    {
+        // A born-digital sub-document: OriginDocumentId is set, which is what the recursion guard keys on.
+        var doc = Document.CreateDerived(
+            Guid.NewGuid(),
+            tenantId: null,
+            fileOrigin: new FileOrigin(
+                blobName: $"{Guid.NewGuid():N}.md",
+                uploadedByUserName: "test-user",
+                contentType: "text/markdown",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                fileSize: 256,
+                originalFileName: "segment-abc.md"),
+            originDocumentId: Guid.NewGuid(),
+            originConstituentKey: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64]);
 
         typeof(Document)
             .GetProperty(nameof(Document.Markdown))!

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Lifecycle/DocumentReadyEventHandler_Tests.cs
@@ -68,10 +68,11 @@ public class DocumentReadyEventHandler_Tests
     }
 
     [Fact]
-    public async Task Container_Ready_Publishes_Eto_With_Marker_And_Null_Type()
+    public async Task Container_Ready_Does_Not_Publish_Eto()
     {
-        // #346: a container reaches Ready with no type. The ETO must carry IsContainer=true and
-        // DocumentTypeCode=null so downstream skips building a record from the container.
+        // #346 (Codex review): a container has no confirmed type, so it is not a consumable document — the handler
+        // suppresses its DocumentReadyEto (downstream consumes only the sub-documents' own Ready events). It still
+        // reaches Ready lifecycle for the operator UI.
         var doc = CreateContainerDocument();
         SetupDocumentRepository(doc);
 
@@ -80,14 +81,10 @@ public class DocumentReadyEventHandler_Tests
 
         await _handler.HandleEventAsync(evt);
 
-        await _eventBus.Received(1).PublishAsync(
-            Arg.Is<DocumentReadyEto>(e =>
-                e.DocumentId == doc.Id &&
-                e.IsContainer &&
-                e.DocumentTypeCode == null),
-            Arg.Any<bool>());
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Any<DocumentReadyEto>(), Arg.Any<bool>());
 
-        // A container has no DocumentTypeId, so the handler must not even attempt a type lookup.
+        // A container short-circuits before the type lookup.
         await _documentTypeRepository.DidNotReceive().FindAsync(
             Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Segmentation/MarkdownSlicer_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Segmentation/MarkdownSlicer_Tests.cs
@@ -88,6 +88,25 @@ public class MarkdownSlicer_Tests
     }
 
     [Fact]
+    public void Matches_A_Marker_Only_At_A_Line_Start_Not_A_Mid_Line_Occurrence()
+    {
+        // "Amount" appears mid-line inside the first slice's body AND at the start of the second slice's line. The
+        // cut must bind to the line-start occurrence, not the earlier mid-line one (which would silently mis-slice).
+        const string markdown = "Invoice 1 Amount X\nAmount\npaid";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("Invoice 1", IsDocument: true),
+            new("Amount", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeTrue();
+
+        slices.Count.ShouldBe(2);
+        slices[0].Text.ShouldBe("Invoice 1 Amount X"); // full first line; the mid-line "Amount" is not used as the cut
+        slices[1].Text.ShouldBe("Amount\npaid");
+    }
+
+    [Fact]
     public void Returns_False_When_A_Marker_Is_Not_Found_Verbatim()
     {
         const string markdown = "Invoice A first\nInvoice B second";

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Segmentation/MarkdownSlicer_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Segmentation/MarkdownSlicer_Tests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using Dignite.DocumentAI.Documents.Pipelines.Segmentation;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Segmentation;
+
+/// <summary>
+/// Pure-logic tests for <see cref="MarkdownSlicer"/> (#346): the deterministic cutter that turns the LLM's
+/// verbatim boundary markers into slices. This is the heart of the born-digital stability decision (the LLM never
+/// regenerates content), so its verification + edge cases are covered directly without an ABP host.
+/// </summary>
+public class MarkdownSlicer_Tests
+{
+    [Fact]
+    public void Splits_Two_Documents_At_Markers()
+    {
+        const string markdown = "Invoice A first\nInvoice B second";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("Invoice A", IsDocument: true),
+            new("Invoice B", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeTrue();
+
+        slices.Count.ShouldBe(2);
+        slices[0].Text.ShouldBe("Invoice A first");
+        slices[0].IsDocument.ShouldBeTrue();
+        slices[0].Ordinal.ShouldBe(0);
+        slices[1].Text.ShouldBe("Invoice B second");
+        slices[1].Ordinal.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Folds_Leading_Preamble_Into_First_Slice()
+    {
+        // Content before the first marker (a transmittal line the LLM did not mark) must not be dropped.
+        const string markdown = "PREAMBLE LINE\nInvoice A body\nInvoice B body";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("Invoice A", IsDocument: true),
+            new("Invoice B", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeTrue();
+
+        slices.Count.ShouldBe(2);
+        slices[0].Text.ShouldContain("PREAMBLE LINE");
+        slices[0].Text.ShouldContain("Invoice A body");
+        slices[1].Text.ShouldBe("Invoice B body");
+    }
+
+    [Fact]
+    public void Repeated_Marker_Maps_To_Successive_Occurrences()
+    {
+        // Two documents whose first lines are identical: the forward-advancing search must map each marker to the
+        // next occurrence, not both to the first.
+        const string markdown = "Invoice\nfirst\nInvoice\nsecond";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("Invoice", IsDocument: true),
+            new("Invoice", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeTrue();
+
+        slices.Count.ShouldBe(2);
+        slices[0].Text.ShouldBe("Invoice\nfirst");
+        slices[1].Text.ShouldBe("Invoice\nsecond");
+    }
+
+    [Fact]
+    public void Preserves_IsDocument_Flag_For_NonDocument_Slices()
+    {
+        const string markdown = "TABLE OF CONTENTS\nInvoice A body";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("TABLE OF CONTENTS", IsDocument: false),
+            new("Invoice A", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeTrue();
+
+        slices.Count.ShouldBe(2);
+        slices[0].IsDocument.ShouldBeFalse();
+        slices[1].IsDocument.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Returns_False_When_A_Marker_Is_Not_Found_Verbatim()
+    {
+        const string markdown = "Invoice A first\nInvoice B second";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("Invoice A", IsDocument: true),
+            new("Invoice C never appears", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeFalse();
+        slices.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Returns_False_For_Empty_Input_Or_No_Boundaries()
+    {
+        MarkdownSlicer.TrySlice("", new List<SegmentBoundary> { new("x", true) }, out var s1).ShouldBeFalse();
+        s1.ShouldBeEmpty();
+
+        MarkdownSlicer.TrySlice("some text", new List<SegmentBoundary>(), out var s2).ShouldBeFalse();
+        s2.ShouldBeEmpty();
+
+        MarkdownSlicer.TrySlice("some text", null, out var s3).ShouldBeFalse();
+        s3.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Matches_A_Marker_That_Came_Back_With_PromptBoundary_Lt_Encoding()
+    {
+        // The LLM reads the Markdown after PromptBoundary.WrapDocument has encoded '<' as "&lt;"; a marker carrying
+        // that encoding must still be located against the raw Markdown via the decode fallback.
+        const string markdown = "<order> details here\nInvoice B body";
+        var boundaries = new List<SegmentBoundary>
+        {
+            new("&lt;order> details", IsDocument: true),
+            new("Invoice B", IsDocument: true)
+        };
+
+        MarkdownSlicer.TrySlice(markdown, boundaries, out var slices).ShouldBeTrue();
+
+        slices.Count.ShouldBe(2);
+        slices[0].Text.ShouldContain("<order> details here");
+        slices[1].Text.ShouldBe("Invoice B body");
+    }
+}

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
@@ -50,6 +52,7 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
     private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly IDistributedEventBus _eventBus;
     private readonly DocumentSegmentationWorkflow _workflow;
+    private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
     private readonly IGuidGenerator _guidGenerator;
 
     public DocumentSegmentationJob_Tests()
@@ -60,6 +63,7 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
         _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _workflow = GetRequiredService<DocumentSegmentationWorkflow>();
+        _blobContainer = GetRequiredService<IBlobContainer<DocumentAIDocumentContainer>>();
         _guidGenerator = GetRequiredService<IGuidGenerator>();
     }
 
@@ -167,6 +171,131 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
 
         await WithUnitOfWorkAsync(async () =>
             (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).Count.ShouldBe(2));
+    }
+
+    [Fact]
+    public async Task Byte_Identical_Document_Slices_Are_Deduped_While_Distinct_Slices_Each_Spawn()
+    {
+        // #346 fix: a byte-identical slice collapses to one sub-document (an accidental repeat — mirrors the figure
+        // path's identical-image de-dup) and is LOGGED, not silently dropped; the distinct slices still each spawn,
+        // and SegmentKey stays a pure content hash (== FileOrigin.ContentHash == OriginConstituentKey).
+        var containerId = await ArrangeContainerAsync("DOCA body line\nDOCA body line\nDOCB other line");
+        StubSplit(("DOCA body", true), ("DOCA body", true), ("DOCB other", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count.ShouldBe(2); // the duplicate "DOCA" slice was de-duplicated
+            segments.Select(s => s.SliceText).OrderBy(t => t).ToArray()
+                .ShouldBe(new[] { "DOCA body line", "DOCB other line" });
+            // SegmentKey is the pure content hash of the slice text (no positional salt).
+            foreach (var s in segments)
+            {
+                s.SegmentKey.ShouldBe(ContentHasher.Sha256Hex(System.Text.Encoding.UTF8.GetBytes(s.SliceText)));
+            }
+
+            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId);
+            derived.Count.ShouldBe(2);
+        });
+    }
+
+    [Fact]
+    public async Task Retry_That_Finds_All_Segments_Already_Spawned_Clears_A_Stale_Flag()
+    {
+        // #346 fix (sweep): a prior/concurrent run flagged the container, and a concurrent worker spawned the last
+        // slice, so THIS run finds zero Pending. It must still clear the stale flag (FinalizeSegmentationFlagAsync
+        // runs even with nothing Pending), so a fully-segmented container does not linger in the review queue.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var container = await _documentRepository.GetAsync(containerId);
+            container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: true);
+            await _documentRepository.UpdateAsync(container, autoSave: true);
+
+            // Two segments already fully Spawned (as if a concurrent worker finished them).
+            var s1 = NewSegment(containerId, "Invoice A first", 0);
+            s1.MarkSpawned(_guidGenerator.Create());
+            await _segmentRepository.InsertAsync(s1, autoSave: true);
+            var s2 = NewSegment(containerId, "Invoice B second", 1);
+            s2.MarkSpawned(_guidGenerator.Create());
+            await _segmentRepository.InsertAsync(s2, autoSave: true);
+        });
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        // No LLM re-split (segments already exist), and the stale flag is cleared.
+        await _workflow.DidNotReceive().RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons.ShouldBe(DocumentReviewReasons.None));
+    }
+
+    [Fact]
+    public async Task Unparseable_LLM_Response_Flags_Container_Without_Faulting_The_Job()
+    {
+        // #346 fix: a schema-drift / non-JSON structured response is caught and flagged for review, not allowed to
+        // fault the job into an endless ABP retry loop.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        _workflow.RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<DocumentSegmentationOutcome>(_ => throw new JsonException("schema drift"));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons
+                .ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Spawn_Failure_Flags_Container_And_Leaves_Segments_Pending()
+    {
+        // #346 fix: Phase B failures are not silent either — the container is flagged before the rethrow so an
+        // operator sees it even after ABP exhausts retries.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        StubSplit(("Invoice A", true), ("Invoice B", true));
+        _blobContainer
+            .When(x => x.SaveAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("blob store down"));
+
+        await Should.ThrowAsync<AggregateException>(
+            () => _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId }));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons
+                .ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId))
+                .ShouldAllBe(s => s.Status == DocumentSegmentStatus.Pending);
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Full_Segmentation_Clears_A_Prior_SegmentationIncomplete_Flag()
+    {
+        // #346 fix: a retry that finally spawns every slice clears the flag a prior partial run left, so a container
+        // that ultimately segments fully does not linger in the review queue.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var container = await _documentRepository.GetAsync(containerId);
+            container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: true);
+            await _documentRepository.UpdateAsync(container, autoSave: true);
+        });
+        StubSplit(("Invoice A", true), ("Invoice B", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons.ShouldBe(DocumentReviewReasons.None);
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).Count.ShouldBe(2);
+        });
     }
 
     private async Task<Guid> ArrangeContainerAsync(string markdown)

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -253,6 +253,37 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
     }
 
     [Fact]
+    public async Task Reclassify_During_Phase_A_Does_Not_Re_Flag_The_Now_Typed_Document()
+    {
+        // #346 fix (high-effort review): the container passes LoadAsync (still a container), but an operator
+        // reclassifies it to a concrete type DURING the slow LLM split (IsContainer cleared). The split then fails
+        // verification, so the Phase A flag path (MarkSegmentationIncompleteAsync) runs — it must re-check IsContainer
+        // and NOT re-flag the now-typed document, or it would push the operator's reclassification back into the
+        // review queue with no way to clear it (no segment rows are persisted on this path, so the count-driven clear
+        // in FinalizeSegmentationFlagAsync never runs). Mirrors the guard CommitSpawnAsync / FinalizeSegmentationFlagAsync apply.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+
+        // Untrusted markers -> the split is rejected -> MarkSegmentationIncompleteAsync runs.
+        StubSplit(("Phantom marker one", true), ("Phantom marker two", true));
+        // ...but mid-split (the external phase), the document is reclassified away from container — the race this guard closes.
+        _workflow
+            .When(x => x.RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(_ => ReclassifyAwayFromContainer(containerId));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var doc = await _documentRepository.GetAsync(containerId);
+            doc.IsContainer.ShouldBeFalse();
+            // The now-typed document must NOT carry the segmentation-incomplete flag.
+            doc.ReviewReasons.ShouldBe(DocumentReviewReasons.None);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
     public async Task Unparseable_LLM_Response_Flags_Container_Without_Faulting_The_Job()
     {
         // #346 fix: a schema-drift / non-JSON structured response is caught and flagged for review, not allowed to
@@ -402,6 +433,21 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
 
         return containerId;
     }
+
+    // Simulates an operator reclassifying the container to a concrete type WHILE the LLM split runs (the external
+    // phase). Mirrors how ArrangeContainerAsync sets Markdown — flips IsContainer via its private setter and commits,
+    // so the job's subsequent FindActiveContainerAsync sees the document is no longer a container. Blocking is safe:
+    // xUnit async tests run with no SynchronizationContext, and at this point the job holds no ambient UoW.
+    private void ReclassifyAwayFromContainer(Guid containerId)
+        => WithUnitOfWorkAsync(async () =>
+        {
+            var doc = await _documentRepository.GetAsync(containerId);
+            typeof(Document)
+                .GetProperty(nameof(Document.IsContainer))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(doc, [false]);
+            await _documentRepository.UpdateAsync(doc, autoSave: true);
+        }).GetAwaiter().GetResult();
 
     private DocumentSegment NewSegment(Guid containerId, string sliceText, int ordinal)
         => new(

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -41,6 +41,14 @@ public class DocumentSegmentationJobTestModule : AbpModule
             Options.Create(new DocumentAIBehaviorOptions()),
             new DefaultPromptProvider());
         context.Services.AddSingleton(workflow);
+
+        // Lower the caps so the bound tests don't need 50 slices / 200k chars. All other tests in this class use
+        // <= 2 distinct slices and < 100-char Markdown, so they are unaffected.
+        context.Services.Configure<DocumentAIBehaviorOptions>(o =>
+        {
+            o.MaxSegmentsPerDocument = 4;
+            o.MaxSegmentationMarkdownLength = 100;
+        });
     }
 }
 
@@ -296,6 +304,54 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
             (await _documentRepository.GetAsync(containerId)).ReviewReasons.ShouldBe(DocumentReviewReasons.None);
             (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).Count.ShouldBe(2);
         });
+    }
+
+    [Fact]
+    public async Task Total_Slice_Count_Over_The_Cap_Flags_Container_Even_When_Most_Are_Non_Document()
+    {
+        // #346 fix: the cap bounds TOTAL slices, not just document slices — a flood of cover/index slices cannot
+        // insert unbounded rows. 2 documents + 3 covers = 5 total > the test cap of 4, so the container is flagged
+        // even though only 2 are documents.
+        var containerId = await ArrangeContainerAsync("A doc\nB doc\nC cover\nD cover\nE cover");
+        StubSplit(("A doc", true), ("B doc", true), ("C cover", false), ("D cover", false), ("E cover", false));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons
+                .ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Oversized_Container_Markdown_Flags_For_Review_Without_Calling_The_LLM()
+    {
+        // #346 fix: segmentation feeds the whole Markdown to the LLM, so an over-limit container degrades to a
+        // review signal instead of paying for an enormous prompt — and the LLM is never called.
+        var oversized = new string('x', 150); // > the test cap of 100
+        var containerId = await ArrangeContainerAsync(oversized);
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await _workflow.DidNotReceive().RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons
+                .ShouldBe(DocumentReviewReasons.SegmentationIncomplete));
+    }
+
+    [Fact]
+    public async Task Two_Splits_Of_The_Same_Container_Collide_On_The_Ordinal_Unique_Index()
+    {
+        // #346 fix: the unique (SourceDocumentId, Ordinal) index makes concurrent double-splits mutually exclusive —
+        // every split numbers its first slice Ordinal 0, so the second committer is rejected by the DB.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        await WithUnitOfWorkAsync(async () =>
+            await _segmentRepository.InsertAsync(NewSegment(containerId, "first split slice", 0), autoSave: true));
+
+        await Should.ThrowAsync<Exception>(() => WithUnitOfWorkAsync(async () =>
+            await _segmentRepository.InsertAsync(NewSegment(containerId, "second split slice", 0), autoSave: true)));
     }
 
     private async Task<Guid> ArrangeContainerAsync(string markdown)

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -182,11 +183,12 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
     }
 
     [Fact]
-    public async Task Byte_Identical_Document_Slices_Are_Deduped_While_Distinct_Slices_Each_Spawn()
+    public async Task Byte_Identical_Slices_Flag_For_Review_Instead_Of_Silently_Dropping()
     {
-        // #346 fix: a byte-identical slice collapses to one sub-document (an accidental repeat — mirrors the figure
-        // path's identical-image de-dup) and is LOGGED, not silently dropped; the distinct slices still each spawn,
-        // and SegmentKey stays a pure content hash (== FileOrigin.ContentHash == OriginConstituentKey).
+        // #346 fix (Codex review): content alone can't tell an accidental duplicate from a genuine repeated
+        // instance, and the pure content hash is the idempotency identity (no positional salt). So a byte-identical
+        // slice flags the WHOLE container for human review rather than silently collapsing and risking dropping a
+        // real document. Nothing is persisted/spawned until a human resolves it.
         var containerId = await ArrangeContainerAsync("DOCA body line\nDOCA body line\nDOCB other line");
         StubSplit(("DOCA body", true), ("DOCA body", true), ("DOCB other", true));
 
@@ -194,18 +196,29 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
 
         await WithUnitOfWorkAsync(async () =>
         {
-            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
-            segments.Count.ShouldBe(2); // the duplicate "DOCA" slice was de-duplicated
-            segments.Select(s => s.SliceText).OrderBy(t => t).ToArray()
-                .ShouldBe(new[] { "DOCA body line", "DOCB other line" });
-            // SegmentKey is the pure content hash of the slice text (no positional salt).
-            foreach (var s in segments)
-            {
-                s.SegmentKey.ShouldBe(ContentHasher.Sha256Hex(System.Text.Encoding.UTF8.GetBytes(s.SliceText)));
-            }
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons
+                .ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+        });
+    }
 
-            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId);
-            derived.Count.ShouldBe(2);
+    [Fact]
+    public async Task Reclassified_Container_Is_Skipped_Without_Splitting_Or_Spawning()
+    {
+        // #346 fix (Codex review): a job enqueued for a mis-detected container that was since reclassified to a
+        // concrete type (IsContainer cleared) must NOT split/spawn — that would inject spurious sub-documents
+        // downstream alongside the now-typed document's own fields.
+        var docId = await ArrangeContainerAsync("Invoice A first\nInvoice B second", asContainer: false);
+        StubSplit(("Invoice A", true), ("Invoice B", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = docId });
+
+        await _workflow.DidNotReceive().RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == docId)).ShouldBeEmpty();
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == docId)).ShouldBeEmpty();
         });
     }
 
@@ -354,7 +367,7 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
             await _segmentRepository.InsertAsync(NewSegment(containerId, "second split slice", 0), autoSave: true)));
     }
 
-    private async Task<Guid> ArrangeContainerAsync(string markdown)
+    private async Task<Guid> ArrangeContainerAsync(string markdown, bool asContainer = true)
     {
         var containerId = _guidGenerator.Create();
         await WithUnitOfWorkAsync(async () =>
@@ -374,6 +387,15 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
                 .GetProperty(nameof(Document.Markdown))!
                 .GetSetMethod(nonPublic: true)!
                 .Invoke(doc, [markdown]);
+
+            // The segmentation job only runs for actual containers; mark it unless the test wants a doc that was
+            // reclassified away from container (IsContainer == false).
+            if (asContainer)
+            {
+                typeof(Document)
+                    .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+                    .Invoke(doc, null);
+            }
 
             await _documentRepository.InsertAsync(doc, autoSave: true);
         });

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Ai;
+using Dignite.DocumentAI.Documents;
+using Dignite.DocumentAI.Documents.Pipelines.Segmentation;
+using Dignite.DocumentAI.Documents.Pipelines.TextExtraction;
+using Dignite.DocumentAI.Documents.Segments;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.DocumentAI.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(DocumentAIEntityFrameworkCoreTestModule))]
+public class DocumentSegmentationJobTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<DocumentAIDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+
+        // Split seam: a partial substitute of the segmentation workflow whose RunAsync each test stubs to a chosen
+        // boundary set — no real LLM call (mirrors the figure routing test's classification-workflow seam).
+        var workflow = Substitute.ForPartsOf<DocumentSegmentationWorkflow>(
+            Substitute.For<IChatClient>(),
+            Options.Create(new DocumentAIBehaviorOptions()),
+            new DefaultPromptProvider());
+        context.Services.AddSingleton(workflow);
+    }
+}
+
+public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmentationJobTestModule>
+{
+    private readonly DocumentSegmentationJob _job;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly IDistributedEventBus _eventBus;
+    private readonly DocumentSegmentationWorkflow _workflow;
+    private readonly IGuidGenerator _guidGenerator;
+
+    public DocumentSegmentationJob_Tests()
+    {
+        _job = GetRequiredService<DocumentSegmentationJob>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _segmentRepository = GetRequiredService<IRepository<DocumentSegment, Guid>>();
+        _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
+        _eventBus = GetRequiredService<IDistributedEventBus>();
+        _workflow = GetRequiredService<DocumentSegmentationWorkflow>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+    }
+
+    [Fact]
+    public async Task Container_Splits_Into_Seeded_Derived_Documents()
+    {
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        StubSplit(("Invoice A", true), ("Invoice B", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count.ShouldBe(2);
+            segments.ShouldAllBe(s => s.Status == DocumentSegmentStatus.Spawned);
+
+            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId);
+            derived.Count.ShouldBe(2);
+            // Each derived sub-document is keyed by its slice hash (= the segment key) and carries a Markdown FileOrigin.
+            derived.ShouldAllBe(d => d.FileOrigin.ContentType == "text/markdown");
+            foreach (var d in derived)
+            {
+                d.OriginConstituentKey.ShouldNotBeNull();
+                segments.ShouldContain(s => s.SegmentKey == d.OriginConstituentKey && s.RoutedDocumentId == d.Id);
+                d.FileOrigin.ContentHash.ShouldBe(d.OriginConstituentKey);
+            }
+        });
+
+        await _eventBus.Received(2).PublishAsync(Arg.Any<DocumentUploadedEto>());
+        // Each derived sub-document runs the full normal pipeline (text-extraction enqueued).
+        await _backgroundJobManager.Received(2).EnqueueAsync(
+            Arg.Any<DocumentTextExtractionJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task Untrusted_Split_Flags_Container_And_Spawns_Nothing()
+    {
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        // Markers the LLM "returned" but that do not appear verbatim -> MarkdownSlicer rejects the split.
+        StubSplit(("Phantom marker one", true), ("Phantom marker two", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var container = await _documentRepository.GetAsync(containerId);
+            container.ReviewReasons.ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
+
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+        });
+
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentUploadedEto>());
+    }
+
+    [Fact]
+    public async Task Fewer_Than_Two_Document_Slices_Flags_Container()
+    {
+        var containerId = await ArrangeContainerAsync("Invoice A only");
+        StubSplit(("Invoice A", true)); // a single document slice is not a real bundle
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetAsync(containerId)).ReviewReasons
+                .ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Resumes_From_Existing_Segments_Without_Re_Splitting()
+    {
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+
+        // Simulate a crash after the split persisted but before any spawn: two Pending segments already exist.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _segmentRepository.InsertAsync(NewSegment(containerId, "Invoice A first", 0), autoSave: true);
+            await _segmentRepository.InsertAsync(NewSegment(containerId, "Invoice B second", 1), autoSave: true);
+        });
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        // The LLM split must be skipped on resume (segments already exist), and the Pending segments spawn.
+        await _workflow.DidNotReceive().RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).Count.ShouldBe(2);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId))
+                .ShouldAllBe(s => s.Status == DocumentSegmentStatus.Spawned);
+        });
+    }
+
+    [Fact]
+    public async Task Rerun_Is_Idempotent_And_Does_Not_Duplicate_Sub_Documents()
+    {
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        StubSplit(("Invoice A", true), ("Invoice B", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).Count.ShouldBe(2));
+    }
+
+    private async Task<Guid> ArrangeContainerAsync(string markdown)
+    {
+        var containerId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var doc = new Document(
+                containerId,
+                tenantId: null,
+                fileOrigin: new FileOrigin(
+                    blobName: $"blobs/{containerId:N}.pdf",
+                    uploadedByUserName: "test-user",
+                    contentType: "application/pdf",
+                    contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                    fileSize: 2048,
+                    originalFileName: "bundle.pdf"));
+
+            typeof(Document)
+                .GetProperty(nameof(Document.Markdown))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(doc, [markdown]);
+
+            await _documentRepository.InsertAsync(doc, autoSave: true);
+        });
+
+        return containerId;
+    }
+
+    private DocumentSegment NewSegment(Guid containerId, string sliceText, int ordinal)
+        => new(
+            _guidGenerator.Create(),
+            tenantId: null,
+            sourceDocumentId: containerId,
+            segmentKey: ContentHasher.Sha256Hex(System.Text.Encoding.UTF8.GetBytes(sliceText)),
+            sliceText: sliceText,
+            ordinal: ordinal);
+
+    private void StubSplit(params (string Marker, bool IsDocument)[] boundaries)
+    {
+        var outcome = new DocumentSegmentationOutcome();
+        foreach (var (marker, isDocument) in boundaries)
+        {
+            outcome.Boundaries.Add(new SegmentBoundary(marker, isDocument));
+        }
+
+        _workflow.RunAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(outcome);
+    }
+}

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
@@ -134,6 +134,34 @@ public class EfCoreDocumentRepositoryStatistics_Tests : DocumentAIEntityFramewor
         stats.TotalStorageBytes.ShouldBe(100); // the container's bytes are excluded
     }
 
+    [Fact]
+    public async Task GetStatistics_Counts_SegmentationIncomplete_Container_In_NeedsReview_But_Not_Totals()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // A normal Ready business document.
+            await SeedDocAsync(DocumentLifecycleStatus.Ready, 100);
+
+            // #346: a container whose segmentation failed is excluded from totals/storage (it's a wrapper) but MUST
+            // be counted in NeedsReview, because it also appears in the operator review queue — so the dashboard
+            // count and the queue do not drift (#333).
+            var container = NewDocument(999);
+            typeof(Document)
+                .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(container, null);
+            container.SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: true);
+            container.TransitionLifecycle(DocumentLifecycleStatus.Ready);
+            await _documentRepository.InsertAsync(container, autoSave: true);
+        });
+
+        var stats = await WithUnitOfWorkAsync(() => _documentRepository.GetStatisticsAsync());
+
+        stats.TotalCount.ShouldBe(1);          // container excluded from the document total
+        stats.ReadyCount.ShouldBe(1);          // only the normal Ready document
+        stats.NeedsReviewCount.ShouldBe(1);    // but the segmentation-incomplete container IS counted as needing review
+        stats.TotalStorageBytes.ShouldBe(100); // container bytes excluded
+    }
+
     // ─── helpers ───────────────────────────────────────────────────────────
 
     private async Task SeedDocAsync(

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Documents;
 using Shouldly;
@@ -106,6 +107,31 @@ public class EfCoreDocumentRepositoryStatistics_Tests : DocumentAIEntityFramewor
         });
         tenantStats.TotalCount.ShouldBe(2);
         tenantStats.TotalStorageBytes.ShouldBe(500);
+    }
+
+    [Fact]
+    public async Task GetStatistics_Excludes_Containers()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // A normal Ready business document is counted.
+            await SeedDocAsync(DocumentLifecycleStatus.Ready, 100);
+
+            // #346: a container is an infrastructure wrapper, not a business document — excluded from the overview
+            // (its sub-documents are the real records), even though it reached Ready.
+            var container = NewDocument(999);
+            typeof(Document)
+                .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(container, null);
+            container.TransitionLifecycle(DocumentLifecycleStatus.Ready);
+            await _documentRepository.InsertAsync(container, autoSave: true);
+        });
+
+        var stats = await WithUnitOfWorkAsync(() => _documentRepository.GetStatisticsAsync());
+
+        stats.TotalCount.ShouldBe(1);          // the container is excluded
+        stats.ReadyCount.ShouldBe(1);          // only the normal Ready document
+        stats.TotalStorageBytes.ShouldBe(100); // the container's bytes are excluded
     }
 
     // ─── helpers ───────────────────────────────────────────────────────────

--- a/host/src/Migrations/20260617055228_Added_DocumentSegments.Designer.cs
+++ b/host/src/Migrations/20260617055228_Added_DocumentSegments.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.DocumentAI.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.DocumentAI.Host.Migrations
 {
     [DbContext(typeof(DocumentAIHostDbContext))]
-    partial class DocumentAIHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617055228_Added_DocumentSegments")]
+    partial class Added_DocumentSegments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260617055228_Added_DocumentSegments.cs
+++ b/host/src/Migrations/20260617055228_Added_DocumentSegments.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.DocumentAI.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Added_DocumentSegments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DocAIDocumentSegments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SourceDocumentId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SegmentKey = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    SliceText = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Ordinal = table.Column<int>(type: "int", nullable: false),
+                    RoutedDocumentId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DocAIDocumentSegments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DocAIDocumentSegments_DocAIDocuments_SourceDocumentId",
+                        column: x => x.SourceDocumentId,
+                        principalTable: "DocAIDocuments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DocAIDocumentSegments_SourceDocumentId_SegmentKey",
+                table: "DocAIDocumentSegments",
+                columns: new[] { "SourceDocumentId", "SegmentKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DocAIDocumentSegments");
+        }
+    }
+}

--- a/host/src/Migrations/20260617071007_Added_DocumentSegments.Designer.cs
+++ b/host/src/Migrations/20260617071007_Added_DocumentSegments.Designer.cs
@@ -13,7 +13,7 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.DocumentAI.Host.Migrations
 {
     [DbContext(typeof(DocumentAIHostDbContext))]
-    [Migration("20260617055228_Added_DocumentSegments")]
+    [Migration("20260617071007_Added_DocumentSegments")]
     partial class Added_DocumentSegments
     {
         /// <inheritdoc />
@@ -678,6 +678,9 @@ namespace Dignite.DocumentAI.Host.Migrations
                         .HasColumnName("TenantId");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("SourceDocumentId", "Ordinal")
+                        .IsUnique();
 
                     b.HasIndex("SourceDocumentId", "SegmentKey")
                         .IsUnique();

--- a/host/src/Migrations/20260617071007_Added_DocumentSegments.cs
+++ b/host/src/Migrations/20260617071007_Added_DocumentSegments.cs
@@ -40,6 +40,12 @@ namespace Dignite.DocumentAI.Host.Migrations
                 });
 
             migrationBuilder.CreateIndex(
+                name: "IX_DocAIDocumentSegments_SourceDocumentId_Ordinal",
+                table: "DocAIDocumentSegments",
+                columns: new[] { "SourceDocumentId", "Ordinal" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "IX_DocAIDocumentSegments_SourceDocumentId_SegmentKey",
                 table: "DocAIDocumentSegments",
                 columns: new[] { "SourceDocumentId", "SegmentKey" },

--- a/host/src/Migrations/DocumentAIHostDbContextModelSnapshot.cs
+++ b/host/src/Migrations/DocumentAIHostDbContextModelSnapshot.cs
@@ -676,6 +676,9 @@ namespace Dignite.DocumentAI.Host.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("SourceDocumentId", "Ordinal")
+                        .IsUnique();
+
                     b.HasIndex("SourceDocumentId", "SegmentKey")
                         .IsUnique();
 


### PR DESCRIPTION
Part of #346 (PR3b). Supersedes #348, which GitHub auto-closed when its stacked base branch (`feat/346-container-documents`, PR3a #347) was squash-merged and deleted; this branch has been rebased onto `main`, so the diff is now PR3b-only.

## What

Born-digital container segmentation: the generalization of #306 figure routing to text bundles. A document classified as a **container** (#346, PR3a) has its Markdown split into constituent documents, each spawned as a derived sub-document seeded from its slice — reusing the same derived-document sink as figure routing.

- `DocumentSegment` ledger (mirrors `DocumentFigure`) + `DocumentSegmentationWorkflow` (keyed Structured `IChatClient`, returns verbatim start markers + isDocument) + `MarkdownSlicer` (deterministic, line-anchored cutting of the original Markdown — never regenerates text, #346 decision #8) + `DocumentSegmentationJob` (two-phase resumable: split-once → spawn-per-Pending; short-UoW; per-segment fault isolation).
- Classification container branch enqueues the job (same UoW) + recursion guard (a derived doc is never re-detected as a container).
- Text-extraction seed path: figure → segment fallback.
- Non-blocking `DocumentReviewReasons.SegmentationIncomplete` review signal (untrusted split / <2 distinct doc slices / over caps / unparseable / byte-identical slices), surfaced in the operator UI (Angular).
- Reclassify reversibility: a container reclassified to a concrete type clears `IsContainer` + the segmentation flag; the segmentation job's `FindActiveContainerAsync` guard (all 4 phases) prevents a stale job from injecting sub-documents or re-flagging the now-typed document.

## Review

Carried multiple review rounds (code-review ×2, Codex adversarial, combined-epic review). Follow-up design gaps found in the combined review are tracked separately as #349 (reclassify-after-segmentation sub-document retraction) and #350 (MCP/Angular egress container marker) — not in scope here.

## Migration

Adds `DocAIDocumentSegments` (additive: new table + two unique indexes + FK cascade). **Not applied** — generated only; apply via DbMigrator / `dotnet ef database update` after merge.

## Tests

Application 262 / EntityFrameworkCore 99 green locally (incl. a regression test for the mid-split reclassify guard).