### PR TITLE
feat(parse-pdf,ocr): strip running headers/footers and page numbers (#383)

### DIFF
--- a/core/src/Dignite.Extract.Ocr.VisionLlm/Dignite.Extract.Ocr.VisionLlm.csproj
+++ b/core/src/Dignite.Extract.Ocr.VisionLlm/Dignite.Extract.Ocr.VisionLlm.csproj
@@ -31,4 +31,8 @@
     <ProjectReference Include="..\Dignite.Extract.Ocr\Dignite.Extract.Ocr.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dignite.Extract.Ocr.VisionLlm.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/core/src/Dignite.Extract.Ocr.VisionLlm/VisionLlmOcrInstructions.cs
+++ b/core/src/Dignite.Extract.Ocr.VisionLlm/VisionLlmOcrInstructions.cs
@@ -12,10 +12,15 @@ internal static class VisionLlmOcrInstructions
 {
     /// <summary>System role: defines the OCR transcription task and the anti-repetition rule.</summary>
     public const string SystemPrompt =
-        "You are an OCR engine. Transcribe ALL text visible in the image into Markdown, exactly as it appears. " +
+        "You are an OCR engine. Transcribe the text visible in the image into Markdown, exactly as it appears. " +
         "Preserve document structure: Markdown headings for headings, Markdown tables for tabular data, and lists for lists. " +
         "For receipts, invoices, and forms, keep every line item, label, quantity, and amount — render line-item tables as a Markdown table (or list), aligning columns left to right. " +
         "Transcribe numbers, currency symbols, and dates verbatim. Do not compute totals, summarize, reorder, translate, or invent any content. " +
+        // #383: page chrome is mechanical noise that pollutes the body; drop it. This is a single-page,
+        // semantic judgment (the model sees one page at a time) — guarded by the explicit protection list
+        // below so body content at the page bottom is never sacrificed.
+        "Do NOT transcribe running page headers, running page footers, or standalone page numbers — for example a title or confidentiality/copyright line repeated at the very top or bottom edge of the page, or page numbering such as \"3\", \"- 3 -\", \"Page 3 of 10\", or \"第 3 页\". " +
+        "NEVER drop signatures, signature blocks, seals, stamps, company chops, total or subtotal amounts, or footnotes — these are body content and must be transcribed even when they sit at the very bottom of the page. " +
         "Output ONLY the transcribed Markdown — no preamble, no commentary, no explanations, and do not wrap the whole output in a Markdown code fence. " +
         "Transcribe each piece of text exactly once; never repeat a line or block. " +
         "If the image contains no readable text, output nothing at all.";

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfExtractor.cs
@@ -137,10 +137,18 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
 
             var languageHints = ResolveLanguageHints(context);
 
-            foreach (var pageContent in pages)
+            // #383: detect running headers / footers + page numbers (content that repeats in the top/bottom
+            // edge band across pages) once over all pages, so it does not pollute the Markdown body. Position
+            // only selects candidates; a line is dropped only when its digit-normalized text repeats across
+            // enough pages — so a per-page signature / seal / total / footnote is preserved, and a single-page
+            // document drops nothing.
+            var runningContent = PdfRunningHeaderFooter.Detect(pages.ConvertAll(p => p.Words));
+
+            for (var pageIndex = 0; pageIndex < pages.Count; pageIndex++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                var pageContent = pages[pageIndex];
                 var figures = new List<PdfReadingOrder.Figure>();
 
                 List<IPdfImage> images;
@@ -253,7 +261,15 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     }
                 }
 
-                var pageMarkdown = PdfReadingOrder.RenderPage(pageContent.Words, figures, _options.ReconstructTables);
+                // #383: drop the words of any running header/footer / page-number lines detected across pages,
+                // then render. Filter the page's own word list by reference identity (the drop set holds the
+                // same Word instances).
+                var droppable = runningContent[pageIndex];
+                var renderWords = droppable.Count == 0
+                    ? pageContent.Words
+                    : pageContent.Words.Where(w => !droppable.Contains(w)).ToList();
+
+                var pageMarkdown = PdfReadingOrder.RenderPage(renderWords, figures, _options.ReconstructTables);
                 if (!string.IsNullOrWhiteSpace(pageMarkdown))
                 {
                     pageMarkdowns.Add(pageMarkdown);

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -50,6 +50,15 @@ internal static class PdfReadingOrder
     /// <summary>A reconstructed visual line of the text layer.</summary>
     public readonly record struct TextLine(PdfRectangle Bounds, string Text);
 
+    /// <summary>
+    /// A reconstructed visual line plus the <see cref="Word"/> instances it was built from (left-to-right,
+    /// matching <see cref="Text"/>). Lets <see cref="PdfRunningHeaderFooter"/> map a detected running
+    /// header/footer line back to the exact words to drop from the page before rendering (#383). The word
+    /// instances are the same references that were passed in, so callers can filter the original word list by
+    /// reference identity.
+    /// </summary>
+    internal readonly record struct LineWithWords(PdfRectangle Bounds, string Text, IReadOnlyList<Word> Words);
+
     // Only bind a nearby text line to a figure when it reads like a figure/table caption. Keeps ordinary
     // adjacent body text from being relocated into the figure block.
     // Latin labels use a word boundary (so "figured"/"tablet" don't match). CJK labels (图/圖/図/表 — zh-Hans,
@@ -91,10 +100,28 @@ internal static class PdfReadingOrder
     /// </summary>
     public static IReadOnlyList<TextLine> GroupWordsIntoLines(IReadOnlyList<Word> words)
     {
+        var withWords = GroupWordsIntoLinesWithWords(words);
+        var lines = new List<TextLine>(withWords.Count);
+        foreach (var line in withWords)
+        {
+            lines.Add(new TextLine(line.Bounds, line.Text));
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Same line reconstruction as <see cref="GroupWordsIntoLines"/>, but each returned line also carries the
+    /// <see cref="Word"/> instances it was built from (left-to-right, matching the line text). Used by
+    /// <see cref="PdfRunningHeaderFooter"/> to drop the exact words of a detected running header/footer line
+    /// from the page before rendering (#383).
+    /// </summary>
+    internal static IReadOnlyList<LineWithWords> GroupWordsIntoLinesWithWords(IReadOnlyList<Word> words)
+    {
         var meaningful = words.Where(w => !string.IsNullOrWhiteSpace(w.Text)).ToList();
         if (meaningful.Count == 0)
         {
-            return Array.Empty<TextLine>();
+            return Array.Empty<LineWithWords>();
         }
 
         // Process top-to-bottom so a line cluster accretes its words in vertical order.
@@ -131,13 +158,12 @@ internal static class PdfReadingOrder
             }
         }
 
-        var lines = new List<TextLine>(clusters.Count);
+        var lines = new List<LineWithWords>(clusters.Count);
         for (var i = 0; i < clusters.Count; i++)
         {
-            var text = string.Join(
-                " ",
-                clusters[i].OrderBy(w => w.BoundingBox.Left).Select(w => w.Text));
-            lines.Add(new TextLine(clusterBounds[i], text));
+            var orderedWords = clusters[i].OrderBy(w => w.BoundingBox.Left).ToList();
+            var text = string.Join(" ", orderedWords.Select(w => w.Text));
+            lines.Add(new LineWithWords(clusterBounds[i], text, orderedWords));
         }
 
         return lines

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfRunningHeaderFooter.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfRunningHeaderFooter.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UglyToad.PdfPig.Content;
+
+namespace Dignite.Extract.Parse.Pdf;
+
+/// <summary>
+/// Cross-page running header / footer + page-number detection for a digital PDF (#383). Such chrome
+/// (a title or confidentiality line repeated at the page edge, "Page 3 of 10", "第 3 页", a bare "3")
+/// is mechanical noise that pollutes the Markdown body and degrades downstream chunking / classification /
+/// field extraction, so it is stripped before rendering.
+/// <para>
+/// <b>Mechanism — repetition, gated by position (not position alone).</b> Position only <i>selects</i>
+/// candidates: the first / last <see cref="CandidateLinesPerEdge"/> visual lines of each page (the
+/// header / footer band). A candidate is dropped only when its <b>digit-normalized</b> text
+/// (so "第 1 页" / "第 2 页" collapse to one template, and "Page 1 of 10" matches "Page 2 of 10")
+/// repeats in the <b>same band</b> across at least <see cref="MinRepeatPageFraction"/> of the pages
+/// (floor <see cref="MinRepeatPageCount"/>). This is deliberately <b>not</b> "delete anything in the
+/// margin band": a per-page signature block / seal / total / footnote sits in the band on a single page,
+/// never repeats, and is therefore preserved — honouring the PdfPig stack's non-lossy discipline
+/// (cf. <see cref="PdfExtractor.IsFullPageScanBackground"/> erring toward keeping).
+/// </para>
+/// <para>
+/// <b>Single-page documents drop nothing</b> — there is no cross-page signal, which is the natural and
+/// accepted consequence of a repetition-based detector (a lone invoice page keeps its footer).
+/// </para>
+/// </summary>
+internal static class PdfRunningHeaderFooter
+{
+    /// <summary>How many visual lines at each page edge (top and bottom) are header/footer candidates.</summary>
+    private const int CandidateLinesPerEdge = 3;
+
+    /// <summary>Absolute floor on the number of pages a candidate must repeat across before it is dropped.</summary>
+    private const int MinRepeatPageCount = 2;
+
+    /// <summary>
+    /// Fraction of the document's pages a candidate must repeat across (in the same band) to be treated as
+    /// running chrome. With the <see cref="MinRepeatPageCount"/> floor, a 2-page document needs the line on
+    /// both pages; a 10-page document needs it on at least five.
+    /// </summary>
+    private const double MinRepeatPageFraction = 0.5;
+
+    // Runs of ASCII or full-width digits collapse to a single placeholder so a varying page number reads as
+    // one stable template across pages ("第 1 页"/"第 2 页" -> "第 # 页", "Page 1 of 10" -> "page # of #").
+    private static readonly Regex DigitRun = new("[0-9０-９]+", RegexOptions.Compiled);
+    private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
+
+    // Band tags keyed into the template so a top-of-page line and a bottom-of-page line never count as the
+    // same running candidate (a header repeats at the top, a footer at the bottom).
+    private const char TopBand = 'T';
+    private const char BottomBand = 'B';
+
+    /// <summary>
+    /// Detects running header/footer/page-number lines across the given pages and returns, per page (by
+    /// index), the set of <see cref="Word"/> instances to drop before rendering. The returned word instances
+    /// are the same references found in <paramref name="pageWords"/>, so the caller filters by reference
+    /// identity. Pages with nothing to drop get an empty set; a document with fewer than
+    /// <see cref="MinRepeatPageCount"/> pages drops nothing.
+    /// </summary>
+    public static IReadOnlyList<IReadOnlySet<Word>> Detect(IReadOnlyList<IReadOnlyList<Word>> pageWords)
+    {
+        var pageCount = pageWords.Count;
+        var result = new List<IReadOnlySet<Word>>(pageCount);
+        for (var i = 0; i < pageCount; i++)
+        {
+            result.Add(EmptyWordSet);
+        }
+
+        if (pageCount < MinRepeatPageCount)
+        {
+            // Single page (or empty): no cross-page repetition is possible, so nothing is running chrome.
+            return result;
+        }
+
+        // Collect every edge-band candidate line, keyed by (band, normalized text), tracking which pages each
+        // template appears on. A line that is both in the top and bottom band (a very short page) registers
+        // under both bands.
+        var candidates = new List<Candidate>();
+        var pagesByKey = new Dictionary<string, HashSet<int>>();
+
+        for (var page = 0; page < pageCount; page++)
+        {
+            var lines = PdfReadingOrder.GroupWordsIntoLinesWithWords(pageWords[page]);
+            var lineCount = lines.Count;
+            for (var i = 0; i < lineCount; i++)
+            {
+                var isTop = i < CandidateLinesPerEdge;
+                var isBottom = i >= lineCount - CandidateLinesPerEdge;
+                if (!isTop && !isBottom)
+                {
+                    continue;
+                }
+
+                var normalized = Normalize(lines[i].Text);
+                if (normalized.Length == 0)
+                {
+                    continue;
+                }
+
+                if (isTop)
+                {
+                    Register(candidates, pagesByKey, page, TopBand, normalized, lines[i].Words);
+                }
+
+                if (isBottom)
+                {
+                    Register(candidates, pagesByKey, page, BottomBand, normalized, lines[i].Words);
+                }
+            }
+        }
+
+        var threshold = Math.Max(MinRepeatPageCount, (int)Math.Ceiling(pageCount * MinRepeatPageFraction));
+        var runningKeys = pagesByKey
+            .Where(kv => kv.Value.Count >= threshold)
+            .Select(kv => kv.Key)
+            .ToHashSet();
+
+        if (runningKeys.Count == 0)
+        {
+            return result;
+        }
+
+        // Materialize the per-page drop sets only for pages that actually have running content.
+        var dropByPage = new Dictionary<int, HashSet<Word>>();
+        foreach (var candidate in candidates)
+        {
+            if (!runningKeys.Contains(candidate.Key))
+            {
+                continue;
+            }
+
+            if (!dropByPage.TryGetValue(candidate.Page, out var set))
+            {
+                set = new HashSet<Word>();
+                dropByPage[candidate.Page] = set;
+            }
+
+            foreach (var word in candidate.Words)
+            {
+                set.Add(word);
+            }
+        }
+
+        foreach (var (page, set) in dropByPage)
+        {
+            result[page] = set;
+        }
+
+        return result;
+    }
+
+    private static void Register(
+        List<Candidate> candidates,
+        Dictionary<string, HashSet<int>> pagesByKey,
+        int page,
+        char band,
+        string normalized,
+        IReadOnlyList<Word> words)
+    {
+        var key = band + normalized;
+        candidates.Add(new Candidate(page, key, words));
+        if (!pagesByKey.TryGetValue(key, out var pages))
+        {
+            pages = new HashSet<int>();
+            pagesByKey[key] = pages;
+        }
+
+        pages.Add(page);
+    }
+
+    /// <summary>
+    /// Normalizes a candidate line into a cross-page-stable template: collapse digit runs to a placeholder
+    /// (so page numbers match), collapse whitespace, trim, and lower-case (a running header keeps consistent
+    /// case across pages; lower-casing is a no-op for CJK and harmless for Latin).
+    /// </summary>
+    private static string Normalize(string text)
+    {
+        var normalized = DigitRun.Replace(text, "#");
+        normalized = WhitespaceRun.Replace(normalized, " ").Trim();
+        return normalized.ToLowerInvariant();
+    }
+
+    private static readonly IReadOnlySet<Word> EmptyWordSet = new HashSet<Word>();
+
+    private readonly record struct Candidate(int Page, string Key, IReadOnlyList<Word> Words);
+}

--- a/core/test/Dignite.Extract.Ocr.VisionLlm.Tests/VisionLlmOcrInstructions_Tests.cs
+++ b/core/test/Dignite.Extract.Ocr.VisionLlm.Tests/VisionLlmOcrInstructions_Tests.cs
@@ -1,0 +1,35 @@
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Extract.Ocr.VisionLlm;
+
+/// <summary>
+/// #383: guards the running header/footer + page-number exclusion in the OCR system prompt, and — more
+/// importantly — that it is paired with the explicit protection of page-bottom body content (signatures,
+/// seals, totals, footnotes). The prompt is the only lever on the VisionLlm path (single-page OCR cannot do
+/// cross-page detection), so the safety clause must not be silently dropped.
+/// </summary>
+public class VisionLlmOcrInstructions_Tests
+{
+    [Fact]
+    public void System_prompt_excludes_running_headers_footers_and_page_numbers()
+    {
+        var prompt = VisionLlmOcrInstructions.SystemPrompt;
+
+        prompt.ShouldContain("running page headers");
+        prompt.ShouldContain("running page footers");
+        prompt.ShouldContain("page numbers");
+    }
+
+    [Fact]
+    public void System_prompt_protects_page_bottom_body_content()
+    {
+        var prompt = VisionLlmOcrInstructions.SystemPrompt;
+
+        // The carve-out that keeps the exclusion from sacrificing real content at the bottom of the page.
+        prompt.ShouldContain("NEVER drop");
+        prompt.ShouldContain("signature");
+        prompt.ShouldContain("total");
+        prompt.ShouldContain("footnotes");
+    }
+}

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfFixtures.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfFixtures.cs
@@ -69,4 +69,26 @@ internal static class PdfFixtures
 
         return builder.Build();
     }
+
+    /// <summary>
+    /// Builds a multi-page PDF — one page per inner list of (Text, baselineY) lines — needed to exercise the
+    /// cross-page running header/footer detection (#383), which has no signal on a single page.
+    /// </summary>
+    public static byte[] BuildMultiPage(
+        IReadOnlyList<IReadOnlyList<(string Text, double BaselineY)>> pages)
+    {
+        var builder = new PdfDocumentBuilder();
+        var font = builder.AddStandard14Font(Standard14Font.Helvetica);
+
+        foreach (var texts in pages)
+        {
+            var page = builder.AddPage(PageWidth, PageHeight);
+            foreach (var (text, baselineY) in texts)
+            {
+                page.AddText(text, 12, new PdfPoint(50, baselineY), font);
+            }
+        }
+
+        return builder.Build();
+    }
 }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfRunningHeaderFooter_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfRunningHeaderFooter_Tests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Dignite.Extract.Abstractions.Parse;
+using Dignite.Extract.Ocr;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Extract.Parse.Pdf;
+
+/// <summary>
+/// #383: cross-page running header / footer + page-number stripping, exercised end-to-end through
+/// <see cref="PdfExtractor"/> on multi-page digital PDFs. The pages carry no images, so the stubbed
+/// <see cref="IOcrProvider"/> is never called.
+/// </summary>
+public class PdfRunningHeaderFooter_Tests
+{
+    private readonly IOcrProvider _ocr = Substitute.For<IOcrProvider>();
+
+    private PdfExtractor CreateExtractor()
+        => new(
+            _ocr,
+            Options.Create(new PdfExtractorOptions()),
+            Options.Create(new ExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+
+    private static TextExtractionContext PdfContext()
+        => new() { ContentType = "application/pdf", FileExtension = ".pdf" };
+
+    // A page edge band (header ~810, footer ~30) with body lines in between. PDF origin is bottom-left, so
+    // a larger Y is higher on the page.
+    private static IReadOnlyList<(string, double)> Page(string header, string footer, params string[] body)
+    {
+        var lines = new List<(string, double)> { (header, 810.0) };
+        var y = 700.0;
+        foreach (var line in body)
+        {
+            lines.Add((line, y));
+            y -= 40.0;
+        }
+
+        lines.Add((footer, 30.0));
+        return lines;
+    }
+
+    [Fact]
+    public async Task Strips_running_header_and_page_number_footer_across_pages()
+    {
+        var pdf = PdfFixtures.BuildMultiPage(new[]
+        {
+            Page("ACME CONFIDENTIAL", "Page 1 of 3", "Section one alpha", "Detail about the alpha topic"),
+            Page("ACME CONFIDENTIAL", "Page 2 of 3", "Section two beta", "Detail about the beta topic"),
+            Page("ACME CONFIDENTIAL", "Page 3 of 3", "Section three gamma", "Detail about the gamma topic")
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // Running header repeated at the top edge of every page → stripped.
+        result.Markdown.ShouldNotContain("ACME CONFIDENTIAL");
+        // Page-number footer: the digit varies per page but the normalized template "page # of #" repeats →
+        // stripped on every page (this is the original #383 complaint).
+        result.Markdown.ShouldNotContain("of 3");
+
+        // Distinct body content is preserved — including lines that fall inside the edge band but do not repeat.
+        result.Markdown.ShouldContain("Section one alpha");
+        result.Markdown.ShouldContain("Section two beta");
+        result.Markdown.ShouldContain("Section three gamma");
+        result.Markdown.ShouldContain("Detail about the alpha topic");
+    }
+
+    [Fact]
+    public async Task Preserves_a_non_repeating_signature_and_total_at_the_page_bottom()
+    {
+        // The critical safety case: a signature block and a total sit in the FOOTER band of the last page but
+        // do NOT repeat across pages, so they must survive even though the genuine page-number footer beside
+        // them is stripped. "Delete by position alone" would lose them — "delete only what repeats" keeps them.
+        var pdf = PdfFixtures.BuildMultiPage(new[]
+        {
+            Page("MASTER AGREEMENT", "Page 1 of 2", "Clause one is here"),
+            new List<(string, double)>
+            {
+                ("MASTER AGREEMENT", 810.0),
+                ("Clause two is here", 700.0),
+                ("Total: 9,999.00 USD", 70.0),
+                ("Signed: Jane Doe", 50.0),
+                ("Page 2 of 2", 30.0)
+            }
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // Body at the very bottom of the page is kept (the whole point of repetition-gated stripping).
+        result.Markdown.ShouldContain("Signed: Jane Doe");
+        result.Markdown.ShouldContain("Total: 9,999.00 USD");
+        // The repeating header + page-number footer are still stripped.
+        result.Markdown.ShouldNotContain("MASTER AGREEMENT");
+        result.Markdown.ShouldNotContain("of 2");
+        result.Markdown.ShouldContain("Clause one is here");
+        result.Markdown.ShouldContain("Clause two is here");
+    }
+
+    [Fact]
+    public async Task Keeps_the_footer_of_a_single_page_document()
+    {
+        // Single page → no cross-page repetition signal → nothing is stripped (accepted #383 limitation).
+        var pdf = PdfFixtures.BuildMultiPage(new[]
+        {
+            Page("ACME CONFIDENTIAL", "Page 1 of 1", "The only body line")
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        result.Markdown.ShouldContain("ACME CONFIDENTIAL");
+        result.Markdown.ShouldContain("Page 1 of 1");
+        result.Markdown.ShouldContain("The only body line");
+    }
+
+    [Fact]
+    public async Task Does_not_strip_a_repeated_line_outside_the_edge_band()
+    {
+        // A line that repeats verbatim across pages but sits in the MIDDLE of the page (outside the
+        // first/last-N candidate band) is body content, not chrome — position gates candidate selection, so
+        // it is never even considered for stripping.
+        IReadOnlyList<(string, double)> MakePage(string suffix, string footer) => new List<(string, double)>
+        {
+            ("TOP HEADER", 810.0),
+            ($"first unique {suffix}", 720.0),
+            ($"second unique {suffix}", 690.0),
+            ("REPEATED MIDDLE LINE", 640.0), // identical on both pages, but middle of the page
+            ($"third unique {suffix}", 590.0),
+            ($"fourth unique {suffix}", 560.0),
+            (footer, 30.0)
+        };
+
+        var pdf = PdfFixtures.BuildMultiPage(new[]
+        {
+            MakePage("a", "Page 1 of 2"),
+            MakePage("b", "Page 2 of 2")
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // Middle repeated line is kept; edge-band running header/footer are stripped.
+        result.Markdown.ShouldContain("REPEATED MIDDLE LINE");
+        result.Markdown.ShouldNotContain("TOP HEADER");
+        result.Markdown.ShouldNotContain("of 2");
+    }
+}


### PR DESCRIPTION
Closes #383.

## Problem
Page chrome — a title/confidentiality line repeated at the page edge, `Page 3 of 10`, `第 3 页`, a bare `3` — was extracted into `Document.Markdown`, polluting the body and degrading downstream chunking / classification / field extraction.

## Approach
Each PDF path removes it with the mechanism native to its medium (an intentional, principled asymmetry):

### Digital PDF — cross-page repetition detection (`PdfRunningHeaderFooter`)
- **Position only selects candidates**: the first / last N visual lines of each page (top / bottom band).
- **Repetition deletes**: a candidate is dropped only when its **digit-normalized** text (so `第 1 页` / `第 2 页` collapse to one template, `Page 1 of 10` matches `Page 2 of 10`) repeats in the **same band** across ≥ 50% of pages (floor 2).
- This is deliberately **not** "delete anything in the margin band" — a per-page **signature / seal / total / footnote** sits in the band on a single page, never repeats, and is **preserved** (honours the PdfPig stack's non-lossy discipline, cf. the #309 full-page-scan guard).
- A **single-page document drops nothing** (no cross-page signal) — accepted.
- Thresholds are **internal constants, no host toggle** — this is confirmed noise (per the #383 discussion).

### Scanned PDF / image — VisionLlm OCR prompt
The provider transcribes **one page per call** and cannot do cross-page detection, so the exclusion lives in the **compile-time system prompt**, paired with an explicit carve-out that **protects signatures, seals, stamps, totals, and footnotes**.

## Invariants held
- `Document` text payload unchanged — Markdown only, no new field, no `Dictionary<string,object>` bag.
- The #268 completeness signal is **deliberately not tripped** (intentional, desired removal — mirrors the #309 skip).
- `PdfReadingOrder.GroupWordsIntoLines` refactored to expose per-line `Word` instances (`GroupWordsIntoLinesWithWords`) so the detector drops exact words by reference identity; public behaviour unchanged.
- VisionLlm prompt remains a compile-time constant (no runtime user-string concatenation).

## Accepted limitations (documented in #383)
- Single-page documents keep their footer.
- Page numbers appearing on only a few / first / last page may not reach the repetition threshold.
- A bare repeating number in the footer band is treated as a page number.

## Test plan
- `PdfRunningHeaderFooter_Tests`: running header + page-number footer stripped across pages; **page-bottom signature & total preserved**; single-page footer kept; mid-page repeated line kept (position gate).
- `VisionLlmOcrInstructions_Tests`: prompt excludes headers/footers/page numbers **and** protects page-bottom body content.
- **Parse.Pdf 63 pass, VisionLlm 37 pass** (incl. all pre-existing tests, confirming the `GroupWordsIntoLines` refactor is behaviour-preserving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
