### PR TITLE
feat(documents): emit DocumentReclassifiedToContainerEto on type→container re-recognition (#355)

### DIFF
--- a/.claude/rules/integration-events.md
+++ b/.claude/rules/integration-events.md
@@ -27,6 +27,7 @@ paths:
 | `DocumentDeletedEto` | document soft-deleted (into recycle bin) — downstream should set derived data to a recoverable archived state |
 | `DocumentRestoredEto` | document restored from recycle bin — downstream should un-archive |
 | `DocumentPermanentlyDeletedEto` | document permanently deleted (including the original file / archive blob) — downstream should physically delete derived data |
+| `DocumentReclassifiedToContainerEto` | a previously concrete-typed document was re-recognized as a **container** (#355) — its type + type-bound fields are cleared, so downstream should **retract** the record it derived from the former type. The document itself is not deleted; its constituents become sub-documents queryable by `OriginDocumentId`. Thin payload (`DocumentId` / `TenantId` / `EventTime`), not Ready-gated. The type→container mirror of the container→type retraction (#349, which reuses `DocumentDeletedEto` for the spawned sub-documents). Fires only on a real transition — a fresh upload first classified as a container emits nothing. |
 
 **Payload design**: event payloads are uniformly thin (ID + key metadata); downstream pulls detailed data back via REST/MCP.
 

--- a/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReclassifiedToContainerEto.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/Documents/DocumentReclassifiedToContainerEto.cs
@@ -1,0 +1,38 @@
+using System;
+using Volo.Abp.EventBus;
+
+namespace Dignite.DocumentAI.Abstractions.Documents;
+
+/// <summary>
+/// Published when a previously concrete-typed document is re-recognized as a <b>container</b> (#355): its type
+/// (and any type-bound field values) is cleared, so any business record a downstream consumer derived from its
+/// former <see cref="DocumentClassifiedEto"/> / <see cref="DocumentReadyEto"/> is now invalid and must be
+/// <b>retracted</b>. The document itself is not deleted — it lives on as a container whose constituents become
+/// independent sub-documents (read them by querying <c>OriginDocumentId == this DocumentId</c>).
+/// <para>
+/// This is the type→container mirror of the container→type retraction (#349), which reuses
+/// <see cref="DocumentDeletedEto"/> for the spawned sub-documents. Not gated by the Ready gate: the retraction
+/// must reach downstream regardless of the container's confidence. A fresh upload first classified as a container
+/// fires nothing (there was no prior typed record to retract).
+/// </para>
+/// <para>
+/// Thin payload (the channel philosophy): downstream retracts the record keyed by <see cref="DocumentId"/> and
+/// pulls any current detail back via REST/MCP. Idempotency under at-least-once delivery uses
+/// <c>(DocumentId, EventType, EventTime)</c>.
+/// </para>
+/// </summary>
+[EventName("DocumentAI.Document.ReclassifiedToContainer")]
+public class DocumentReclassifiedToContainerEto
+{
+    public string Version { get; init; } = "1.0";
+
+    public Guid DocumentId { get; init; }
+
+    public Guid? TenantId { get; init; }
+
+    /// <summary>
+    /// Event occurrence time. DocumentAI fills it with <see cref="Volo.Abp.Timing.IClock.Now"/> at publish time.
+    /// Downstream consumers can use <c>(DocumentId, EventType, EventTime)</c> for idempotence under at-least-once delivery.
+    /// </summary>
+    public required DateTime EventTime { get; init; }
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerSetEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerSetEventHandler.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.EventBus;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Timing;
+
+namespace Dignite.DocumentAI.Documents.Pipelines.Lifecycle;
+
+/// <summary>
+/// Listens to <see cref="ContainerMarkerSetEvent"/> (#355) and publishes the outbound
+/// <see cref="DocumentReclassifiedToContainerEto"/>. The event fires only on a real type→container transition
+/// (a previously concrete-typed document re-recognized as a container), so this handler always corresponds to a
+/// record downstream may have built and now needs to retract.
+/// <para>
+/// Mirror of <see cref="ContainerMarkerClearedEventHandler"/> (#349, the container→type direction). Unlike that
+/// handler, this one does <b>no</b> aggregate work — a document becoming a container has no already-spawned
+/// sub-documents to retract (it was a concrete-typed document, not a container); the sub-documents it will go on to
+/// spawn are produced by segmentation afterwards. So this handler's sole job is the outbound signal. It runs in the
+/// same transaction as the marker set (local event), so the ETO is written to the transactional outbox atomically
+/// with the reclassification — never lost, never published for a rolled-back transition.
+/// </para>
+/// </summary>
+public class ContainerMarkerSetEventHandler
+    : ILocalEventHandler<ContainerMarkerSetEvent>, ITransientDependency
+{
+    private readonly IDistributedEventBus _distributedEventBus;
+    private readonly IClock _clock;
+
+    public ContainerMarkerSetEventHandler(
+        IDistributedEventBus distributedEventBus,
+        IClock clock)
+    {
+        _distributedEventBus = distributedEventBus;
+        _clock = clock;
+    }
+
+    public virtual async Task HandleEventAsync(ContainerMarkerSetEvent eventData)
+    {
+        await _distributedEventBus.PublishAsync(
+            new DocumentReclassifiedToContainerEto
+            {
+                DocumentId = eventData.DocumentId,
+                TenantId = eventData.TenantId,
+                EventTime = _clock.Now
+            });
+    }
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/ContainerMarkerSetEvent.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/ContainerMarkerSetEvent.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Dignite.DocumentAI.Documents;
+
+/// <summary>
+/// Local domain event raised on a false→true transition of <see cref="Document.IsContainer"/> <b>when the
+/// document previously had a concrete type</b> (#355): a document that was already classified to a real type
+/// (so downstream may have built a business record from its <c>DocumentClassifiedEto</c> / <c>DocumentReadyEto</c>)
+/// is now re-recognized as a <b>container</b>, which clears that type. Published through <c>AddLocalEvent</c>
+/// inside <see cref="Document.MarkAsContainer"/> in the same transaction as the marker set.
+/// <para>
+/// This is the mirror image of <see cref="ContainerMarkerClearedEvent"/> (#349, the container→type direction).
+/// Without a signal, downstream would keep the now-invalid typed record <b>and</b> additionally consume the
+/// sub-documents the container goes on to spawn — a double-count. The in-process handler
+/// (<c>ContainerMarkerSetEventHandler</c>) reacts within the same transaction by publishing the outbound
+/// <c>DocumentReclassifiedToContainerEto</c>, telling downstream to retract the record derived from the former type.
+/// </para>
+/// <para>
+/// Gated on a real type→container transition: a fresh upload first detected as a container had no prior type and
+/// no downstream record, so it raises nothing. Valid consumption is limited to this in-process publish hook inside
+/// the DocumentAI channel layer; business side effects belong to downstream consumers of the outbound ETO.
+/// </para>
+/// </summary>
+public class ContainerMarkerSetEvent
+{
+    /// <summary>The document whose container marker was just set (the former concrete-typed document).</summary>
+    public Guid DocumentId { get; }
+
+    /// <summary>The document's tenant, carried so the handler can publish the ETO without an extra load.</summary>
+    public Guid? TenantId { get; }
+
+    public ContainerMarkerSetEvent(Guid documentId, Guid? tenantId)
+    {
+        DocumentId = documentId;
+        TenantId = tenantId;
+    }
+}

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -390,6 +390,14 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// </summary>
     internal void MarkAsContainer()
     {
+        // #355: capture the prior state before clearing it. A false→true transition where the document previously
+        // had a concrete type means a re-recognition turned an already-classified document (downstream may have
+        // built a record from its DocumentClassifiedEto / DocumentReadyEto) into a container — that record is now
+        // invalid and downstream must be told to retract it. A fresh upload first detected as a container had no
+        // prior type and no downstream record, so it raises nothing.
+        var wasContainer = IsContainer;
+        var hadConcreteType = DocumentTypeId.HasValue;
+
         IsContainer = true;
         DocumentTypeId = null;
         ClassificationConfidence = 0;
@@ -402,6 +410,13 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null;
         _extractedFieldValues.Clear();
+
+        // #355: mirror of the container→type retraction (#349 ContainerMarkerClearedEvent). The in-process handler
+        // publishes DocumentReclassifiedToContainerEto so downstream retracts the record derived from the former type.
+        if (!wasContainer && hadConcreteType)
+        {
+            AddLocalEvent(new ContainerMarkerSetEvent(Id, TenantId));
+        }
     }
 
     internal void ConfirmClassification(Guid documentTypeId)

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/EtoContract_Tests.cs
@@ -145,6 +145,24 @@ public class EtoContract_Tests
     }
 
     [Fact]
+    public void DocumentReclassifiedToContainerEto_RoundTrips_Through_SystemTextJson()
+    {
+        var eto = new DocumentReclassifiedToContainerEto
+        {
+            DocumentId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            EventTime = SampleEventTime
+        };
+
+        var roundTrip = RoundTrip(eto);
+
+        roundTrip.DocumentId.ShouldBe(eto.DocumentId);
+        roundTrip.TenantId.ShouldBe(eto.TenantId);
+        roundTrip.EventTime.ShouldBe(eto.EventTime);
+        roundTrip.Version.ShouldBe("1.0");
+    }
+
+    [Fact]
     public void DocumentPermanentlyDeletedEto_RoundTrips_Through_SystemTextJson()
     {
         var eto = new DocumentPermanentlyDeletedEto

--- a/core/test/Dignite.DocumentAI.Domain.Tests/Documents/ContainerMarkerSetEvent_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Domain.Tests/Documents/ContainerMarkerSetEvent_Tests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Shouldly;
+using Volo.Abp.Domain.Entities;
+using Xunit;
+
+namespace Dignite.DocumentAI.Documents;
+
+/// <summary>
+/// #355 domain-level tests: the <see cref="ContainerMarkerSetEvent"/> local event must be raised on a false→true
+/// transition of <see cref="Document.IsContainer"/> <b>only when the document previously had a concrete type</b>
+/// (a re-recognition that turned an already-classified document into a container, whose former typed record
+/// downstream must retract). A fresh upload first detected as a container — or a document already a container —
+/// raises nothing. Mirror of <see cref="ContainerMarkerClearedEvent_Tests"/> (the container→type direction).
+/// </summary>
+public class ContainerMarkerSetEvent_Tests
+{
+    [Fact]
+    public void Reclassifying_A_Concrete_Typed_Document_To_Container_Raises_The_Event()
+    {
+        var doc = NewDocument();
+        // First classified to a concrete type (downstream may now hold a record), then re-recognized as a container.
+        ApplyAutomaticClassificationResult(doc, TypeId("invoice.general"), 0.95);
+
+        MarkAsContainer(doc);
+
+        doc.IsContainer.ShouldBeTrue();
+        doc.DocumentTypeId.ShouldBeNull();
+        LocalEvents(doc).OfType<ContainerMarkerSetEvent>()
+            .ShouldContain(e => e.DocumentId == doc.Id && e.TenantId == doc.TenantId);
+    }
+
+    [Fact]
+    public void Fresh_Document_First_Detected_As_Container_Raises_No_Event()
+    {
+        var doc = NewDocument();
+
+        MarkAsContainer(doc);
+
+        doc.IsContainer.ShouldBeTrue();
+        // No prior type means no downstream record to retract — a spurious retraction would confuse consumers.
+        LocalEvents(doc).OfType<ContainerMarkerSetEvent>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Re_Detecting_An_Existing_Container_As_Container_Raises_No_Event()
+    {
+        var doc = NewDocument();
+        MarkAsContainer(doc);
+
+        MarkAsContainer(doc);
+
+        LocalEvents(doc).OfType<ContainerMarkerSetEvent>().ShouldBeEmpty();
+    }
+
+    private static Document NewDocument()
+        => new(
+            Guid.NewGuid(), null,
+            new FileOrigin(
+                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+
+    private static void MarkAsContainer(Document doc)
+        => typeof(Document)
+            .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, null);
+
+    private static void ApplyAutomaticClassificationResult(Document doc, Guid typeId, double confidence)
+        => typeof(Document)
+            .GetMethod("ApplyAutomaticClassificationResult", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, [typeId, confidence]);
+
+    // AggregateRoot exposes its queued local events through IGeneratesDomainEvents.GetLocalEvents().
+    private static object[] LocalEvents(Document doc)
+        => ((IGeneratesDomainEvents)doc).GetLocalEvents().Select(r => r.EventData).ToArray();
+
+    private static Guid TypeId(string typeCode)
+        => new(MD5.HashData(Encoding.UTF8.GetBytes("type:" + typeCode)));
+}

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ReclassifyToContainerSignal_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ReclassifyToContainerSignal_Tests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Documents;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Dignite.DocumentAI.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(DocumentAIEntityFrameworkCoreTestModule))]
+public class ReclassifyToContainerSignalTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Substitute the out-of-process event bus so the test can assert on what the real
+        // ContainerMarkerSetEventHandler publishes; everything else runs against the real DB.
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// #355 integration tests: re-recognizing an already concrete-typed document as a <b>container</b> must publish a
+/// <see cref="DocumentReclassifiedToContainerEto"/> so downstream retracts the record it built from the former type.
+/// Runs against the real SQLite DB so the <c>ContainerMarkerSetEvent</c> local event actually dispatches to
+/// <c>ContainerMarkerSetEventHandler</c> on UoW completion. Mirror of <see cref="ContainerReclassifyRetraction_Tests"/>
+/// (the container→type direction).
+/// <para>
+/// <see cref="IDistributedEventBus"/> is an NSubstitute substitute, so these tests verify that the local event
+/// dispatches to the handler on UoW completion and that <c>PublishAsync</c> is invoked exactly once (and only on a
+/// real type→container transition). Outbox enrolment / atomicity is a framework guarantee, out of scope here.
+/// </para>
+/// </summary>
+public class ReclassifyToContainerSignal_Tests
+    : DocumentAITestBase<ReclassifyToContainerSignalTestModule>
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentType, Guid> _documentTypeRepository;
+    private readonly IDistributedEventBus _eventBus;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public ReclassifyToContainerSignal_Tests()
+    {
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _documentTypeRepository = GetRequiredService<IRepository<DocumentType, Guid>>();
+        _eventBus = GetRequiredService<IDistributedEventBus>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public async Task Re_Recognizing_A_Typed_Document_As_Container_Publishes_The_Retraction_Eto()
+    {
+        var typeId = await SeedDocumentTypeAsync("invoice.general");
+        var documentId = await ArrangeClassifiedDocumentAsync(typeId);
+
+        // The document is re-recognized as a container (the marker flips false→true while it still has a type).
+        await MarkAsContainerInUowAsync(documentId);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.GetAsync(documentId);
+            document.IsContainer.ShouldBeTrue();
+            document.DocumentTypeId.ShouldBeNull();
+        });
+
+        // The local event dispatched on UoW completion and the handler published exactly one retraction ETO.
+        await _eventBus.Received(1).PublishAsync(Arg.Is<DocumentReclassifiedToContainerEto>(
+            e => e.DocumentId == documentId));
+    }
+
+    [Fact]
+    public async Task Fresh_Document_First_Detected_As_Container_Publishes_No_Retraction_Eto()
+    {
+        // A never-classified document (no prior type) detected as a container: no downstream record existed.
+        var documentId = await ArrangeUnclassifiedDocumentAsync();
+
+        await MarkAsContainerInUowAsync(documentId);
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(documentId)).IsContainer.ShouldBeTrue());
+
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentReclassifiedToContainerEto>());
+    }
+
+    private async Task<Guid> SeedDocumentTypeAsync(string typeCode)
+    {
+        var typeId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+            await _documentTypeRepository.InsertAsync(
+                new DocumentType(typeId, tenantId: null, typeCode, typeCode), autoSave: true));
+        return typeId;
+    }
+
+    private async Task<Guid> ArrangeClassifiedDocumentAsync(Guid typeId)
+    {
+        var documentId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = NewDocument(documentId);
+            typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(document, typeId);
+            await _documentRepository.InsertAsync(document, autoSave: true);
+        });
+        return documentId;
+    }
+
+    private async Task<Guid> ArrangeUnclassifiedDocumentAsync()
+    {
+        var documentId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+            await _documentRepository.InsertAsync(NewDocument(documentId), autoSave: true));
+        return documentId;
+    }
+
+    private Document NewDocument(Guid id)
+        => new(
+            id,
+            tenantId: null,
+            fileOrigin: new FileOrigin(
+                blobName: $"blobs/{id:N}.pdf",
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+
+    /// <summary>
+    /// Loads the document and flips its container marker inside one UoW, mirroring the classification job's
+    /// container branch: the <c>ContainerMarkerSetEvent</c> local event dispatches when this UoW completes.
+    /// </summary>
+    private async Task MarkAsContainerInUowAsync(Guid documentId)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        var document = await _documentRepository.GetAsync(documentId);
+        typeof(Document)
+            .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(document, null);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+        await uow.CompleteAsync();
+    }
+}


### PR DESCRIPTION
Closes #355.

## Problem

The container→type transition raises `ContainerMarkerClearedEvent` (#349), whose handler retracts the spawned sub-documents (soft-delete + `DocumentDeletedEto`). The **reverse** had no symmetric signal: when a previously concrete-typed document is re-recognized as a **container**, `MarkAsContainer` clears its type and suppresses `DocumentClassifiedEto` / `DocumentReadyEto` — so a downstream consumer that built a record from the former classification was **never told to retract it**, double-counting that stale record plus the container's new sub-documents.

## Change (mirror of #349)

- **`ContainerMarkerSetEvent`** (local domain event) raised by `Document.MarkAsContainer` **only** on a real `false→true` transition where the document **previously had a concrete type**. A fresh upload first detected as a container had no prior downstream record → raises nothing.
- **`ContainerMarkerSetEventHandler`** (Application/Lifecycle) publishes the new **`DocumentReclassifiedToContainerEto`** in the same transaction (transactional outbox). Thin payload (`DocumentId` / `TenantId` / `EventTime`), **not Ready-gated** — the retraction must reach downstream regardless of confidence. The document is not deleted; its constituents become sub-documents queryable by `OriginDocumentId`.

## Design notes (the open questions from #355)

- **Event shape:** chose a dedicated `DocumentReclassifiedToContainerEto` over reusing `DocumentDeletedEto` — the document is *not* deleted, and overloading delete semantics would mislead downstream into physically deleting on `DocumentPermanentlyDeletedEto`. A dedicated event is unambiguous.
- **Symmetry:** added the `ContainerMarkerSetEvent` local event so the aggregate stays the single source of the transition, mirroring `ContainerMarkerClearedEvent` exactly (publish happens in the App-layer handler; the Domain never touches `IDistributedEventBus`).
- **Ready-gate:** the handler publishes unconditionally on the transition, independent of the container's confidence/Ready state.

## Tests

- Domain: `ContainerMarkerSetEvent_Tests` — raises only on a real type→container transition; fresh-container and already-container raise nothing.
- ETO contract: `DocumentReclassifiedToContainerEto` JSON round-trip.
- Integration (real SQLite): `ReclassifyToContainerSignal_Tests` — the local event dispatches to the handler on UoW completion → ETO published exactly once; a fresh container publishes nothing.
- Documented in `.claude/rules/integration-events.md`.

Surfaced by the #306 post-merge review (finding F2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
