### PR TITLE
feat(angular): review-queue navigation — list review button + detail return

### DIFF
--- a/angular/packages/extract/documents/src/lib/documents/document-detail/document-detail.component.ts
+++ b/angular/packages/extract/documents/src/lib/documents/document-detail/document-detail.component.ts
@@ -11,7 +11,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { forkJoin, of, switchMap, tap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { marked } from 'marked';
 import { LocalizationPipe, LocalizationService, PermissionService } from '@abp/ng.core';
@@ -73,6 +73,7 @@ const KNOWN_PIPELINE_CODES = [
 export class DocumentDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly location = inject(Location);
   private readonly documentService = inject(DocumentService);
   private readonly documentPipelineRunService = inject(DocumentPipelineRunService);
   private readonly documentTypeService = inject(DocumentTypeService);
@@ -483,7 +484,16 @@ export class DocumentDetailComponent implements OnInit {
   }
 
   goBack(): void {
-    this.router.navigate(['/documents/list']);
+    // Return to wherever the operator came from — the review queue, the list, a cabinet-filtered view, etc.
+    // — instead of always the list. The Angular Router stamps an incrementing navigationId on history.state;
+    // it is > 1 once any in-app navigation has happened, and 1 on a direct deep-link / refresh (no in-app
+    // history to pop). Fall back to the list in that case so Back never leaves the app.
+    const navId = (this.location.getState() as { navigationId?: number } | null)?.navigationId;
+    if (navId && navId > 1) {
+      this.location.back();
+    } else {
+      this.router.navigate(['/documents/list']);
+    }
   }
 
   delete(): void {

--- a/angular/packages/extract/documents/src/lib/documents/document-list/document-list.component.html
+++ b/angular/packages/extract/documents/src/lib/documents/document-list/document-list.component.html
@@ -14,19 +14,19 @@
       >
         <i class="fas fa-sync-alt" [class.fa-spin]="isLoading()"></i>
       </button>
-      <button
-        class="btn"
-        [class.btn-warning]="hasReviewReasonsFilter()"
-        [class.btn-outline-warning]="!hasReviewReasonsFilter()"
-        (click)="toggleManualReviewFilter()"
-        title="{{ '::Document:NeedsReview' | abpLocalization }}"
-      >
-        <i class="fas fa-user-edit me-1"></i>
-        {{ '::Document:NeedsReview' | abpLocalization }}
-        @if (reviewNeededCount() > 0) {
-          <span class="badge bg-danger ms-1">{{ reviewNeededCount() }}</span>
-        }
-      </button>
+      @if (canConfirm) {
+        <button
+          class="btn btn-outline-warning"
+          routerLink="/documents/review"
+          title="{{ '::Menu:DocumentReviewQueue' | abpLocalization }}"
+        >
+          <i class="fas fa-clipboard-check me-1"></i>
+          {{ '::Document:NeedsReview' | abpLocalization }}
+          @if (reviewQueueCount() > 0) {
+            <span class="badge bg-danger ms-1">{{ reviewQueueCount() }}</span>
+          }
+        </button>
+      }
       @if (canUpload) {
         <button class="btn btn-primary" (click)="uploadNew()">
           <i class="fas fa-upload me-1"></i>

--- a/angular/packages/extract/documents/src/lib/documents/document-list/document-list.component.ts
+++ b/angular/packages/extract/documents/src/lib/documents/document-list/document-list.component.ts
@@ -37,6 +37,7 @@ import {
   DocumentListItemDto,
   DocumentReviewReasons,
   DocumentService,
+  DocumentStatisticsService,
   DocumentTypeDto,
   DocumentTypeService,
   FieldDefinitionDto,
@@ -75,6 +76,7 @@ interface TableActivateEvent {
 })
 export class DocumentListComponent implements OnInit {
   private readonly documentService = inject(DocumentService);
+  private readonly statisticsService = inject(DocumentStatisticsService);
   private readonly documentTypeService = inject(DocumentTypeService);
   private readonly fieldDefinitionService = inject(FieldDefinitionService);
   private readonly cabinetService = inject(CabinetService);
@@ -110,7 +112,6 @@ export class DocumentListComponent implements OnInit {
   // track key) to force a fresh instance — deterministic, no setTimeout/flicker.
   tableKey = signal(0);
 
-  hasReviewReasonsFilter = signal<boolean | undefined>(undefined);
   typeFilter = signal<string>('');
   cabinetFilter = signal<string>('');
   lifecycleFilter = signal<DocumentLifecycleStatus | undefined>(undefined);
@@ -131,9 +132,10 @@ export class DocumentListComponent implements OnInit {
   selectedTypeId = signal('');
   isConfirming = signal(false);
 
-  reviewNeededCount = computed(() =>
-    this.documents().items.filter(d => d.requiresReview).length,
-  );
+  // #284 review-queue gateway: the toolbar badge shows the canonical needs-review total for the current
+  // layer (DocumentStatisticsDto.NeedsReviewCount — same RequiresAttention predicate the review queue runs,
+  // #333), not a page-local count, so it stays correct across pagination and once the list is unfiltered.
+  reviewQueueCount = signal(0);
 
   // #354: render the row actions column when the user has confirm/delete actions OR any row is a container —
   // containers expose a "view sub-documents" action regardless of those permissions.
@@ -153,6 +155,8 @@ export class DocumentListComponent implements OnInit {
     // cabinet- or type-filtered list before the initial load runs.
     this.applyQueryParamFilters();
     this.hookListQuery();
+    // Review-queue badge total — only fetched/shown for operators who can open the queue (#284).
+    this.loadReviewQueueCount();
     // Document types drive the type filter, the dynamic extracted-field columns, and
     // the confirm-classification picker. Every Documents.Default user needs them, and
     // the read is now decoupled from schema-admin permission (#223 — GetVisible no longer
@@ -269,7 +273,6 @@ export class DocumentListComponent implements OnInit {
       cabinetId: this.cabinetFilter() || undefined,
       originDocumentId: this.originDocumentIdFilter() || undefined,
       lifecycleStatus: this.lifecycleFilter(),
-      hasReviewReasons: this.hasReviewReasonsFilter(),
     };
   }
 
@@ -489,6 +492,8 @@ export class DocumentListComponent implements OnInit {
             next: () => {
               this.toaster.success('::Document:DeletedSuccessfully', '::Success');
               this.list.getWithoutPageReset();
+              // A deleted document leaves the (soft-delete-filtered) review queue — refresh the badge.
+              this.loadReviewQueueCount();
             },
             error: () => this.toaster.error('::Document:DeleteFailed', '::Error'),
           });
@@ -496,9 +501,17 @@ export class DocumentListComponent implements OnInit {
       });
   }
 
-  toggleManualReviewFilter(): void {
-    this.hasReviewReasonsFilter.update(v => (v ? undefined : true));
-    this.refreshListFromFirstPage();
+  // Canonical needs-review total for the toolbar badge. Gated on canConfirm so non-reviewers (who don't
+  // see the gateway button) never fire the call. The statistics endpoint shares the review queue's
+  // RequiresAttention predicate (#333), so the badge and the queue never drift.
+  private loadReviewQueueCount(): void {
+    if (!this.canConfirm) return;
+    this.statisticsService.get()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: stats => this.reviewQueueCount.set(stats.needsReviewCount ?? 0),
+        error: () => this.reviewQueueCount.set(0),
+      });
   }
 
   // #284: show the confirm-classification button only when the document still requires attention
@@ -547,6 +560,8 @@ export class DocumentListComponent implements OnInit {
         this.closeConfirmDialog();
         this.toaster.success('::Document:ClassificationConfirmed', '::Success');
         this.list.getWithoutPageReset();
+        // Confirming a classification clears its review reason — keep the badge in step with the queue.
+        this.loadReviewQueueCount();
       },
       error: () => {
         this.isConfirming.set(false);


### PR DESCRIPTION
> **Draft — packaged from the shared working tree, not my own change.** These two Angular UI commits were authored in this working copy by a concurrent session and had landed on a mis-named branch (`feat/383-strip-running-header-footer`). I reorganized them onto this clean branch off current `main`. Opened as a **draft** so CI can validate the Angular build; final scope, description, and merge are the author's call.

## Commits
- **`feat(angular): link document list review button to the review queue`** — points the document-list toolbar review badge at the canonical needs-review total (`DocumentStatisticsService.NeedsReviewCount`) instead of a page-local count, and links the button to the review queue.
- **`fix(angular): return from document detail to the originating page`** — document detail navigates back to the originating page/route rather than a fixed default.

## Notes
- **No `core/` changes** — touches only the documents Angular package (`document-list` + `document-detail` components, 3 files).
- Not linked to a closing issue (review-queue context appears related to #284 / #333) — author to confirm scope before un-drafting.
