### PR TITLE
fix(documents): retract only segmentation sub-documents on container reclassify (#364)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
 using Dignite.DocumentAI.Documents.Segments;
@@ -20,10 +22,13 @@ namespace Dignite.DocumentAI.Documents.Pipelines.Lifecycle;
 /// <para>
 /// Within the same transaction as the marker clear (local event), this handler:
 /// <list type="bullet">
-///   <item>loads the spawned sub-documents (<see cref="IDocumentRepository.GetListByOriginAsync"/>, those whose
-///   <see cref="Document.OriginDocumentId"/> is the container) and soft-deletes each, publishing a
-///   <see cref="DocumentDeletedEto"/> per sub-document — mirroring <c>DocumentAppService.DeleteAsync</c> so downstream
-///   moves their derived data to a recoverable archived state;</item>
+///   <item>loads the sub-documents <b>this container's segmentation spawned</b> — identified by the container's
+///   <see cref="DocumentSegment"/> ledger (<see cref="DocumentSegment.RoutedDocumentId"/>), <b>not</b> a blanket
+///   <see cref="Document.OriginDocumentId"/> sweep — and soft-deletes each, publishing a
+///   <see cref="DocumentDeletedEto"/> per sub-document so downstream moves their derived data to a recoverable
+///   archived state. <b>#306 figure-routed children are intentionally left intact</b>: figure routing is orthogonal
+///   to container-ness (a normal concrete-typed document keeps its routed figure sub-documents), so retracting them
+///   would lose a legitimate routing and orphan its <c>DocumentFigure</c> row (#364);</item>
 ///   <item>removes the container's <see cref="DocumentSegment"/> work-queue rows (keyed by
 ///   <see cref="DocumentSegment.SourceDocumentId"/>), so a stale segmentation job finds nothing to resume and the
 ///   ledger no longer references a non-container.</item>
@@ -60,45 +65,57 @@ public class ContainerMarkerClearedEventHandler
     {
         var containerId = eventData.DocumentId;
 
-        // Retract the spawned sub-documents: soft-delete each + publish DocumentDeletedEto so downstream archives the
-        // derived data. A container that was never segmented (or whose segmentation never spawned) yields an empty
-        // list — a no-op, which is correct.
-        //
-        // Bounded fan-out: the sub-document count is already capped upstream by
-        // DocumentAIBehaviorOptions.MaxSegmentsPerDocument (default 50) — the segmentation job (SplitAndPersistAsync)
-        // refuses to spawn when the split exceeds that cap (flagging the container for review instead), so at most
-        // MaxSegmentsPerDocument rows can ever come back from GetListByOriginAsync. Because that bound is small and
-        // fixed, this loop needs no Take(N)/pagination and no background job — the retraction runs synchronously,
-        // entirely within the reclassify UoW (see the per-document delete note below).
-        var subDocuments = await _documentRepository.GetListByOriginAsync(containerId);
-        foreach (var subDocument in subDocuments)
-        {
-            // Intentional deferred flush: DeleteAsync WITHOUT autoSave (contrast the eager bulk DeleteAsync(predicate)
-            // for segments below). The soft-delete UPDATE is deferred to the ambient reclassify UoW's SaveChanges, so
-            // it commits together with that UoW. DO NOT add autoSave: true here — doing so would flush this one
-            // sub-document mid-handler, partially committing before the rest of the retraction and before the
-            // reclassify completes, breaking the all-in-one-UoW guarantee: every soft-delete, every DocumentDeletedEto,
-            // and the DocumentClassifiedEto must land in a single transactional-outbox commit (atomic, all-or-nothing).
-            await _documentRepository.DeleteAsync(subDocument);
+        // #364: retract ONLY the sub-documents THIS container's segmentation (#346) spawned, identified by the
+        // container's DocumentSegment ledger (RoutedDocumentId is set on a Spawned segment). A blanket
+        // OriginDocumentId sweep would also delete #306 figure-routed children — which are orthogonal to
+        // container-ness (a normal concrete-typed document keeps its routed figure sub-documents) — and would orphan
+        // their DocumentFigure rows. So drive the retraction from the segment rows; figure children + their figure
+        // ledger rows are left untouched. A container that was never segmented (or whose segmentation never spawned)
+        // yields no routed ids — a no-op, which is correct.
+        var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+        var spawnedSubDocumentIds = segments
+            .Where(s => s.RoutedDocumentId.HasValue)
+            .Select(s => s.RoutedDocumentId!.Value)
+            .ToList();
 
-            await _distributedEventBus.PublishAsync(
-                new DocumentDeletedEto
-                {
-                    DocumentId = subDocument.Id,
-                    TenantId = subDocument.TenantId,
-                    EventTime = _clock.Now
-                });
+        var retractedCount = 0;
+        if (spawnedSubDocumentIds.Count > 0)
+        {
+            // Bounded fan-out: segment count is capped upstream by DocumentAIBehaviorOptions.MaxSegmentsPerDocument
+            // (default 50 — the segmentation job flags the container for review rather than spawn beyond that), so this
+            // list is small and fixed: no Take(N)/pagination and no background job, the retraction runs synchronously
+            // within the reclassify UoW (see the per-document delete note below).
+            var subDocuments = await _documentRepository.GetListAsync(d => spawnedSubDocumentIds.Contains(d.Id));
+            foreach (var subDocument in subDocuments)
+            {
+                // Intentional deferred flush: DeleteAsync WITHOUT autoSave (contrast the eager bulk DeleteAsync(predicate)
+                // for segments below). The soft-delete UPDATE is deferred to the ambient reclassify UoW's SaveChanges, so
+                // it commits together with that UoW. DO NOT add autoSave: true here — doing so would flush this one
+                // sub-document mid-handler, partially committing before the rest of the retraction and before the
+                // reclassify completes, breaking the all-in-one-UoW guarantee: every soft-delete, every DocumentDeletedEto,
+                // and the DocumentClassifiedEto must land in a single transactional-outbox commit (atomic, all-or-nothing).
+                await _documentRepository.DeleteAsync(subDocument);
+
+                await _distributedEventBus.PublishAsync(
+                    new DocumentDeletedEto
+                    {
+                        DocumentId = subDocument.Id,
+                        TenantId = subDocument.TenantId,
+                        EventTime = _clock.Now
+                    });
+                retractedCount++;
+            }
         }
 
         // Remove the container's segment work-queue rows: they reference a document that is no longer a container, so a
         // stale segmentation job finds nothing to resume (DocumentSegment has no soft delete — it is working state).
         await _segmentRepository.DeleteAsync(s => s.SourceDocumentId == containerId);
 
-        if (subDocuments.Count > 0)
+        if (retractedCount > 0)
         {
             _logger.LogInformation(
-                "Container {ContainerId} reclassified to a concrete type; retracted {SubDocumentCount} spawned sub-document(s) and removed its segment rows (#349).",
-                containerId, subDocuments.Count);
+                "Container {ContainerId} reclassified to a concrete type; retracted {SubDocumentCount} segmentation sub-document(s) and removed its segment rows (#349/#364); figure-routed sub-documents (#306) left intact.",
+                containerId, retractedCount);
         }
     }
 }

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
 using Dignite.DocumentAI.Documents;
+using Dignite.DocumentAI.Documents.Figures;
 using Dignite.DocumentAI.Documents.Segments;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -55,6 +56,7 @@ public class ContainerReclassifyRetraction_Tests
     private readonly IDocumentAppService _appService;
     private readonly IDocumentRepository _documentRepository;
     private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IRepository<DocumentFigure, Guid> _figureRepository;
     private readonly IRepository<DocumentType, Guid> _documentTypeRepository;
     private readonly IDistributedEventBus _eventBus;
     private readonly IGuidGenerator _guidGenerator;
@@ -64,6 +66,7 @@ public class ContainerReclassifyRetraction_Tests
         _appService = GetRequiredService<IDocumentAppService>();
         _documentRepository = GetRequiredService<IDocumentRepository>();
         _segmentRepository = GetRequiredService<IRepository<DocumentSegment, Guid>>();
+        _figureRepository = GetRequiredService<IRepository<DocumentFigure, Guid>>();
         _documentTypeRepository = GetRequiredService<IRepository<DocumentType, Guid>>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _guidGenerator = GetRequiredService<IGuidGenerator>();
@@ -115,6 +118,44 @@ public class ContainerReclassifyRetraction_Tests
 
         // No sub-documents existed, so no retraction events fire (the marker-cleared handler is a no-op here).
         await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentDeletedEto>());
+    }
+
+    [Fact]
+    public async Task Reclassifying_A_Container_Retracts_Only_Segment_Children_Leaving_Figure_Routed_Ones_Intact()
+    {
+        // #364: a container can ALSO carry #306 figure-routed children (figures are routed during text extraction,
+        // independent of container-ness). Reclassifying the container to a concrete type must retract only the
+        // segmentation (#346) children — the figure-routed child (and its DocumentFigure ledger row) must survive,
+        // exactly as it would for a normal concrete-typed document, instead of being blanket-deleted by an
+        // OriginDocumentId sweep.
+        var typeId = await SeedDocumentTypeAsync("invoice.general");
+        var containerId = await ArrangeSegmentedContainerAsync(subDocumentCount: 2);
+        var (figureChildId, figureRowId) = await ArrangeFigureRoutedChildAsync(containerId);
+
+        await _appService.ReclassifyAsync(
+            containerId, new ReclassifyDocumentInput { DocumentTypeId = typeId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // Only the figure-routed child survives under the OriginDocumentId; the two segmentation children are gone.
+            var survivors = await _documentRepository.GetListByOriginAsync(containerId);
+            survivors.Count.ShouldBe(1);
+            survivors[0].Id.ShouldBe(figureChildId);
+
+            // The figure ledger row is untouched (not orphaned), still pointing at its surviving child.
+            var figures = await _figureRepository.GetListAsync(f => f.SourceDocumentId == containerId);
+            figures.Count.ShouldBe(1);
+            figures[0].Id.ShouldBe(figureRowId);
+            figures[0].RoutedDocumentId.ShouldBe(figureChildId);
+
+            // The container's segment rows are gone.
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+        });
+
+        // DocumentDeletedEto fired for exactly the two segmentation children — never for the figure-routed child.
+        await _eventBus.Received(2).PublishAsync(Arg.Any<DocumentDeletedEto>());
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Is<DocumentDeletedEto>(e => e.DocumentId == figureChildId));
     }
 
     private async Task<Guid> SeedDocumentTypeAsync(string typeCode)
@@ -187,5 +228,49 @@ public class ContainerReclassifyRetraction_Tests
         });
 
         return containerId;
+    }
+
+    /// <summary>
+    /// Seeds one #306 figure-routed child onto an existing container: a Spawned <see cref="DocumentFigure"/> row plus
+    /// its derived <see cref="Document"/> (OriginDocumentId == container, keyed by the figure's image-bytes hash).
+    /// Figure routing runs during text extraction, independent of container-ness — so a container can carry these
+    /// alongside its segmentation children. Returns the derived figure-child id and the figure ledger row id.
+    /// </summary>
+    private async Task<(Guid FigureChildId, Guid FigureRowId)> ArrangeFigureRoutedChildAsync(Guid containerId)
+    {
+        var figureChildId = _guidGenerator.Create();
+        var figureRowId = _guidGenerator.Create();
+        var figureHash = ContentHasher.Sha256Hex(System.Text.Encoding.UTF8.GetBytes("figure-image-bytes"));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var derived = Document.CreateDerived(
+                figureChildId,
+                tenantId: null,
+                fileOrigin: new FileOrigin(
+                    blobName: $"{figureChildId:N}.png",
+                    uploadedByUserName: "test-user",
+                    contentType: "image/png",
+                    contentHash: figureHash,
+                    fileSize: 1234,
+                    originalFileName: "figure.png"),
+                originDocumentId: containerId,
+                originConstituentKey: figureHash);
+            await _documentRepository.InsertAsync(derived, autoSave: true);
+
+            var figure = new DocumentFigure(
+                figureRowId,
+                tenantId: null,
+                sourceDocumentId: containerId,
+                contentHash: figureHash,
+                cropBlobName: $"figures/{containerId:N}/{figureHash}",
+                contentType: "image/png",
+                transcription: "INVOICE photo",
+                pageNumber: 1);
+            figure.MarkSpawned(figureChildId);
+            await _figureRepository.InsertAsync(figure, autoSave: true);
+        });
+
+        return (figureChildId, figureRowId);
     }
 }


### PR DESCRIPTION
Closes #364.

## Problem

`ContainerMarkerClearedEventHandler` (#349, the container→type retraction) retracted **every** `OriginDocumentId` child via `GetListByOriginAsync`, including **#306 figure-routed children**. Figure routing is orthogonal to container-ness — a normal concrete-typed document keeps its routed figure sub-documents — so reclassifying a container that also had a routed figure soft-deleted that legitimate figure sub-document (publishing a `DocumentDeletedEto` for it) and left its `DocumentFigure` ledger row dangling.

Reachable via the **common** flow (figures are routed during text extraction, before classification): an embedded-figure PDF classified as a container → segmentation fails → operator reclassifies it to a concrete type from the review queue.

## Fix

Drive the retraction from the container's `DocumentSegment` ledger (`RoutedDocumentId` on a Spawned segment) instead of a blanket `OriginDocumentId` sweep. Only segmentation children are retracted; #306 figure children and their `DocumentFigure` rows are left intact — exactly as they would be for a normal concrete-typed parent. The reverse direction (#355, type→container) already kept figure children, so this restores symmetry.

## Tests

Added `Reclassifying_A_Container_Retracts_Only_Segment_Children_Leaving_Figure_Routed_Ones_Intact`: a container with both 2 segmentation children and 1 figure-routed child, reclassified to a concrete type → only the 2 segmentation children are retracted (2 × `DocumentDeletedEto`), the figure child + its `DocumentFigure` row survive, no `DocumentDeletedEto` for the figure child. Revert-proven (fails on the old blanket sweep). Existing #349 retraction tests stay green.

EntityFrameworkCore 106 / Application 265 green locally. No schema change.