### PR TITLE
feat(parse,pipelines): figure OCR markers as egress provenance annotations (#381)

### DIFF
--- a/core/src/Dignite.Extract.Abstractions/Parse/ImageOcrMarkup.cs
+++ b/core/src/Dignite.Extract.Abstractions/Parse/ImageOcrMarkup.cs
@@ -6,68 +6,65 @@ using System.Text;
 namespace Dignite.Extract.Abstractions.Parse;
 
 /// <summary>
-/// In-band markers that bracket an embedded-figure OCR transcription inlined into the working Markdown (#371,
-/// unifying figure routing #306/#365 and born-digital segmentation #346 into one Markdown-borne sub-document
-/// pass; MarkItDown's <c>[Image OCR]…[End OCR]</c> is the prior art). A figure's transcription is already inlined
-/// at its reading position (#301); these sentinels only <b>delimit</b> it so two pipeline-internal consumers can
-/// recognize a figure span — the classification "contains an embedded standalone document?" signal, and the
-/// unified sub-document detection pass.
+/// In-band <b>provenance annotations</b> that bracket an embedded-figure OCR transcription inlined into the Markdown
+/// (#371, unifying figure routing #306/#365 and born-digital segmentation #346 into one Markdown-borne sub-document
+/// pass; MarkItDown's <c>*[Image OCR]*…*[End OCR]*</c> is the prior art and the exact format we adopt). A figure's
+/// transcription is already inlined at its reading position (#301); these markers <b>delimit</b> it and tell any
+/// consumer — human, RAG engine, LLM — that the bracketed text came from OCR of an embedded image.
 /// <para>
-/// <b>Pipeline-internal only — never reaches the egress.</b> The sentinels are <see cref="Strip"/>-ped before the
-/// Markdown becomes the persisted egress payload (<c>Document.Markdown</c>), so the channel text stays clean
-/// (Markdown-first). The marked copy is kept only as an internal pipeline artifact for the consumers above.
-/// <see cref="Strip"/> is the exact inverse of <see cref="Wrap"/>, so a stripped document equals the pre-#371
-/// inline output byte for byte.
+/// <b>Provenance annotation, not a pipeline control signal (#381).</b> The markers stay in <c>Document.Markdown</c>,
+/// the persisted egress payload — they are no longer stripped before persistence. This aligns Dignite Extract with
+/// MarkItDown's philosophy (the markers are part of the final Markdown), dissolves the salt that #376 needed only to
+/// keep a stripped egress safe from re-ingested MarkItDown content, and makes a re-ingested MarkItDown document fall
+/// out naturally: its <c>*[Image OCR]*</c> blocks are already provenance-annotated content and need no special-casing.
+/// The pipeline still reads the markers as structure — <see cref="Contains"/> is a (now demoted) recall signal for
+/// figure routing, and the unified sub-document pass uses <see cref="IsOpenLine"/> / <see cref="ExtractBodies"/> /
+/// <see cref="Strip"/> to derive a spawned child's seed text — but the markers themselves travel all the way to the
+/// egress, not just to an internal artifact.
 /// </para>
 /// <para>
-/// Each sentinel is a line of its own. The open line optionally carries the 1-based source page
-/// (<c>[Image OCR p:3]</c>) as a lightweight recovery anchor (#371 / #210: a position is provenance, never
-/// identity — identity is the span content hash). Only compile-time constants are emitted (no runtime
-/// user-string concatenation, per the LLM security conventions); the page number is the sole interpolated value
-/// and is an <see cref="int"/>.
+/// Each marker is a line of its own. The open line optionally carries the 1-based source page
+/// (<c>*[Image OCR p:3]*</c>) as a lightweight recovery anchor (#371 / #210: a position is provenance, never
+/// identity — identity is the span content hash); the bare <c>*[Image OCR]*</c> form (MarkItDown's own string, and a
+/// page-less figure) is equally recognized. Only compile-time constants are emitted (no runtime user-string
+/// concatenation, per the LLM security conventions); the page number is the sole interpolated value and is an
+/// <see cref="int"/>.
 /// </para>
 /// </summary>
 public static class ImageOcrMarkup
 {
-    /// <summary>
-    /// A fixed, high-entropy salt baked into every sentinel (#376). MarkItDown's bare <c>[Image OCR]</c> /
-    /// <c>[End OCR]</c> is a string a real document line can legitimately equal — most concretely, a document that was
-    /// itself produced by MarkItDown and then re-ingested carries those exact lines. Without the salt,
-    /// <see cref="Strip"/> would delete such a content line from the egress Markdown (silent data loss) and
-    /// <see cref="ExtractBodies"/> / the slicer would mis-close a figure block on it. The salt makes a coincidental
-    /// collision astronomically unlikely while the readable "Image OCR" label keeps the marker LLM-legible. It is
-    /// pipeline-internal and never reaches the egress (<see cref="Strip"/> removes the whole sentinel line before the
-    /// Markdown is persisted).
-    /// </summary>
-    private const string Salt = "9f1d3a7c";
+    /// <summary>The open marker with no page anchor (<c>*[Image OCR]*</c>) — byte-identical to MarkItDown's own.</summary>
+    public const string OpenMarker = "*[Image OCR]*";
 
-    /// <summary>The open sentinel with no page anchor (<c>[Image OCR 9f1d3a7c]</c>).</summary>
-    public const string OpenMarker = "[Image OCR " + Salt + "]";
+    /// <summary>Prefix of a page-anchored open marker; the full line is <c>*[Image OCR p:{page}]*</c>.</summary>
+    public const string OpenPagePrefix = "*[Image OCR p:";
 
-    /// <summary>Prefix of a page-anchored open sentinel; the full line is <c>[Image OCR 9f1d3a7c p:{page}]</c>.</summary>
-    public const string OpenPagePrefix = "[Image OCR " + Salt + " p:";
+    /// <summary>Suffix that closes a page-anchored open marker (the italic <c>*</c> after the <c>]</c>).</summary>
+    private const string PageSuffix = "]*";
 
-    /// <summary>The close sentinel (<c>[End OCR 9f1d3a7c]</c>).</summary>
-    public const string CloseMarker = "[End OCR " + Salt + "]";
+    /// <summary>The close marker (<c>*[End OCR]*</c>) — byte-identical to MarkItDown's own.</summary>
+    public const string CloseMarker = "*[End OCR]*";
 
     /// <summary>
-    /// Wraps a figure's OCR <paramref name="transcription"/> in the open/close sentinels, each on its own line,
+    /// Wraps a figure's OCR <paramref name="transcription"/> in the open/close markers, each on its own line,
     /// with an optional 1-based <paramref name="pageNumber"/> anchor on the open line. A non-positive / null page
     /// produces the bare open marker.
     /// </summary>
     public static string Wrap(string? transcription, int? pageNumber)
     {
         var open = pageNumber is { } p && p > 0
-            ? OpenPagePrefix + p.ToString(CultureInfo.InvariantCulture) + "]"
+            ? OpenPagePrefix + p.ToString(CultureInfo.InvariantCulture) + PageSuffix
             : OpenMarker;
         return open + "\n" + (transcription ?? string.Empty) + "\n" + CloseMarker;
     }
 
     /// <summary>
-    /// Whether <paramref name="markdown"/> contains at least one figure open sentinel <b>on its own line</b> — the
-    /// cheap structural "has figures" signal (the trigger fallback, the marked-artifact archive gate, and the
-    /// per-span Figure/Text kind decision). Whole-line matching (consistent with <see cref="Strip"/>) so ordinary
-    /// content that merely <i>mentions</i> <c>[Image OCR]</c> inside a longer line is not mistaken for a figure span.
+    /// Whether <paramref name="markdown"/> contains at least one figure open marker <b>on its own line</b> — the
+    /// cheap structural "has figures" signal. Since #381 this is a <b>demoted</b> recall hint (figure / sub-document
+    /// spawning is decided by LLM semantic judgment, not gated on this), still used as the zero-cost deterministic
+    /// trigger that lets the focused segmentation pass look at a figure-bearing document. Whole-line matching
+    /// (consistent with <see cref="Strip"/>) so ordinary content that merely <i>mentions</i> <c>*[Image OCR]*</c>
+    /// inside a longer line is not mistaken for a figure span.
     /// </summary>
     public static bool Contains(string? markdown)
     {
@@ -88,9 +85,14 @@ public static class ImageOcrMarkup
     }
 
     /// <summary>
-    /// Removes every sentinel <b>line</b> (open or close), leaving the transcription content in place — the exact
-    /// inverse of <see cref="Wrap"/>. A line is treated as a sentinel only when the sentinel is the whole trimmed
-    /// line, so ordinary prose that merely mentions the label is untouched.
+    /// Removes every marker <b>line</b> (open or close), leaving the transcription content in place — the exact
+    /// inverse of <see cref="Wrap"/>. A line is treated as a marker only when the marker is the whole trimmed line,
+    /// so ordinary prose that merely mentions the label is untouched.
+    /// <para>
+    /// Since #381 this is <b>no longer applied to the egress</b> (<c>Document.Markdown</c> keeps the markers). It
+    /// survives as a content utility for the unified sub-document pass, which uses it to derive a spawned text
+    /// child's clean seed (stripping the inline figure markers a folded text span carried).
+    /// </para>
     /// </summary>
     public static string Strip(string? markdown)
     {
@@ -104,11 +106,11 @@ public static class ImageOcrMarkup
 
     /// <summary>
     /// Returns the concatenated figure transcription <b>body</b> — the content between each
-    /// <c>[Image OCR]…[End OCR]</c> pair, joined by newlines — with everything OUTSIDE the sentinels (and the
-    /// sentinel lines themselves) dropped. Used (#371/#373) to spawn a figure sub-document from ONLY its figure body,
+    /// <c>*[Image OCR]*…*[End OCR]*</c> pair, joined by newlines — with everything OUTSIDE the markers (and the
+    /// marker lines themselves) dropped. Used (#371/#373) to spawn a figure sub-document from ONLY its figure body,
     /// so any surrounding parent text the LLM folded into the span (e.g. by omitting a separate parent-body boundary)
     /// is excluded; the figure child is the transcription, nothing more. Returns the empty string when there is no
-    /// figure block. An unclosed open sentinel keeps the rest as body (fail-open, never drops content silently).
+    /// figure block. An unclosed open marker keeps the rest as body (fail-open, never drops content silently).
     /// </summary>
     public static string ExtractBodies(string? markdown)
     {
@@ -147,7 +149,7 @@ public static class ImageOcrMarkup
         return sb.ToString();
     }
 
-    /// <summary>Whether the (trimmed) line is a figure open sentinel (bare or page-anchored).</summary>
+    /// <summary>Whether the (trimmed) line is a figure open marker (bare or page-anchored).</summary>
     public static bool IsOpenLine(string? line)
     {
         if (line is null)
@@ -159,12 +161,12 @@ public static class ImageOcrMarkup
         return trimmed == OpenMarker || IsPageOpen(trimmed);
     }
 
-    /// <summary>Whether the (trimmed) line is the figure close sentinel.</summary>
+    /// <summary>Whether the (trimmed) line is the figure close marker.</summary>
     public static bool IsCloseLine(string? line)
         => line is not null && line.Trim() == CloseMarker;
 
     /// <summary>
-    /// Parses the 1-based page from a page-anchored open sentinel line (<c>[Image OCR p:3]</c>), or <c>null</c>
+    /// Parses the 1-based page from a page-anchored open marker line (<c>*[Image OCR p:3]*</c>), or <c>null</c>
     /// for a bare open line / any non-open line.
     /// </summary>
     public static int? TryParsePage(string? line)
@@ -180,7 +182,7 @@ public static class ImageOcrMarkup
             return null;
         }
 
-        var body = trimmed.Substring(OpenPagePrefix.Length, trimmed.Length - OpenPagePrefix.Length - 1);
+        var body = trimmed.Substring(OpenPagePrefix.Length, trimmed.Length - OpenPagePrefix.Length - PageSuffix.Length);
         return int.TryParse(body, NumberStyles.None, CultureInfo.InvariantCulture, out var page) ? page : null;
     }
 
@@ -190,22 +192,22 @@ public static class ImageOcrMarkup
         return trimmed == CloseMarker || trimmed == OpenMarker || IsPageOpen(trimmed);
     }
 
-    /// <summary>Whether the already-trimmed text is a well-formed <c>[Image OCR p:{digits}]</c> open line.</summary>
+    /// <summary>Whether the already-trimmed text is a well-formed <c>*[Image OCR p:{digits}]*</c> open line.</summary>
     private static bool IsPageOpen(string trimmed)
     {
         if (!trimmed.StartsWith(OpenPagePrefix, StringComparison.Ordinal)
-            || !trimmed.EndsWith("]", StringComparison.Ordinal))
+            || !trimmed.EndsWith(PageSuffix, StringComparison.Ordinal))
         {
             return false;
         }
 
-        var bodyLength = trimmed.Length - OpenPagePrefix.Length - 1;
+        var bodyLength = trimmed.Length - OpenPagePrefix.Length - PageSuffix.Length;
         if (bodyLength <= 0)
         {
             return false;
         }
 
-        for (var i = OpenPagePrefix.Length; i < trimmed.Length - 1; i++)
+        for (var i = OpenPagePrefix.Length; i < trimmed.Length - PageSuffix.Length; i++)
         {
             if (trimmed[i] < '0' || trimmed[i] > '9')
             {

--- a/core/src/Dignite.Extract.Application/Ai/DefaultPromptProvider.cs
+++ b/core/src/Dignite.Extract.Application/Ai/DefaultPromptProvider.cs
@@ -39,8 +39,8 @@ public class DefaultPromptProvider : IPromptProvider, ITransientDependency
         "line-item overflow of one invoice or contract (the same document identity / header repeats); or a single " +
         "register, ledger, or itemized table that merely lists many rows. When in doubt, set isContainer to false. " +
         // #371: a NON-container parent may still embed a standalone document (an invoice photo inside a contract).
-        // The input brackets each embedded-image OCR region with the salted figure sentinels (#376); flag those that
-        // are a complete document of their own. Conservative — mirrors the isContainer / figure-gate reject-list.
+        // The input brackets each embedded-image OCR region with the *[Image OCR]* provenance markers (#381); flag
+        // those that are a complete document of their own. Conservative — mirrors the isContainer / figure-gate reject-list.
         "Set containsEmbeddedDocument to true when the document is NOT a container but embeds an image that is itself " +
         "a complete, self-contained document — for example an invoice or receipt photo, or a scanned certificate, " +
         "shown inside a contract or report; the classification input marks each embedded-image OCR region with " +
@@ -65,7 +65,7 @@ public class DefaultPromptProvider : IPromptProvider, ITransientDependency
         "You analyze one document's Markdown and identify which spans are standalone sub-documents that should be " +
         "filed and processed on their own, versus content of the document itself. The content is provided as " +
         "Markdown and may contain embedded-image OCR regions, each bracketed by " + ImageOcrMarkup.OpenMarker +
-        " (or " + ImageOcrMarkup.OpenPagePrefix + "N]) and " + ImageOcrMarkup.CloseMarker +
+        " (or " + ImageOcrMarkup.OpenPagePrefix + "N]*) and " + ImageOcrMarkup.CloseMarker +
         " markers — these are images embedded in the document, transcribed to text. " +
         "You are told whether the document is a CONTAINER (a bundle of several independent documents) or a single " +
         "concrete document that may merely EMBED a standalone document (such as an invoice photo inside a contract). " +

--- a/core/src/Dignite.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Extract.Application/Documents/DocumentAppService.cs
@@ -397,21 +397,6 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
             }
         }
 
-        // #371: permanently delete the marked-Markdown pipeline artifact (if any) together, using its stable
-        // per-document key (best-effort, like the original file / native payload blobs). Only figure-bearing
-        // documents have one; DeleteAsync on a missing blob is a no-op for the file-system / typical providers.
-        var markedMarkdownBlobName = DocumentConsts.MarkedMarkdownBlobPrefix + id;
-        try
-        {
-            await _blobContainer.DeleteAsync(markedMarkdownBlobName);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex,
-                "Failed to delete marked Markdown blob {BlobName} for document {DocumentId}.",
-                markedMarkdownBlobName, id);
-        }
-
         // Notify downstream consumers: the Document is unrecoverable, so derived data should be physically deleted.
         await _distributedEventBus.PublishAsync(
             new DocumentPermanentlyDeletedEto

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dignite.Extract.Abstractions.Documents;
@@ -11,7 +10,6 @@ using Dignite.Extract.Documents.Pipelines.Segmentation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.BackgroundJobs;
-using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.MultiTenancy;
@@ -31,9 +29,6 @@ public class DocumentClassificationBackgroundJob
     private readonly ExtractBehaviorOptions _aiOptions;
     private readonly ICurrentTenant _currentTenant;
     private readonly IBackgroundJobManager _backgroundJobManager;
-    // #371: classification reads the MARKED Markdown (with [Image OCR] sentinels) so the embedded-document signal
-    // can recognize figure spans; the blob is the same artifact the unified pass reads.
-    private readonly IBlobContainer<ExtractDocumentContainer> _blobContainer;
 
     public DocumentClassificationBackgroundJob(
         IDocumentRepository documentRepository,
@@ -47,8 +42,7 @@ public class DocumentClassificationBackgroundJob
         IClock clock,
         IOptions<ExtractBehaviorOptions> aiOptions,
         ICurrentTenant currentTenant,
-        IBackgroundJobManager backgroundJobManager,
-        IBlobContainer<ExtractDocumentContainer> blobContainer)
+        IBackgroundJobManager backgroundJobManager)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _documentTypeRepository = documentTypeRepository;
@@ -58,7 +52,6 @@ public class DocumentClassificationBackgroundJob
         _aiOptions = aiOptions.Value;
         _currentTenant = currentTenant;
         _backgroundJobManager = backgroundJobManager;
-        _blobContainer = blobContainer;
     }
 
     public override async Task ExecuteAsync(DocumentClassificationJobArgs args)
@@ -67,11 +60,12 @@ public class DocumentClassificationBackgroundJob
 
         try
         {
-            // #371: classify over the MARKED Markdown (external blob read, no UoW) so the embedded-document signal
-            // sees the [Image OCR] figure spans; fall back to the clean Document.Markdown when there is no artifact.
-            var marked = await TryReadMarkedMarkdownAsync(workItem.DocumentId) ?? workItem.Markdown;
-            var outcome = await ClassifyAsync(workItem, marked);
-            await CompleteRunAsync(workItem, outcome, ImageOcrMarkup.Contains(marked));
+            // #381: classify over Document.Markdown, which now retains the *[Image OCR]* figure provenance markers
+            // (no separate marked artifact anymore). The embedded-document signal sees the figure spans directly, and
+            // the figure-bearing recall trigger keys on ImageOcrMarkup.Contains over the same text.
+            var markdown = workItem.Markdown;
+            var outcome = await ClassifyAsync(workItem, markdown);
+            await CompleteRunAsync(workItem, outcome, ImageOcrMarkup.Contains(markdown));
         }
         catch (Exception ex)
         {
@@ -156,28 +150,6 @@ public class DocumentClassificationBackgroundJob
     private static bool IsSchemaDeserializationError(Exception ex)
         => ex is JsonException || ex.GetBaseException() is JsonException;
 
-    /// <summary>
-    /// External read (no UoW): the marked Markdown artifact (#371) for the document, or <c>null</c> when there is
-    /// none (a non-figure document, or an archive that failed open) — the caller then classifies over the clean
-    /// <c>Document.Markdown</c>. Fails open: a read error degrades to <c>null</c>, never faulting classification.
-    /// </summary>
-    private async Task<string?> TryReadMarkedMarkdownAsync(Guid documentId)
-    {
-        var blobName = DocumentConsts.MarkedMarkdownBlobPrefix + documentId;
-        try
-        {
-            var bytes = await _blobContainer.GetAllBytesOrNullAsync(blobName);
-            return bytes is null ? null : Encoding.UTF8.GetString(bytes);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex,
-                "Failed to read marked Markdown blob {BlobName} for document {DocumentId}; classifying over the clean Document.Markdown.",
-                blobName, documentId);
-            return null;
-        }
-    }
-
     private async Task ApplyClassificationResultAsync(
         Document document,
         DocumentPipelineRun run,
@@ -200,7 +172,7 @@ public class DocumentClassificationBackgroundJob
             await PipelineRunManager.CompleteClassificationAsContainerAsync(document, run);
 
             // Enqueued in the SAME UoW as the completion so the container marker and the detection job commit
-            // atomically via the outbox. The unified pass (#371) reads the marked Markdown and splits both text and
+            // atomically via the outbox. The unified pass (#371) reads Document.Markdown and splits both text and
             // figure spans — there is no separate figure-routing job anymore.
             await _backgroundJobManager.EnqueueAsync(
                 new DocumentSegmentationJobArgs { SourceDocumentId = document.Id });
@@ -248,10 +220,10 @@ public class DocumentClassificationBackgroundJob
 
         // #371/#379: a non-container parent may still embed a standalone document to route to its own sub-document.
         // Enqueue the unified pass when the classifier flagged it, OR — deterministically — whenever the source is
-        // figure-bearing (its marked Markdown carries an [Image OCR] sentinel). Keying figure recall on the
+        // figure-bearing (its Document.Markdown carries an *[Image OCR]* marker). Keying figure recall on the
         // already-computed, zero-cost ImageOcrMarkup.Contains signal (#379) makes the focused segmentation LLM the
         // single standalone-vs-element decision-maker, closing the within-window hole where a multi-objective
-        // classifier under-flagged an embedded figure (ContainsEmbeddedDocument=false) on a doc whose marked Markdown
+        // classifier under-flagged an embedded figure (ContainsEmbeddedDocument=false) on a doc whose Document.Markdown
         // fit inside the classification truncation window — previously the figure arm fired only beyond that window,
         // so an in-window embedded document was never routed and never entered review (a silent recall miss).
         // No structural pre-check guards the figure arm: this trigger is only reached for a non-container parent, where

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Classification/DocumentClassificationWorkflow.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Classification/DocumentClassificationWorkflow.cs
@@ -160,7 +160,7 @@ public class DocumentClassificationWorkflow : ITransientDependency
             // dominates the type guess downstream — the BackgroundJob takes the container branch and ignores typeCode.
             IsContainer = parsed?.IsContainer ?? false,
             // #371: a non-container parent that embeds a standalone document (e.g. an invoice photo inside a
-            // contract — a figure span the classification input shows bracketed by [Image OCR]…[End OCR]) still
+            // contract — a figure span the classification input shows bracketed by *[Image OCR]*…*[End OCR]*) still
             // triggers the unified sub-document detection pass. Rides the same call (zero extra LLM cost).
             ContainsEmbeddedDocument = parsed?.ContainsEmbeddedDocument ?? false
         };
@@ -249,7 +249,7 @@ public class DocumentClassificationWorkflow : ITransientDependency
         /// <summary>
         /// #371: <c>true</c> when the document is NOT a container but contains an embedded image that is itself a
         /// complete standalone document (an invoice photo inside a contract) — a figure span the classification input
-        /// shows bracketed by <c>[Image OCR]…[End OCR]</c>. Triggers the unified sub-document detection pass for a
+        /// shows bracketed by <c>*[Image OCR]*…*[End OCR]*</c>. Triggers the unified sub-document detection pass for a
         /// concrete-typed parent. Conservative (the prompt's reject-list); ignored when <see cref="IsContainer"/> is set.
         /// </summary>
         public bool ContainsEmbeddedDocument { get; set; }

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Extract.Abstractions.Documents;
@@ -123,15 +122,12 @@ public class DocumentParseBackgroundJob
                 result = await _textExtractor.ExtractAsync(blobStream, ctx, _cancellationTokenProvider.Token);
             }
 
-            // #371: the PDF provider brackets each embedded-figure transcription with [Image OCR p:N]…[End OCR]
-            // sentinels. Archive the marked Markdown as an internal pipeline artifact (read by classification's
-            // embedded-document signal + the unified sub-document pass to recognize figure spans), then strip the
-            // sentinels IN PLACE so Document.Markdown — the egress payload — and the title below are clean
-            // (Markdown-first). For a document with no figure sentinels (most uploads, all seeded sub-documents)
-            // this is a no-op: archiving is skipped and Strip returns the input unchanged.
-            await ArchiveMarkedMarkdownAsync(args.DocumentId, result.Markdown);
-            result.Markdown = ImageOcrMarkup.Strip(result.Markdown);
-
+            // #381: the PDF provider brackets each embedded-figure transcription with *[Image OCR p:N]*…*[End OCR]*
+            // provenance markers (#371). These are no longer stripped — they are MarkItDown-style annotations that
+            // stay in Document.Markdown (the egress payload) so any consumer — human, RAG engine, LLM — can see the
+            // bracketed text came from OCR. The title generated below therefore runs over the marked Markdown, which
+            // is fine: the markers are ordinary italic-annotated content, exactly as a re-ingested MarkItDown document
+            // already carries them.
             var title = await TryGenerateTitleAsync(result.Markdown, _cancellationTokenProvider.Token)
                 ?? MarkdownTitleExtractor.ExtractTitle(result.Markdown)
                 ?? FallbackTitleFromFileName(workItem.OriginalFileName);
@@ -219,7 +215,7 @@ public class DocumentParseBackgroundJob
         // Advance classification as soon as text extraction completes. OCR has no quality gate:
         // #196 found average OCR confidence does not predict real quality. Quality issues are handled later through classification review
         // plus operator rerun / re-upload. Figure sub-document routing now rides classification (#371): the embedded
-        // [Image OCR] sentinels make the classifier flag an embedded document and enqueue the unified pass — no
+        // *[Image OCR]* markers make the classifier flag an embedded document and enqueue the unified pass — no
         // separate figure-routing enqueue here anymore.
         await _pipelineJobScheduler.QueueAsync(document, ExtractPipelines.Classification);
 
@@ -256,40 +252,6 @@ public class DocumentParseBackgroundJob
         var manifest = await TryArchiveNativePayloadAsync(documentId, result.NativePayload);
         return new DocumentParseMetadata(
             result.ProviderName, manifest, result.IsComplete, result.IncompleteReason);
-    }
-
-    /// <summary>
-    /// External phase (no UoW): archives the <b>marked</b> Markdown (#371) — the working Markdown still carrying
-    /// the in-band <c>[Image OCR]…[End OCR]</c> figure sentinels — under the stable per-document key
-    /// <c>markdown-marked/{documentId}</c>, so classification (the embedded-document signal) and the unified
-    /// sub-document pass can recognize figure spans. <c>Document.Markdown</c> itself is persisted with the
-    /// sentinels stripped (Markdown-first); this marked copy is a pipeline-internal artifact only.
-    /// <para>
-    /// Skips a document with no figure sentinels (the consumers fall back to the clean <c>Document.Markdown</c>),
-    /// and <b>fails open</b>: a write failure only loses the figure-span hint, never the text extraction itself.
-    /// The stable key is overwritten on re-extraction and reclaimed on permanent delete, so a failed-completion
-    /// write leaves at most one overwrite-stable orphan (like the native payload archive).
-    /// </para>
-    /// </summary>
-    protected virtual async Task ArchiveMarkedMarkdownAsync(Guid documentId, string? markedMarkdown)
-    {
-        if (string.IsNullOrEmpty(markedMarkdown) || !ImageOcrMarkup.Contains(markedMarkdown))
-        {
-            return;
-        }
-
-        var blobName = DocumentConsts.MarkedMarkdownBlobPrefix + documentId;
-        try
-        {
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(markedMarkdown), writable: false);
-            await _blobContainer.SaveAsync(blobName, stream, overrideExisting: true);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex,
-                "Failed to archive marked Markdown for document {DocumentId} to blob {BlobName}; classification and the unified sub-document pass will fall back to Document.Markdown.",
-                documentId, blobName);
-        }
     }
 
     private async Task<NativePayloadManifest?> TryArchiveNativePayloadAsync(Guid documentId, NativePayload? payload)

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -28,9 +28,9 @@ namespace Dignite.Extract.Documents.Pipelines.Segmentation;
 /// Unified sub-document detection job (#371): the one Markdown-borne, LLM-decided pass that folds born-digital
 /// container segmentation (#346) and figure routing (#306/#365) into a single decision. Enqueued from the
 /// classification complete-phase when the source is a container <b>or</b> a concrete document that embeds a
-/// standalone document, it runs <see cref="DocumentSegmentationWorkflow"/> over the source's <b>marked</b> Markdown
-/// (the working copy still carrying the <c>[Image OCR]…[End OCR]</c> figure sentinels) and spawns each standalone
-/// span as a derived <see cref="Document"/> seeded from its (stripped, clean) slice.
+/// standalone document, it runs <see cref="DocumentSegmentationWorkflow"/> over the source's <c>Document.Markdown</c>
+/// (which retains the inline <c>*[Image OCR]*…*[End OCR]*</c> figure provenance markers, #381) and spawns each
+/// standalone span as a derived <see cref="Document"/> seeded from its (stripped, clean) slice.
 /// <para>
 /// <b>One identity model, one spawn sink.</b> Every span — text or figure — is keyed by the SHA-256 of its clean
 /// slice text and spawned through the shared <see cref="DerivedDocumentSpawner"/> as a text-only sub-document; a
@@ -142,7 +142,7 @@ public class DocumentSegmentationJob
         }
     }
 
-    /// <summary>Load phase (short UoW + a post-UoW blob read): snapshot the source's tenant/uploader, marked Markdown, container flag, parent context, and whether the document is already marked segmented (#377, the precise resume gate).</summary>
+    /// <summary>Load phase (short UoW): snapshot the source's tenant/uploader, Document.Markdown (with inline figure markers, #381), container flag, parent context, and whether the document is already marked segmented (#377, the precise resume gate).</summary>
     protected virtual async Task<DetectionContext?> LoadAsync(Guid sourceDocumentId)
     {
         Document? source;
@@ -185,12 +185,9 @@ public class DocumentSegmentationJob
             await uow.CompleteAsync();
         }
 
-        // Marked Markdown is an external blob read -> outside the UoW. Fall back to the clean Document.Markdown when
-        // there is no marked artifact (a non-figure container, or an archive that failed open): the detection then
-        // runs on clean text, which simply has no figure spans to recognize.
-        var markedMarkdown = await TryReadMarkedMarkdownAsync(sourceDocumentId)
-                             ?? source.Markdown
-                             ?? string.Empty;
+        // #381: detect over Document.Markdown, which now retains the *[Image OCR]* figure provenance markers inline
+        // (no separate marked artifact anymore). A non-figure source simply has no figure spans to recognize.
+        var markdown = source.Markdown ?? string.Empty;
 
         var detection = new SubDocumentDetectionContext(
             source.IsContainer, source.Title, parentTypeCode, parentTypeDisplayName);
@@ -199,21 +196,21 @@ public class DocumentSegmentationJob
             sourceDocumentId,
             source.TenantId,
             source.FileOrigin.UploadedByUserName,
-            markedMarkdown,
+            markdown,
             source.IsContainer,
             alreadySegmented,
             detection);
     }
 
     /// <summary>
-    /// Phase A: one LLM detection (external, no UoW) over the marked Markdown -> deterministic slicing -> per-span
+    /// Phase A: one LLM detection (external, no UoW) over Document.Markdown -> deterministic slicing -> per-span
     /// kind/clean-text/key/page -> a short UoW that inserts the spawnable segment rows. A container with an
     /// untrusted / &lt;2 / over-cap / unparseable result is flagged <see cref="DocumentReviewReasons.SegmentationIncomplete"/>;
     /// an embedded-document parent degrades the same conditions to a logged no-op (it extracts normally).
     /// </summary>
     protected virtual async Task DetectAndPersistAsync(DetectionContext context, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(context.MarkedMarkdown))
+        if (string.IsNullOrWhiteSpace(context.Markdown))
         {
             await IncompleteOrSkipAsync(context, "the source has no Markdown to segment");
             return;
@@ -221,11 +218,11 @@ public class DocumentSegmentationJob
 
         // The whole Markdown is fed (boundaries can be anywhere), so an unbounded source is an unbounded prompt-token
         // cost. Above the cap, degrade to a review signal (container) / a logged skip (embedded-document).
-        if (context.MarkedMarkdown.Length > _behaviorOptions.MaxSegmentationMarkdownLength)
+        if (context.Markdown.Length > _behaviorOptions.MaxSegmentationMarkdownLength)
         {
             await IncompleteOrSkipAsync(
                 context,
-                $"the Markdown ({context.MarkedMarkdown.Length} chars) exceeds the segmentation limit of {_behaviorOptions.MaxSegmentationMarkdownLength}");
+                $"the Markdown ({context.Markdown.Length} chars) exceeds the segmentation limit of {_behaviorOptions.MaxSegmentationMarkdownLength}");
             return;
         }
 
@@ -238,7 +235,7 @@ public class DocumentSegmentationJob
         {
             try
             {
-                outcome = await _segmentationWorkflow.RunAsync(context.MarkedMarkdown, context.Detection, cancellationToken);
+                outcome = await _segmentationWorkflow.RunAsync(context.Markdown, context.Detection, cancellationToken);
             }
             catch (Exception ex) when (IsSchemaDeserializationError(ex))
             {
@@ -254,7 +251,7 @@ public class DocumentSegmentationJob
             return;
         }
 
-        if (!MarkdownSlicer.TrySlice(context.MarkedMarkdown, outcome.Boundaries, out var markedSlices))
+        if (!MarkdownSlicer.TrySlice(context.Markdown, outcome.Boundaries, out var markedSlices))
         {
             await IncompleteOrSkipAsync(context, "the LLM split could not be verified against the Markdown");
             return;
@@ -641,23 +638,6 @@ public class DocumentSegmentationJob
         return source is { IsContainer: true } ? source : null;
     }
 
-    private async Task<string?> TryReadMarkedMarkdownAsync(Guid documentId)
-    {
-        var blobName = DocumentConsts.MarkedMarkdownBlobPrefix + documentId;
-        try
-        {
-            var bytes = await _blobContainer.GetAllBytesOrNullAsync(blobName);
-            return bytes is null ? null : Encoding.UTF8.GetString(bytes);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex,
-                "Failed to read marked Markdown blob {BlobName} for source {SourceId}; falling back to Document.Markdown.",
-                blobName, documentId);
-            return null;
-        }
-    }
-
     private async Task TryDeleteBlobAsync(string blobName)
     {
         try
@@ -686,12 +666,12 @@ public class DocumentSegmentationJob
     private static bool IsSchemaDeserializationError(Exception ex)
         => ex is JsonException || ex.GetBaseException() is JsonException;
 
-    /// <summary>Per-source detection context loaded once up front: provenance, the marked Markdown to detect over, the container flag, whether a prior split exists, and the parent context for the LLM.</summary>
+    /// <summary>Per-source detection context loaded once up front: provenance, the Document.Markdown to detect over (with inline figure markers, #381), the container flag, whether a prior split exists, and the parent context for the LLM.</summary>
     protected sealed record DetectionContext(
         Guid SourceDocumentId,
         Guid? TenantId,
         string UploadedByUserName,
-        string MarkedMarkdown,
+        string Markdown,
         bool IsContainer,
         bool AlreadySegmented,
         SubDocumentDetectionContext Detection);
@@ -705,6 +685,6 @@ public class DocumentSegmentationJob
 
 public class DocumentSegmentationJobArgs
 {
-    /// <summary>The source document whose marked Markdown should be analyzed for standalone sub-documents.</summary>
+    /// <summary>The source document whose Markdown (with inline figure markers, #381) should be analyzed for standalone sub-documents.</summary>
     public Guid SourceDocumentId { get; set; }
 }

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationWorkflow.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationWorkflow.cs
@@ -13,8 +13,8 @@ using Volo.Abp.DependencyInjection;
 namespace Dignite.Extract.Documents.Pipelines.Segmentation;
 
 /// <summary>
-/// Unified sub-document detection pass (#371): one LLM pass over a source document's <b>marked</b> Markdown (the
-/// working Markdown still carrying the <c>[Image OCR]…[End OCR]</c> figure sentinels) that decides, per span —
+/// Unified sub-document detection pass (#371): one LLM pass over a source document's <c>Document.Markdown</c> (which
+/// retains the inline <c>*[Image OCR]*…*[End OCR]*</c> figure provenance markers, #381) that decides, per span —
 /// text spans and figure spans alike — whether it is a standalone sub-document or content of the parent. It folds
 /// the born-digital container segmentation (#346) and the figure-document gate (#306/#365) into a single decision
 /// made with full surrounding context.
@@ -58,7 +58,7 @@ public class DocumentSegmentationWorkflow : ITransientDependency
             return outcome;
         }
 
-        // The WHOLE (marked) Markdown is fed: sub-document boundaries can be anywhere, and a truncated tail would
+        // The WHOLE Markdown is fed: sub-document boundaries can be anywhere, and a truncated tail would
         // silently lose the last documents. Output stays small regardless of input size because only short verbatim
         // markers are returned.
         var userMessage = $$"""
@@ -157,7 +157,7 @@ public class DocumentSegmentationWorkflow : ITransientDependency
         {
             /// <summary>
             /// The verbatim first line / opening snippet of the span, copied exactly from the Markdown — for an
-            /// embedded-image span this first line is the <c>[Image OCR]</c> / <c>[Image OCR p:N]</c> marker line.
+            /// embedded-image span this first line is the <c>*[Image OCR]*</c> / <c>*[Image OCR p:N]*</c> marker line.
             /// </summary>
             public string StartMarker { get; set; } = default!;
 

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/MarkdownSlicer.cs
@@ -6,14 +6,14 @@ namespace Dignite.Extract.Documents.Pipelines.Segmentation;
 
 /// <summary>
 /// A span boundary proposed by the unified sub-document detection pass (#346/#371): a <b>verbatim</b> start marker
-/// copied from the source Markdown (the <c>[Image OCR]</c> marker line for a figure span) plus whether the span it
+/// copied from the source Markdown (the <c>*[Image OCR]*</c> marker line for a figure span) plus whether the span it
 /// opens is itself a standalone sub-document (vs the parent's own content / a cover / an element of the parent).
 /// </summary>
 public sealed record SegmentBoundary(string StartMarker, bool IsSubDocument);
 
 /// <summary>
 /// A deterministically-cut span of a source document's Markdown (#346/#371). <see cref="IsFigure"/> is the span's
-/// STRUCTURAL kind — true when its opening boundary marker is an <c>[Image OCR]</c> sentinel line (the span IS a
+/// STRUCTURAL kind — true when its opening boundary marker is an <c>*[Image OCR]*</c> marker line (the span IS a
 /// figure), false for a text span even when it embeds an inline figure block (#371: kind comes from the boundary,
 /// not from scanning the body).
 /// </summary>
@@ -82,7 +82,7 @@ public static class MarkdownSlicer
             }
 
             // #371: the span's figure-ness is a structural property of the boundary the LLM opened it with — an
-            // [Image OCR] sentinel line means the span IS a figure; a prose first line means a text span (even if
+            // *[Image OCR]* marker line means the span IS a figure; a prose first line means a text span (even if
             // it embeds an inline figure block). Carry it here rather than scanning the slice body downstream.
             slices.Add(new MarkdownSlice(
                 text, boundaries[i].IsSubDocument, slices.Count, ImageOcrMarkup.IsOpenLine(boundaries[i].StartMarker)));

--- a/core/src/Dignite.Extract.Domain.Shared/Documents/DocumentConsts.cs
+++ b/core/src/Dignite.Extract.Domain.Shared/Documents/DocumentConsts.cs
@@ -60,15 +60,6 @@ public static class DocumentConsts
     public static long MaxNativePayloadArchiveBytes { get; set; } = 16L * 1024 * 1024;
 
     /// <summary>
-    /// Blob key prefix for the marked-Markdown pipeline artifact (#371): the working Markdown still carrying the
-    /// in-band <c>[Image OCR]…[End OCR]</c> figure sentinels, written by text extraction and read by classification
-    /// (the embedded-document signal) and the unified sub-document pass. Stable per-document key
-    /// (<c>markdown-marked/{documentId}</c>, re-extraction overwrites, no orphans); never exposed at the egress —
-    /// <c>Document.Markdown</c> is persisted with the sentinels stripped.
-    /// </summary>
-    public const string MarkedMarkdownBlobPrefix = "markdown-marked/";
-
-    /// <summary>
     /// Hard per-call result limit for programmatic / LLM-triggered retrieval, such as MCP search tools.
     /// Fail-closed safety gate: prevents prompt injection from inducing broad queries that explode LLM context or create cost attacks.
     /// Compile-time <c>const</c>: the safety boundary cannot be enlarged by runtime configuration.

--- a/core/src/Dignite.Extract.Domain.Shared/Documents/DocumentSegmentKind.cs
+++ b/core/src/Dignite.Extract.Domain.Shared/Documents/DocumentSegmentKind.cs
@@ -15,7 +15,7 @@ namespace Dignite.Extract.Documents.Segments;
 /// retraction (#364: <see cref="Text"/> children are retracted — they existed only because the parent was a bundle —
 /// while <see cref="Figure"/> children are kept, exactly as a freshly-uploaded concrete document keeps an embedded
 /// figure). The per-span clean-text derivation (<c>ExtractBodies</c> for a figure body vs <c>Strip</c> for a text
-/// span) is decided at carve time from the slice's opening sentinel, before the kind is recorded.
+/// span) is decided at carve time from the slice's opening marker, before the kind is recorded.
 /// </summary>
 public enum DocumentSegmentKind
 {
@@ -23,9 +23,9 @@ public enum DocumentSegmentKind
     Text = 0,
 
     /// <summary>
-    /// An embedded-figure OCR span (#306): in the marked Markdown it was bracketed by the in-band
-    /// <c>[Image OCR]…[End OCR]</c> sentinels. Spawned as a text-only sub-document (the transcription); no image
-    /// crop is persisted.
+    /// An embedded-figure OCR span (#306): in the document Markdown it was bracketed by the in-band
+    /// <c>*[Image OCR]*…*[End OCR]*</c> provenance markers. Spawned as a text-only sub-document (the transcription);
+    /// no image crop is persisted.
     /// </summary>
     Figure = 1
 }

--- a/core/src/Dignite.Extract.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.Extract.Domain/Documents/Segments/DocumentSegment.cs
@@ -67,7 +67,7 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
 
     /// <summary>
     /// 1-based source page of a <see cref="DocumentSegmentKind.Figure"/> span (#371): a lightweight provenance anchor
-    /// parsed from the <c>[Image OCR p:N]</c> sentinel (the crop itself is not persisted, per Markdown-first). It
+    /// parsed from the <c>*[Image OCR p:N]*</c> marker (the crop itself is not persisted, per Markdown-first). It
     /// records <b>where</b> the figure came from; <b>no code re-parses the source to recover the image</b> — the
     /// anchor only keeps that possible out-of-band should a future need arise. <c>null</c> for a
     /// <see cref="DocumentSegmentKind.Text"/> span or a page-less source. Provenance only — never identity (#210).

--- a/core/src/Dignite.Extract.EntityFrameworkCore/EntityFrameworkCore/ExtractDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Extract.EntityFrameworkCore/EntityFrameworkCore/ExtractDbContextModelCreatingExtensions.cs
@@ -234,7 +234,7 @@ public static class ExtractDbContextModelCreatingExtensions
             b.Property(x => x.Ordinal).IsRequired();
             // #371: which span kind this segment was carved from (Text constituent vs embedded Figure); drives the
             // container→type retraction filter (#364). PageNumber is a nullable recovery anchor (page) for
-            // Figure-kind rows, parsed from the [Image OCR p:N] sentinel; neither is indexed.
+            // Figure-kind rows, parsed from the *[Image OCR p:N]* marker; neither is indexed.
             b.Property(x => x.Kind).IsRequired();
             b.Property(x => x.Status).IsRequired();
 

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfExtractor.cs
@@ -253,10 +253,11 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     if (transcription.Length > 0)
                     {
                         // Inline output (#301): woven into the page Markdown at the reading position, bracketed by
-                        // [Image OCR p:N]…[End OCR] sentinels (#371) carrying the page anchor. The figure span — its
-                        // transcription + page — now travels entirely in the (marked) Markdown; the unified
-                        // sub-document detection pass routes it from there, so no separate out-of-band figure list /
-                        // candidate crop is produced (the #306 TextExtractionResult.Figures channel is retired).
+                        // *[Image OCR p:N]*…*[End OCR]* provenance markers (#371/#381) carrying the page anchor. The
+                        // figure span — its transcription + page — travels entirely in Document.Markdown (the markers
+                        // stay in the egress); the unified sub-document detection pass routes it from there, so no
+                        // separate out-of-band figure list / candidate crop is produced (the #306
+                        // TextExtractionResult.Figures channel is retired).
                         figures.Add(new PdfReadingOrder.Figure(image.BoundingBox, transcription, pageContent.Page.Number));
                     }
                 }

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -310,13 +310,12 @@ internal static class PdfReadingOrder
             if (item.IsFigure)
             {
                 FlushParagraph();
-                // #371: bracket the figure's OCR transcription with in-band [Image OCR p:N]…[End OCR] sentinels so
-                // the pipeline-internal consumers (the classification embedded-document signal + the unified
-                // sub-document detection pass) can recognize the figure span. The sentinels are stripped before
-                // Document.Markdown (the egress payload), so once stripped this is byte-equivalent to the pre-#371
-                // inline output (ImageOcrMarkup.Strip is the inverse of Wrap).
+                // #371/#381: bracket the figure's OCR transcription with in-band *[Image OCR p:N]*…*[End OCR]*
+                // provenance markers (MarkItDown-style). These stay in Document.Markdown (the egress payload): they
+                // annotate the bracketed text as OCR for any consumer, and the pipeline reads them to recognize the
+                // figure span (the classification embedded-document signal + the unified sub-document detection pass).
                 // The caption is a digital-text-layer line bound to this figure, so escape it; item.Text is the OCR
-                // transcription (already Markdown) and is emitted verbatim inside the sentinels.
+                // transcription (already Markdown) and is emitted verbatim inside the markers.
                 var figureMarkup = ImageOcrMarkup.Wrap(item.Text, item.PageNumber);
                 blocks.Add(item.Caption is { Length: > 0 } caption
                     ? MarkdownText.EscapeBlockText(caption) + "\n\n" + figureMarkup

--- a/core/test/Dignite.Extract.Application.Tests/Ai/DefaultPromptProvider_Tests.cs
+++ b/core/test/Dignite.Extract.Application.Tests/Ai/DefaultPromptProvider_Tests.cs
@@ -61,7 +61,7 @@ public class DefaultPromptProvider_Tests
     public void Segmentation_Prompt_Is_The_Unified_Sub_Document_Detection_Prompt()
     {
         // #371: the unified pass decides per span isSubDocument over the marked Markdown, recognizing embedded-image
-        // OCR regions by their in-band [Image OCR] sentinels (the #359 "do not split an inlined figure" guard is
+        // OCR regions by their in-band *[Image OCR]* markers (the #359 "do not split an inlined figure" guard is
         // dissolved — figure spans are now first-class detection candidates). Pin the unified framing so it cannot be
         // silently reworded away without a deliberate test update.
         var instructions = _provider.GetSegmentationPrompt("en").SystemInstructions;
@@ -75,7 +75,7 @@ public class DefaultPromptProvider_Tests
     {
         // #371: container detection and the embedded-standalone-document signal both ride the classification call.
         // The unified sub-document pass keys off containsEmbeddedDocument, and the prompt names the in-band
-        // [Image OCR] sentinels that mark each embedded-image OCR region. Pin the wording so the signal cannot be
+        // *[Image OCR]* markers that mark each embedded-image OCR region. Pin the wording so the signal cannot be
         // silently dropped or reworded away without a deliberate test update.
         var instructions = _provider.GetClassificationPrompt("en").SystemInstructions;
 

--- a/core/test/Dignite.Extract.Application.Tests/Ai/ImageOcrMarkup_Tests.cs
+++ b/core/test/Dignite.Extract.Application.Tests/Ai/ImageOcrMarkup_Tests.cs
@@ -5,14 +5,27 @@ using Xunit;
 namespace Dignite.Extract.Ai;
 
 /// <summary>
-/// Unit tests for <see cref="ImageOcrMarkup"/> (#371): the in-band <c>[Image OCR]…[End OCR]</c> sentinels that bracket
-/// an embedded-figure OCR transcription in the working (marked) Markdown. The two load-bearing invariants are that
-/// <see cref="ImageOcrMarkup.Strip"/> is the exact inverse of <see cref="ImageOcrMarkup.Wrap"/> (so a stripped
-/// document equals the pre-#371 inline output byte for byte) and that only WHOLE trimmed-line sentinels are stripped
-/// (so ordinary prose that merely mentions the label survives). Pure unit test; no ABP host required.
+/// Unit tests for <see cref="ImageOcrMarkup"/> (#371/#381): the in-band <c>*[Image OCR]*…*[End OCR]*</c> provenance
+/// markers that bracket an embedded-figure OCR transcription in the document Markdown. Since #381 the markers are
+/// MarkItDown-aligned (italic-wrapped, salt-free) and stay in <c>Document.Markdown</c> at the egress — they are no
+/// longer stripped before persistence. <see cref="ImageOcrMarkup.Strip"/> survives as a content utility for deriving
+/// a spawned sub-document's seed and remains the exact inverse of <see cref="ImageOcrMarkup.Wrap"/>; only WHOLE
+/// trimmed-line markers are matched (so ordinary prose that merely mentions the label survives). Pure unit test; no
+/// ABP host required.
 /// </summary>
 public class ImageOcrMarkup_Tests
 {
+    [Fact]
+    public void Markers_Are_MarkItDown_Aligned_And_Salt_Free()
+    {
+        // #381: the markers are byte-identical to MarkItDown's own — italic-wrapped, carrying no salt — and the page
+        // anchor is a *[Image OCR p:N]* suffix form. Pin the exact strings so the egress format cannot drift silently.
+        ImageOcrMarkup.OpenMarker.ShouldBe("*[Image OCR]*");
+        ImageOcrMarkup.CloseMarker.ShouldBe("*[End OCR]*");
+        ImageOcrMarkup.Wrap("inv", pageNumber: 3).ShouldBe("*[Image OCR p:3]*\ninv\n*[End OCR]*");
+        ImageOcrMarkup.Wrap("inv", pageNumber: null).ShouldBe("*[Image OCR]*\ninv\n*[End OCR]*");
+    }
+
     [Fact]
     public void Strip_Is_The_Inverse_Of_Wrap()
     {
@@ -20,14 +33,14 @@ public class ImageOcrMarkup_Tests
     }
 
     [Fact]
-    public void Strip_Removes_Sentinel_Lines_Leaving_Surrounding_Content_In_Place()
+    public void Strip_Removes_Marker_Lines_Leaving_Surrounding_Content_In_Place()
     {
         var marked = "a\n\n" + ImageOcrMarkup.Wrap("inv", 3) + "\n\nb";
         ImageOcrMarkup.Strip(marked).ShouldBe("a\n\ninv\n\nb");
     }
 
     [Fact]
-    public void Strip_Returns_Text_With_No_Sentinels_Unchanged()
+    public void Strip_Returns_Text_With_No_Markers_Unchanged()
     {
         const string plain = "just some prose\nover two lines";
         ImageOcrMarkup.Strip(plain).ShouldBe(plain);
@@ -43,10 +56,10 @@ public class ImageOcrMarkup_Tests
     [Fact]
     public void TryParsePage_And_Line_Predicates_Recognize_Both_Open_Forms_And_The_Close()
     {
-        ImageOcrMarkup.TryParsePage(ImageOcrMarkup.OpenPagePrefix + "3]").ShouldBe(3);
+        ImageOcrMarkup.TryParsePage("*[Image OCR p:3]*").ShouldBe(3);
         ImageOcrMarkup.TryParsePage(ImageOcrMarkup.OpenMarker).ShouldBeNull();
 
-        ImageOcrMarkup.IsOpenLine(ImageOcrMarkup.OpenPagePrefix + "3]").ShouldBeTrue();
+        ImageOcrMarkup.IsOpenLine("*[Image OCR p:3]*").ShouldBeTrue();
         ImageOcrMarkup.IsOpenLine(ImageOcrMarkup.OpenMarker).ShouldBeTrue();
 
         ImageOcrMarkup.IsCloseLine(ImageOcrMarkup.CloseMarker).ShouldBeTrue();
@@ -55,24 +68,27 @@ public class ImageOcrMarkup_Tests
     [Fact]
     public void Strip_Leaves_A_Body_Line_That_Merely_Mentions_The_Label_As_A_Substring()
     {
-        // Only a WHOLE trimmed-line sentinel is removed; the label embedded mid-line is ordinary prose and survives.
+        // Only a WHOLE trimmed-line marker is removed; the label embedded mid-line is ordinary prose and survives.
         var midLine = "see " + ImageOcrMarkup.OpenMarker + " note";
         ImageOcrMarkup.Strip(midLine).ShouldBe(midLine);
     }
 
     [Fact]
-    public void Bare_MarkItDown_Style_Markers_Are_Not_Mistaken_For_Sentinels()
+    public void Reingested_MarkItDown_Markers_Are_Recognized_As_Provenance_Markers()
     {
-        // #376: the sentinel carries a collision-resistant salt, so a real content line equal to MarkItDown's own bare
-        // "[Image OCR]" / "[End OCR]" (e.g. a document MarkItDown produced and then re-ingested) is ORDINARY content —
-        // it must survive Strip and never be parsed as a figure boundary, or the egress Markdown would silently lose
-        // those lines and the slicer would mis-close a figure block on them.
-        ImageOcrMarkup.IsOpenLine("[Image OCR]").ShouldBeFalse();
-        ImageOcrMarkup.IsOpenLine("[Image OCR p:3]").ShouldBeFalse();
-        ImageOcrMarkup.IsCloseLine("[End OCR]").ShouldBeFalse();
+        // #381: with the salt removed, our markers ARE MarkItDown's own bare *[Image OCR]* / *[End OCR]*. A document
+        // MarkItDown produced and then re-ingested carries those exact lines as provenance-annotated content — they
+        // are recognized as a figure span (intended, no special-casing) and, since the pipeline no longer strips,
+        // they stay in the egress Markdown rather than being silently deleted.
+        ImageOcrMarkup.IsOpenLine("*[Image OCR]*").ShouldBeTrue();
+        ImageOcrMarkup.IsOpenLine("*[Image OCR p:3]*").ShouldBeTrue();
+        ImageOcrMarkup.IsCloseLine("*[End OCR]*").ShouldBeTrue();
 
-        const string reingested = "intro\n[Image OCR]\nold transcription\n[End OCR]\noutro";
-        ImageOcrMarkup.Strip(reingested).ShouldBe(reingested); // nothing stripped — content, not our sentinels
-        ImageOcrMarkup.Contains(reingested).ShouldBeFalse();
+        // A non-italic "[Image OCR]" line (missing the * wrapping) is NOT our marker — whole-line exact match.
+        ImageOcrMarkup.IsOpenLine("[Image OCR]").ShouldBeFalse();
+
+        const string reingested = "intro\n*[Image OCR]*\nold transcription\n*[End OCR]*\noutro";
+        ImageOcrMarkup.Contains(reingested).ShouldBeTrue();
+        ImageOcrMarkup.ExtractBodies(reingested).ShouldBe("old transcription");
     }
 }

--- a/core/test/Dignite.Extract.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Extract.Application.Tests/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob_Tests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +17,6 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.BackgroundJobs;
-using Volo.Abp.BlobStoring;
 using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Modularity;
 using Xunit;
@@ -37,10 +34,6 @@ public class DocumentClassificationJobTestModule : AbpModule
         context.Services.AddSingleton(Substitute.For<IDocumentRepository>());
         context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
         context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
-        // #371: classification now reads the marked-Markdown blob (GetAllBytesOrNullAsync) to see [Image OCR] figure
-        // spans for the embedded-document signal. A substitute container returns null from GetOrNullAsync, so the job
-        // falls back to Document.Markdown — preserving these tests' clean-Markdown classification behavior.
-        context.Services.AddSingleton(Substitute.For<IBlobContainer<ExtractDocumentContainer>>());
         // #216: Manager + background-job BeginRun / CompleteRun / FailRun all use IDocumentPipelineRunRepository.
         context.Services.AddSingleton(PipelineRunRepositoryFake.Create());
 
@@ -87,7 +80,6 @@ public class DocumentClassificationBackgroundJob_Tests
     private readonly DocumentClassificationWorkflow _workflow;
     private readonly IDistributedEventBus _eventBus;
     private readonly IBackgroundJobManager _backgroundJobManager;
-    private readonly IBlobContainer<ExtractDocumentContainer> _markedBlobContainer;
 
     public DocumentClassificationBackgroundJob_Tests()
     {
@@ -97,7 +89,6 @@ public class DocumentClassificationBackgroundJob_Tests
         _workflow = GetRequiredService<DocumentClassificationWorkflow>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
-        _markedBlobContainer = GetRequiredService<IBlobContainer<ExtractDocumentContainer>>();
     }
 
     [Fact]
@@ -275,27 +266,17 @@ public class DocumentClassificationBackgroundJob_Tests
     [Fact]
     public async Task FigureBearing_InWindow_Document_Routes_Even_Without_Embedded_Signal()
     {
-        // #379 (HIGH) — the within-window embedded-figure recall hole. A figure-bearing document whose MARKED Markdown
-        // fits INSIDE the classification truncation window (MaxTextLengthPerExtraction = 8000) but whose embedded
-        // figure the multi-objective classifier under-flagged (ContainsEmbeddedDocument = false) must STILL route the
-        // unified pass — figure recall now keys purely on the deterministic ImageOcrMarkup.Contains signal, decoupled
-        // from both the LLM flag and the truncation window. On the pre-#379 code (figure arm gated on
-        // markedLength > window) this in-window document never routed and never entered review — a silent recall miss.
-        // The focused segmentation pass then owns the per-span standalone-vs-element judgment (a decorative figure is a
-        // clean no-op there, not a review flag).
-        var doc = CreateDocument("A short contract body with an embedded invoice photo.");
+        // #379 (HIGH) — the within-window embedded-figure recall hole. A figure-bearing document whose Document.Markdown
+        // fits INSIDE the classification truncation window (MaxTextLengthPerExtraction = 8000) but whose embedded figure
+        // the multi-objective classifier under-flagged (ContainsEmbeddedDocument = false) must STILL route the unified
+        // pass — figure recall keys purely on the deterministic ImageOcrMarkup.Contains signal over Document.Markdown
+        // (#381: the *[Image OCR]* markers now live in Document.Markdown itself), decoupled from both the LLM flag and
+        // the truncation window. The focused segmentation pass then owns the per-span standalone-vs-element judgment (a
+        // decorative figure is a clean no-op there, not a review flag).
+        var markdown = "Contract body.\n" + ImageOcrMarkup.Wrap("INVOICE\nVendor: Acme\nTotal: $4,200", pageNumber: 2);
+        markdown.Length.ShouldBeLessThan(8000); // guards the in-window premise (distinct from the over-window case below)
+        var doc = CreateDocument(markdown);
         SetupDocumentRepository(doc);
-
-        // A real salted [Image OCR] span, comfortably inside the 8000 window (so the classifier saw it; the point is it
-        // under-flagged, not that the tail was truncated). GetAllBytesOrNullAsync is an extension over the interface
-        // GetOrNullAsync(Stream), so stub the latter.
-        var markedMarkdown = "Contract body.\n" + ImageOcrMarkup.Wrap("INVOICE\nVendor: Acme\nTotal: $4,200", pageNumber: 2);
-        markedMarkdown.Length.ShouldBeLessThan(8000); // guards the in-window premise (distinct from the over-window case below)
-        var markedBytes = Encoding.UTF8.GetBytes(markedMarkdown);
-        var markedBlobName = DocumentConsts.MarkedMarkdownBlobPrefix + doc.Id;
-        _markedBlobContainer
-            .GetOrNullAsync(markedBlobName, Arg.Any<CancellationToken>())
-            .Returns(_ => new MemoryStream(markedBytes));
 
         _workflow
             .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -319,22 +300,15 @@ public class DocumentClassificationBackgroundJob_Tests
     [Fact]
     public async Task FigureBearing_OverWindow_Document_Routes_Even_Without_Embedded_Signal()
     {
-        // #371/#379: a figure-bearing document whose MARKED Markdown exceeds the classification truncation window
+        // #371/#379: a figure-bearing document whose Document.Markdown exceeds the classification truncation window
         // (MaxTextLengthPerExtraction = 8000) may carry an embedded figure the classifier never saw (the tail was
-        // truncated out of the prompt). It must route even when ContainsEmbeddedDocument is false. Since #379 routing
-        // is window-INDEPENDENT (keyed on ImageOcrMarkup.Contains), so this is now one instance of the general
-        // figure-bearing trigger rather than a special over-window fallback arm.
-        var doc = CreateDocument("Leading body text used as the clean fallback Markdown.");
+        // truncated out of the prompt). It must route even when ContainsEmbeddedDocument is false. Routing is
+        // window-INDEPENDENT: ImageOcrMarkup.Contains is evaluated over the FULL Document.Markdown (#381), not the
+        // truncated classification input, so the figure marker at the tail is still detected.
+        var markdown = ImageOcrMarkup.Wrap(new string('x', 9000), pageNumber: 2);
+        markdown.Length.ShouldBeGreaterThan(8000); // guards the over-window premise
+        var doc = CreateDocument(markdown);
         SetupDocumentRepository(doc);
-
-        // Marked-Markdown blob: a real salted [Image OCR] span (so ImageOcrMarkup.Contains == true) padded beyond the
-        // window. GetAllBytesOrNullAsync is an extension over the interface GetOrNullAsync(Stream), so stub the latter.
-        var markedMarkdown = ImageOcrMarkup.Wrap(new string('x', 9000), pageNumber: 2);
-        var markedBytes = Encoding.UTF8.GetBytes(markedMarkdown);
-        var markedBlobName = DocumentConsts.MarkedMarkdownBlobPrefix + doc.Id;
-        _markedBlobContainer
-            .GetOrNullAsync(markedBlobName, Arg.Any<CancellationToken>())
-            .Returns(_ => new MemoryStream(markedBytes));
 
         _workflow
             .RunAsync(Arg.Any<IReadOnlyList<DocumentType>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())

--- a/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -123,13 +123,12 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
     }
 
     [Fact]
-    public async Task Text_Extraction_Job_Archives_Marked_Markdown_And_Persists_Clean_Markdown()
+    public async Task Text_Extraction_Job_Keeps_Figure_Markers_In_Egress_Markdown()
     {
-        // #371 Markdown-first egress invariant: when extraction produces [Image OCR]-marked Markdown, the job archives
-        // the marked copy to the pipeline-internal markdown-marked/{id} blob (the classifier + segmentation pass read
-        // it) AND strips the sentinels before the write-once SetMarkdown, so the persisted Document.Markdown (the
-        // egress text payload) is sentinel-free. Without this, routing scaffolding would leak into the channel text
-        // consumed by RAG / classification / egress, or the classifier would lose its embedded-document signal.
+        // #381: figure OCR transcriptions are bracketed with *[Image OCR]*…*[End OCR]* provenance markers that STAY in
+        // Document.Markdown (the egress payload), MarkItDown-style — they are no longer stripped, and there is no
+        // separate marked-Markdown artifact. Downstream (RAG / classification / egress) sees the OCR provenance, and
+        // the pipeline reads the same inline markers to recognize the figure span.
         var documentId = _guidGenerator.Create();
         var textExtractionRunId = await ArrangeQueuedParseAsync(documentId);
 
@@ -145,22 +144,21 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
             PipelineRunId = textExtractionRunId
         });
 
-        // (a) The marked copy is archived to the pipeline-internal blob (overrideExisting for re-extraction).
-        await _blobContainer.Received(1).SaveAsync(
-            DocumentConsts.MarkedMarkdownBlobPrefix + documentId,
-            Arg.Any<Stream>(),
-            true,
-            Arg.Any<CancellationToken>());
+        // (a) No separate marked-Markdown artifact is archived (and there is no native payload here either), so the
+        // job writes no blob at all — the markers live in Document.Markdown itself.
+        await _blobContainer.DidNotReceive().SaveAsync(
+            Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
 
-        // (b) The persisted egress payload is sentinel-free, yet the figure transcription body is retained inline.
+        // (b) The persisted egress payload retains the markers verbatim AND the figure transcription body inline.
         await WithUnitOfWorkAsync(async () =>
         {
             var doc = await _documentRepository.GetAsync(documentId, includeDetails: false);
             doc.Markdown.ShouldNotBeNull();
             var markdown = doc.Markdown!;
-            ImageOcrMarkup.Contains(markdown).ShouldBeFalse();
+            ImageOcrMarkup.Contains(markdown).ShouldBeTrue();
             markdown.ShouldContain(figureBody);
-            markdown.ShouldNotContain("9f1d3a7c"); // the sentinel salt must never reach the egress Markdown
+            markdown.ShouldContain("*[Image OCR p:3]*");
+            markdown.ShouldContain("*[End OCR]*");
         });
     }
 

--- a/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -46,7 +46,7 @@ public class DocumentSegmentationJobTestModule : AbpModule
         context.Services.AddSingleton(workflow);
 
         // Lower the caps so the bound tests don't need 50 slices / 200k chars. All other tests in this class use
-        // <= 2 distinct slices and < 130-char Markdown (the salted figure sentinels, #376, add ~18 chars per figure),
+        // <= 2 distinct slices and < 130-char Markdown (the *[Image OCR p:N]* / *[End OCR]* figure markers add ~30 chars per figure),
         // so they are unaffected.
         context.Services.Configure<ExtractBehaviorOptions>(o =>
         {
@@ -116,8 +116,8 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
     [Fact]
     public async Task Embedded_Figure_Span_In_A_Concrete_Document_Spawns_One_Figure_Sub_Document()
     {
-        // #371 (b): a single concrete-typed document (NOT a container) whose MARKED Markdown carries an inlined,
-        // sentinel-bracketed image-invoice transcription that the LLM returns standalone. The unified pass routes
+        // #371 (b): a single concrete-typed document (NOT a container) whose Document.Markdown carries an inlined,
+        // marker-bracketed image-invoice transcription that the LLM returns standalone. The unified pass routes
         // ONLY that figure span (kind Figure) into one derived sub-document; the parent keeps its own type and is
         // never flagged (it extracts normally — figure routing is orthogonal to its own content).
         var invoiceText = "INVOICE No 42 Total 100";
@@ -128,7 +128,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
             markdown: "Contract body", asContainer: false, markedMarkdown: marked);
 
         // The figure span's first line IS the open sentinel — that is the verbatim marker the LLM returns for it.
-        StubSplit(("Contract body", false), (ImageOcrMarkup.OpenPagePrefix + "1]", true));
+        StubSplit(("Contract body", false), (ImageOcrMarkup.OpenPagePrefix + "1]*", true));
 
         await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = docId });
 
@@ -159,7 +159,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
     [Fact]
     public async Task Inlined_Figure_Span_In_A_Container_Spawns_Exactly_One_Invoice_Sub_Document()
     {
-        // #356/#359 REGRESSION: a born-digital container whose MARKED Markdown carries an inlined, sentinel-bracketed
+        // #356/#359 REGRESSION: a born-digital container whose Document.Markdown carries an inlined, marker-bracketed
         // image-invoice transcription (#301) between two real text documents, and the LLM returns that figure span
         // standalone alongside the two text documents. Under the unified pass (#371) figure and text spans share one
         // identity (SHA-256 of the clean span text) and one spawn sink, so the inlined invoice can spawn at most ONCE:
@@ -172,7 +172,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
 
         StubSplit(
             ("Service A-B", true),
-            (ImageOcrMarkup.OpenPagePrefix + "1]", true),
+            (ImageOcrMarkup.OpenPagePrefix + "1]*", true),
             ("Lease X-Y", true));
 
         await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
@@ -201,7 +201,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
     public async Task Text_Constituent_Embedding_An_Inline_Figure_Is_Kind_Text_Not_Figure()
     {
         // #371 hardening (own /code-review): a genuine text constituent (a contract) that embeds an inline figure —
-        // its MARKED slice is prose PLUS an [Image OCR] block (#301) — must be recorded Kind.Text. The span's kind is
+        // its slice is prose PLUS an *[Image OCR]* block (#301) — must be recorded Kind.Text. The span's kind is
         // the kind of its OPENING boundary (prose), NOT "does the body contain a sentinel somewhere". Otherwise it
         // would be mislabeled Figure and survive the container→type retraction (which keeps Kind==Figure), a
         // #364-class stale-sub-document leak. The child's seed also strips the sentinels (the inline figure is just
@@ -211,7 +211,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
             markdown: "Contract A clauses\nmore clauses\nContract B clauses", asContainer: true, markedMarkdown: marked);
 
         // The LLM returns each contract as ONE span keyed on its prose first line; the inline figure stays inside
-        // contract A's span rather than being emitted as its own [Image OCR] boundary.
+        // contract A's span rather than being emitted as its own *[Image OCR]* boundary.
         StubSplit(
             ("Contract A clauses", true),
             ("Contract B clauses", true));
@@ -222,7 +222,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
         {
             var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
             segments.Count.ShouldBe(2);
-            // Both opened on prose -> both Kind.Text, even though contract A's slice body carries an [Image OCR]
+            // Both opened on prose -> both Kind.Text, even though contract A's slice body carries an *[Image OCR]*
             // block. NONE mislabeled Figure.
             segments.ShouldAllBe(s => s.Kind == DocumentSegmentKind.Text);
 
@@ -245,8 +245,8 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
         var sourceId = await ArrangeContainerAsync(
             markdown: "Parent contract body text", asContainer: false, markedMarkdown: marked);
 
-        // The LLM omits the parent-body span and returns only the figure boundary (its [Image OCR] line).
-        StubSplit((ImageOcrMarkup.OpenPagePrefix + "2]", true));
+        // The LLM omits the parent-body span and returns only the figure boundary (its *[Image OCR]* line).
+        StubSplit((ImageOcrMarkup.OpenPagePrefix + "2]*", true));
 
         await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = sourceId });
 
@@ -292,7 +292,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
         // The container split re-detects all three spans, INCLUDING the already-routed figure.
         StubSplit(
             ("Invoice A first", true),
-            (ImageOcrMarkup.OpenPagePrefix + "1]", true),
+            (ImageOcrMarkup.OpenPagePrefix + "1]*", true),
             ("Invoice B second", true));
 
         await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
@@ -321,7 +321,7 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
     {
         // #377 edge 1: a concrete doc with one already-routed figure is re-recognized as a container; the
         // container-mode re-split returns exactly ONE new text constituent and (non-deterministically) OMITS the
-        // figure's [Image OCR] boundary this run. The "≥2 real bundle" guard must count the surviving figure row
+        // figure's *[Image OCR]* boundary this run. The "≥2 real bundle" guard must count the surviving figure row
         // toward the bundle (not just this run's spans), so the legitimate text constituent is PERSISTED rather than
         // dropped and the container flagged incomplete. Pre-#377 the guard saw prepared.Count == 1 < 2 and flagged.
         var figureText = "INVOICE No 9 Total 9";
@@ -371,8 +371,8 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
             markdown: "scan bundle", asContainer: true, markedMarkdown: marked);
 
         StubSplit(
-            (ImageOcrMarkup.OpenPagePrefix + "1]", true),
-            (ImageOcrMarkup.OpenPagePrefix + "2]", true));
+            (ImageOcrMarkup.OpenPagePrefix + "1]*", true),
+            (ImageOcrMarkup.OpenPagePrefix + "2]*", true));
 
         // First run: splits the two figures, persists them, sets IsSegmented.
         await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
@@ -715,10 +715,14 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
                     fileSize: 2048,
                     originalFileName: "bundle.pdf"));
 
+            // #381: the unified pass reads Document.Markdown, which now carries the inline *[Image OCR]*…*[End OCR]*
+            // figure markers (no separate marked artifact). A figure test supplies that marked content via
+            // markedMarkdown and it becomes Document.Markdown; a non-figure test just passes plain markdown.
+            var documentMarkdown = markedMarkdown ?? markdown;
             typeof(Document)
                 .GetProperty(nameof(Document.Markdown))!
                 .GetSetMethod(nonPublic: true)!
-                .Invoke(doc, [markdown]);
+                .Invoke(doc, [documentMarkdown]);
 
             // The segmentation job only runs for actual containers; mark it unless the test wants a doc that was
             // reclassified away from container (IsContainer == false).
@@ -731,20 +735,6 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
 
             await _documentRepository.InsertAsync(doc, autoSave: true);
         });
-
-        // #371: the unified pass reads the MARKED Markdown blob (the working copy still carrying the
-        // [Image OCR]…[End OCR] figure sentinels), falling back to Document.Markdown when there is no marked blob.
-        // Seed the marked blob only when a test needs in-band figure spans; otherwise the clean Markdown fallback
-        // is exercised.
-        if (markedMarkdown is not null)
-        {
-            var blobName = DocumentConsts.MarkedMarkdownBlobPrefix + containerId;
-            // GetAllBytesOrNullAsync is an IBlobContainer EXTENSION method (NSubstitute cannot stub an extension
-            // method); stub the underlying GetOrNullAsync to return a FRESH stream per call so the extension reads
-            // the bytes back each time the job loads the marked Markdown.
-            _blobContainer.GetOrNullAsync(blobName, Arg.Any<CancellationToken>())
-                .Returns(_ => new MemoryStream(Encoding.UTF8.GetBytes(markedMarkdown)));
-        }
 
         return containerId;
     }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -107,20 +107,20 @@ public class PdfExtractor_Tests
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
 
-        // #371: the figure no longer rides an out-of-band Figures list — its transcription travels IN-BAND in
-        // the (marked) Markdown, bracketed by [Image OCR p:N]…[End OCR] sentinels carrying the 1-based page
-        // anchor. UsedOcr stays false (a digital extraction) and FigureOcrCount still records the embedded-image OCR.
+        // #371/#381: the figure no longer rides an out-of-band Figures list — its transcription travels IN-BAND in
+        // Document.Markdown (the egress payload), bracketed by *[Image OCR p:N]*…*[End OCR]* provenance markers
+        // carrying the 1-based page anchor. UsedOcr stays false (a digital extraction) and FigureOcrCount still records the embedded-image OCR.
         result.UsedOcr.ShouldBeFalse();
         result.FigureOcrCount.ShouldBe(1);
 
         result.Markdown.ShouldContain("INVOICE No. 42");
-        result.Markdown.ShouldContain(ImageOcrMarkup.CloseMarker); // "[End OCR]"
-        // The single fixture page is page 1, so the open sentinel carries the page anchor "[Image OCR p:1]"
-        // (the page-anchored form, NOT the bare OpenMarker "[Image OCR]").
-        result.Markdown.ShouldContain(ImageOcrMarkup.OpenPagePrefix + "1]");
+        result.Markdown.ShouldContain(ImageOcrMarkup.CloseMarker); // "*[End OCR]*"
+        // The single fixture page is page 1, so the open marker carries the page anchor "*[Image OCR p:1]*"
+        // (the page-anchored form, NOT the bare OpenMarker "*[Image OCR]*").
+        result.Markdown.ShouldContain(ImageOcrMarkup.OpenPagePrefix + "1]*");
 
-        // The transcription sits between the open and close sentinels (the bracketed figure span).
-        var open = result.Markdown.IndexOf(ImageOcrMarkup.OpenPagePrefix + "1]", StringComparison.Ordinal);
+        // The transcription sits between the open and close markers (the bracketed figure span).
+        var open = result.Markdown.IndexOf(ImageOcrMarkup.OpenPagePrefix + "1]*", StringComparison.Ordinal);
         var transcription = result.Markdown.IndexOf("INVOICE No. 42", StringComparison.Ordinal);
         var close = result.Markdown.IndexOf(ImageOcrMarkup.CloseMarker, StringComparison.Ordinal);
         open.ShouldBeGreaterThanOrEqualTo(0);
@@ -135,7 +135,7 @@ public class PdfExtractor_Tests
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
 
-        // No figure → no in-band [Image OCR] sentinels at all, and no OCR ran.
+        // No figure → no in-band *[Image OCR]* markers at all, and no OCR ran.
         ImageOcrMarkup.Contains(result.Markdown).ShouldBeFalse();
         result.Markdown.ShouldNotContain(ImageOcrMarkup.CloseMarker);
         result.FigureOcrCount.ShouldBe(0);

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfReadingOrder_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfReadingOrder_Tests.cs
@@ -259,8 +259,8 @@ public class PdfReadingOrder_Tests
     public void Render_does_not_escape_the_ocr_transcription_of_a_figure()
     {
         // A figure transcription is OCR-provider Markdown (here, a table); it is intentional structure and
-        // must be emitted verbatim, never escaped. #371: it is now bracketed by the salted [Image OCR]…[End OCR]
-        // sentinels (#376; no page anchor here — the Figure carries no page number), but the transcription is verbatim.
+        // must be emitted verbatim, never escaped. #371/#381: it is now bracketed by the *[Image OCR]*…*[End OCR]*
+        // provenance markers (no page anchor here — the Figure carries no page number), but the transcription is verbatim.
         var figures = new List<PdfReadingOrder.Figure>
         {
             new(new PdfRectangle(0, 400, 200, 520), "| a | b |\n| --- | --- |\n| 1 | 2 |")


### PR DESCRIPTION
Implements the #381 decision: align `ImageOcrMarkup` with MarkItDown — figure OCR markers become content **provenance annotations that stay in egress**, not pipeline control signals that get stripped.

## Changes
- Drop the #376 salt; markers are bare MarkItDown-style `*[Image OCR]*` / `*[End OCR]*`, page anchor kept as `*[Image OCR p:N]*`.
- Keep markers in egress: `Document.Markdown` retains them (no longer stripped before persistence). `ImageOcrMarkup.Strip` survives only as the utility that derives a spawned sub-document's seed text.
- Remove the `markdown-marked/{id}` dual-copy machinery entirely (`ArchiveMarkedMarkdownAsync`, both `TryReadMarkedMarkdownAsync` readers, the permanent-delete cleanup, and `DocumentConsts.MarkedMarkdownBlobPrefix`); classification and segmentation read `Document.Markdown` directly.
- Re-ingested MarkItDown documents are handled naturally — their `*[Image OCR]*` blocks are recognized as provenance content, no special-casing.

## Out of scope (deferred per the issue)
The deterministic figure-routing trigger (`hasFigures`) and the figure spawn-decision redesign are intentionally unchanged this round.

## Verification
- Full Application / EFCore / Parse.Pdf / Mcp / HttpApi / Parse test suites green (555 tests).
- Solution builds clean (0 errors).
- Adversarial multi-dimension review of the diff (correctness / completeness / security / egress-contract / consistency): **zero** confirmed in-scope findings.

Closes #381