### PR TITLE
fix(documents): clear IsSegmented on automatic container->concrete reclassify (#371/#377)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
@@ -65,13 +65,12 @@ public class ContainerMarkerClearedEventHandler
     {
         var containerId = eventData.DocumentId;
 
-        // #364: retract ONLY the sub-documents THIS container's segmentation (#346) spawned, identified by the
-        // container's DocumentSegment ledger (RoutedDocumentId is set on a Spawned segment). A blanket
-        // OriginDocumentId sweep would also delete #306 figure-routed children — which are orthogonal to
-        // container-ness (a normal concrete-typed document keeps its routed figure sub-documents) — and would orphan
-        // their DocumentFigure rows. So drive the retraction from the segment rows; figure children + their figure
-        // ledger rows are left untouched. A container that was never segmented (or whose segmentation never spawned)
-        // yields no routed ids — a no-op, which is correct.
+        // #364 / #371: retract ONLY the sub-documents THIS container's segmentation (#346) spawned, identified by the
+        // container's DocumentSegment ledger (RoutedDocumentId is set on a Spawned segment). A blanket OriginDocumentId
+        // sweep would also delete genuinely-embedded FIGURE-kind sub-documents — orthogonal to container-ness (a normal
+        // concrete-typed document keeps its embedded sub-documents) — so drive the retraction from the segment rows and
+        // filter by Kind (below). A container that was never segmented (or whose segmentation never spawned) yields no
+        // routed ids — a no-op, which is correct.
         var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
         // #371: retract only TEXT-kind sub-documents (bundle constituents that existed only because the parent was a
         // container). FIGURE-kind sub-documents are genuinely embedded documents (an invoice photo inside what is now

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -358,6 +358,13 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         RejectionReason = null; // #284 review-fix: leaving Rejected disposition -> clear stale rejection reason; only Rejected should have one.
         if (wasContainer)
         {
+            // #377 (#371 post-merge review): symmetric with the operator path (ConfirmClassification). A
+            // container->concrete reclassify retracts the container's segment rows (#349 below), so its
+            // segmentation completion no longer holds — clear IsSegmented so the now-concrete document's own
+            // embedded-document routing can run when re-segmented, instead of being skipped by the stale resume
+            // marker. Previously only the operator path cleared this, so the automatic high-confidence path
+            // (reachable via RerecognizeAsync) silently gated off the now-concrete document's embedded-figure routing.
+            IsSegmented = false;
             AddLocalEvent(new ContainerMarkerClearedEvent(Id));
         }
     }

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -84,7 +84,7 @@ public class EfCoreDocumentRepository
         // Never use IgnoreQueryFilters(), because it would also disable IMultiTenant and allow future callers without app-layer tenant validation
         // to hard-delete across tenants (#220).
         // ExecuteDeleteAsync relies on DB-level ON DELETE CASCADE. All three child FKs — DocumentExtractedField,
-        // DocumentPipelineRun, and DocumentFigure (#306) — use OnDelete(Cascade), and the narrowed filter does not affect cascading.
+        // DocumentPipelineRun, and DocumentSegment (#346/#371) — use OnDelete(Cascade), and the narrowed filter does not affect cascading.
         using (DataFilter.Disable<ISoftDelete>())
         {
             var dbContext = await GetDbContextAsync();

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.DocumentAI.Abstractions.Documents;
+using Dignite.DocumentAI.Abstractions.TextExtraction;
 using Dignite.DocumentAI.Ai;
 using Dignite.DocumentAI.Documents;
 using Dignite.DocumentAI.Documents.Pipelines;
@@ -83,6 +87,7 @@ public class DocumentClassificationBackgroundJob_Tests
     private readonly DocumentClassificationWorkflow _workflow;
     private readonly IDistributedEventBus _eventBus;
     private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly IBlobContainer<DocumentAIDocumentContainer> _markedBlobContainer;
 
     public DocumentClassificationBackgroundJob_Tests()
     {
@@ -92,6 +97,7 @@ public class DocumentClassificationBackgroundJob_Tests
         _workflow = GetRequiredService<DocumentClassificationWorkflow>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
+        _markedBlobContainer = GetRequiredService<IBlobContainer<DocumentAIDocumentContainer>>();
     }
 
     [Fact]
@@ -206,6 +212,137 @@ public class DocumentClassificationBackgroundJob_Tests
         // It classified to a real type, so the normal field-extraction cascade event still fires.
         await _eventBus.Received(1).PublishAsync(
             Arg.Is<DocumentClassifiedEto>(e => e.DocumentId == doc.Id), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task EmbeddedDocument_NonContainer_Routes_And_Still_Publishes_ClassifiedEto()
+    {
+        // #371 D6(a): a non-container parent the classifier flags as embedding a standalone document still extracts its
+        // own fields (DocumentClassifiedEto fires) AND enqueues the unified sub-document pass to route the embedded
+        // document. The two are not mutually exclusive — the parent is a real typed document that happens to embed one.
+        var doc = CreateDocument("A service agreement that has a scanned invoice photo embedded in it.");
+        SetupDocumentRepository(doc);
+
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.92,
+                ContainsEmbeddedDocument = true,
+                Reason = "A contract that embeds a standalone invoice"
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        // The parent is still classified and its own field-extraction cascade fires.
+        doc.DocumentTypeId.ShouldBe(DocumentClassificationJobTestModule.ContractTypeId);
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentClassifiedEto>(e => e.DocumentId == doc.Id), Arg.Any<bool>());
+
+        // AND the unified sub-document pass is enqueued to route the embedded document.
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentSegmentationJobArgs>(a => a.SourceDocumentId == doc.Id),
+            Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task NoEmbeddedDocument_SmallDocument_Does_Not_Route()
+    {
+        // #371 D6(b): the common case — a small, figure-free document the classifier does NOT flag as embedding a
+        // standalone document must NOT pay for the heavy segmentation pass. Guards a regression that drops the
+        // ContainsEmbeddedDocument disjunct or inverts the markedLength comparison.
+        var doc = CreateDocument("A short single service agreement with no embedded documents.");
+        SetupDocumentRepository(doc);
+
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.92,
+                ContainsEmbeddedDocument = false
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        doc.DocumentTypeId.ShouldBe(DocumentClassificationJobTestModule.ContractTypeId);
+        await _backgroundJobManager.DidNotReceive().EnqueueAsync(
+            Arg.Any<DocumentSegmentationJobArgs>(), Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task FigureBearing_OverWindow_Document_Routes_Even_Without_Embedded_Signal()
+    {
+        // #371 D6(b) fallback arm: a figure-bearing document whose MARKED Markdown exceeds the classification
+        // truncation window (MaxTextLengthPerExtraction = 8000) may carry an embedded figure the classifier never saw
+        // (the tail was truncated out of the prompt). It must route even when ContainsEmbeddedDocument is false, so a
+        // beyond-window embedded document is not silently missed.
+        var doc = CreateDocument("Leading body text used as the clean fallback Markdown.");
+        SetupDocumentRepository(doc);
+
+        // Marked-Markdown blob: a real salted [Image OCR] span (so ImageOcrMarkup.Contains == true) padded beyond the
+        // window. GetAllBytesOrNullAsync is an extension over the interface GetOrNullAsync(Stream), so stub the latter.
+        var markedMarkdown = ImageOcrMarkup.Wrap(new string('x', 9000), pageNumber: 2);
+        var markedBytes = Encoding.UTF8.GetBytes(markedMarkdown);
+        var markedBlobName = DocumentConsts.MarkedMarkdownBlobPrefix + doc.Id;
+        _markedBlobContainer
+            .GetOrNullAsync(markedBlobName, Arg.Any<CancellationToken>())
+            .Returns(_ => new MemoryStream(markedBytes));
+
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.92,
+                ContainsEmbeddedDocument = false
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentSegmentationJobArgs>(a => a.SourceDocumentId == doc.Id),
+            Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task Automatic_Reclassify_Of_Segmented_Container_To_Concrete_Type_Clears_IsSegmented()
+    {
+        // #371/#377 post-merge fix: the AUTOMATIC high-confidence path (ApplyAutomaticClassificationResult, reachable
+        // via RerecognizeAsync) must clear IsSegmented on a container->concrete transition, exactly like the operator
+        // path (ConfirmClassification). Otherwise the stale resume marker silently gates off the now-concrete
+        // document's own embedded-document routing (DocumentSegmentationJob's !AlreadySegmented gate skips the split),
+        // so the embedded figure is never routed. This test fails on the pre-fix code (IsSegmented stays true).
+        var doc = CreateDocument("A document once detected as a container, now re-recognized as a single contract.");
+        typeof(Document)
+            .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, null);
+        doc.MarkSegmented(); // simulate the prior container segmentation having completed
+        doc.IsContainer.ShouldBeTrue();
+        doc.IsSegmented.ShouldBeTrue();
+        SetupDocumentRepository(doc);
+
+        // Automatic high-confidence classification to a concrete type that also embeds a standalone document.
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.92,
+                ContainsEmbeddedDocument = true
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        doc.IsContainer.ShouldBeFalse();
+        doc.DocumentTypeId.ShouldBe(DocumentClassificationJobTestModule.ContractTypeId);
+        // The fix: the stale resume marker is cleared, so the re-enqueued segmentation pass will actually run instead
+        // of being skipped by !AlreadySegmented — the now-concrete document's embedded figure can be routed.
+        doc.IsSegmented.ShouldBeFalse();
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentSegmentationJobArgs>(a => a.SourceDocumentId == doc.Id),
+            Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
     }
 
     [Fact]

--- a/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.DocumentAI.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -123,6 +123,48 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
     }
 
     [Fact]
+    public async Task Text_Extraction_Job_Archives_Marked_Markdown_And_Persists_Clean_Markdown()
+    {
+        // #371 Markdown-first egress invariant: when extraction produces [Image OCR]-marked Markdown, the job archives
+        // the marked copy to the pipeline-internal markdown-marked/{id} blob (the classifier + segmentation pass read
+        // it) AND strips the sentinels before the write-once SetMarkdown, so the persisted Document.Markdown (the
+        // egress text payload) is sentinel-free. Without this, routing scaffolding would leak into the channel text
+        // consumed by RAG / classification / egress, or the classifier would lose its embedded-document signal.
+        var documentId = _guidGenerator.Create();
+        var textExtractionRunId = await ArrangeQueuedTextExtractionAsync(documentId);
+
+        var figureBody = "INVOICE No 42 Total 100";
+        var marked = "# Contract\n\nBody before the figure.\n\n"
+            + ImageOcrMarkup.Wrap(figureBody, pageNumber: 3)
+            + "\n\nBody after the figure.";
+        StubExtraction(marked, usedOcr: false);
+
+        await _textExtractionJob.ExecuteAsync(new DocumentTextExtractionJobArgs
+        {
+            DocumentId = documentId,
+            PipelineRunId = textExtractionRunId
+        });
+
+        // (a) The marked copy is archived to the pipeline-internal blob (overrideExisting for re-extraction).
+        await _blobContainer.Received(1).SaveAsync(
+            DocumentConsts.MarkedMarkdownBlobPrefix + documentId,
+            Arg.Any<Stream>(),
+            true,
+            Arg.Any<CancellationToken>());
+
+        // (b) The persisted egress payload is sentinel-free, yet the figure transcription body is retained inline.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var doc = await _documentRepository.GetAsync(documentId, includeDetails: false);
+            doc.Markdown.ShouldNotBeNull();
+            var markdown = doc.Markdown!;
+            ImageOcrMarkup.Contains(markdown).ShouldBeFalse();
+            markdown.ShouldContain(figureBody);
+            markdown.ShouldNotContain("9f1d3a7c"); // the sentinel salt must never reach the egress Markdown
+        });
+    }
+
+    [Fact]
     public async Task Text_Extraction_Job_Should_Queue_Classification_For_Ocr_Path()
     {
         // #196 contract lock: OCR does not perform pre-quality gating. Even poor recognition quality on the OCR


### PR DESCRIPTION
ApplyAutomaticClassificationResult (the automatic high-confidence path, reachable via RerecognizeAsync) cleared IsContainer but, unlike the operator path ConfirmClassification (#377), did not clear IsSegmented on a container->concrete transition. The stale resume marker then made DocumentSegmentationJob's !AlreadySegmented gate skip the split, so a re-recognized container's embedded figure was silently never routed. Mirror the #377 clear into the automatic path.

Tests (post-merge review of #371 / PR #375): add the previously-absent coverage for the D6 routing trigger (DocumentClassificationBackgroundJob.shouldRoute: embedded-document arm routes and still publishes DocumentClassifiedEto; sub-window no-embedded does not route; over-window figure fallback routes), an automatic-path regression test proving IsSegmented is cleared, and a job-level strip-seam test proving the marked Markdown is archived while the persisted Document.Markdown stays sentinel-free (Markdown-first).

Also fix two stale doc-comments that still named the retired DocumentFigure (now DocumentSegment). One-line production change (the IsSegmented clear); no EF migration; no egress-contract change. 557 core tests green (Domain 179 / Application 277 / EFCore 101).
