### PR TITLE
feat(documents): filter documents by OriginDocumentId for sub-document discovery (#354)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application.Contracts/Documents/GetDocumentListInput.cs
+++ b/core/src/Dignite.DocumentAI.Application.Contracts/Documents/GetDocumentListInput.cs
@@ -31,6 +31,14 @@ public class GetDocumentListInput : PagedAndSortedResultRequestDto
     public Guid? CabinetId { get; set; }
 
     /// <summary>
+    /// Provenance filter (#354): when set, returns only the sub-documents derived from this source document
+    /// (those whose <c>Document.OriginDocumentId</c> equals it) — the queryable form of the container /
+    /// sub-document relationship surfaced by #350. null means no filter. Stays under the ABP <c>IMultiTenant</c>
+    /// global filter, so it can only ever reach documents in the caller's own tenant.
+    /// </summary>
+    public Guid? OriginDocumentId { get; set; }
+
+    /// <summary>
     /// ExtractedFields value filters. Multiple filters are ANDed, and all are anchored to
     /// <see cref="DocumentTypeCode"/>. When provided, <see cref="DocumentTypeCode"/> is required
     /// because field declaration types must be resolved by type. Each element must carry Name plus at

--- a/core/src/Dignite.DocumentAI.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/DocumentAppService.cs
@@ -763,6 +763,11 @@ public class DocumentAppService : DocumentAIAppService, IDocumentAppService
         if (input.CabinetId.HasValue)
             query = query.Where(x => x.CabinetId == input.CabinetId.Value);
 
+        // Sub-document provenance filter (#354): list the documents derived from a given source (e.g. a
+        // container's children). The IMultiTenant global filter still applies, so both ends stay tenant-scoped.
+        if (input.OriginDocumentId.HasValue)
+            query = query.Where(x => x.OriginDocumentId == input.OriginDocumentId.Value);
+
         // Filter by manual-review disposition phase (#284). Rejected documents have ReviewDisposition=Rejected and can be queried explicitly.
         if (input.ReviewDisposition.HasValue)
             query = query.Where(d => d.ReviewDisposition == input.ReviewDisposition.Value);

--- a/core/src/Dignite.DocumentAI.Mcp/Documents/DocumentSearchTool.cs
+++ b/core/src/Dignite.DocumentAI.Mcp/Documents/DocumentSearchTool.cs
@@ -32,15 +32,21 @@ public sealed class DocumentSearchTool
         + "and/or one or more extracted-field filters (all combined with AND). Returns up to 50 rows "
         + "(id, uri, title, type, lifecycle, created-at, and the document's extracted field values); read a "
         + "match's full Markdown via its docai://documents/{id} resource uri. Structured field/metadata "
-        + "search only — no keyword/full-text or semantic/vector retrieval. documentTypeCode is required; if the "
-        + "user has not said which document type to search, ask them first. Discover a type's filterable field "
-        + "names and data types via its docai://document-types/{code} resource.")]
+        + "search only — no keyword/full-text or semantic/vector retrieval. documentTypeCode is required UNLESS "
+        + "originDocumentId is given; if the user has not said which document type to search, ask them first. "
+        + "To list the sub-documents of a container, pass that container's id as originDocumentId. Discover a "
+        + "type's filterable field names and data types via its docai://document-types/{code} resource.")]
     public static async Task<IReadOnlyList<DocumentSearchResultItem>> SearchAsync(
         IDocumentAppService documentAppService,
-        [Description("Required. The document type code to search within (e.g. a classification result like "
-            + "'contract.general'). Every search anchors to a single document type; a field value query needs it "
-            + "to resolve each field's data type. If unknown, ask the user which document type to search.")]
-        string documentTypeCode,
+        [Description("The document type code to search within (e.g. a classification result like "
+            + "'contract.general'). Required UNLESS originDocumentId is given; a field value query always needs "
+            + "it to resolve each field's data type. If unknown and not listing a container's children, ask the "
+            + "user which document type to search.")]
+        string? documentTypeCode = null,
+        [Description("List only the sub-documents derived from this source document id — i.e. the children of a "
+            + "container (the documents whose origin is this id). Pass a container's id here to enumerate its "
+            + "sub-documents. Optional; when given, documentTypeCode is not required.")]
+        string? originDocumentId = null,
         [Description("Filter by lifecycle status. One of: Uploaded, Processing, Ready, Failed, Archived. Optional.")]
         string? lifecycleStatus = null,
         [Description("Extracted-field filters, all combined with AND (every filter must match). Each entry "
@@ -56,16 +62,27 @@ public sealed class DocumentSearchTool
         int? maxResultCount = null,
         CancellationToken cancellationToken = default)
     {
-        // documentTypeCode is a required contract. Each retrieval is anchored to one document type because field value queries
-        // need it to resolve each field's data type; the description also states required. Empty string would make GetListAsync
-        // degrade to metadata retrieval across all types, contrary to the contract. Reject loudly instead of silently widening.
-        // Permissions / tenant / limits still apply inside AppService, so this is not a security risk.
-        if (string.IsNullOrWhiteSpace(documentTypeCode))
+        // Sub-document provenance query (#354): listing a container's children is anchored by originDocumentId,
+        // not by type — the children are heterogeneously typed and their types are unknown to the caller. Parse
+        // leniently (LLM clients pass string GUIDs); a malformed value is treated as "no provenance filter".
+        Guid? originDocumentIdValue = null;
+        if (!string.IsNullOrWhiteSpace(originDocumentId)
+            && Guid.TryParse(originDocumentId, out var parsedOriginId))
+        {
+            originDocumentIdValue = parsedOriginId;
+        }
+
+        // documentTypeCode anchors a type/field query and stays required — EXCEPT when originDocumentId is given,
+        // where the query is a provenance lookup that does not need a type. Without either, an empty documentTypeCode
+        // would make GetListAsync degrade to metadata retrieval across all types, contrary to the contract; reject
+        // loudly instead of silently widening. Permissions / tenant / limits still apply inside AppService.
+        if (string.IsNullOrWhiteSpace(documentTypeCode) && originDocumentIdValue is null)
         {
             throw new McpException(
-                "documentTypeCode is required: every search anchors to a single document type. "
-                + "If the user has not said which type to search, ask them first; discover a type's "
-                + "filterable fields via its docai://document-types/{code} resource.");
+                "documentTypeCode is required unless originDocumentId is given: every type/field search anchors to a "
+                + "single document type. If the user has not said which type to search, ask them first; discover a "
+                + "type's filterable fields via its docai://document-types/{code} resource. To list a container's "
+                + "sub-documents, pass the container id as originDocumentId.");
         }
 
         // Leniently parse lifecycle filter values. LLM clients usually pass string names such as "Ready".
@@ -81,6 +98,7 @@ public sealed class DocumentSearchTool
         var input = new GetDocumentListInput
         {
             DocumentTypeCode = documentTypeCode,
+            OriginDocumentId = originDocumentIdValue,
             LifecycleStatus = lifecycle,
             FieldFilters = fieldFilters?.ToList(),
             // Clamp hard result-set limit to MaxSearchResultCount. This is an MCP transport concern:

--- a/core/test/Dignite.DocumentAI.Mcp.Tests/Documents/DocumentSearchTool_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Mcp.Tests/Documents/DocumentSearchTool_Tests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Dignite.DocumentAI.Ai;
 using Dignite.DocumentAI.Documents;
 using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using NSubstitute;
 using Shouldly;
@@ -65,11 +66,51 @@ public class DocumentSearchTool_Tests : DocumentAITestBase<DocumentSearchToolTes
         // Other LLM-facing parameters are controls: they are scalars (IsService=false) and already expose
         // normally.
         properties.TryGetProperty("documentTypeCode", out _).ShouldBeTrue();
+        properties.TryGetProperty("originDocumentId", out _).ShouldBeTrue();
         properties.TryGetProperty("lifecycleStatus", out _).ShouldBeTrue();
         properties.TryGetProperty("maxResultCount", out _).ShouldBeTrue();
 
         // DI-injected service parameters must not appear in the LLM schema.
         properties.TryGetProperty("documentAppService", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Lists_sub_documents_by_origin_without_requiring_a_type()
+    {
+        // #354: listing a container's sub-documents is a provenance query anchored by originDocumentId, not by
+        // type — the children are heterogeneously typed. documentTypeCode must NOT be required in this case, and
+        // the parsed origin id must flow into GetDocumentListInput.OriginDocumentId.
+        var containerId = Guid.NewGuid();
+        var subDocId = Guid.NewGuid();
+        _documentAppService
+            .GetListAsync(Arg.Any<GetDocumentListInput>())
+            .Returns(new PagedResultDto<DocumentListItemDto>(1, new List<DocumentListItemDto>
+            {
+                new()
+                {
+                    Id = subDocId,
+                    LifecycleStatus = DocumentLifecycleStatus.Ready,
+                    CreationTime = new DateTime(2024, 1, 1),
+                    OriginDocumentId = containerId
+                }
+            }));
+
+        var result = await DocumentSearchTool.SearchAsync(
+            _documentAppService, originDocumentId: containerId.ToString());
+
+        await _documentAppService.Received(1).GetListAsync(Arg.Is<GetDocumentListInput>(i =>
+            i.OriginDocumentId == containerId && string.IsNullOrEmpty(i.DocumentTypeCode)));
+        result.Count.ShouldBe(1);
+        result[0].Id.ShouldBe(subDocId);
+        result[0].OriginDocumentId.ShouldBe(containerId);
+    }
+
+    [Fact]
+    public async Task Requires_documentTypeCode_unless_originDocumentId_is_given()
+    {
+        // Neither a type anchor nor an origin anchor: reject loudly instead of silently widening to all types.
+        await Should.ThrowAsync<McpException>(() => DocumentSearchTool.SearchAsync(_documentAppService));
+        await _documentAppService.DidNotReceive().GetListAsync(Arg.Any<GetDocumentListInput>());
     }
 
     [Fact]


### PR DESCRIPTION
Part of #354 (backend + MCP egress; Angular "view sub-documents" wiring remains).

## Problem

#350 surfaced container / sub-document provenance (`OriginDocumentId`) on the egress and the descriptions instruct an AI client to list a container's children by querying `OriginDocumentId == containerId` — but **no such filter existed** (`GetDocumentListInput` had none; the MCP tool exposed none and *required* `documentTypeCode`). The advertised "follow provenance → list sub-documents" workflow was **not executable**.

## Change

- **REST:** `GetDocumentListInput.OriginDocumentId` (`Guid?`, optional), applied in `DocumentAppService.ApplyFilter` exactly like the existing `CabinetId` filter. Stays under the ABP `IMultiTenant` global filter — both ends tenant-scoped, never a cross-tenant handle.
- **MCP `search_docai_documents`:** new optional `originDocumentId` parameter; **relaxes the mandatory `documentTypeCode`** when `originDocumentId` is given (a container's children are heterogeneously typed — a provenance query, not a type/field query). Lenient GUID parsing, consistent with `lifecycleStatus`.
- **Tests:** schema test asserts `originDocumentId` is exposed in the MCP input schema (Autofac schema-generation path, per anti-pattern C); behavior tests cover list-by-origin without a type and the require-type-unless-origin guard. All 10 `DocumentSearchTool_Tests` pass.

## Scope

- Egress contract addition, gated by the now-filed #354 (per the channel-boundary rule).
- **Not included:** Angular `document-list` "view sub-documents" wiring (`TODO(#350)`) — needs a proxy regen; tracked as remaining work on #354.
- No event / Markdown / field-architecture change.

Surfaced by the #306 post-merge review ([finding F1](https://github.com/dignite-projects/dignite-extract/issues/306#issuecomment-4736625886)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
