### PR TITLE
fix(documents): suppress inlined figure transcription slices in container segmentation (#359)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
 using Dignite.DocumentAI.Ai;
+using Dignite.DocumentAI.Documents.Figures;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.BackgroundJobs;
@@ -54,6 +55,7 @@ public class DocumentSegmentationJob
 {
     private readonly IDocumentRepository _documentRepository;
     private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IRepository<DocumentFigure, Guid> _documentFigureRepository;
     private readonly DocumentSegmentationWorkflow _segmentationWorkflow;
     private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
     private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
@@ -68,6 +70,7 @@ public class DocumentSegmentationJob
     public DocumentSegmentationJob(
         IDocumentRepository documentRepository,
         IRepository<DocumentSegment, Guid> segmentRepository,
+        IRepository<DocumentFigure, Guid> documentFigureRepository,
         DocumentSegmentationWorkflow segmentationWorkflow,
         DocumentPipelineJobScheduler pipelineJobScheduler,
         IBlobContainer<DocumentAIDocumentContainer> blobContainer,
@@ -81,6 +84,7 @@ public class DocumentSegmentationJob
     {
         _documentRepository = documentRepository;
         _segmentRepository = segmentRepository;
+        _documentFigureRepository = documentFigureRepository;
         _segmentationWorkflow = segmentationWorkflow;
         _pipelineJobScheduler = pipelineJobScheduler;
         _blobContainer = blobContainer;
@@ -160,6 +164,18 @@ public class DocumentSegmentationJob
         var hasExistingSegments =
             await _segmentRepository.FirstOrDefaultAsync(s => s.SourceDocumentId == containerDocumentId) is not null;
 
+        // #359: snapshot this container's inlined figure transcriptions so SplitAndPersistAsync can refuse to carve an
+        // already-inlined figure (e.g. an image invoice) into its own sub-document. Figure routing (#306) is the sole
+        // owner of figure-as-document; a text slice would be keyed by the slice-text hash, which does NOT collide with
+        // the figure's image-bytes-hash-keyed derived document on the unique (OriginDocumentId, OriginConstituentKey)
+        // index, so without this guard segmentation would silently duplicate it. The figure rows are persisted by
+        // text extraction, which always completes before classification enqueues this job, so they are readable here.
+        var figureTranscriptions = (await _documentFigureRepository.GetListAsync(
+                f => f.SourceDocumentId == containerDocumentId))
+            .Select(f => f.Transcription)
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+
         await uow.CompleteAsync();
 
         return new SegmentationContext(
@@ -167,7 +183,8 @@ public class DocumentSegmentationJob
             container.TenantId,
             container.FileOrigin.UploadedByUserName,
             container.Markdown ?? string.Empty,
-            hasExistingSegments);
+            hasExistingSegments,
+            figureTranscriptions);
     }
 
     /// <summary>
@@ -274,7 +291,29 @@ public class DocumentSegmentationJob
             return;
         }
 
-        var documentSliceCount = keyed.Count(p => p.Slice.IsDocument);
+        // #359: a document slice whose text is essentially an inlined figure transcription must not spawn — figure
+        // routing (#306) is the single owner of figure-as-document, and a text slice keyed by the slice hash would
+        // NOT collide with the figure's image-hash-keyed derived document, so it would silently duplicate it. Such a
+        // slice is downgraded to NotADocument (kept for audit), so it neither counts toward the document-slice total
+        // below nor produces a sub-document. Unconditional: an inlined figure transcription is never a standalone
+        // segmentation document, independent of whether figure routing itself spawned or rejected that figure.
+        var figureInlinedOrdinals = new HashSet<int>();
+        if (context.FigureTranscriptions.Count > 0)
+        {
+            foreach (var (slice, _) in keyed)
+            {
+                if (slice.IsDocument &&
+                    IsDominatedByFigureTranscription(slice.Text, context.FigureTranscriptions))
+                {
+                    figureInlinedOrdinals.Add(slice.Ordinal);
+                    Logger.LogInformation(
+                        "Container {ContainerId} slice at ordinal {Ordinal} is an inlined figure transcription; not spawning it as a sub-document (#359, owned by figure routing #306).",
+                        context.ContainerId, slice.Ordinal);
+                }
+            }
+        }
+
+        var documentSliceCount = keyed.Count(p => p.Slice.IsDocument && !figureInlinedOrdinals.Contains(p.Slice.Ordinal));
         if (documentSliceCount < 2)
         {
             // Fewer than two DISTINCT document slices means this was not really a multi-document bundle; do not spawn
@@ -314,8 +353,11 @@ public class DocumentSegmentationJob
                     key,
                     slice.Text,
                     slice.Ordinal,
-                    // Cover / index / transmittal slices are recorded for audit but never spawned.
-                    slice.IsDocument ? DocumentSegmentStatus.Pending : DocumentSegmentStatus.NotADocument));
+                    // Cover / index / transmittal slices, and inlined figure transcriptions (#359), are recorded for
+                    // audit but never spawned.
+                    slice.IsDocument && !figureInlinedOrdinals.Contains(slice.Ordinal)
+                        ? DocumentSegmentStatus.Pending
+                        : DocumentSegmentStatus.NotADocument));
             }
 
             await uow.CompleteAsync();
@@ -536,6 +578,34 @@ public class DocumentSegmentationJob
     private static bool IsSchemaDeserializationError(Exception ex)
         => ex is JsonException || ex.GetBaseException() is JsonException;
 
+    // #359: the slice must be ESSENTIALLY one figure's transcription — the transcription appears verbatim in it AND
+    // makes up at least this fraction of it (a short digital-text caption may precede it, #301). A real document whose
+    // body merely CONTAINS an inlined image keeps a much larger non-figure remainder, so the transcription is a
+    // minority of the slice and the slice stays a document. Content comparison, not offset matching: DocumentFigure
+    // has no positional anchor (#210 — identity is content), but its Transcription is the verbatim inlined text.
+    private const double FigureDominanceRatio = 0.9;
+
+    private static bool IsDominatedByFigureTranscription(string sliceText, IReadOnlyList<string> figureTranscriptions)
+    {
+        foreach (var transcription in figureTranscriptions)
+        {
+            // Skip a transcription too short to dominate this slice (cheap length gate before the substring scan); the
+            // `Contains` then confirms it is the verbatim inlined text, so it makes up >= FigureDominanceRatio of it.
+            if (string.IsNullOrWhiteSpace(transcription) ||
+                transcription.Length < sliceText.Length * FigureDominanceRatio)
+            {
+                continue;
+            }
+
+            if (sliceText.Contains(transcription, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private async Task TryDeleteBlobAsync(string blobName)
     {
         try
@@ -554,7 +624,8 @@ public class DocumentSegmentationJob
         Guid? TenantId,
         string UploadedByUserName,
         string Markdown,
-        bool HasExistingSegments);
+        bool HasExistingSegments,
+        IReadOnlyList<string> FigureTranscriptions);
 
     /// <summary>Detached snapshot of one still-Pending segment, carried across the per-segment external + UoW phases.</summary>
     protected sealed record PendingSegment(Guid SegmentId, string SegmentKey, string SliceText, int Ordinal);

--- a/core/test/Dignite.DocumentAI.Application.Tests/Ai/DefaultPromptProvider_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Ai/DefaultPromptProvider_Tests.cs
@@ -49,4 +49,20 @@ public class DefaultPromptProvider_Tests
         template.SystemInstructions.ShouldNotContain("Ignore previous instructions");
         template.SystemInstructions.ShouldNotContain("ignore prior rules");
     }
+
+    [Fact]
+    public void Segmentation_Prompt_Interpolates_Valid_Language_Tag()
+    {
+        _provider.GetSegmentationPrompt("zh-Hans").SystemInstructions.ShouldEndWith("Respond in: zh-Hans.");
+    }
+
+    [Fact]
+    public void Segmentation_Prompt_Instructs_Not_To_Split_Inlined_Figure_Transcriptions()
+    {
+        // #359: this prompt instruction is the LLM-side half of the inlined-figure guard (the code-side half lives in
+        // DocumentSegmentationJob, which refuses to spawn a slice dominated by a figure transcription). Pin the
+        // wording so it cannot be silently dropped or reworded away without a deliberate test update.
+        _provider.GetSegmentationPrompt("en").SystemInstructions
+            .ShouldContain("Do NOT split a figure or image transcription that is already inlined");
+    }
 }

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
 using Dignite.DocumentAI.Ai;
 using Dignite.DocumentAI.Documents;
+using Dignite.DocumentAI.Documents.Figures;
 using Dignite.DocumentAI.Documents.Pipelines.Segmentation;
 using Dignite.DocumentAI.Documents.Pipelines.TextExtraction;
 using Dignite.DocumentAI.Documents.Segments;
@@ -58,6 +59,7 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
     private readonly DocumentSegmentationJob _job;
     private readonly IDocumentRepository _documentRepository;
     private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IRepository<DocumentFigure, Guid> _figureRepository;
     private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly IDistributedEventBus _eventBus;
     private readonly DocumentSegmentationWorkflow _workflow;
@@ -69,6 +71,7 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
         _job = GetRequiredService<DocumentSegmentationJob>();
         _documentRepository = GetRequiredService<IDocumentRepository>();
         _segmentRepository = GetRequiredService<IRepository<DocumentSegment, Guid>>();
+        _figureRepository = GetRequiredService<IRepository<DocumentFigure, Guid>>();
         _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _workflow = GetRequiredService<DocumentSegmentationWorkflow>();
@@ -106,6 +109,66 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
         // Each derived sub-document runs the full normal pipeline (text-extraction enqueued).
         await _backgroundJobManager.Received(2).EnqueueAsync(
             Arg.Any<DocumentTextExtractionJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task Inlined_Figure_Transcription_Is_Not_Spawned_As_A_Sub_Document()
+    {
+        // #359: figure routing (#306) is the single owner of figure-as-document. A born-digital container whose
+        // Markdown carries an inlined image-invoice transcription (#301) between two real text documents must NOT
+        // re-spawn that invoice as a text sub-document when the LLM (ignoring the segmentation prompt's instruction)
+        // cuts the inlined transcription into its own slice — that would duplicate the figure-routed invoice (the
+        // text-slice hash and the image-bytes hash differ, so the unique index cannot dedup them). The figure slice is
+        // downgraded to NotADocument; only the two genuine text documents spawn.
+        var invoiceTranscription = "INVOICE No 42 Total 100";
+        var containerId = await ArrangeContainerAsync(
+            $"Service Agreement A-B\n{invoiceTranscription}\nLease Contract X-Y",
+            figureTranscriptions: new[] { invoiceTranscription });
+        StubSplit(("Service Agreement", true), ("INVOICE No 42", true), ("Lease Contract", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var invoiceSliceKey = ContentHasher.Sha256Hex(
+                System.Text.Encoding.UTF8.GetBytes(invoiceTranscription));
+
+            // Only the two genuine text documents spawn; the inlined invoice figure is not re-spawned by segmentation.
+            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId);
+            derived.Count.ShouldBe(2);
+            derived.ShouldNotContain(d => d.OriginConstituentKey == invoiceSliceKey);
+
+            // The figure slice is persisted as NotADocument (audit), the two real docs as Spawned.
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count.ShouldBe(3);
+            segments.Count(s => s.Status == DocumentSegmentStatus.Spawned).ShouldBe(2);
+            segments.ShouldContain(s =>
+                s.SegmentKey == invoiceSliceKey && s.Status == DocumentSegmentStatus.NotADocument);
+        });
+    }
+
+    [Fact]
+    public async Task Document_Whose_Body_Merely_Contains_A_Figure_Still_Spawns()
+    {
+        // #359 guard against over-suppression: the suppression only fires when a slice is ESSENTIALLY a figure
+        // transcription (>= FigureDominanceRatio of it). A real document whose body merely INCLUDES a small inlined
+        // figure keeps a large non-figure remainder, so the transcription is a minority of the slice and the document
+        // still spawns. If suppression keyed off `Contains` alone, this slice would be wrongly dropped, leaving fewer
+        // than two document slices and flagging the container — so this test fails on a too-aggressive threshold.
+        var containerId = await ArrangeContainerAsync(
+            "Service Agreement A-B\nFig 1 logo\nLease Contract X-Y body text",
+            figureTranscriptions: new[] { "Fig 1 logo" });
+        StubSplit(("Service Agreement", true), ("Lease Contract", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { ContainerDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // Both real documents spawn; the embedded figure does not suppress its host document.
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).Count.ShouldBe(2);
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId))
+                .ShouldAllBe(s => s.Status == DocumentSegmentStatus.Spawned);
+        });
     }
 
     [Fact]
@@ -398,7 +461,8 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
             await _segmentRepository.InsertAsync(NewSegment(containerId, "second split slice", 0), autoSave: true)));
     }
 
-    private async Task<Guid> ArrangeContainerAsync(string markdown, bool asContainer = true)
+    private async Task<Guid> ArrangeContainerAsync(
+        string markdown, bool asContainer = true, string[]? figureTranscriptions = null)
     {
         var containerId = _guidGenerator.Create();
         await WithUnitOfWorkAsync(async () =>
@@ -429,6 +493,18 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
             }
 
             await _documentRepository.InsertAsync(doc, autoSave: true);
+
+            // #359: seed DocumentFigure rows as text extraction (#306) would have, carrying the verbatim transcription
+            // that PdfExtractor inlined into the container Markdown (#301). Segmentation reads these to refuse carving
+            // an already-inlined figure into its own sub-document.
+            foreach (var transcription in figureTranscriptions ?? Array.Empty<string>())
+            {
+                var contentHash = $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64];
+                await _figureRepository.InsertAsync(new DocumentFigure(
+                    _guidGenerator.Create(), tenantId: null, sourceDocumentId: containerId,
+                    contentHash: contentHash, cropBlobName: $"figures/{containerId}/{contentHash}",
+                    contentType: "image/png", transcription: transcription, pageNumber: 1), autoSave: true);
+            }
         });
 
         return containerId;


### PR DESCRIPTION
Closes #359.

## Problem

A born-digital container can hold a contract plus an **image invoice** whose OCR transcription is inlined into `Document.Markdown` (#301). Two derived-sub-document paths act on the same source:

- **Path A — figure routing (#306)**: the invoice image is routed to a sub-document keyed by `SHA-256(image bytes)`.
- **Path B — container segmentation (#346)**: the Markdown is split; each `IsDocument=true` slice spawns a sub-document keyed by `SHA-256(slice text)`.

Path B avoided re-processing the inlined figure only via a **soft prompt instruction** (`DefaultPromptProvider.GetSegmentationPrompt`), not a code invariant. If the LLM ignored it and cut the inlined transcription into its own slice, Path B spawned a **second** invoice sub-document. The two keys differ in dimension (image-bytes hash vs slice-text hash), so the unique `(OriginDocumentId, OriginConstituentKey)` index — which covers same-path reruns/concurrency — could **not** dedup this cross-path case. The same invoice ended up as two sub-documents.

## Fix (figure-aware segmentation — promote the soft constraint to a code invariant)

- `DocumentSegmentationJob` injects `IRepository<DocumentFigure, Guid>` and snapshots the container's figure transcriptions in `LoadAsync` (figure rows are persisted by text extraction, always before classification enqueues segmentation).
- In `SplitAndPersistAsync`, any `IsDocument` slice that is **essentially** one of those transcriptions (verbatim `Contains` **and** the transcription is ≥ `FigureDominanceRatio` (0.9) of the slice) is downgraded to `NotADocument` — neither counted toward the document-slice total nor spawned, kept for audit.
- **Content comparison, not offset matching**: `DocumentFigure` carries no positional anchor (#210, identity is content, not position), but its `Transcription` is inlined verbatim, so content comparison is both available and robust.
- **Unconditional**: an inlined figure transcription is never a standalone segmentation document, independent of whether figure routing spawned or rejected that figure (mirrors the prompt's unconditional wording).

### Why a ratio, not exact match
A short digital-text caption may precede the transcription in the inlined block (#301), so exact equality is too strict. A genuine document whose body merely *contains* an inlined figure keeps a large non-figure remainder (transcription is a minority), so it stays a document — guarded by a dedicated test.

## Residual risk (accepted, best-effort)
If the LLM cuts through the **middle** of a multi-line transcription, neither half equals the full transcription and content comparison misses it. The existing `SegmentationIncomplete` review-flag remains the backstop. A "wrap inlined figures with visible markers" alternative was rejected: it would pollute `Document.Markdown` (the sole text payload), violating Markdown-first.

## Tests
- `Inlined_Figure_Transcription_Is_Not_Spawned_As_A_Sub_Document` — figure slice between two real docs is downgraded to `NotADocument`; only the two real docs spawn; no slice-text-hash invoice sub-document.
- `Document_Whose_Body_Merely_Contains_A_Figure_Still_Spawns` — minority figure does not over-suppress its host document (guards the 0.9 threshold).
- `DefaultPromptProvider_Tests` — pins the segmentation prompt's "do not split an inlined figure transcription" wording + language interpolation (previously untested).

Full EF Core test project: **103 passing**. Application builds with 0 warnings / 0 errors.

## Locked decisions (from #359)
- Unconditional suppression (not coupled to `figure.Status`).
- Threshold `FigureDominanceRatio = 0.9` (private const, not an option for now).
- Matched slice → `NotADocument` (not merged into the previous slice).
- Residual mid-cut case accepted as a known best-effort boundary.
