### PR TITLE
perf(documents): avoid double-buffering the figure crop on sub-document spawn (#306)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
@@ -263,26 +263,26 @@ public class DocumentFigureRoutingJob
     {
         // External: copy the candidate crop into an independent, derived-document-owned blob so the derived
         // document outlives the source (the source's permanent delete reclaims the candidate crop, not this copy).
-        byte[] cropBytes;
+        // The crop content hash is already known (figure.ContentHash), so there is no need to materialize a byte[]
+        // for re-hashing — buffer the crop once and rewind the same stream to save it (avoids a second full-size
+        // copy / LOH allocation per spawned figure).
+        var extension = ImageExtensionForContentType(figure.ContentType);
+        var derivedBlobName = _guidGenerator.Create().ToString("N") + extension;
+        long fileSize;
         await using (var cropStream = await _blobContainer.GetAsync(figure.CropBlobName))
         using (var buffer = new MemoryStream())
         {
             await cropStream.CopyToAsync(buffer, cancellationToken);
-            cropBytes = buffer.ToArray();
-        }
-
-        var extension = ImageExtensionForContentType(figure.ContentType);
-        var derivedBlobName = _guidGenerator.Create().ToString("N") + extension;
-        using (var saveStream = new MemoryStream(cropBytes, writable: false))
-        {
-            await _blobContainer.SaveAsync(derivedBlobName, saveStream, overrideExisting: true, cancellationToken);
+            fileSize = buffer.Length;
+            buffer.Position = 0;
+            await _blobContainer.SaveAsync(derivedBlobName, buffer, overrideExisting: true, cancellationToken);
         }
 
         var derivedDocumentId = _guidGenerator.Create();
 
         try
         {
-            await CommitSpawnAsync(workItem, figure, derivedBlobName, derivedDocumentId, extension, cropBytes.LongLength);
+            await CommitSpawnAsync(workItem, figure, derivedBlobName, derivedDocumentId, extension, fileSize);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {


### PR DESCRIPTION
## What

`DocumentFigureRoutingJob.SpawnDerivedDocumentAsync` copied the candidate crop into the derived-document-owned blob via `GetAsync` → `MemoryStream` → `ToArray()` (byte[]) → a **second** `MemoryStream` → `SaveAsync`, holding the whole crop twice (an LOH allocation per spawned figure for crops > 85 KB). The crop content hash is already known (`figure.ContentHash`), so the `byte[]` bought nothing — it was only used to feed `SaveAsync` and `FileOrigin.fileSize`.

Buffer the crop **once** and rewind the same stream to save it; read `fileSize` from the buffer length.

## Why

Surfaced by the #306 post-merge review ([review comment](https://github.com/dignite-projects/dignite-extract/issues/306#issuecomment-4736625886), finding F5). Pure internal efficiency — **no behavior change**: same blob written, same `FileOrigin`, same orphan-reclaim semantics.

## Scope

- No contract / egress / event change.
- Channel boundaries untouched.
- Builds clean (`Dignite.Extract.Application`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)