### PR TITLE
refactor(documents): allow null FileOrigin on segment-derived sub-documents

### DIFF
--- a/core/src/Dignite.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Extract.Application/Documents/DocumentAppService.cs
@@ -331,6 +331,10 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
 
         // Only fetch the blob stream: scalar fields + owned FileOrigin are loaded with the entity, and no child collection is needed.
         var document = await _documentRepository.GetAsync(id, includeDetails: false);
+
+        if (document.FileOrigin is null)
+            throw new BusinessException(ExtractErrorCodes.Document.NoSourceBlob);
+
         var stream = await _blobContainer.GetAsync(document.FileOrigin.BlobName);
 
         return new RemoteStreamContent(
@@ -369,15 +373,18 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
 
         await _documentRepository.HardDeleteAsync(id);
 
-        try
+        if (document.FileOrigin is not null)
         {
-            await _blobContainer.DeleteAsync(document.FileOrigin.BlobName);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex,
-                "Failed to delete blob {BlobName} for document {DocumentId}.",
-                document.FileOrigin.BlobName, id);
+            try
+            {
+                await _blobContainer.DeleteAsync(document.FileOrigin.BlobName);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex,
+                    "Failed to delete blob {BlobName} for document {DocumentId}.",
+                    document.FileOrigin.BlobName, id);
+            }
         }
 
         // #210: permanently delete archived native payload blobs together, using stable keys from the manifest and no prefix cleanup.
@@ -458,7 +465,7 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
         if (document.IsDeleted)
         {
             throw new BusinessException(ExtractErrorCodes.Document.InRecycleBin)
-                .WithData("FileName", document.FileOrigin.BlobName);
+                .WithData("FileName", document.FileOrigin?.BlobName);
         }
 
         var latestRun = await _pipelineRunManager.EnsureRetryableAsync(id, input.PipelineCode);
@@ -488,7 +495,7 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
         if (document.IsDeleted)
         {
             throw new BusinessException(ExtractErrorCodes.Document.InRecycleBin)
-                .WithData("FileName", document.FileOrigin.BlobName);
+                .WithData("FileName", document.FileOrigin?.BlobName);
         }
 
         // Automatic classification input is Document.Markdown. If text extraction has not produced text yet, reclassification cannot run.
@@ -522,7 +529,7 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
         if (document.IsDeleted)
         {
             throw new BusinessException(ExtractErrorCodes.Document.InRecycleBin)
-                .WithData("FileName", document.FileOrigin.BlobName);
+                .WithData("FileName", document.FileOrigin?.BlobName);
         }
 
         // Field extraction hangs off DocumentType; unclassified documents have nothing to extract against.

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
@@ -80,15 +80,15 @@ public class DerivedDocumentSpawner : ITransientDependency
     /// </typeparam>
     /// <param name="sourceDocumentId">The source document the constituent belongs to (the derived doc's <c>OriginDocumentId</c>).</param>
     /// <param name="tenantId">The source/derived tenant; the UoW and the delegates run under this tenant.</param>
-    /// <param name="constituentKey">The content-derived key (the derived doc's <c>OriginConstituentKey</c>, == <paramref name="fileOrigin"/>.ContentHash).</param>
-    /// <param name="fileOrigin">The derived document's file origin, already pointing at a blob the caller wrote.</param>
+    /// <param name="constituentKey">The content-derived key (the derived doc's <c>OriginConstituentKey</c>): SHA-256 of the clean slice text.</param>
+    /// <param name="fileOrigin">The derived document's file origin, or <c>null</c> for sub-documents with no source blob (figure spans seeded from segment SliceText).</param>
     /// <param name="reloadClaimable">Reloads the candidate inside the UoW; returns it when still claimable, or <c>null</c> to abort.</param>
     /// <param name="markSpawned">Marks the (reloaded) candidate spawned with the derived document id and persists it.</param>
     public virtual async Task<Guid?> SpawnAsync<TCandidate>(
         Guid sourceDocumentId,
         Guid? tenantId,
         string constituentKey,
-        FileOrigin fileOrigin,
+        FileOrigin? fileOrigin,
         Func<Task<TCandidate?>> reloadClaimable,
         Func<TCandidate, Guid, Task> markSpawned,
         CancellationToken cancellationToken = default)
@@ -120,9 +120,9 @@ public class DerivedDocumentSpawner : ITransientDependency
                     DocumentId = derived.Id,
                     TenantId = derived.TenantId,
                     EventTime = _clock.Now,
-                    FileName = fileOrigin.OriginalFileName,
-                    FileSize = fileOrigin.FileSize,
-                    ContentType = fileOrigin.ContentType
+                    FileName = fileOrigin?.OriginalFileName,
+                    FileSize = fileOrigin?.FileSize ?? 0,
+                    ContentType = fileOrigin?.ContentType
                 });
 
             // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown from

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
@@ -108,13 +108,19 @@ public class DocumentParseBackgroundJob
             }
             else
             {
+                // Sub-documents derived from segment SliceText always have SeedMarkdown set; a null BlobName here
+                // indicates a configuration or data inconsistency — fail fast rather than NPE on GetAsync.
+                if (workItem.BlobName is null)
+                    throw new InvalidOperationException(
+                        $"Document has no source blob and no seed Markdown (run {workItem.RunId}).");
+
                 // The caller owns the blob stream. With the FileSystem provider this is a FileStream holding an OS file handle,
                 // so it must be disposed, consistent with DocumentAppService.GetBlobAsync disposeStream:true.
                 // Use await using so it is released when this try block (External phase) ends; CompleteRunAsync no longer needs it.
                 await using var blobStream = await _blobContainer.GetAsync(workItem.BlobName);
                 var ctx = new TextExtractionContext
                 {
-                    ContentType = workItem.ContentType,
+                    ContentType = workItem.ContentType!,
                     FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty),
                     LanguageHints = { "ja", "en" }
                 };
@@ -177,9 +183,9 @@ public class DocumentParseBackgroundJob
 
         return new ParseWorkItem(
             run.Id,
-            document.FileOrigin.BlobName,
-            document.FileOrigin.ContentType,
-            document.FileOrigin.OriginalFileName,
+            document.FileOrigin?.BlobName,
+            document.FileOrigin?.ContentType,
+            document.FileOrigin?.OriginalFileName,
             seedMarkdown,
             seedProviderName);
     }
@@ -361,8 +367,8 @@ public class DocumentParseBackgroundJob
 
     private sealed record ParseWorkItem(
         Guid RunId,
-        string BlobName,
-        string ContentType,
+        string? BlobName,
+        string? ContentType,
         string? OriginalFileName,
         string? SeedMarkdown,
         string? SeedProviderName);

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -14,7 +13,6 @@ using Dignite.Extract.Documents.Segments;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.BackgroundJobs;
-using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Guids;
@@ -52,9 +50,8 @@ namespace Dignite.Extract.Documents.Pipelines.Segmentation;
 /// segment; the unique index is the duplicate-spawn backstop; per-segment faults are isolated and surfaced.
 /// </para>
 /// <para>
-/// <b>UoW discipline</b> (background-jobs.md): the LLM detection, blob reads, and slice-blob writes run outside any
-/// UoW; only the segment-row inserts and each derived-document insert + status change + pipeline enqueue run inside
-/// short UoWs.
+/// <b>UoW discipline</b> (background-jobs.md): the LLM detection and blob reads run outside any UoW; only the
+/// segment-row inserts and each derived-document insert + status change + pipeline enqueue run inside short UoWs.
 /// </para>
 /// </summary>
 [BackgroundJobName("Extract.DocumentSegmentation")]
@@ -66,7 +63,6 @@ public class DocumentSegmentationJob
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly DocumentSegmentationWorkflow _segmentationWorkflow;
     private readonly DerivedDocumentSpawner _derivedDocumentSpawner;
-    private readonly IBlobContainer<ExtractDocumentContainer> _blobContainer;
     private readonly ICurrentTenant _currentTenant;
     private readonly IGuidGenerator _guidGenerator;
     private readonly IUnitOfWorkManager _unitOfWorkManager;
@@ -79,7 +75,6 @@ public class DocumentSegmentationJob
         IDocumentTypeRepository documentTypeRepository,
         DocumentSegmentationWorkflow segmentationWorkflow,
         DerivedDocumentSpawner derivedDocumentSpawner,
-        IBlobContainer<ExtractDocumentContainer> blobContainer,
         ICurrentTenant currentTenant,
         IGuidGenerator guidGenerator,
         IUnitOfWorkManager unitOfWorkManager,
@@ -91,7 +86,6 @@ public class DocumentSegmentationJob
         _documentTypeRepository = documentTypeRepository;
         _segmentationWorkflow = segmentationWorkflow;
         _derivedDocumentSpawner = derivedDocumentSpawner;
-        _blobContainer = blobContainer;
         _currentTenant = currentTenant;
         _guidGenerator = guidGenerator;
         _unitOfWorkManager = unitOfWorkManager;
@@ -195,7 +189,7 @@ public class DocumentSegmentationJob
         return new DetectionContext(
             sourceDocumentId,
             source.TenantId,
-            source.FileOrigin.UploadedByUserName,
+            source.FileOrigin?.UploadedByUserName ?? string.Empty,
             markdown,
             source.IsContainer,
             alreadySegmented,
@@ -455,60 +449,31 @@ public class DocumentSegmentationJob
     private async Task SpawnDerivedDocumentAsync(
         PendingSegment segment, DetectionContext context, CancellationToken cancellationToken)
     {
-        // External (no UoW): write the clean slice to an independent, derived-document-owned blob so the derived
-        // document outlives the source (the source's permanent delete reclaims the source/segment rows, not this blob).
-        var sliceBytes = Encoding.UTF8.GetBytes(segment.SliceText);
-        var derivedBlobName = _guidGenerator.Create().ToString("N") + ".md";
-        using (var saveStream = new MemoryStream(sliceBytes, writable: false))
-        {
-            await _blobContainer.SaveAsync(derivedBlobName, saveStream, overrideExisting: true, cancellationToken);
-        }
-
-        var shortKey = segment.SegmentKey.Length > 8 ? segment.SegmentKey[..8] : segment.SegmentKey;
-        var fileOrigin = new FileOrigin(
-            blobName: derivedBlobName,
-            uploadedByUserName: context.UploadedByUserName,
-            contentType: "text/markdown",
-            contentHash: segment.SegmentKey,
-            fileSize: sliceBytes.LongLength,
-            originalFileName: $"segment-{shortKey}.md");
-
-        try
-        {
-            // Shared complete-phase UoW (#358): insert the derived document, mark this segment Spawned, publish
-            // DocumentUploadedEto, and queue text extraction — atomically. The reload guard is kind-aware (#371):
-            var spawnedId = await _derivedDocumentSpawner.SpawnAsync<DocumentSegment>(
-                context.SourceDocumentId,
-                context.TenantId,
-                segment.SegmentKey,
-                fileOrigin,
-                reloadClaimable: async () =>
-                {
-                    var entity = await _segmentRepository.FindAsync(segment.SegmentId);
-                    if (entity is not { Status: DocumentSegmentStatus.Pending })
-                    {
-                        return null;
-                    }
-
-                    return await IsStillSpawnableAsync(context.SourceDocumentId, entity.Kind) ? entity : null;
-                },
-                markSpawned: async (entity, derivedId) =>
-                {
-                    entity.MarkSpawned(derivedId);
-                    await _segmentRepository.UpdateAsync(entity);
-                },
-                cancellationToken);
-
-            if (spawnedId is null)
+        // Shared complete-phase UoW (#358): insert the derived document, mark this segment Spawned, publish
+        // DocumentUploadedEto, and queue text extraction — atomically. The reload guard is kind-aware (#371).
+        // FileOrigin is null: sub-documents carry no source blob; their Markdown is seeded from segment.SliceText
+        // by DocumentParseBackgroundJob instead of re-extracting a blob.
+        await _derivedDocumentSpawner.SpawnAsync<DocumentSegment>(
+            context.SourceDocumentId,
+            context.TenantId,
+            segment.SegmentKey,
+            fileOrigin: null,
+            reloadClaimable: async () =>
             {
-                await TryDeleteBlobAsync(derivedBlobName);
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            await TryDeleteBlobAsync(derivedBlobName);
-            throw;
-        }
+                var entity = await _segmentRepository.FindAsync(segment.SegmentId);
+                if (entity is not { Status: DocumentSegmentStatus.Pending })
+                {
+                    return null;
+                }
+
+                return await IsStillSpawnableAsync(context.SourceDocumentId, entity.Kind) ? entity : null;
+            },
+            markSpawned: async (entity, derivedId) =>
+            {
+                entity.MarkSpawned(derivedId);
+                await _segmentRepository.UpdateAsync(entity);
+            },
+            cancellationToken);
     }
 
     /// <summary>
@@ -636,18 +601,6 @@ public class DocumentSegmentationJob
     {
         var source = await _documentRepository.FindAsync(sourceId, includeDetails: false);
         return source is { IsContainer: true } ? source : null;
-    }
-
-    private async Task TryDeleteBlobAsync(string blobName)
-    {
-        try
-        {
-            await _blobContainer.DeleteAsync(blobName);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Failed to delete blob {BlobName} during sub-document detection cleanup.", blobName);
-        }
     }
 
     private static int? ExtractFirstPage(string markedSliceText)

--- a/core/src/Dignite.Extract.Domain.Shared/ExtractErrorCodes.cs
+++ b/core/src/Dignite.Extract.Domain.Shared/ExtractErrorCodes.cs
@@ -25,6 +25,8 @@ public static class ExtractErrorCodes
         // not in whitelist).
         public const string FileTooLarge = "Extract:DocumentFileTooLarge";
         public const string UnsupportedFileType = "Extract:DocumentUnsupportedFileType";
+        // Derived sub-documents spawned from segment SliceText have no source blob; download is unavailable.
+        public const string NoSourceBlob = "Extract:DocumentNoSourceBlob";
     }
 
     public static class DocumentType

--- a/core/src/Dignite.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Extract.Domain.Shared/Localization/Extract/en.json
@@ -334,6 +334,7 @@
     "Extract:DocumentInRecycleBin": "This file already exists in the recycle bin ({FileName}).",
     "Extract:DocumentFileTooLarge": "File '{FileName}' exceeds the maximum allowed size of {MaxBytes} bytes.",
     "Extract:DocumentUnsupportedFileType": "File '{FileName}' has an unsupported type ('{ContentType}'). Please upload a supported image or PDF.",
+    "Extract:DocumentNoSourceBlob": "This document has no source file available for download.",
     "Extract:UnknownPipelineCode": "Pipeline '{PipelineCode}' is not retryable.",
     "Extract:PipelineNeverRan": "Pipeline '{PipelineCode}' has not started yet.",
     "Extract:PipelineRetryInProgress": "Pipeline '{PipelineCode}' already has an attempt in progress.",

--- a/core/src/Dignite.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -26,6 +26,7 @@
     "Extract:DocumentInRecycleBin": "该文件已在回收站中 ({FileName})。",
     "Extract:DocumentFileTooLarge": "文件 '{FileName}' 超过了允许的最大大小 {MaxBytes} 字节。",
     "Extract:DocumentUnsupportedFileType": "文件 '{FileName}' 的类型 ('{ContentType}') 不受支持。请上传受支持的图片或 PDF。",
+    "Extract:DocumentNoSourceBlob": "该文档没有可供下载的源文件。",
     "Extract:UnknownPipelineCode": "流水线 '{PipelineCode}' 不支持重试。",
     "Extract:PipelineNeverRan": "流水线 '{PipelineCode}' 尚未运行。",
     "Extract:PipelineRetryInProgress": "流水线 '{PipelineCode}' 已有进行中的尝试。",

--- a/core/src/Dignite.Extract.Domain/Documents/Document.cs
+++ b/core/src/Dignite.Extract.Domain/Documents/Document.cs
@@ -17,8 +17,8 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     // Multi-tenancy
     public virtual Guid? TenantId { get; private set; }
 
-    /// <summary>File origin information (immutable).</summary>
-    public virtual FileOrigin FileOrigin { get; private set; } = default!;
+    /// <summary>File origin information (immutable). Null for derived sub-documents that carry no source blob (figure spans seeded from segment SliceText).</summary>
+    public virtual FileOrigin? FileOrigin { get; private set; }
 
     /// <summary>
     /// Owning cabinet (manual organization dimension, #194). Nullable; null means "uncategorized".
@@ -71,7 +71,7 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// <summary>
     /// Display title for the document, written after a successful text extraction pipeline run and immutable afterward.
     /// Extracted from <see cref="Markdown"/> by <see cref="MarkdownTitleExtractor"/>; if extraction fails, upstream falls back to the file name without extension.
-    /// Historical records from before the migration may be null; read paths should fall back to <see cref="FileOrigin"/>.OriginalFileName / <see cref="FileOrigin"/>.BlobName.
+    /// Historical records from before the migration may be null; read paths should fall back to <see cref="FileOrigin"/>?.OriginalFileName / <see cref="FileOrigin"/>?.BlobName.
     /// </summary>
     public virtual string? Title { get; private set; }
 
@@ -140,9 +140,8 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
 
     /// <summary>
     /// Content-derived stable key of the source constituent this document was derived from (#306 figure path /
-    /// #346 born-digital path): the SHA-256 of the figure bytes <b>or</b> of the Markdown slice, equal to this
-    /// document's <c>FileOrigin.ContentHash</c>. NOT bbox (which drifts, #210). Unique together with
-    /// <see cref="OriginDocumentId"/> so re-extraction / routing retry never duplicate-spawn.
+    /// #346 born-digital path): the SHA-256 of the Markdown slice text. NOT bbox (which drifts, #210). Unique
+    /// together with <see cref="OriginDocumentId"/> so re-extraction / routing retry never duplicate-spawn.
     /// <c>null</c> for normally-uploaded documents.
     /// </summary>
     public virtual string? OriginConstituentKey { get; private set; }
@@ -168,12 +167,12 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     public Document(
         Guid id,
         Guid? tenantId,
-        FileOrigin fileOrigin,
+        FileOrigin? fileOrigin,
         Guid? cabinetId = null)
         : base(id)
     {
         TenantId = tenantId;
-        FileOrigin = Check.NotNull(fileOrigin, nameof(fileOrigin));
+        FileOrigin = fileOrigin;
         CabinetId = cabinetId;
         LifecycleStatus = DocumentLifecycleStatus.Uploaded;
     }
@@ -183,13 +182,13 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// (#306 / #346, Scenario B): an embedded figure (image path) or a Markdown slice (born-digital path). It is a
     /// normal peer <see cref="Document"/> that runs the full pipeline + egress; the only difference is the
     /// back-reference (<see cref="OriginDocumentId"/> / <see cref="OriginConstituentKey"/>).
-    /// <paramref name="originConstituentKey"/> equals <paramref name="fileOrigin"/>'s <c>ContentHash</c> (the
-    /// constituent content hash), tying storage and routing idempotency together.
+    /// <paramref name="fileOrigin"/> is <c>null</c> for figure sub-documents (no source blob; Markdown is seeded
+    /// from the segment SliceText instead of re-extracting a blob).
     /// </summary>
     public static Document CreateDerived(
         Guid id,
         Guid? tenantId,
-        FileOrigin fileOrigin,
+        FileOrigin? fileOrigin,
         Guid originDocumentId,
         string originConstituentKey)
     {

--- a/core/src/Dignite.Extract.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.Extract.Domain/Documents/Segments/DocumentSegment.cs
@@ -19,11 +19,11 @@ namespace Dignite.Extract.Documents.Segments;
 /// the first-class, restorable artifact).
 /// </para>
 /// <para>
-/// <b>The slice text lives on the row</b> (<see cref="SliceText"/>), mirroring <c>DocumentFigure.Transcription</c>:
-/// it seeds the spawned derived document's text extraction (no re-extraction, so the exact slice is preserved —
-/// the #346 "never regenerate slice text" decision), and the derived document's own <c>FileOrigin</c> blob is
-/// written fresh from it at spawn time (derived-owned, so it outlives the container). <see cref="SegmentKey"/> is
-/// the SHA-256 of the slice text and doubles as the derived document's <c>FileOrigin.ContentHash</c> /
+/// <b>The slice text lives on the row</b> (<see cref="SliceText"/>): it seeds the spawned derived document's
+/// Markdown directly (no re-extraction, so the exact slice is preserved — the #346 "never regenerate slice text"
+/// decision). The derived sub-document carries <b>no <c>FileOrigin</c></b> (it has no source blob of its own; its
+/// text originates from this row, not from re-extracting a file), so this row is the only durable home of the slice.
+/// <see cref="SegmentKey"/> is the SHA-256 of the slice text and doubles as the derived document's
 /// <c>OriginConstituentKey</c>, giving idempotent routing (unique <c>(SourceDocumentId, SegmentKey)</c>);
 /// <see cref="Ordinal"/> is reading-order provenance only. A container's status is sticky (#346), so within one mode
 /// a key collision only ever comes from a job retry; the one cross-mode case — a concrete document's embedded-figure
@@ -40,17 +40,17 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
 
     /// <summary>
     /// SHA-256 (lowercase hex) of the slice text. Doubles as the derived document's
-    /// <c>OriginConstituentKey</c> / <c>FileOrigin.ContentHash</c> and is unique per source
+    /// <c>OriginConstituentKey</c> and is unique per source
     /// (<c>(SourceDocumentId, SegmentKey)</c>), so a job retry never duplicate-spawns.
     /// </summary>
     public virtual string SegmentKey { get; private set; } = default!;
 
     /// <summary>
-    /// The Markdown slice text. Working state on this aggregate: it seeds the derived document's text extraction
-    /// (skipping re-extraction so the exact slice is preserved) and is written to the derived document's
-    /// <c>FileOrigin</c> blob at spawn time. It is <b>not</b> a channel text egress, so it does not conflict with
-    /// Markdown-first (which governs the <see cref="Document"/> aggregate's text payload). Mirrors
-    /// <c>DocumentFigure.Transcription</c> (nvarchar(max), not indexed).
+    /// The Markdown slice text. Working state on this aggregate: it seeds the derived document's Markdown directly
+    /// (skipping re-extraction so the exact slice is preserved) — the derived sub-document has no <c>FileOrigin</c>
+    /// blob, so this row is where its text originates. It is <b>not</b> a channel text egress, so it does not conflict
+    /// with Markdown-first (which governs the <see cref="Document"/> aggregate's text payload). Stored as
+    /// nvarchar(max), not indexed.
     /// </summary>
     public virtual string SliceText { get; private set; } = default!;
 

--- a/core/src/Dignite.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -33,7 +33,7 @@ public class EfCoreDocumentRepository
         var dbSet = await GetDbSetAsync();
         return await dbSet
             .FirstOrDefaultAsync(
-                d => d.FileOrigin.BlobName == blobName,
+                d => d.FileOrigin != null && d.FileOrigin.BlobName == blobName,
                 GetCancellationToken(cancellationToken));
     }
 
@@ -46,7 +46,7 @@ public class EfCoreDocumentRepository
             var dbSet = await GetDbSetAsync();
             return await dbSet
                 .FirstOrDefaultAsync(
-                    d => d.FileOrigin.ContentHash == contentHash,
+                    d => d.FileOrigin != null && d.FileOrigin.ContentHash == contentHash,
                     GetCancellationToken(cancellationToken));
         }
     }
@@ -204,7 +204,7 @@ public class EfCoreDocumentRepository
                 // attention, so it is INCLUDED in NeedsReview below — the review-queue list (DocumentAppService.ApplyFilter)
                 // counts it too, so the dashboard count and the queue never drift (#333).
                 Count = g.Sum(d => d.IsContainer ? 0L : 1L),
-                Bytes = g.Sum(d => d.IsContainer ? 0L : d.FileOrigin.FileSize),
+                Bytes = g.Sum(d => d.IsContainer ? 0L : (d.FileOrigin != null ? d.FileOrigin.FileSize : 0L)),
                 NeedsReview = g.Sum(d =>
                     d.ReviewReasons != DocumentReviewReasons.None
                     && d.ReviewDisposition != DocumentReviewDisposition.Rejected

--- a/core/src/Dignite.Extract.EntityFrameworkCore/EntityFrameworkCore/ExtractDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Extract.EntityFrameworkCore/EntityFrameworkCore/ExtractDbContextModelCreatingExtensions.cs
@@ -78,7 +78,7 @@ public static class ExtractDbContextModelCreatingExtensions
             // resume gate for the unified sub-document pass); not exposed at the egress.
             b.Property(x => x.IsSegmented).IsRequired();
 
-            // #306 / #346 Scenario B back-reference: content-derived key of the source constituent (= FileOrigin.ContentHash).
+            // #306 / #346 Scenario B back-reference: SHA-256 of the clean constituent Markdown slice.
             b.Property(x => x.OriginConstituentKey).HasMaxLength(DocumentConsts.MaxOriginConstituentKeyLength);
 
             // Text extraction provenance (#210): provider name + archived manifest, serialized as a whole into a typed JSON column (#206 cross-DB principle).
@@ -92,25 +92,21 @@ public static class ExtractDbContextModelCreatingExtensions
                 .HasForeignKey(f => f.DocumentId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            // FileOrigin is optional: user-uploaded documents always have one; derived sub-documents spawned from
+            // segment SliceText carry no source blob and store null. All owned columns are nullable in the DB so that
+            // sub-document rows can write null for the whole owned entity.
             b.OwnsOne(x => x.FileOrigin, fo =>
             {
-                fo.Property(x => x.BlobName)
-                    .IsRequired()
-                    .HasMaxLength(FileOriginConsts.MaxBlobNameLength);
-                fo.Property(x => x.UploadedByUserName)
-                    .IsRequired()
-                    .HasMaxLength(FileOriginConsts.MaxUploadedByUserNameLength);
+                fo.Property(x => x.BlobName).HasMaxLength(FileOriginConsts.MaxBlobNameLength);
+                fo.Property(x => x.UploadedByUserName).HasMaxLength(FileOriginConsts.MaxUploadedByUserNameLength);
                 fo.Property(x => x.OriginalFileName).HasMaxLength(FileOriginConsts.MaxOriginalFileNameLength);
-                fo.Property(x => x.ContentType)
-                    .IsRequired()
-                    .HasMaxLength(FileOriginConsts.MaxContentTypeLength);
-                fo.Property(x => x.ContentHash)
-                    .IsRequired()
-                    .HasMaxLength(FileOriginConsts.MaxContentHashLength);
+                fo.Property(x => x.ContentType).HasMaxLength(FileOriginConsts.MaxContentTypeLength);
+                fo.Property(x => x.ContentHash).HasMaxLength(FileOriginConsts.MaxContentHashLength);
 
                 fo.HasIndex(x => x.BlobName);
                 fo.HasIndex(x => x.ContentHash);
             });
+            b.Navigation(x => x.FileOrigin).IsRequired(false);
 
             // The DocumentPipelineRun FK + CASCADE are declared explicitly in the child-side configuration block (#216).
 

--- a/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -17,6 +16,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
@@ -64,7 +64,6 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
     private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly IDistributedEventBus _eventBus;
     private readonly DocumentSegmentationWorkflow _workflow;
-    private readonly IBlobContainer<ExtractDocumentContainer> _blobContainer;
     private readonly IGuidGenerator _guidGenerator;
 
     public DocumentSegmentationJob_Tests()
@@ -75,7 +74,6 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
         _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _workflow = GetRequiredService<DocumentSegmentationWorkflow>();
-        _blobContainer = GetRequiredService<IBlobContainer<ExtractDocumentContainer>>();
         _guidGenerator = GetRequiredService<IGuidGenerator>();
     }
 
@@ -97,13 +95,13 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
 
             var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId);
             derived.Count.ShouldBe(2);
-            // Each derived sub-document is keyed by its slice hash (= the segment key) and carries a Markdown FileOrigin.
-            derived.ShouldAllBe(d => d.FileOrigin.ContentType == "text/markdown");
+            // Each derived sub-document carries NO FileOrigin (no source blob): its Markdown is seeded from the
+            // segment's SliceText, and its identity is the OriginConstituentKey (= the segment key / slice hash).
+            derived.ShouldAllBe(d => d.FileOrigin == null);
             foreach (var d in derived)
             {
                 d.OriginConstituentKey.ShouldNotBeNull();
                 segments.ShouldContain(s => s.SegmentKey == d.OriginConstituentKey && s.RoutedDocumentId == d.Id);
-                d.FileOrigin.ContentHash.ShouldBe(d.OriginConstituentKey);
             }
         });
 
@@ -610,9 +608,14 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
         // operator sees it even after ABP exhausts retries.
         var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
         StubSplit(("Invoice A", true), ("Invoice B", true));
-        _blobContainer
-            .When(x => x.SaveAsync(Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()))
-            .Do(_ => throw new InvalidOperationException("blob store down"));
+        // A sub-document has no source blob to write, so the canonical Phase B failure is now an egress step inside the
+        // spawn UoW. Make DocumentUploadedEto publishing throw: it runs after the derived insert but before the
+        // segment's Spawned mark is flushed, so the segment is left Pending (ABP then retries) and the job rethrows.
+        // (The test UoW disables transactions, so the autosaved derived row is not rolled back here as the spawn UoW
+        // would in production — this test asserts the retry contract: container flagged + segment Pending + rethrow.)
+        _eventBus
+            .PublishAsync(Arg.Any<DocumentUploadedEto>())
+            .ThrowsAsync(new InvalidOperationException("event bus down"));
 
         await Should.ThrowAsync<AggregateException>(
             () => _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId }));
@@ -623,7 +626,6 @@ public class DocumentSegmentationJob_Tests : ExtractTestBase<DocumentSegmentatio
                 .ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
             (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId))
                 .ShouldAllBe(s => s.Status == DocumentSegmentStatus.Pending);
-            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
         });
     }
 

--- a/host/src/Migrations/20260620092115_AllowNullFileOriginForSubDocuments.Designer.cs
+++ b/host/src/Migrations/20260620092115_AllowNullFileOriginForSubDocuments.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.Extract.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.Extract.Host.Migrations
 {
     [DbContext(typeof(ExtractHostDbContext))]
-    partial class ExtractHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620092115_AllowNullFileOriginForSubDocuments")]
+    partial class AllowNullFileOriginForSubDocuments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260620092115_AllowNullFileOriginForSubDocuments.cs
+++ b/host/src/Migrations/20260620092115_AllowNullFileOriginForSubDocuments.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.Extract.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowNullFileOriginForSubDocuments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_UploadedByUserName",
+                table: "ExtractDocuments",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "FileOrigin_FileSize",
+                table: "ExtractDocuments",
+                type: "bigint",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_ContentType",
+                table: "ExtractDocuments",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_ContentHash",
+                table: "ExtractDocuments",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(64)",
+                oldMaxLength: 64);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_BlobName",
+                table: "ExtractDocuments",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_UploadedByUserName",
+                table: "ExtractDocuments",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "FileOrigin_FileSize",
+                table: "ExtractDocuments",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L,
+                oldClrType: typeof(long),
+                oldType: "bigint",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_ContentType",
+                table: "ExtractDocuments",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_ContentHash",
+                table: "ExtractDocuments",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileOrigin_BlobName",
+                table: "ExtractDocuments",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## What

Sub-documents spawned from a container''s `DocumentSegment` slices have no real source file — their Markdown is seeded directly from `DocumentSegment.SliceText`, not extracted from a blob. Previously the spawner wrote a synthetic `{guid}.md` blob holding only the OCR text and pointed `FileOrigin` at it, which was a misleading "source file" and an orphan-blob risk (the blob was written outside the spawn UoW).

This makes `FileOrigin` optional end to end so a derived sub-document can legitimately carry none.

## Changes

- **Domain**: `Document.FileOrigin` is now `FileOrigin?`; the constructor and `CreateDerived` accept null; `OriginConstituentKey` is the SHA-256 of the clean slice text (no longer `= FileOrigin.ContentHash`).
- **Segmentation**: `DocumentSegmentationJob` no longer writes any blob for derived docs (removes the synthetic-blob write + its orphan-cleanup try/catch); spawns with `fileOrigin: null`.
- **Parse**: `DocumentParseBackgroundJob` null-guards `FileOrigin` reads; the existing seed-Markdown path already skips blob fetch for derived docs.
- **Egress**: `DocumentAppService.GetBlobAsync` throws `BusinessException(Extract:DocumentNoSourceBlob)` when a document has no source blob; permanent-delete skips blob deletion when `FileOrigin` is null.
- **EF Core**: `FileOrigin` owned-entity columns are nullable and the navigation is optional; migration `AllowNullFileOriginForSubDocuments` alters the five `FileOrigin_*` columns to nullable.
- **Docs**: `DocumentSegment` XML comments updated to match — the slice row is the sub-doc''s only durable text source; `SegmentKey` doubles as `OriginConstituentKey` only.

## Migration

`20260620092115_AllowNullFileOriginForSubDocuments` — five `AlterColumn` ops making `FileOrigin_BlobName` / `_UploadedByUserName` / `_ContentType` / `_ContentHash` / `_FileSize` nullable on `ExtractDocuments`. `Down()` restores `NOT NULL` with empty/zero defaults.

## Notes

- New-document upload still requires a real `FileOrigin`; only segment-derived sub-documents carry null.
- Downloading the source of a sub-document now returns a localized `DocumentNoSourceBlob` business error instead of a synthetic `.md`.