### PR TITLE
fix(documents): close within-window embedded-figure recall hole (#379)

### DIFF
--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
@@ -71,7 +71,7 @@ public class DocumentClassificationBackgroundJob
             // sees the [Image OCR] figure spans; fall back to the clean Document.Markdown when there is no artifact.
             var marked = await TryReadMarkedMarkdownAsync(workItem.DocumentId) ?? workItem.Markdown;
             var outcome = await ClassifyAsync(workItem, marked);
-            await CompleteRunAsync(workItem, outcome, ImageOcrMarkup.Contains(marked), marked.Length);
+            await CompleteRunAsync(workItem, outcome, ImageOcrMarkup.Contains(marked));
         }
         catch (Exception ex)
         {
@@ -138,8 +138,7 @@ public class DocumentClassificationBackgroundJob
     private async Task CompleteRunAsync(
         ClassificationWorkItem workItem,
         DocumentClassificationOutcome outcome,
-        bool hasFigures,
-        int markedLength)
+        bool hasFigures)
     {
         using var uow = UnitOfWorkManager.Begin(requiresNew: true);
 
@@ -148,7 +147,7 @@ public class DocumentClassificationBackgroundJob
         var (document, run) = await LoadDocumentAndRunAsync(
             workItem.DocumentId, workItem.RunId, DocumentAIPipelines.Classification, includeFieldValues: true);
 
-        await ApplyClassificationResultAsync(document, run, outcome, hasFigures, markedLength);
+        await ApplyClassificationResultAsync(document, run, outcome, hasFigures);
         await DocumentRepository.UpdateAsync(document, autoSave: true);
 
         await uow.CompleteAsync();
@@ -183,8 +182,7 @@ public class DocumentClassificationBackgroundJob
         Document document,
         DocumentPipelineRun run,
         DocumentClassificationOutcome outcome,
-        bool hasFigures,
-        int markedLength)
+        bool hasFigures)
     {
         var isDerived = document.OriginDocumentId.HasValue;
 
@@ -248,16 +246,23 @@ public class DocumentClassificationBackgroundJob
                 document, run, outcome.Reason, outcome.Candidates);
         }
 
-        // #371: a non-container parent may still embed a standalone document to route to its own sub-document. Enqueue
-        // the unified pass when the classifier flagged it, OR — a fallback for a figure beyond the classification
-        // truncation window — when the source is figure-bearing and its marked Markdown is longer than that window
-        // (so the embedded-document signal may not have seen the tail figure). Runs IN ADDITION to the parent's own
-        // extraction (DocumentClassifiedEto was published above for a confirmed type); the recursion guard prevents a
-        // seeded sub-document (which carries no figures) from descending. Enqueued in this same UoW, so the job and
-        // the run completion commit atomically via the outbox.
-        var shouldRoute = !isDerived
-            && (outcome.ContainsEmbeddedDocument
-                || (hasFigures && markedLength > _aiOptions.MaxTextLengthPerExtraction));
+        // #371/#379: a non-container parent may still embed a standalone document to route to its own sub-document.
+        // Enqueue the unified pass when the classifier flagged it, OR — deterministically — whenever the source is
+        // figure-bearing (its marked Markdown carries an [Image OCR] sentinel). Keying figure recall on the
+        // already-computed, zero-cost ImageOcrMarkup.Contains signal (#379) makes the focused segmentation LLM the
+        // single standalone-vs-element decision-maker, closing the within-window hole where a multi-objective
+        // classifier under-flagged an embedded figure (ContainsEmbeddedDocument=false) on a doc whose marked Markdown
+        // fit inside the classification truncation window — previously the figure arm fired only beyond that window,
+        // so an in-window embedded document was never routed and never entered review (a silent recall miss).
+        // No structural pre-check guards the figure arm: this trigger is only reached for a non-container parent, where
+        // the pass routes ONLY figure spans, so "has a candidate span" is exactly "Contains a figure" — a pre-check
+        // would be vacuous, and any content-length variant that skipped present figures would reopen the recall hole.
+        // A decorative-only figure is a clean no-op in the pass (logged, marked segmented, no review flag), and the
+        // per-doc IsSegmented gate means each figure-bearing document pays the segmentation LLM at most once.
+        // Runs IN ADDITION to the parent's own extraction (DocumentClassifiedEto was published above for a confirmed
+        // type); the recursion guard prevents a seeded sub-document (which carries no figures) from descending.
+        // Enqueued in this same UoW, so the job and the run completion commit atomically via the outbox.
+        var shouldRoute = !isDerived && (outcome.ContainsEmbeddedDocument || hasFigures);
         if (shouldRoute)
         {
             await _backgroundJobManager.EnqueueAsync(

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
@@ -70,7 +70,14 @@ public class DerivedDocumentSpawner : ITransientDependency
     /// document id, or <c>null</c> when <paramref name="reloadClaimable"/> reports the candidate is no longer
     /// claimable (the caller decides what to do with the blob it already wrote, per its own naming scheme).
     /// </summary>
-    /// <typeparam name="TCandidate">The candidate ledger aggregate (<c>DocumentSegment</c>, #371).</typeparam>
+    /// <typeparam name="TCandidate">
+    /// The candidate ledger aggregate. After #371 unified the figure + born-digital ledgers there is exactly one
+    /// caller, passing <c>DocumentSegment</c>; the generic is <b>deliberately retained</b> as a decoupling seam — it
+    /// keeps this sink (in <c>Pipelines</c>) from referencing the ledger type (in <c>Documents.Segments</c>) or
+    /// hard-coding a reload/mark protocol, so the candidate's claim + spawn mutation enter through the two delegates
+    /// (<paramref name="reloadClaimable"/> / <paramref name="markSpawned"/>). Not dead generality — it is the boundary
+    /// that kept the shared #358 spawn protocol caller-agnostic.
+    /// </typeparam>
     /// <param name="sourceDocumentId">The source document the constituent belongs to (the derived doc's <c>OriginDocumentId</c>).</param>
     /// <param name="tenantId">The source/derived tenant; the UoW and the delegates run under this tenant.</param>
     /// <param name="constituentKey">The content-derived key (the derived doc's <c>OriginConstituentKey</c>, == <paramref name="fileOrigin"/>.ContentHash).</param>

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Lifecycle/ContainerMarkerClearedEventHandler.cs
@@ -72,12 +72,15 @@ public class ContainerMarkerClearedEventHandler
         // filter by Kind (below). A container that was never segmented (or whose segmentation never spawned) yields no
         // routed ids — a no-op, which is correct.
         var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
-        // #371: retract only TEXT-kind sub-documents (bundle constituents that existed only because the parent was a
-        // container). FIGURE-kind sub-documents are genuinely embedded documents (an invoice photo inside what is now
-        // a concrete-typed contract) and survive the reclassify — exactly as a freshly-uploaded concrete document with
-        // an embedded figure keeps it (#364, now a Kind filter on the single unified ledger).
+        // #371: retract only container-bound (Text) sub-documents — bundle constituents that existed only because the
+        // parent was a container. Container-independent (Figure) sub-documents are genuinely embedded documents (an
+        // invoice photo inside what is now a concrete-typed contract) and survive the reclassify — exactly as a
+        // freshly-uploaded concrete document with an embedded figure keeps it (#364). This in-memory filter goes
+        // through the exhaustive IsContainerIndependent switch (#379 LOW), so a future third kind throws here (the
+        // first decision site reached) rather than being silently kept; the SQL bulk delete below keeps the literal
+        // Kind value it cannot translate a method call.
         var spawnedSubDocumentIds = segments
-            .Where(s => s.Kind == DocumentSegmentKind.Text && s.RoutedDocumentId.HasValue)
+            .Where(s => !s.Kind.IsContainerIndependent() && s.RoutedDocumentId.HasValue)
             .Select(s => s.RoutedDocumentId!.Value)
             .ToList();
 

--- a/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.DocumentAI.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -530,7 +530,9 @@ public class DocumentSegmentationJob
             return false;
         }
 
-        return kind == DocumentSegmentKind.Figure || source.IsContainer;
+        // A container-independent kind (Figure) spawns regardless; a container-bound kind (Text) only while the
+        // source is still a container. Exhaustive — adding a kind forces IsContainerIndependent to declare its stance.
+        return kind.IsContainerIndependent() || source.IsContainer;
     }
 
     /// <summary>

--- a/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentSegmentKind.cs
+++ b/core/src/Dignite.DocumentAI.Domain.Shared/Documents/DocumentSegmentKind.cs
@@ -1,16 +1,21 @@
+using System;
+
 namespace Dignite.DocumentAI.Documents.Segments;
 
 /// <summary>
 /// What kind of source span a <see cref="DocumentSegment"/> was carved from by the unified sub-document detection
 /// pass (#371, which folds figure routing #306/#365 and born-digital segmentation #346 into one Markdown-borne
 /// pass). Both kinds share one ledger, one identity model (the SHA-256 of the clean span text), and one spawn
-/// sink (<c>DerivedDocumentSpawner</c>); the distinction drives only <b>retraction</b> semantics (#364).
-/// <para>
-/// When a container is reclassified to a concrete type, <see cref="Text"/> children are retracted — they existed
-/// only because the parent was a container bundle — while <see cref="Figure"/> children are kept: a genuinely
-/// embedded document (an invoice photo inside a contract) survives a concrete-typed parent, exactly as a
-/// freshly-uploaded concrete document with an embedded figure would keep it.
-/// </para>
+/// sink (<c>DerivedDocumentSpawner</c>); the distinction <b>forks behaviour at several sites</b> — the central
+/// property being that a <see cref="Figure"/> is <b>orthogonal to its source's container-ness</b> while a
+/// <see cref="Text"/> span is container-bound. That property is centralised in
+/// <see cref="DocumentSegmentKindExtensions.IsContainerIndependent"/> (an exhaustive switch — a third kind forces it
+/// to declare its stance) and drives: the spawn gate and the still-spawnable guard (a Figure spawns even on a
+/// concrete-typed parent; a Text span spawns only while the source is a container), and the container→concrete
+/// retraction (#364: <see cref="Text"/> children are retracted — they existed only because the parent was a bundle —
+/// while <see cref="Figure"/> children are kept, exactly as a freshly-uploaded concrete document keeps an embedded
+/// figure). The per-span clean-text derivation (<c>ExtractBodies</c> for a figure body vs <c>Strip</c> for a text
+/// span) is decided at carve time from the slice's opening sentinel, before the kind is recorded.
 /// </summary>
 public enum DocumentSegmentKind
 {
@@ -23,4 +28,29 @@ public enum DocumentSegmentKind
     /// crop is persisted.
     /// </summary>
     Figure = 1
+}
+
+/// <summary>
+/// Compiler-/runtime-checked semantics for <see cref="DocumentSegmentKind"/> (#379 LOW): the scattered
+/// <c>Kind == Figure</c> / <c>Kind == Text</c> comparisons that fork spawn + retraction behaviour are funnelled
+/// through one exhaustive switch, so adding a third kind forces this single declaration to be revisited (the
+/// <c>default</c> arm throws as a runtime backstop) instead of silently defaulting at each decision site — guarding
+/// against a future #364-class missed-branch bug.
+/// </summary>
+public static class DocumentSegmentKindExtensions
+{
+    /// <summary>
+    /// Whether a span of this kind is <b>orthogonal to its source's container-ness</b> (#364/#371): a
+    /// <see cref="DocumentSegmentKind.Figure"/> is a genuinely embedded document, so it spawns even on a
+    /// concrete-typed parent and <b>survives</b> a container→concrete reclassification; a
+    /// <see cref="DocumentSegmentKind.Text"/> exists only as a container-bundle constituent, so it spawns only while
+    /// the source is a container and is <b>retracted</b> when the source is reclassified to a concrete type.
+    /// </summary>
+    public static bool IsContainerIndependent(this DocumentSegmentKind kind) => kind switch
+    {
+        DocumentSegmentKind.Figure => true,
+        DocumentSegmentKind.Text => false,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(kind), kind, "Unhandled DocumentSegmentKind; declare its container-orthogonality stance here.")
+    };
 }

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Document.cs
@@ -119,9 +119,11 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// nothing standalone to route. Set by <see cref="MarkSegmented"/> in the same transaction as the segment rows,
     /// and used by <c>DocumentSegmentationJob</c> as the precise resume gate (skip the LLM split when set), replacing
     /// the imperfect "infer completion from segment-row Kind" heuristic that could not tell an embedded-run figure
-    /// row apart from a container-run figure row (#372/#377). It is <b>cleared</b> on a concrete→container
-    /// re-recognition (<see cref="MarkAsContainer"/>, false→true) so a re-recognized container runs its container
-    /// split exactly once. Failure / incomplete / byte-identical outcomes do NOT set it, so a retry re-runs the split.
+    /// row apart from a container-run figure row (#372/#377). It is <b>cleared on every container↔concrete
+    /// transition</b> — both directions — through the single <see cref="SetContainerFlag"/> choke point (#378/#379):
+    /// a concrete→container re-recognition so the new container runs its split exactly once, and a container→concrete
+    /// reclassify so the now-concrete document's own embedded-document routing can run instead of being skipped by a
+    /// stale marker. Failure / incomplete / byte-identical outcomes do NOT set it, so a retry re-runs the split.
     /// Internal pipeline state — not exposed at the egress.
     /// </summary>
     public virtual bool IsSegmented { get; private set; }
@@ -346,25 +348,21 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         DocumentTypeId = Check.NotDefaultOrNull<Guid>(documentTypeId, nameof(documentTypeId));
         ClassificationConfidence = Check.Range(classificationConfidence, nameof(classificationConfidence), 0d, 1d);
         SetReviewReason(DocumentReviewReasons.UnresolvedClassification, present: false);
-        // #346: a concrete type is now assigned, so this is no longer a container; clear the marker and any stale
-        // segmentation-incomplete signal to avoid the contradictory "has a type AND is a container" state.
-        // #349: capture the prior marker state and, on a true→false transition, raise ContainerMarkerClearedEvent so
-        // the in-process handler retracts any already-spawned sub-documents (soft-delete + DocumentDeletedEto) and
-        // removes the container's segment rows, preventing downstream double-counting.
+        // #346: a concrete type is now assigned, so this is no longer a container; clear the marker (and the stale
+        // segmentation-incomplete signal) to avoid the contradictory "has a type AND is a container" state.
+        // #377/#379: routing the flag through SetContainerFlag clears the stale IsSegmented resume marker on the
+        // container->concrete transition (single choke point — see SetContainerFlag), so the now-concrete document's
+        // own embedded-document routing can run when re-segmented instead of being skipped. #378 was exactly this
+        // omission on the automatic path (reachable via RerecognizeAsync) while only the operator path cleared it.
+        // #349: on a true->false transition raise ContainerMarkerClearedEvent so the in-process handler retracts any
+        // already-spawned sub-documents (soft-delete + DocumentDeletedEto) and removes the container's segment rows.
         var wasContainer = IsContainer;
-        IsContainer = false;
+        SetContainerFlag(false);
         SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null; // #284 review-fix: leaving Rejected disposition -> clear stale rejection reason; only Rejected should have one.
         if (wasContainer)
         {
-            // #377 (#371 post-merge review): symmetric with the operator path (ConfirmClassification). A
-            // container->concrete reclassify retracts the container's segment rows (#349 below), so its
-            // segmentation completion no longer holds — clear IsSegmented so the now-concrete document's own
-            // embedded-document routing can run when re-segmented, instead of being skipped by the stale resume
-            // marker. Previously only the operator path cleared this, so the automatic high-confidence path
-            // (reachable via RerecognizeAsync) silently gated off the now-concrete document's embedded-figure routing.
-            IsSegmented = false;
             AddLocalEvent(new ContainerMarkerClearedEvent(Id));
         }
     }
@@ -418,7 +416,12 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         var wasContainer = IsContainer;
         var hadConcreteType = DocumentTypeId.HasValue;
 
-        IsContainer = true;
+        // #377/#379: SetContainerFlag clears IsSegmented on the concrete->container transition (single choke point —
+        // see SetContainerFlag), so any prior segmentation completion (an embedded-document run that already routed a
+        // figure before this re-recognition) does NOT count as the container split having run, and the container split
+        // runs exactly once now. A document that merely STAYS a container (wasContainer true) is a no-op here and
+        // keeps its marker, so it is not re-split.
+        SetContainerFlag(true);
         DocumentTypeId = null;
         ClassificationConfidence = 0;
         // A container is a correct outcome: clear the classification / field review reasons rather than setting them,
@@ -430,15 +433,6 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         ReviewDisposition = DocumentReviewDisposition.NotReviewed;
         RejectionReason = null;
         _extractedFieldValues.Clear();
-
-        // #377: on a false→true transition the document is NEWLY a container, so any prior segmentation completion
-        // (from an embedded-document run that already routed a figure before this re-recognition) does NOT count as
-        // the container split having run. Clear the marker so the container split runs exactly once now; a container
-        // that merely STAYS a container (wasContainer true) keeps its marker and is not re-split.
-        if (!wasContainer)
-        {
-            IsSegmented = false;
-        }
 
         // #355: mirror of the container→type retraction (#349 ContainerMarkerClearedEvent). The in-process handler
         // publishes DocumentReclassifiedToContainerEto so downstream retracts the record derived from the former type.
@@ -460,6 +454,34 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         IsSegmented = true;
     }
 
+    /// <summary>
+    /// The single mutator of <see cref="IsContainer"/> (#378/#379 hardening): every container↔concrete transition
+    /// flows through here so the coupled <see cref="IsSegmented"/> invariant cannot leak. Any <b>actual</b> change of
+    /// the flag — either direction — invalidates a prior segmentation completion, because the container split and a
+    /// concrete document's embedded-figure routing are different passes whose completion must not gate the other; so
+    /// the resume marker is cleared on every transition. A no-op call (the flag is already at the requested value)
+    /// leaves <see cref="IsSegmented"/> untouched, preserving a still-container's split marker and a still-concrete
+    /// document's embedded-routing marker. Callers retain the direction-specific concerns (the
+    /// <c>ContainerMarkerCleared</c>/<c>Set</c> events and review-reason resets), which depend on context they capture
+    /// before calling this.
+    /// <para>
+    /// #378 was a silent-data-loss bug caused by one concrete-assigning path forgetting to clear
+    /// <see cref="IsSegmented"/> while the other cleared it; funnelling the flag through one setter makes that class
+    /// of omission unrepresentable. The aggregate-level transition-matrix test (<c>IsSegmentedTransitionMatrix_Tests</c>)
+    /// asserts every reclassification path clears it.
+    /// </para>
+    /// </summary>
+    private void SetContainerFlag(bool isContainer)
+    {
+        if (IsContainer == isContainer)
+        {
+            return;
+        }
+
+        IsContainer = isContainer;
+        IsSegmented = false;
+    }
+
     internal void ConfirmClassification(Guid documentTypeId)
     {
         DocumentTypeId = Check.NotDefaultOrNull<Guid>(documentTypeId, nameof(documentTypeId));
@@ -469,21 +491,18 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
         SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: false);
         // #346: operator reclassifying a container to a concrete type clears the container marker (reversibility)
         // and any stale segmentation-incomplete signal; subsequent DocumentClassifiedEto cascades field extraction.
-        // #349: capture the prior marker state and, on a true→false transition, raise ContainerMarkerClearedEvent so
-        // the in-process handler retracts any already-spawned sub-documents (soft-delete + DocumentDeletedEto) and
-        // removes the container's segment rows, preventing downstream double-counting.
+        // #377/#379: SetContainerFlag clears the stale IsSegmented resume marker on the container->concrete transition
+        // (single choke point — see SetContainerFlag), so the now-concrete document's own embedded-document routing can
+        // run if it is later re-segmented instead of being skipped by a stale marker.
+        // #349: on a true->false transition raise ContainerMarkerClearedEvent so the in-process handler retracts any
+        // already-spawned sub-documents (soft-delete + DocumentDeletedEto) and removes the container's segment rows.
         var wasContainer = IsContainer;
-        IsContainer = false;
+        SetContainerFlag(false);
         SetReviewReason(DocumentReviewReasons.SegmentationIncomplete, present: false);
         ReviewDisposition = DocumentReviewDisposition.Confirmed;
         RejectionReason = null; // #284 review-fix: rejection is recoverable; clear stale rejection reason after Reclassify / Confirm.
         if (wasContainer)
         {
-            // #377: symmetric with MarkAsContainer clearing the marker on concrete→container. A container→concrete
-            // reclassify retracts the container's segment rows (#349 below), so its segmentation completion no longer
-            // holds — clear IsSegmented so the now-concrete document's own embedded-document routing can run if it is
-            // later re-segmented, instead of being skipped by a stale marker.
-            IsSegmented = false;
             AddLocalEvent(new ContainerMarkerClearedEvent(Id));
         }
     }

--- a/core/src/Dignite.DocumentAI.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.DocumentAI.Domain/Documents/Segments/DocumentSegment.cs
@@ -66,10 +66,11 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
     public virtual DocumentSegmentKind Kind { get; private set; }
 
     /// <summary>
-    /// 1-based source page of a <see cref="DocumentSegmentKind.Figure"/> span (#371): a lightweight recovery anchor
-    /// parsed from the <c>[Image OCR p:N]</c> sentinel, so the original image can be recovered by re-parsing the
-    /// source file if ever needed (the crop is not persisted). <c>null</c> for a <see cref="DocumentSegmentKind.Text"/>
-    /// span or a page-less source. Provenance only — never identity (#210).
+    /// 1-based source page of a <see cref="DocumentSegmentKind.Figure"/> span (#371): a lightweight provenance anchor
+    /// parsed from the <c>[Image OCR p:N]</c> sentinel (the crop itself is not persisted, per Markdown-first). It
+    /// records <b>where</b> the figure came from; <b>no code re-parses the source to recover the image</b> — the
+    /// anchor only keeps that possible out-of-band should a future need arise. <c>null</c> for a
+    /// <see cref="DocumentSegmentKind.Text"/> span or a page-less source. Provenance only — never identity (#210).
     /// </summary>
     public virtual int? PageNumber { get; private set; }
 

--- a/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.DocumentAI.EntityFrameworkCore/EntityFrameworkCore/DocumentAIDbContextModelCreatingExtensions.cs
@@ -253,11 +253,15 @@ public static class DocumentAIDbContextModelCreatingExtensions
             b.HasIndex(x => new { x.SourceDocumentId, x.SegmentKey })
                 .IsUnique();
 
-            // Concurrency guard (#346): one split per container. The LLM split is non-deterministic, so two
-            // concurrent segmentation runs would otherwise produce different SegmentKeys and both commit (a double
-            // split). Every split numbers its slices from Ordinal 0, so this unique index makes the second
-            // committer collide on Ordinal 0 and roll back its whole insert — only one split survives; the loser
-            // retries and resumes from the winner's persisted rows.
+            // Reading-order uniqueness (#346/#372): no two segment rows of one source share an Ordinal. This is a
+            // structural guard, NOT the primary double-split backstop. The authoritative concurrency backstops are the
+            // Document concurrency stamp — both runs re-check !IsSegmented and then UpdateAsync the source via
+            // MarkSegmented in the same UoW as the rows, so the loser's commit conflicts (#377) — and the
+            // (SourceDocumentId, SegmentKey) unique index above. A FRESH split numbers from Ordinal 0, so two
+            // CONCURRENT fresh splits also collide here (both write Ordinal 0) and one rolls back; but a SEQUENTIAL
+            // cross-mode re-split (a concrete doc's embedded figure already routed, then a container re-recognition,
+            // #372/#377) deliberately numbers from Max(Ordinal)+1 and skips already-persisted keys, so it neither
+            // relies on nor trips an Ordinal-0 collision.
             b.HasIndex(x => new { x.SourceDocumentId, x.Ordinal })
                 .IsUnique();
         });

--- a/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
@@ -249,9 +249,10 @@ public class DocumentClassificationBackgroundJob_Tests
     [Fact]
     public async Task NoEmbeddedDocument_SmallDocument_Does_Not_Route()
     {
-        // #371 D6(b): the common case — a small, figure-free document the classifier does NOT flag as embedding a
-        // standalone document must NOT pay for the heavy segmentation pass. Guards a regression that drops the
-        // ContainsEmbeddedDocument disjunct or inverts the markedLength comparison.
+        // #371 D6(b): the common case — a small, figure-FREE document the classifier does NOT flag as embedding a
+        // standalone document must NOT pay for the heavy segmentation pass. After #379 the figure arm keys purely on
+        // the deterministic ImageOcrMarkup.Contains signal, so this guards a regression that drops the
+        // ContainsEmbeddedDocument disjunct or spuriously routes a document with no figure sentinels at all.
         var doc = CreateDocument("A short single service agreement with no embedded documents.");
         SetupDocumentRepository(doc);
 
@@ -272,12 +273,57 @@ public class DocumentClassificationBackgroundJob_Tests
     }
 
     [Fact]
+    public async Task FigureBearing_InWindow_Document_Routes_Even_Without_Embedded_Signal()
+    {
+        // #379 (HIGH) — the within-window embedded-figure recall hole. A figure-bearing document whose MARKED Markdown
+        // fits INSIDE the classification truncation window (MaxTextLengthPerExtraction = 8000) but whose embedded
+        // figure the multi-objective classifier under-flagged (ContainsEmbeddedDocument = false) must STILL route the
+        // unified pass — figure recall now keys purely on the deterministic ImageOcrMarkup.Contains signal, decoupled
+        // from both the LLM flag and the truncation window. On the pre-#379 code (figure arm gated on
+        // markedLength > window) this in-window document never routed and never entered review — a silent recall miss.
+        // The focused segmentation pass then owns the per-span standalone-vs-element judgment (a decorative figure is a
+        // clean no-op there, not a review flag).
+        var doc = CreateDocument("A short contract body with an embedded invoice photo.");
+        SetupDocumentRepository(doc);
+
+        // A real salted [Image OCR] span, comfortably inside the 8000 window (so the classifier saw it; the point is it
+        // under-flagged, not that the tail was truncated). GetAllBytesOrNullAsync is an extension over the interface
+        // GetOrNullAsync(Stream), so stub the latter.
+        var markedMarkdown = "Contract body.\n" + ImageOcrMarkup.Wrap("INVOICE\nVendor: Acme\nTotal: $4,200", pageNumber: 2);
+        markedMarkdown.Length.ShouldBeLessThan(8000); // guards the in-window premise (distinct from the over-window case below)
+        var markedBytes = Encoding.UTF8.GetBytes(markedMarkdown);
+        var markedBlobName = DocumentConsts.MarkedMarkdownBlobPrefix + doc.Id;
+        _markedBlobContainer
+            .GetOrNullAsync(markedBlobName, Arg.Any<CancellationToken>())
+            .Returns(_ => new MemoryStream(markedBytes));
+
+        _workflow
+            .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DocumentClassificationOutcome
+            {
+                TypeCode = "contract.general",
+                ConfidenceScore = 0.92,
+                ContainsEmbeddedDocument = false
+            });
+
+        await _job.ExecuteAsync(new DocumentClassificationJobArgs { DocumentId = doc.Id });
+
+        // The parent still classifies normally...
+        doc.DocumentTypeId.ShouldBe(DocumentClassificationJobTestModule.ContractTypeId);
+        // ...AND the unified pass is enqueued purely on the deterministic figure signal (no embedded flag, in-window).
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentSegmentationJobArgs>(a => a.SourceDocumentId == doc.Id),
+            Arg.Any<BackgroundJobPriority>(), Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
     public async Task FigureBearing_OverWindow_Document_Routes_Even_Without_Embedded_Signal()
     {
-        // #371 D6(b) fallback arm: a figure-bearing document whose MARKED Markdown exceeds the classification
-        // truncation window (MaxTextLengthPerExtraction = 8000) may carry an embedded figure the classifier never saw
-        // (the tail was truncated out of the prompt). It must route even when ContainsEmbeddedDocument is false, so a
-        // beyond-window embedded document is not silently missed.
+        // #371/#379: a figure-bearing document whose MARKED Markdown exceeds the classification truncation window
+        // (MaxTextLengthPerExtraction = 8000) may carry an embedded figure the classifier never saw (the tail was
+        // truncated out of the prompt). It must route even when ContainsEmbeddedDocument is false. Since #379 routing
+        // is window-INDEPENDENT (keyed on ImageOcrMarkup.Contains), so this is now one instance of the general
+        // figure-bearing trigger rather than a special over-window fallback arm.
         var doc = CreateDocument("Leading body text used as the clean fallback Markdown.");
         SetupDocumentRepository(doc);
 

--- a/core/test/Dignite.DocumentAI.Domain.Tests/Documents/IsSegmentedTransitionMatrix_Tests.cs
+++ b/core/test/Dignite.DocumentAI.Domain.Tests/Documents/IsSegmentedTransitionMatrix_Tests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.DocumentAI.Documents;
+
+/// <summary>
+/// #379 (MEDIUM) aggregate-level transition matrix for the <see cref="Document.IsContainer"/> ↔
+/// <see cref="Document.IsSegmented"/> invariant. <c>IsSegmented</c> is the unified-segmentation resume gate (#377): it
+/// MUST be cleared on every container↔concrete reclassification path so a now-concrete document's embedded-document
+/// routing is not skipped, and a re-recognized container runs its split exactly once; and it MUST be preserved on a
+/// non-transition (the completed work is real, not stale). <c>#378</c> was a silent-data-loss bug where the AUTOMATIC
+/// concrete-assigning path forgot to clear it while the operator path cleared it — exactly the divergence this matrix
+/// pins down. All three entry points (<c>ApplyAutomaticClassificationResult</c> / <c>ConfirmClassification</c> /
+/// <c>MarkAsContainer</c>) now funnel through one <c>SetContainerFlag</c> choke point; these tests assert the
+/// observable cleared-on-transition / preserved-on-no-op behaviour for each, independent of that implementation detail.
+/// </summary>
+public class IsSegmentedTransitionMatrix_Tests
+{
+    // --- container -> concrete: every reclassification path clears the stale resume marker ---
+
+    [Fact]
+    public void Automatic_HighConfidence_Reclassify_Container_To_Concrete_Clears_IsSegmented()
+    {
+        var doc = SegmentedContainer();
+
+        ApplyAutomaticClassificationResult(doc, TypeId("contract.general"), 0.95);
+
+        doc.IsContainer.ShouldBeFalse();
+        doc.IsSegmented.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Operator_Confirm_Container_To_Concrete_Clears_IsSegmented()
+    {
+        var doc = SegmentedContainer();
+
+        ConfirmClassification(doc, TypeId("contract.general"));
+
+        doc.IsContainer.ShouldBeFalse();
+        doc.IsSegmented.ShouldBeFalse();
+    }
+
+    // --- concrete -> container: clears the marker so the new container runs its split exactly once ---
+
+    [Fact]
+    public void Reclassify_Concrete_To_Container_Clears_IsSegmented()
+    {
+        var doc = SegmentedConcrete(TypeId("contract.general"));
+
+        MarkAsContainer(doc);
+
+        doc.IsContainer.ShouldBeTrue();
+        doc.IsSegmented.ShouldBeFalse();
+    }
+
+    // --- no transition (flag unchanged): the completion is real work and is preserved, never re-paid ---
+
+    [Fact]
+    public void Automatic_Reclassify_Concrete_To_Concrete_Preserves_IsSegmented()
+    {
+        // A concrete document that already ran its embedded-figure routing (IsSegmented set), re-recognized to another
+        // concrete type, keeps the marker: the figure was already routed (the idempotent insert would skip it), so
+        // re-running the LLM split would only re-pay for nothing. Not a container transition -> no clear.
+        var doc = SegmentedConcrete(TypeId("contract.general"));
+
+        ApplyAutomaticClassificationResult(doc, TypeId("invoice.general"), 0.95);
+
+        doc.IsContainer.ShouldBeFalse();
+        doc.IsSegmented.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Operator_Confirm_Concrete_To_Concrete_Preserves_IsSegmented()
+    {
+        var doc = SegmentedConcrete(TypeId("contract.general"));
+
+        ConfirmClassification(doc, TypeId("invoice.general"));
+
+        doc.IsContainer.ShouldBeFalse();
+        doc.IsSegmented.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Re_MarkAsContainer_On_An_Already_Segmented_Container_Preserves_IsSegmented()
+    {
+        // A container that STAYS a container (re-detected) keeps its split marker so the split is not re-run; only a
+        // false->true transition is newly a container.
+        var doc = SegmentedContainer();
+
+        MarkAsContainer(doc);
+
+        doc.IsContainer.ShouldBeTrue();
+        doc.IsSegmented.ShouldBeTrue();
+    }
+
+    // --- builders + reflection helpers (mirror ContainerMarkerClearedEvent_Tests; the transition methods are internal) ---
+
+    private static Document SegmentedContainer()
+    {
+        var doc = NewDocument();
+        MarkAsContainer(doc);
+        doc.MarkSegmented(); // a prior container split completed atomically with the rows (#377)
+        doc.IsContainer.ShouldBeTrue();
+        doc.IsSegmented.ShouldBeTrue();
+        return doc;
+    }
+
+    private static Document SegmentedConcrete(Guid typeId)
+    {
+        var doc = NewDocument();
+        ApplyAutomaticClassificationResult(doc, typeId, 0.95); // a concrete type, never a container
+        doc.MarkSegmented();                                   // its embedded-figure routing completed
+        doc.IsContainer.ShouldBeFalse();
+        doc.IsSegmented.ShouldBeTrue();
+        return doc;
+    }
+
+    private static Document NewDocument()
+        => new(
+            Guid.NewGuid(), null,
+            new FileOrigin(
+                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "test.pdf"));
+
+    private static void MarkAsContainer(Document doc)
+        => typeof(Document)
+            .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, null);
+
+    private static void ApplyAutomaticClassificationResult(Document doc, Guid typeId, double confidence)
+        => typeof(Document)
+            .GetMethod("ApplyAutomaticClassificationResult", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, [typeId, confidence]);
+
+    private static void ConfirmClassification(Document doc, Guid typeId)
+        => typeof(Document)
+            .GetMethod("ConfirmClassification", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(doc, [typeId]);
+
+    private static Guid TypeId(string typeCode)
+        => new(MD5.HashData(Encoding.UTF8.GetBytes("type:" + typeCode)));
+}


### PR DESCRIPTION
Closes #379.

Follow-up to the #371 first-principles review. Implements the HIGH recall fix plus the MEDIUM/LOW hardening checklist.

## HIGH — within-window embedded-figure recall hole

**Decision: option (a)** ([Decision Log](https://github.com/dignite-projects/dignite-extract/issues/379#issuecomment-4748948771)). The trigger now routes the unified sub-document pass whenever the source is figure-bearing, on the already-computed deterministic signal:

```
shouldRoute = !isDerived && (outcome.ContainsEmbeddedDocument || hasFigures)   // hasFigures = ImageOcrMarkup.Contains(marked)
```

Dropping the `markedLength > MaxTextLengthPerExtraction` qualifier closes the hole where an **in-window** embedded figure that the multi-objective classifier under-flagged (`ContainsEmbeddedDocument = false`) was never routed and never entered review — a silent recall miss on a trust-first channel. The focused segmentation pass owns the standalone-vs-element judgment; a decorative-only figure is a clean no-op there (logged, marked segmented, no review flag), and the per-doc `IsSegmented` gate means each figure-bearing document pays the segmentation LLM at most once.

No structural pre-check guards the figure arm: this trigger is only reached for a non-container parent, where the pass routes **only** figure spans, so "has a candidate span" ⟺ `Contains` — a pre-check would be vacuous, and any content-length variant that skipped present figures would reopen the hole.

**Acceptance test:** `DocumentClassificationBackgroundJob_Tests.FigureBearing_InWindow_Document_Routes_Even_Without_Embedded_Signal` (fails on pre-fix code).

## Hardening (#379 checklist)

- **(medium) `IsSegmented` invariant.** The three scattered manual clears now funnel through a single private `Document.SetContainerFlag` choke point — the only mutator of `IsContainer`, clearing `IsSegmented` on every real container↔concrete transition — making the #378 silent-data-loss omission unrepresentable. New aggregate-level `IsSegmentedTransitionMatrix_Tests` asserts cleared-on-transition / preserved-on-no-op across all three reclassification paths.
- **(medium) Dropped figure confidence gate.** Recorded as an intentional decision — **accept the bare `bool IsSubDocument`** (no per-span confidence floor): [#371 Decision Log](https://github.com/dignite-projects/dignite-extract/issues/371#issuecomment-4748949472).
- **(low) `DocumentSegmentKind` branching.** The scattered `Kind == X` forks (spawn gate, retraction) are centralized in an exhaustive `IsContainerIndependent` switch (`default` throws); the lying enum docstring is corrected. The EF bulk-delete keeps its literal value predicate (untranslatable method call); the in-memory `.Where` goes through the switch, so a future third kind throws there first.
- **(low) Docs.** `(SourceDocumentId, Ordinal)` index comment names the real concurrency backstop (concurrency stamp + `SegmentKey` unique index) instead of the imprecise "numbers from Ordinal 0"; `DocumentSegment.PageNumber` no longer promises an unimplemented re-parse recovery; `DerivedDocumentSpawner<T>` notes its one-caller generic as a deliberately-retained decoupling seam.

**(low) marked-blob archive — deliberately kept fail-open.** Promoting `ArchiveMarkedMarkdownAsync` to a hard fault would sacrifice the primary Markdown payload to protect an auxiliary recall hint (violating Markdown-first), and the figure transcription is not lost (it stays inline in the parent's Markdown). Left as the existing logged fail-open.

## Verification

- Build: 0 errors, 0 warnings in the changed projects (the only warnings are pre-existing in `host/src/`).
- Tests green: Domain 185 + Application 278 + EntityFrameworkCore 101 = **564 passed / 0 failed**.
- **No schema change → no EF migration.**
