### PR TITLE
feat(documents): retract sub-documents when a container is reclassified (#349)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Documents.Segments;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Timing;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Lifecycle;
+
+/// <summary>
+/// Listens to <see cref="ContainerMarkerClearedEvent"/> (#349) and retracts the sub-documents a now-reclassified
+/// container previously spawned. The container's <see cref="Document.IsContainer"/> marker just transitioned
+/// true→false (operator reclassify via <c>ConfirmClassification</c>, or a high-confidence automatic
+/// <c>ApplyAutomaticClassificationResult</c> re-recognition): it is now a single concrete-typed document, so the
+/// derived sub-documents it had spawned are stale and would double-count downstream with no retraction signal.
+/// <para>
+/// Within the same transaction as the marker clear (local event), this handler:
+/// <list type="bullet">
+///   <item>loads the spawned sub-documents (<see cref="IDocumentRepository.GetListByOriginAsync"/>, those whose
+///   <see cref="Document.OriginDocumentId"/> is the container) and soft-deletes each, publishing a
+///   <see cref="DocumentDeletedEto"/> per sub-document — mirroring <c>DocumentAppService.DeleteAsync</c> so downstream
+///   moves their derived data to a recoverable archived state;</item>
+///   <item>removes the container's <see cref="DocumentSegment"/> work-queue rows (keyed by
+///   <see cref="DocumentSegment.SourceDocumentId"/>), so a stale segmentation job finds nothing to resume and the
+///   ledger no longer references a non-container.</item>
+/// </list>
+/// Multi-tenancy: this runs in the ambient context where the marker was cleared; the sub-documents and segment rows
+/// share the container's <c>TenantId</c> and are matched by ABP's <c>IMultiTenant</c> global filter — the filter is
+/// never pierced.
+/// </para>
+/// </summary>
+public class ContainerMarkerClearedEventHandler
+    : ILocalEventHandler<ContainerMarkerClearedEvent>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IDistributedEventBus _distributedEventBus;
+    private readonly IClock _clock;
+    private readonly ILogger<ContainerMarkerClearedEventHandler> _logger;
+
+    public ContainerMarkerClearedEventHandler(
+        IDocumentRepository documentRepository,
+        IRepository<DocumentSegment, Guid> segmentRepository,
+        IDistributedEventBus distributedEventBus,
+        IClock clock,
+        ILogger<ContainerMarkerClearedEventHandler> logger)
+    {
+        _documentRepository = documentRepository;
+        _segmentRepository = segmentRepository;
+        _distributedEventBus = distributedEventBus;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public virtual async Task HandleEventAsync(ContainerMarkerClearedEvent eventData)
+    {
+        var containerId = eventData.DocumentId;
+
+        // Retract the spawned sub-documents: soft-delete each + publish DocumentDeletedEto so downstream archives the
+        // derived data. A container that was never segmented (or whose segmentation never spawned) yields an empty
+        // list — a no-op, which is correct.
+        var subDocuments = await _documentRepository.GetListByOriginAsync(containerId);
+        foreach (var subDocument in subDocuments)
+        {
+            await _documentRepository.DeleteAsync(subDocument);
+
+            await _distributedEventBus.PublishAsync(
+                new DocumentDeletedEto
+                {
+                    DocumentId = subDocument.Id,
+                    TenantId = subDocument.TenantId,
+                    EventTime = _clock.Now
+                });
+        }
+
+        // Remove the container's segment work-queue rows: they reference a document that is no longer a container, so a
+        // stale segmentation job finds nothing to resume (DocumentSegment has no soft delete — it is working state).
+        await _segmentRepository.DeleteAsync(s => s.SourceDocumentId == containerId);
+
+        if (subDocuments.Count > 0)
+        {
+            _logger.LogInformation(
+                "Container {ContainerId} reclassified to a concrete type; retracted {SubDocumentCount} spawned sub-document(s) and removed its segment rows (#349).",
+                containerId, subDocuments.Count);
+        }
+    }
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
@@ -63,9 +63,22 @@ public class ContainerMarkerClearedEventHandler
         // Retract the spawned sub-documents: soft-delete each + publish DocumentDeletedEto so downstream archives the
         // derived data. A container that was never segmented (or whose segmentation never spawned) yields an empty
         // list — a no-op, which is correct.
+        //
+        // Bounded fan-out: the sub-document count is already capped upstream by
+        // DocumentAIBehaviorOptions.MaxSegmentsPerDocument (default 50) — the segmentation job (SplitAndPersistAsync)
+        // refuses to spawn when the split exceeds that cap (flagging the container for review instead), so at most
+        // MaxSegmentsPerDocument rows can ever come back from GetListByOriginAsync. Because that bound is small and
+        // fixed, this loop needs no Take(N)/pagination and no background job — the retraction runs synchronously,
+        // entirely within the reclassify UoW (see the per-document delete note below).
         var subDocuments = await _documentRepository.GetListByOriginAsync(containerId);
         foreach (var subDocument in subDocuments)
         {
+            // Intentional deferred flush: DeleteAsync WITHOUT autoSave (contrast the eager bulk DeleteAsync(predicate)
+            // for segments below). The soft-delete UPDATE is deferred to the ambient reclassify UoW's SaveChanges, so
+            // it commits together with that UoW. DO NOT add autoSave: true here — doing so would flush this one
+            // sub-document mid-handler, partially committing before the rest of the retraction and before the
+            // reclassify completes, breaking the all-in-one-UoW guarantee: every soft-delete, every DocumentDeletedEto,
+            // and the DocumentClassifiedEto must land in a single transactional-outbox commit (atomic, all-or-nothing).
             await _documentRepository.DeleteAsync(subDocument);
 
             await _distributedEventBus.PublishAsync(

--- a/core/src/Dignite.DocumentAI.Domain/Documents/ContainerMarkerClearedEvent.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/ContainerMarkerClearedEvent.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Dignite.DocumentAI.Documents;
+
+/// <summary>
+/// Local domain event raised on a true→false transition of <see cref="Document.IsContainer"/> (#349):
+/// the document was previously a <b>container</b> and has now been reclassified to a concrete type
+/// (operator <c>ConfirmClassification</c> reclassify, or a high-confidence automatic
+/// <c>ApplyAutomaticClassificationResult</c> re-recognition). Published through
+/// <c>AddLocalEvent</c> inside those methods in the same transaction as the marker clear.
+/// <para>
+/// A container that was already segmented spawned derived sub-documents
+/// (<see cref="Document.OriginDocumentId"/> == this container's id) and recorded
+/// <c>DocumentSegment</c> work-queue rows. Once the container stops being a container, those
+/// sub-documents no longer have a parent that delegates to them — leaving them live would
+/// double-count downstream with no retraction signal (#349). The in-process handler
+/// (<c>ContainerMarkerClearedEventHandler</c>) reacts within the same transaction: it soft-deletes
+/// the spawned sub-documents (emitting <c>DocumentDeletedEto</c> per sub-document so downstream
+/// archives their derived data) and removes the container's <c>DocumentSegment</c> rows.
+/// </para>
+/// <para>
+/// Valid consumption is limited to this in-process retraction hook inside the DocumentAI channel
+/// layer. Business side effects belong to downstream consumers, which subscribe to the outbound
+/// <c>DocumentDeletedEto</c> in their own process instead of attaching to this local event.
+/// </para>
+/// </summary>
+public class ContainerMarkerClearedEvent
+{
+    /// <summary>The document whose container marker was just cleared (the former container).</summary>
+    public Guid DocumentId { get; }
+
+    public ContainerMarkerClearedEvent(Guid documentId)
+    {
+        DocumentId = documentId;
+    }
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -335,10 +335,18 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         SetReviewReason(DocumentReviewReasons.UnresolvedClassification, present: false);
         // #346: a concrete type is now assigned, so this is no longer a container; clear the marker and any stale
         // segmentation-incomplete signal to avoid the contradictory "has a type AND is a container" state.
+        // #349: capture the prior marker state and, on a true→false transition, raise ContainerMarkerClearedEvent so
+        // the in-process handler retracts any already-spawned sub-documents (soft-delete + DocumentDeletedEto) and
+        // removes the container's segment rows, preventing downstream double-counting.
+        var wasContainer = IsContainer;
         IsContainer = false;
         SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null; // #284 review-fix: leaving Rejected disposition -> clear stale rejection reason; only Rejected should have one.
+        if (wasContainer)
+        {
+            AddLocalEvent(new ContainerMarkerClearedEvent(Id));
+        }
     }
 
     /// <summary>
@@ -405,10 +413,18 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: false);
         // #346: operator reclassifying a container to a concrete type clears the container marker (reversibility)
         // and any stale segmentation-incomplete signal; subsequent DocumentClassifiedEto cascades field extraction.
+        // #349: capture the prior marker state and, on a true→false transition, raise ContainerMarkerClearedEvent so
+        // the in-process handler retracts any already-spawned sub-documents (soft-delete + DocumentDeletedEto) and
+        // removes the container's segment rows, preventing downstream double-counting.
+        var wasContainer = IsContainer;
         IsContainer = false;
         SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.Confirmed;
         RejectionReason = null; // #284 review-fix: rejection is recoverable; clear stale rejection reason after Reclassify / Confirm.
+        if (wasContainer)
+        {
+            AddLocalEvent(new ContainerMarkerClearedEvent(Id));
+        }
     }
 
     /// <summary>

--- a/core/src/Dignite.DocumentAI.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/IDocumentRepository.cs
@@ -19,6 +19,23 @@ public interface IDocumentRepository : IRepository<Document, Guid>
     Task HardDeleteAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists the derived sub-documents spawned from <paramref name="originDocumentId"/> (#306 / #346 Scenario B):
+    /// every <see cref="Document"/> whose <see cref="Document.OriginDocumentId"/> equals it. Served by the composite
+    /// unique index <c>(OriginDocumentId, OriginConstituentKey)</c> whose leading column is <c>OriginDocumentId</c>,
+    /// so no extra index is needed.
+    /// <para>
+    /// Used by the #349 container-retraction handler (<c>ContainerMarkerClearedEventHandler</c>): when a container is
+    /// reclassified to a concrete type, its previously-spawned sub-documents must be soft-deleted so they stop
+    /// double-counting downstream. Scalar fields + owned <c>FileOrigin</c> suffice (no child collection), so this does
+    /// not eager-load details. <c>IMultiTenant</c> + <c>ISoftDelete</c> global filters apply automatically by ambient
+    /// state, keeping the result within the container's own layer and excluding already-deleted sub-documents.
+    /// </para>
+    /// </summary>
+    Task<List<Document>> GetListByOriginAsync(
+        Guid originDocumentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Finds a Document by Id and eager-loads <b>only</b> the <see cref="Document.ExtractedFieldValues"/> child collection.
     /// Field extraction write-back paths (<c>FieldExtractionEventHandler</c>) need existing field rows present so
     /// <see cref="Document.SetFields"/> can reconcile correctly (delete old / update in place / insert new).

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -51,6 +51,20 @@ public class EfCoreDocumentRepository
         }
     }
 
+    public virtual async Task<List<Document>> GetListByOriginAsync(
+        Guid originDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        // #349: list a source's derived sub-documents. The composite unique index (OriginDocumentId, OriginConstituentKey)
+        // has OriginDocumentId as its leading column, so this filter is index-served (no new index needed). IMultiTenant
+        // + ISoftDelete global filters apply automatically by ambient state — only the container's own layer, no
+        // already-deleted sub-documents. Scalar fields + owned FileOrigin suffice for the soft-delete + ETO publication.
+        var dbSet = await GetDbSetAsync();
+        return await dbSet
+            .Where(d => d.OriginDocumentId == originDocumentId)
+            .ToListAsync(GetCancellationToken(cancellationToken));
+    }
+
     public override async Task<IQueryable<Document>> WithDetailsAsync()
     {
         return (await GetQueryableAsync()).IncludeDetails();

--- a/core/test/Dignite.DocumentAI.Domain.Tests/Documents/ContainerMarkerClearedEvent_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Domain.Tests/Documents/ContainerMarkerClearedEvent_Tests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Shouldly;
+using Volo.Abp.Domain.Entities;
+using Xunit;
+
+namespace Dignite.DocumentAI.Documents;
+
+/// <summary>
+/// #349 domain-level tests: the <see cref="ContainerMarkerClearedEvent"/> local event must be raised on a true→false
+/// transition of <see cref="Document.IsContainer"/> (and only then), for both classification entry points — the
+/// high-confidence automatic re-recognition (<c>ApplyAutomaticClassificationResult</c>) and the operator reclassify
+/// (<c>ConfirmClassification</c>). A document that was never a container raises nothing.
+/// </summary>
+public class ContainerMarkerClearedEvent_Tests
+{
+    [Fact]
+    public void ApplyAutomaticClassificationResult_On_A_Container_Raises_The_Event()
+    {
+        var doc = NewDocument();
+        MarkAsContainer(doc);
+
+        ApplyAutomaticClassificationResult(doc, TypeId("invoice.general"), 0.95);
+
+        doc.IsContainer.ShouldBeFalse();
+        LocalEvents(doc).OfType<ContainerMarkerClearedEvent>()
+            .ShouldContain(e => e.DocumentId == doc.Id);
+    }
+
+    [Fact]
+    public void ConfirmClassification_On_A_Container_Raises_The_Event()
+    {
+        var doc = NewDocument();
+        MarkAsContainer(doc);
+
+        ConfirmClassification(doc, TypeId("invoice.general"));
+
+        doc.IsContainer.ShouldBeFalse();
+        LocalEvents(doc).OfType<ContainerMarkerClearedEvent>()
+            .ShouldContain(e => e.DocumentId == doc.Id);
+    }
+
+    [Fact]
+    public void Classifying_A_Non_Container_Raises_No_Event()
+    {
+        var doc = NewDocument();
+
+        ApplyAutomaticClassificationResult(doc, TypeId("invoice.general"), 0.95);
+
+        doc.IsContainer.ShouldBeFalse();
+        LocalEvents(doc).OfType<ContainerMarkerClearedEvent>().ShouldBeEmpty();
+    }
+
+    private static Document NewDocument()
+        => new(
+            Guid.NewGuid(), null,
+            new FileOrigin(
+                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+
+    private static void MarkAsContainer(Document doc)
+        => typeof(Document)
+            .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, null);
+
+    private static void ApplyAutomaticClassificationResult(Document doc, Guid typeId, double confidence)
+        => typeof(Document)
+            .GetMethod("ApplyAutomaticClassificationResult", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, [typeId, confidence]);
+
+    private static void ConfirmClassification(Document doc, Guid typeId)
+        => typeof(Document)
+            .GetMethod("ConfirmClassification", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, [typeId]);
+
+    // AggregateRoot exposes its queued local events through IGeneratesDomainEvents.GetLocalEvents().
+    private static object[] LocalEvents(Document doc)
+        => ((IGeneratesDomainEvents)doc).GetLocalEvents().Select(r => r.EventData).ToArray();
+
+    private static Guid TypeId(string typeCode)
+        => new(MD5.HashData(Encoding.UTF8.GetBytes("type:" + typeCode)));
+}

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Documents;
+using Dignite.DocumentAI.Documents.Segments;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.DocumentAI.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(DocumentAIEntityFrameworkCoreTestModule))]
+public class ContainerReclassifyRetractionTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // DocumentAppService.ReclassifyAsync / the segmentation sink touch these collaborators; substitute the
+        // out-of-process ones so the test exercises the real DB + the real ContainerMarkerClearedEventHandler.
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<DocumentAIDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// #349 integration tests: reclassifying an already-segmented container to a concrete type must retract its spawned
+/// sub-documents (soft-delete + a <see cref="DocumentDeletedEto"/> per sub-document) and remove the container's
+/// <see cref="DocumentSegment"/> rows, while the container itself becomes a normal concrete-typed document. Runs
+/// against the real SQLite DB so the <c>ContainerMarkerClearedEvent</c> local event actually dispatches to
+/// <c>ContainerMarkerClearedEventHandler</c> on UoW completion.
+/// </summary>
+public class ContainerReclassifyRetraction_Tests
+    : DocumentAITestBase<ContainerReclassifyRetractionTestModule>
+{
+    private readonly IDocumentAppService _appService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IRepository<DocumentType, Guid> _documentTypeRepository;
+    private readonly IDistributedEventBus _eventBus;
+    private readonly IGuidGenerator _guidGenerator;
+
+    public ContainerReclassifyRetraction_Tests()
+    {
+        _appService = GetRequiredService<IDocumentAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _segmentRepository = GetRequiredService<IRepository<DocumentSegment, Guid>>();
+        _documentTypeRepository = GetRequiredService<IRepository<DocumentType, Guid>>();
+        _eventBus = GetRequiredService<IDistributedEventBus>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+    }
+
+    [Fact]
+    public async Task Reclassifying_A_Segmented_Container_Retracts_Sub_Documents_And_Segments()
+    {
+        var typeId = await SeedDocumentTypeAsync("invoice.general");
+        var containerId = await ArrangeSegmentedContainerAsync(subDocumentCount: 2);
+
+        // Reclassify the container to a concrete type (the operator-correction path).
+        var result = await _appService.ReclassifyAsync(
+            containerId, new ReclassifyDocumentInput { DocumentTypeId = typeId });
+
+        // (d) The container is now a concrete-typed, non-container document.
+        result.IsContainer.ShouldBeFalse();
+        result.DocumentTypeCode.ShouldBe("invoice.general");
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var container = await _documentRepository.GetAsync(containerId);
+            container.IsContainer.ShouldBeFalse();
+            container.DocumentTypeId.ShouldBe(typeId);
+
+            // (a) The sub-documents are soft-deleted (no longer visible under the ambient ISoftDelete filter).
+            (await _documentRepository.GetListByOriginAsync(containerId)).ShouldBeEmpty();
+
+            // (c) The container's segment rows are gone.
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+        });
+
+        // (b) A DocumentDeletedEto was published per sub-document.
+        await _eventBus.Received(2).PublishAsync(Arg.Any<DocumentDeletedEto>());
+    }
+
+    [Fact]
+    public async Task Reclassifying_A_Non_Segmented_Container_Publishes_No_Retraction_Events()
+    {
+        var typeId = await SeedDocumentTypeAsync("invoice.general");
+        var containerId = await ArrangeSegmentedContainerAsync(subDocumentCount: 0);
+
+        await _appService.ReclassifyAsync(
+            containerId, new ReclassifyDocumentInput { DocumentTypeId = typeId });
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(containerId)).IsContainer.ShouldBeFalse());
+
+        // No sub-documents existed, so no retraction events fire (the marker-cleared handler is a no-op here).
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentDeletedEto>());
+    }
+
+    private async Task<Guid> SeedDocumentTypeAsync(string typeCode)
+    {
+        var typeId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+            await _documentTypeRepository.InsertAsync(
+                new DocumentType(typeId, tenantId: null, typeCode, typeCode), autoSave: true));
+        return typeId;
+    }
+
+    /// <summary>
+    /// Seeds a container document (Markdown set, IsContainer marked) plus <paramref name="subDocumentCount"/> derived
+    /// sub-documents (OriginDocumentId == container) and one Spawned segment row each — mirroring the post-segmentation
+    /// state produced by <c>DocumentSegmentationJob.CommitSpawnAsync</c>.
+    /// </summary>
+    private async Task<Guid> ArrangeSegmentedContainerAsync(int subDocumentCount)
+    {
+        var containerId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var container = new Document(
+                containerId,
+                tenantId: null,
+                fileOrigin: new FileOrigin(
+                    blobName: $"blobs/{containerId:N}.pdf",
+                    uploadedByUserName: "test-user",
+                    contentType: "application/pdf",
+                    contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                    fileSize: 2048,
+                    originalFileName: "bundle.pdf"));
+
+            typeof(Document)
+                .GetProperty(nameof(Document.Markdown))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(container, ["Invoice A first\nInvoice B second"]);
+
+            typeof(Document)
+                .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(container, null);
+
+            await _documentRepository.InsertAsync(container, autoSave: true);
+
+            for (var i = 0; i < subDocumentCount; i++)
+            {
+                var sliceText = $"Invoice slice {i}";
+                var segmentKey = ContentHasher.Sha256Hex(System.Text.Encoding.UTF8.GetBytes(sliceText));
+                var derivedId = _guidGenerator.Create();
+
+                var derived = Document.CreateDerived(
+                    derivedId,
+                    tenantId: null,
+                    fileOrigin: new FileOrigin(
+                        blobName: $"{derivedId:N}.md",
+                        uploadedByUserName: "test-user",
+                        contentType: "text/markdown",
+                        contentHash: segmentKey,
+                        fileSize: sliceText.Length,
+                        originalFileName: $"segment-{i}.md"),
+                    originDocumentId: containerId,
+                    originConstituentKey: segmentKey);
+                await _documentRepository.InsertAsync(derived, autoSave: true);
+
+                var segment = new DocumentSegment(
+                    _guidGenerator.Create(), tenantId: null, sourceDocumentId: containerId,
+                    segmentKey: segmentKey, sliceText: sliceText, ordinal: i);
+                segment.MarkSpawned(derivedId);
+                await _segmentRepository.InsertAsync(segment, autoSave: true);
+            }
+        });
+
+        return containerId;
+    }
+}

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
@@ -38,6 +38,16 @@ public class ContainerReclassifyRetractionTestModule : AbpModule
 /// <see cref="DocumentSegment"/> rows, while the container itself becomes a normal concrete-typed document. Runs
 /// against the real SQLite DB so the <c>ContainerMarkerClearedEvent</c> local event actually dispatches to
 /// <c>ContainerMarkerClearedEventHandler</c> on UoW completion.
+/// <para>
+/// <b>Scope of these assertions.</b> <see cref="IDistributedEventBus"/> is an NSubstitute substitute, so these tests
+/// verify, precisely: (1) the local event dispatches to the handler on the reclassify UoW's completion; (2) the four
+/// retraction post-conditions hold against the real DB — the container becomes a concrete-typed non-container, its
+/// sub-documents are soft-deleted, and its segment rows are gone; (3) <c>PublishAsync</c> is invoked exactly once per
+/// sub-document (and never when there are no sub-documents). They do <b>not</b> assert that those publishes enrolled
+/// in the same transactional outbox as the soft-deletes, nor that publish + soft-delete are atomic — the substitute
+/// records calls but does not exercise ABP's real outbox, so outbox atomicity is out of scope here (it is a
+/// framework guarantee; see the all-in-one-UoW note in <c>ContainerMarkerClearedEventHandler</c>).
+/// </para>
 /// </summary>
 public class ContainerReclassifyRetraction_Tests
     : DocumentAITestBase<ContainerReclassifyRetractionTestModule>
@@ -86,7 +96,8 @@ public class ContainerReclassifyRetraction_Tests
             (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
         });
 
-        // (b) A DocumentDeletedEto was published per sub-document.
+        // (b) PublishAsync was invoked exactly once per sub-document (call count only; outbox enrolment / atomicity
+        // with the soft-deletes is not asserted here — see the class summary).
         await _eventBus.Received(2).PublishAsync(Arg.Any<DocumentDeletedEto>());
     }
 


### PR DESCRIPTION
Closes #349. Follow-up to #346 (container + born-digital segmentation).

## Problem
A document classified as a container spawns N derived sub-documents (`OriginDocumentId` → container). Container-ness is reversible (`ConfirmClassification` / `ApplyAutomaticClassificationResult` clear `IsContainer`), but the already-spawned sub-documents were never retracted — so reclassifying an already-segmented container left the parent as a real typed record **and** its N children live for the same physical content → double-counting downstream, no retraction signal.

## Decision (Option 2, via a domain local event)
Recorded on the issue: https://github.com/dignite-projects/dignite-extract/issues/349#issuecomment-4731522295

Cascade-retract on reclassify, triggered by a domain local event so it covers **both** clear paths (operator reclassify + high-confidence re-recognition), reusing the existing `DocumentDeletedEto` (no new event type, no migration).

## Changes
- `Document.cs`: raise `ContainerMarkerClearedEvent` only on a true→false transition of `IsContainer`, in both `ConfirmClassification` and `ApplyAutomaticClassificationResult`.
- New `ContainerMarkerClearedEvent` (Domain) + `IDocumentRepository.GetListByOriginAsync` (served by the existing leading-column `(OriginDocumentId, OriginConstituentKey)` index — **no migration**).
- New `ContainerMarkerClearedEventHandler` (Application): loads sub-documents by origin, soft-deletes each + publishes `DocumentDeletedEto` per sub-document, deletes the container's `DocumentSegment` rows. All in the reclassify UoW (atomic outbox commit). Fan-out bounded by `MaxSegmentsPerDocument` (default 50).

## Tests
- `ContainerReclassifyRetraction_Tests` (EfCore.Tests, real SQLite so the local event dispatches): asserts sub-documents soft-deleted, one `DocumentDeletedEto` per sub-document, segment rows gone, container ends with a concrete type + `IsContainer == false`; plus a no-fire-on-non-container case.
- `ContainerMarkerClearedEvent_Tests` (Domain.Tests): event raised on true→false for both clear paths, not on a normal classify.

## Reviewer notes
- Architecture review: no blockers. Applied follow-ups in `38da5c5` — documented the `MaxSegmentsPerDocument` bound on the retraction loop, commented the intentional deferred-flush (don't add `autoSave:true`), and corrected the test's XML claim (it proves local-event dispatch + DB post-conditions; outbox atomicity is explicitly out of scope as the test substitutes `IDistributedEventBus`).
- Known edge (pre-existing, unchanged): a sub-document spawned in the narrow window between the retraction query and commit could be missed; segmentation's `FindActiveContainerAsync` guard stops new spawns once the cleared marker commits.
