### PR TITLE
docs(text-extraction): clarify FigureOcrCount counts dispatched (incl. failed) OCR calls (#306)

### DIFF
--- a/core/src/Dignite.DocumentAI.Abstractions/Documents/OCRCompletedEto.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/Documents/OCRCompletedEto.cs
@@ -34,10 +34,12 @@ public class OCRCompletedEto
     public bool UsedOcr { get; init; }
 
     /// <summary>
-    /// Number of embedded images transcribed via figure-OCR (#306). <see cref="UsedOcr"/> still means
-    /// "scan vs digital" (a path fact); this is the named figure-OCR signal so downstream
-    /// cost-attribution can see that embedded-image OCR occurred on a digital document. 0 when none ran.
-    /// New optional field; defaults to 0 for producers / consumers that predate it.
+    /// Number of embedded-image OCR calls <b>dispatched</b> via figure-OCR (#306) — counting every call sent to
+    /// <c>IOcrProvider</c>, <b>including ones that threw</b> (a failed call may still incur provider cost), so this
+    /// counts dispatched attempts, not successful transcriptions. <see cref="UsedOcr"/> still means "scan vs
+    /// digital" (a path fact); this is the named figure-OCR signal so downstream cost-attribution can see that
+    /// embedded-image OCR occurred on a digital document. 0 when none ran. New optional field; defaults to 0 for
+    /// producers / consumers that predate it.
     /// </summary>
     public int FigureOcrCount { get; init; }
 }

--- a/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/TextExtractionResult.cs
+++ b/core/src/Dignite.DocumentAI.Abstractions/TextExtraction/TextExtractionResult.cs
@@ -48,11 +48,13 @@ public class TextExtractionResult
     public IReadOnlyList<Figure>? Figures { get; set; }
 
     /// <summary>
-    /// Number of embedded images transcribed via figure-OCR (#306). A digital document reports
-    /// <see cref="UsedOcr"/> = false (it is a digital extraction) yet may transcribe embedded figures
-    /// through <c>IOcrProvider</c>; this named counter lets downstream audit / cost-attribution see that
-    /// embedded-image OCR occurred without overloading the binary <see cref="UsedOcr"/> "scan vs digital"
-    /// flag. 0 when no figure OCR ran.
+    /// Number of embedded-image OCR calls <b>dispatched</b> via figure-OCR (#306) — every call sent to
+    /// <c>IOcrProvider</c> for an embedded figure, <b>including ones that threw</b> (a failed call may still
+    /// incur provider cost / tokens), so this counts dispatched attempts, not successful transcriptions. A
+    /// digital document reports <see cref="UsedOcr"/> = false (it is a digital extraction) yet may dispatch
+    /// embedded-figure OCR; this named counter lets downstream audit / cost-attribution see that embedded-image
+    /// OCR occurred without overloading the binary <see cref="UsedOcr"/> "scan vs digital" flag. 0 when no
+    /// figure OCR ran.
     /// </summary>
     public int FigureOcrCount { get; set; }
 }


### PR DESCRIPTION
## What

Comment-only fix surfaced by the #306 design re-review. `FigureOcrCount`'s XML doc said *"images transcribed"*, but `PdfExtractor` increments it for **every dispatched embedded-image OCR call, including ones that throw** (a failed call may still incur provider cost / tokens). Aligned the doc on both:

- `TextExtractionResult.FigureOcrCount` (source field, Abstractions)
- `OCRCompletedEto.FigureOcrCount` (egress event field)

so the name matches the implementation ("dispatched", not "successfully transcribed").

## Why

`FigureOcrCount` exists as a cost-attribution signal (resolves the #301 `UsedOcr` ambiguity). The semantics were correct in code (`PdfExtractor` + its tests assert a thrown call still counts), only the doc-comment was misleading.

## Scope

- No contract change (field name/type unchanged), no behavior change — XML comments only.
- Other #306 re-review findings: #4 (deterministic derived-blob naming) folded into #358; #5/#7 assessed as not-worth-actioning.