### PR TITLE
refactor(documents): extract shared DerivedDocumentSpawner + content-address derived blobs (#358)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.DocumentAI.Abstractions.Documents;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Timing;
+using Volo.Abp.Uow;
+
+namespace Dignite.DocumentAI.Documents.Pipelines;
+
+/// <summary>
+/// Shared sink for spawning a derived <see cref="Document"/> from one constituent of a source document — the common
+/// short-UoW protocol behind figure routing (#306) and born-digital container segmentation (#346), extracted so the
+/// two jobs no longer duplicate it (#358). In one atomic UoW it: re-checks the candidate is still claimable, inserts
+/// the derived document, marks the candidate spawned, publishes <see cref="DocumentUploadedEto"/>, and queues the
+/// derived document's text-extraction pipeline.
+/// <para>
+/// The caller owns its constituent-specific work: materializing the derived-document blob (the <see cref="FileOrigin"/>
+/// it passes in already points at a written blob) and the candidate aggregate's reload + status mutation (supplied as
+/// <paramref name="reloadClaimable"/> / <paramref name="markSpawned"/>, both run inside this UoW under the source's
+/// tenant). This sink touches no blob storage, so blob lifecycle (write + any cleanup) stays entirely with the caller.
+/// </para>
+/// <para>
+/// <b>Idempotent + self-healing.</b> The derived insert is <c>autoSave: true</c>, so a concurrent double-spawn trips
+/// the unique <c>(OriginDocumentId, OriginConstituentKey)</c> index right here and the exception propagates to the
+/// caller's per-item isolation (the job is retried; on retry the candidate is terminal and skipped). When
+/// <paramref name="reloadClaimable"/> reports the candidate is no longer claimable (a concurrent run already routed it,
+/// or it was removed / reverted), the spawn is aborted cleanly — nothing is inserted and <c>null</c> is returned.
+/// </para>
+/// <para>
+/// <b>UoW discipline</b> (background-jobs.md): the caller's blob IO and any gate/LLM work run outside any UoW; only
+/// this short complete-phase UoW is opened here.
+/// </para>
+/// </summary>
+public class DerivedDocumentSpawner : ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly IDistributedEventBus _distributedEventBus;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly IClock _clock;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    public DerivedDocumentSpawner(
+        IDocumentRepository documentRepository,
+        DocumentPipelineJobScheduler pipelineJobScheduler,
+        IDistributedEventBus distributedEventBus,
+        ICurrentTenant currentTenant,
+        IClock clock,
+        IGuidGenerator guidGenerator,
+        IUnitOfWorkManager unitOfWorkManager)
+    {
+        _documentRepository = documentRepository;
+        _pipelineJobScheduler = pipelineJobScheduler;
+        _distributedEventBus = distributedEventBus;
+        _currentTenant = currentTenant;
+        _clock = clock;
+        _guidGenerator = guidGenerator;
+        _unitOfWorkManager = unitOfWorkManager;
+    }
+
+    /// <summary>
+    /// Complete phase (short UoW): insert the derived document for one constituent, mark its candidate spawned,
+    /// publish <see cref="DocumentUploadedEto"/>, and queue text extraction — atomically. Returns the spawned
+    /// document id, or <c>null</c> when <paramref name="reloadClaimable"/> reports the candidate is no longer
+    /// claimable (the caller decides what to do with the blob it already wrote, per its own naming scheme).
+    /// </summary>
+    /// <typeparam name="TCandidate">The candidate ledger aggregate (e.g. <c>DocumentFigure</c> / <c>DocumentSegment</c>).</typeparam>
+    /// <param name="sourceDocumentId">The source document the constituent belongs to (the derived doc's <c>OriginDocumentId</c>).</param>
+    /// <param name="tenantId">The source/derived tenant; the UoW and the delegates run under this tenant.</param>
+    /// <param name="constituentKey">The content-derived key (the derived doc's <c>OriginConstituentKey</c>, == <paramref name="fileOrigin"/>.ContentHash).</param>
+    /// <param name="fileOrigin">The derived document's file origin, already pointing at a blob the caller wrote.</param>
+    /// <param name="reloadClaimable">Reloads the candidate inside the UoW; returns it when still claimable, or <c>null</c> to abort.</param>
+    /// <param name="markSpawned">Marks the (reloaded) candidate spawned with the derived document id and persists it.</param>
+    public virtual async Task<Guid?> SpawnAsync<TCandidate>(
+        Guid sourceDocumentId,
+        Guid? tenantId,
+        string constituentKey,
+        FileOrigin fileOrigin,
+        Func<Task<TCandidate?>> reloadClaimable,
+        Func<TCandidate, Guid, Task> markSpawned,
+        CancellationToken cancellationToken = default)
+        where TCandidate : class
+    {
+        using (_currentTenant.Change(tenantId))
+        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+        {
+            var candidate = await reloadClaimable();
+            if (candidate is null)
+            {
+                await uow.CompleteAsync();
+                return null;
+            }
+
+            var derivedDocumentId = _guidGenerator.Create();
+            var derived = Document.CreateDerived(
+                derivedDocumentId, tenantId, fileOrigin, sourceDocumentId, constituentKey);
+
+            // autoSave so a concurrent double-spawn trips the unique (OriginDocumentId, OriginConstituentKey) index
+            // right here; the exception propagates to the caller's per-item isolation and the job is retried.
+            await _documentRepository.InsertAsync(derived, autoSave: true);
+
+            await markSpawned(candidate, derivedDocumentId);
+
+            await _distributedEventBus.PublishAsync(
+                new DocumentUploadedEto
+                {
+                    DocumentId = derived.Id,
+                    TenantId = derived.TenantId,
+                    EventTime = _clock.Now,
+                    FileName = fileOrigin.OriginalFileName,
+                    FileSize = fileOrigin.FileSize,
+                    ContentType = fileOrigin.ContentType
+                });
+
+            // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown from
+            // the constituent (figure transcription / segment slice) instead of re-extracting it.
+            await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);
+
+            await uow.CompleteAsync();
+            return derivedDocumentId;
+        }
+    }
+}

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Routing/DocumentFigureRoutingJob.cs
@@ -13,11 +13,9 @@ using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
-using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Threading;
-using Volo.Abp.Timing;
 using Volo.Abp.Uow;
 
 namespace Dignite.DocumentAI.Documents.Pipelines.Routing;
@@ -55,11 +53,9 @@ public class DocumentFigureRoutingJob
     private readonly IRepository<DocumentFigure, Guid> _figureRepository;
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly FigureDocumentGateWorkflow _figureGateWorkflow;
-    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly DerivedDocumentSpawner _derivedDocumentSpawner;
     private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
-    private readonly IDistributedEventBus _distributedEventBus;
     private readonly ICurrentTenant _currentTenant;
-    private readonly IClock _clock;
     private readonly IGuidGenerator _guidGenerator;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
     private readonly DocumentAIBehaviorOptions _behaviorOptions;
@@ -70,11 +66,9 @@ public class DocumentFigureRoutingJob
         IRepository<DocumentFigure, Guid> figureRepository,
         IDocumentTypeRepository documentTypeRepository,
         FigureDocumentGateWorkflow figureGateWorkflow,
-        DocumentPipelineJobScheduler pipelineJobScheduler,
+        DerivedDocumentSpawner derivedDocumentSpawner,
         IBlobContainer<DocumentAIDocumentContainer> blobContainer,
-        IDistributedEventBus distributedEventBus,
         ICurrentTenant currentTenant,
-        IClock clock,
         IGuidGenerator guidGenerator,
         IUnitOfWorkManager unitOfWorkManager,
         IOptions<DocumentAIBehaviorOptions> behaviorOptions,
@@ -84,11 +78,9 @@ public class DocumentFigureRoutingJob
         _figureRepository = figureRepository;
         _documentTypeRepository = documentTypeRepository;
         _figureGateWorkflow = figureGateWorkflow;
-        _pipelineJobScheduler = pipelineJobScheduler;
+        _derivedDocumentSpawner = derivedDocumentSpawner;
         _blobContainer = blobContainer;
-        _distributedEventBus = distributedEventBus;
         _currentTenant = currentTenant;
-        _clock = clock;
         _guidGenerator = guidGenerator;
         _unitOfWorkManager = unitOfWorkManager;
         _behaviorOptions = behaviorOptions.Value;
@@ -284,7 +276,7 @@ public class DocumentFigureRoutingJob
     private async Task SpawnDerivedDocumentAsync(
         RoutingWorkItem workItem, FigureSnapshot figure, CancellationToken cancellationToken)
     {
-        // External: copy the candidate crop into an independent, derived-document-owned blob so the derived
+        // External (no UoW): copy the candidate crop into an independent, derived-document-owned blob so the derived
         // document outlives the source (the source's permanent delete reclaims the candidate crop, not this copy).
         // The crop content hash is already known (figure.ContentHash), so there is no need to materialize a byte[]
         // for re-hashing — buffer the crop once and rewind the same stream to save it (avoids a second full-size
@@ -301,85 +293,51 @@ public class DocumentFigureRoutingJob
             await _blobContainer.SaveAsync(derivedBlobName, buffer, overrideExisting: true, cancellationToken);
         }
 
-        var derivedDocumentId = _guidGenerator.Create();
+        var shortHash = figure.ContentHash.Length > 8 ? figure.ContentHash[..8] : figure.ContentHash;
+        var fileOrigin = new FileOrigin(
+            blobName: derivedBlobName,
+            uploadedByUserName: workItem.SourceUploadedByUserName,
+            contentType: figure.ContentType,
+            contentHash: figure.ContentHash,
+            fileSize: fileSize,
+            originalFileName: $"figure-{shortHash}{extension}");
 
         try
         {
-            await CommitSpawnAsync(workItem, figure, derivedBlobName, derivedDocumentId, extension, fileSize);
+            // Shared complete-phase UoW (#358): insert the derived document, mark this figure Spawned, publish
+            // DocumentUploadedEto, and queue text extraction — atomically. The figure stays Pending and the gate
+            // is not re-paid if this fails (LoadAsync re-loads only still-Pending figures on retry).
+            var spawnedId = await _derivedDocumentSpawner.SpawnAsync<DocumentFigure>(
+                workItem.SourceDocumentId,
+                workItem.TenantId,
+                figure.ContentHash,
+                fileOrigin,
+                reloadClaimable: async () =>
+                {
+                    var entity = await _figureRepository.FindAsync(figure.FigureId);
+                    return entity is { Status: DocumentFigureStatus.Pending } ? entity : null;
+                },
+                markSpawned: async (entity, derivedId) =>
+                {
+                    entity.MarkSpawned(derivedId);
+                    await _figureRepository.UpdateAsync(entity);
+                },
+                cancellationToken);
+
+            if (spawnedId is null)
+            {
+                // A concurrent route already spawned this figure (or it was removed); our copied blob references no
+                // committed document — reclaim the orphan copy.
+                await TryDeleteBlobAsync(derivedBlobName);
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // The spawn UoW failed and rolled back (a concurrent unique-index collision, or any other fault), so
-            // the copied blob now references no committed document — reclaim it, then rethrow so the per-figure
-            // handler records the fault and the job is retried (which writes a fresh copy next time). Mirrors the
-            // text-extraction job's failed-completion crop cleanup. The one CommitSpawnAsync path that returns
-            // without throwing (the candidate is already non-Pending) deletes its own orphan blob, so it is not
-            // double-deleted here.
+            // The spawn UoW rolled back (a concurrent unique-index collision, or any other fault), so the copied blob
+            // references no committed document — reclaim it, then rethrow so the per-figure handler records the fault
+            // and the job is retried (which writes a fresh copy next time).
             await TryDeleteBlobAsync(derivedBlobName);
             throw;
-        }
-    }
-
-    /// <summary>
-    /// Complete phase (short UoW): inserts the derived document, marks the figure Spawned, publishes
-    /// <c>DocumentUploadedEto</c>, and queues the derived document's pipeline — all atomically. Returns early
-    /// (deleting the orphan copied blob) when the candidate is no longer Pending or a concurrent route already
-    /// spawned it; any other failure rolls back and propagates to the caller's orphan-blob cleanup.
-    /// </summary>
-    private async Task CommitSpawnAsync(
-        RoutingWorkItem workItem, FigureSnapshot figure, string derivedBlobName, Guid derivedDocumentId,
-        string extension, long fileSize)
-    {
-        using (_currentTenant.Change(workItem.TenantId))
-        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
-        {
-            var entity = await _figureRepository.FindAsync(figure.FigureId);
-            if (entity is null || entity.Status != DocumentFigureStatus.Pending)
-            {
-                // Another run already routed it (or it was removed). Drop our orphan copied blob and stop.
-                await TryDeleteBlobAsync(derivedBlobName);
-                return;
-            }
-
-            var shortHash = figure.ContentHash.Length > 8 ? figure.ContentHash[..8] : figure.ContentHash;
-            var fileOrigin = new FileOrigin(
-                blobName: derivedBlobName,
-                uploadedByUserName: workItem.SourceUploadedByUserName,
-                contentType: figure.ContentType,
-                contentHash: figure.ContentHash,
-                fileSize: fileSize,
-                originalFileName: $"figure-{shortHash}{extension}");
-
-            var derived = Document.CreateDerived(
-                derivedDocumentId, workItem.TenantId, fileOrigin, workItem.SourceDocumentId, figure.ContentHash);
-
-            // A concurrent route that already committed this figure's derived document trips the unique
-            // (OriginDocumentId, OriginConstituentKey) index here. The failure propagates to SpawnDerivedDocumentAsync,
-            // which reclaims this run's orphan blob and rethrows so the job retries; on retry LoadAsync sees the
-            // figure as Spawned (the winner committed it) and skips it — self-healing, no duplicate. Not narrowing
-            // to a specific exception type is deliberate: any non-unique DB failure also surfaces (job retry)
-            // instead of being silently swallowed as a "concurrency skip".
-            await _documentRepository.InsertAsync(derived, autoSave: true);
-
-            entity.MarkSpawned(derivedDocumentId);
-            await _figureRepository.UpdateAsync(entity);
-
-            await _distributedEventBus.PublishAsync(
-                new DocumentUploadedEto
-                {
-                    DocumentId = derived.Id,
-                    TenantId = derived.TenantId,
-                    EventTime = _clock.Now,
-                    FileName = fileOrigin.OriginalFileName,
-                    FileSize = fileOrigin.FileSize,
-                    ContentType = fileOrigin.ContentType
-                });
-
-            // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown
-            // from this figure's transcription instead of re-OCR'ing the crop (see DocumentTextExtractionBackgroundJob).
-            await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);
-
-            await uow.CompleteAsync();
         }
     }
 

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -15,11 +15,9 @@ using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
-using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Guids;
 using Volo.Abp.MultiTenancy;
 using Volo.Abp.Threading;
-using Volo.Abp.Timing;
 using Volo.Abp.Uow;
 
 namespace Dignite.DocumentAI.Documents.Pipelines.Segmentation;
@@ -57,11 +55,9 @@ public class DocumentSegmentationJob
     private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
     private readonly IRepository<DocumentFigure, Guid> _documentFigureRepository;
     private readonly DocumentSegmentationWorkflow _segmentationWorkflow;
-    private readonly DocumentPipelineJobScheduler _pipelineJobScheduler;
+    private readonly DerivedDocumentSpawner _derivedDocumentSpawner;
     private readonly IBlobContainer<DocumentAIDocumentContainer> _blobContainer;
-    private readonly IDistributedEventBus _distributedEventBus;
     private readonly ICurrentTenant _currentTenant;
-    private readonly IClock _clock;
     private readonly IGuidGenerator _guidGenerator;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
     private readonly DocumentAIBehaviorOptions _behaviorOptions;
@@ -72,11 +68,9 @@ public class DocumentSegmentationJob
         IRepository<DocumentSegment, Guid> segmentRepository,
         IRepository<DocumentFigure, Guid> documentFigureRepository,
         DocumentSegmentationWorkflow segmentationWorkflow,
-        DocumentPipelineJobScheduler pipelineJobScheduler,
+        DerivedDocumentSpawner derivedDocumentSpawner,
         IBlobContainer<DocumentAIDocumentContainer> blobContainer,
-        IDistributedEventBus distributedEventBus,
         ICurrentTenant currentTenant,
-        IClock clock,
         IGuidGenerator guidGenerator,
         IUnitOfWorkManager unitOfWorkManager,
         IOptions<DocumentAIBehaviorOptions> behaviorOptions,
@@ -86,11 +80,9 @@ public class DocumentSegmentationJob
         _segmentRepository = segmentRepository;
         _documentFigureRepository = documentFigureRepository;
         _segmentationWorkflow = segmentationWorkflow;
-        _pipelineJobScheduler = pipelineJobScheduler;
+        _derivedDocumentSpawner = derivedDocumentSpawner;
         _blobContainer = blobContainer;
-        _distributedEventBus = distributedEventBus;
         _currentTenant = currentTenant;
-        _clock = clock;
         _guidGenerator = guidGenerator;
         _unitOfWorkManager = unitOfWorkManager;
         _behaviorOptions = behaviorOptions.Value;
@@ -193,8 +185,8 @@ public class DocumentSegmentationJob
     /// correction or a high-confidence re-recognition clears <see cref="Document.IsContainer"/>). A stale job must
     /// never split, spawn, or re-flag a document that is no longer a container — doing so would inject spurious
     /// sub-documents downstream, or push the operator's reclassification back into the review queue. This is the
-    /// single guard every phase consults (LoadAsync / CommitSpawnAsync / FinalizeSegmentationFlagAsync /
-    /// MarkSegmentationIncompleteAsync); it runs in the caller's ambient UoW and opens none.
+    /// single guard every phase consults (LoadAsync / SpawnDerivedDocumentAsync's reload guard /
+    /// FinalizeSegmentationFlagAsync / MarkSegmentationIncompleteAsync); it runs in the caller's ambient UoW and opens none.
     /// </summary>
     private async Task<Document?> FindActiveContainerAsync(Guid containerId)
     {
@@ -406,8 +398,8 @@ public class DocumentSegmentationJob
     private async Task SpawnDerivedDocumentAsync(
         PendingSegment segment, SegmentationContext context, CancellationToken cancellationToken)
     {
-        // External: write the slice to an independent, derived-document-owned blob so the derived document outlives
-        // the container (the container's permanent delete reclaims the container/segment rows, not this blob).
+        // External (no UoW): write the slice to an independent, derived-document-owned blob so the derived document
+        // outlives the container (the container's permanent delete reclaims the container/segment rows, not this blob).
         var sliceBytes = Encoding.UTF8.GetBytes(segment.SliceText);
         var derivedBlobName = _guidGenerator.Create().ToString("N") + ".md";
         using (var saveStream = new MemoryStream(sliceBytes, writable: false))
@@ -415,88 +407,59 @@ public class DocumentSegmentationJob
             await _blobContainer.SaveAsync(derivedBlobName, saveStream, overrideExisting: true, cancellationToken);
         }
 
-        var derivedDocumentId = _guidGenerator.Create();
+        var shortKey = segment.SegmentKey.Length > 8 ? segment.SegmentKey[..8] : segment.SegmentKey;
+        var fileOrigin = new FileOrigin(
+            blobName: derivedBlobName,
+            uploadedByUserName: context.UploadedByUserName,
+            contentType: "text/markdown",
+            contentHash: segment.SegmentKey,
+            fileSize: sliceBytes.LongLength,
+            originalFileName: $"segment-{shortKey}.md");
 
         try
         {
-            await CommitSpawnAsync(segment, context, derivedBlobName, derivedDocumentId, sliceBytes.LongLength);
+            // Shared complete-phase UoW (#358): insert the derived document, mark this segment Spawned, publish
+            // DocumentUploadedEto, and queue text extraction — atomically. The reload guard additionally re-checks
+            // the container is still a container (it may have been reclassified mid-job): this is segmentation's
+            // own pre-commit guard, folded into the claimable check the shared spawner runs inside its UoW.
+            var spawnedId = await _derivedDocumentSpawner.SpawnAsync<DocumentSegment>(
+                context.ContainerId,
+                context.TenantId,
+                segment.SegmentKey,
+                fileOrigin,
+                reloadClaimable: async () =>
+                {
+                    var entity = await _segmentRepository.FindAsync(segment.SegmentId);
+                    if (entity is not { Status: DocumentSegmentStatus.Pending })
+                    {
+                        return null;
+                    }
+
+                    // #346: the container may have been reclassified to a concrete type between LoadAsync and now
+                    // (the per-segment spawns span time); if the marker is gone, do not spawn.
+                    return await FindActiveContainerAsync(context.ContainerId) is null ? null : entity;
+                },
+                markSpawned: async (entity, derivedId) =>
+                {
+                    entity.MarkSpawned(derivedId);
+                    await _segmentRepository.UpdateAsync(entity);
+                },
+                cancellationToken);
+
+            if (spawnedId is null)
+            {
+                // The segment was already spawned by a concurrent run, removed, or its container was reclassified;
+                // our written blob references no committed document — reclaim the orphan.
+                await TryDeleteBlobAsync(derivedBlobName);
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // The spawn UoW rolled back (a concurrent unique-index collision, or any other fault), so the written
             // blob references no committed document — reclaim it, then rethrow so the per-segment handler records
-            // the fault and the job is retried (which writes a fresh blob next time). The one CommitSpawnAsync path
-            // that returns without throwing (the segment is already non-Pending) deletes its own orphan blob.
+            // the fault and the job is retried (which writes a fresh blob next time).
             await TryDeleteBlobAsync(derivedBlobName);
             throw;
-        }
-    }
-
-    /// <summary>
-    /// Complete phase (short UoW): inserts the derived document, marks the segment Spawned, publishes
-    /// <c>DocumentUploadedEto</c>, and queues the derived document's pipeline — all atomically. Returns early
-    /// (deleting the orphan blob) when the segment is no longer Pending or a concurrent run already spawned it.
-    /// </summary>
-    private async Task CommitSpawnAsync(
-        PendingSegment segment, SegmentationContext context, string derivedBlobName, Guid derivedDocumentId, long fileSize)
-    {
-        using (_currentTenant.Change(context.TenantId))
-        using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
-        {
-            var entity = await _segmentRepository.FindAsync(segment.SegmentId);
-            if (entity is null || entity.Status != DocumentSegmentStatus.Pending)
-            {
-                // Another run already spawned it (or it was removed). Drop our orphan blob and stop.
-                await TryDeleteBlobAsync(derivedBlobName);
-                return;
-            }
-
-            // #346: re-check the container is still a container in THIS UoW — it may have been reclassified between
-            // LoadAsync and now (the per-segment spawns span time). If the marker is gone, do not spawn; the
-            // document is being handled as a concrete type.
-            if (await FindActiveContainerAsync(context.ContainerId) is null)
-            {
-                await TryDeleteBlobAsync(derivedBlobName);
-                return;
-            }
-
-            var shortKey = segment.SegmentKey.Length > 8 ? segment.SegmentKey[..8] : segment.SegmentKey;
-            var fileOrigin = new FileOrigin(
-                blobName: derivedBlobName,
-                uploadedByUserName: context.UploadedByUserName,
-                contentType: "text/markdown",
-                contentHash: segment.SegmentKey,
-                fileSize: fileSize,
-                originalFileName: $"segment-{shortKey}.md");
-
-            var derived = Document.CreateDerived(
-                derivedDocumentId, context.TenantId, fileOrigin, context.ContainerId, segment.SegmentKey);
-
-            // A concurrent run that already committed this segment's derived document trips the unique
-            // (OriginDocumentId, OriginConstituentKey) index here. The failure propagates to
-            // SpawnDerivedDocumentAsync, which reclaims this run's orphan blob and rethrows so the job retries; on
-            // retry the segment is Spawned and skipped — self-healing, no duplicate.
-            await _documentRepository.InsertAsync(derived, autoSave: true);
-
-            entity.MarkSpawned(derivedDocumentId);
-            await _segmentRepository.UpdateAsync(entity);
-
-            await _distributedEventBus.PublishAsync(
-                new DocumentUploadedEto
-                {
-                    DocumentId = derived.Id,
-                    TenantId = derived.TenantId,
-                    EventTime = _clock.Now,
-                    FileName = fileOrigin.OriginalFileName,
-                    FileSize = fileOrigin.FileSize,
-                    ContentType = fileOrigin.ContentType
-                });
-
-            // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown from
-            // this segment's SliceText instead of re-extracting the blob (see DocumentTextExtractionBackgroundJob).
-            await _pipelineJobScheduler.QueueAsync(derived, DocumentAIPipelines.TextExtraction);
-
-            await uow.CompleteAsync();
         }
     }
 
@@ -514,7 +477,7 @@ public class DocumentSegmentationJob
             // concrete type during the slow LLM split (the window between LoadAsync and here); flagging the now-typed
             // document would push the operator's reclassification back into the review queue with no path to clear it
             // — this Phase A path persists no segment rows, so FinalizeSegmentationFlagAsync's count-driven clear
-            // never runs. Mirrors the guard CommitSpawnAsync / FinalizeSegmentationFlagAsync already apply.
+            // never runs. Mirrors the guard SpawnDerivedDocumentAsync / FinalizeSegmentationFlagAsync already apply.
             var container = await FindActiveContainerAsync(context.ContainerId);
             if (container is null)
             {
@@ -550,7 +513,7 @@ public class DocumentSegmentationJob
             var remainingPending = segments.Count(s => s.Status == DocumentSegmentStatus.Pending);
 
             // #346: if the document was reclassified to a concrete type mid-job (IsContainer cleared), do NOT touch
-            // its review flag — its leftover Pending segments are inert (CommitSpawnAsync skips them) and re-flagging
+            // its review flag — its leftover Pending segments are inert (the spawn's reload guard skips them) and re-flagging
             // a now-typed document would wrongly push the operator's reclassification back into the review queue.
             var container = await FindActiveContainerAsync(context.ContainerId);
             if (container is null)

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
@@ -170,7 +170,7 @@ public class ContainerReclassifyRetraction_Tests
     /// <summary>
     /// Seeds a container document (Markdown set, IsContainer marked) plus <paramref name="subDocumentCount"/> derived
     /// sub-documents (OriginDocumentId == container) and one Spawned segment row each — mirroring the post-segmentation
-    /// state produced by <c>DocumentSegmentationJob.CommitSpawnAsync</c>.
+    /// state produced by <c>DocumentSegmentationJob</c>'s derived-document spawn (<c>DerivedDocumentSpawner</c>).
     /// </summary>
     private async Task<Guid> ArrangeSegmentedContainerAsync(int subDocumentCount)
     {

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -323,7 +323,7 @@ public class DocumentSegmentationJob_Tests : DocumentAITestBase<DocumentSegmenta
         // verification, so the Phase A flag path (MarkSegmentationIncompleteAsync) runs — it must re-check IsContainer
         // and NOT re-flag the now-typed document, or it would push the operator's reclassification back into the
         // review queue with no way to clear it (no segment rows are persisted on this path, so the count-driven clear
-        // in FinalizeSegmentationFlagAsync never runs). Mirrors the guard CommitSpawnAsync / FinalizeSegmentationFlagAsync apply.
+        // in FinalizeSegmentationFlagAsync never runs). Mirrors the guard SpawnDerivedDocumentAsync / FinalizeSegmentationFlagAsync apply.
         var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
 
         // Untrusted markers -> the split is rejected -> MarkSegmentationIncompleteAsync runs.


### PR DESCRIPTION
Closes #358.

Figure routing (#306) and segmentation (#346) duplicated the ~120-line derived-document spawn protocol — the complete-phase short UoW (re-check candidate claimable → `CreateDerived` → `InsertAsync(autoSave)` → mark candidate Spawned → publish `DocumentUploadedEto` → queue `TextExtraction` → commit) plus per-item orphan-blob reclaim and unique-index self-heal.

This extracts that UoW body into a shared, generic `DerivedDocumentSpawner`. Each job keeps only its constituent-specific work: materializing the derived blob and the candidate reload + `MarkSpawned` (delegates that run inside the spawner's UoW under the source tenant). Segmentation's "container still a container?" pre-commit guard folds into its `reloadClaimable` delegate.

**Behavior-preserving** — derived-blob naming and orphan-blob cleanup unchanged (the caller still writes the blob and reclaims it on abort/failure). Stale `CommitSpawnAsync` doc references updated (that method's body moved into the spawner). 27 tests green (figure routing + segmentation + container-reclassify retraction); Application + Application.Tests + EF.Tests build 0/0. No contract / egress / event change.

### Note — deterministic blob naming was tried and dropped
An earlier revision also content-addressed the derived blob (`derived-figures/{src}/{hash}`) to drop the orphan-blob cleanup. A code review caught that this **regresses** orphan reclamation: deterministic naming is only safe-to-skip-cleanup in the *collision* case (a concurrent winner committed the same blob). But there are reachable cases where **no `Document` ever owns the blob** — concurrent gate-reject, source permanently deleted mid-spawn, container reclassified mid-spawn, ABP retry exhaustion — and with **no blob-GC anywhere in the repo**, those would leak permanently. So that revision was dropped; the random-name + always-delete cleanup is load-bearing and kept as-is.
