### PR TITLE
refactor(segments): dead-code sweep, segmentation rules, round-trip guardrail + #391 fix (#390)

### DIFF
--- a/.claude/rules/sub-document-segmentation.md
+++ b/.claude/rules/sub-document-segmentation.md
@@ -1,0 +1,80 @@
+---
+description: "Dignite Extract sub-document segmentation subsystem: the two-representation model (DocumentSegment ledger + derived Document), the two-Kind red line, the field lifecycle contract, and the cross-entity invariant (decision record: #390)"
+paths:
+  - "**/Segmentation/**/*.cs"
+  - "**/DerivedDocumentSpawner.cs"
+  - "**/ContainerMarker*.cs"
+  - "**/Segments/**/*.cs"
+  - "**/DocumentSegment*.cs"
+---
+
+# Sub-document Segmentation
+
+> Auto-loaded when editing the segmentation / sub-document detection subsystem. This is the densest, most-iterated
+> subsystem in the channel (#306 → #346 → #355/#356/#359 → #364/#365 → #371/#372/#373 → #377/#379 → #381). Read this
+> **before** touching it: the field-level "is this redundant?" questions are almost always answered by the
+> two-representation model below, recorded as the resolution of #390.
+
+## Two representations of a sub-document — on purpose
+
+A sub-document exists first as a **`DocumentSegment`** (pre-spawn ledger row) and then as a **derived `Document`**
+(post-spawn first-class artifact). This is deliberate denormalization, not accidental duplication:
+
+- **Detection is a single expensive LLM pass.** We need a persistent "detected but not yet spawned" state so the job
+  is resumable / idempotent without re-paying the LLM split. A `Document` cannot serve this role — the moment one
+  exists, the whole pipeline (parse → classify → extract) takes it over; it cannot sit as a "pending slice".
+- **Retraction (#364) needs `Kind` to outlive spawn.** A container→type reclassify retracts `Text` children but keeps
+  `Figure` children; that decision reads the ledger row after the derived document already exists.
+
+Therefore `DocumentSegment` is a **durable internal ledger**, **not** a transient work queue:
+
+- It is **never deleted after parse success** (the "delete-segment-after-parse" aggressive simplification is a
+  boundary change, explicitly deferred — #390 Decision 4; open an issue if ever pursued).
+- It is **never on any egress** (REST / MCP / ETO). Downstream discovers sub-documents only as `Document` rows with
+  `OriginDocumentId` set. Verified zero references in `*.Application.Contracts` / `*.Mcp` / `*.Abstractions`. Keep it
+  that way — exposing the ledger would make an internal work-queue into a channel contract.
+
+The fields mirrored between the two representations are intentional copies made at spawn time:
+`DocumentSegment.SegmentKey → Document.OriginConstituentKey`, `SourceDocumentId → OriginDocumentId`,
+`SliceText → Document.Markdown` (one-way seed), `TenantId → TenantId`.
+
+## 🚦 RED LINE: the subsystem assumes exactly two Kinds {Text, Figure}
+
+`DocumentSegmentKind.IsContainerIndependent()` (exhaustive switch, throws on an unhandled kind), the
+`Strip` vs `ExtractBodies` child-seed split, and the **Text-only** retraction filter in
+`ContainerMarkerClearedEventHandler` are all **binary**. Adding a third `DocumentSegmentKind`
+(Table / Signature / Attachment / …) is a **CHANNEL BOUNDARY change**:
+
+> **STOP and open a GitHub issue** to re-review *every* `IsContainerIndependent()` call site and the
+> container→type retraction semantics **before** writing code.
+
+The exhaustive switch throwing at runtime on an unhandled kind is the **backstop** (it prevents a silent wrong
+default — the #364-class missed-branch bug, hardened in #379), not a license to add a kind quietly.
+
+## Field lifecycle contract (do not add / remove without updating #390)
+
+| Field | Status | Note |
+|---|---|---|
+| `SourceDocumentId`, `SegmentKey`, `Kind`, `Status`, `RoutedDocumentId`, `Ordinal` | **contract** | the idempotency + retraction lifecycle |
+| `RoutedDocumentId` | **keep explicit** | reconstructable from `(OriginDocumentId, OriginConstituentKey)`, but the explicit pointer is the ledger's purpose (idempotency + retraction clarity); reconstructing the join is more complex, not less |
+| `SliceText` | **transient one-way seed** | duplicated by `Document.Markdown` after parse; bounded duplication is accepted; **do not add a parse→segment writeback to clear it** (couples parse job to the ledger for a low-value saving) |
+| `PageNumber` | **retained provenance** | deliberate out-of-band anchor (Markdown-first "named, strongly-typed, nullable extension field" rule); write-only by design, not dead weight |
+
+Watch for accreted residue: a fast-iterated subsystem leaves write-only fields / never-assigned enum values / dead
+projections. #390 removed three (`DocumentSegmentStatus.NotADocument`, `DetectionContext.UploadedByUserName`,
+`PendingSegment.SliceText`). Re-run a dead-code sweep when adding the next iteration.
+
+## Cross-entity invariant (two coupled state machines)
+
+`DocumentSegment` (`Status` Pending/Spawned + `Kind`) and `Document` (`IsContainer` / `IsSegmented`) are two coupled
+state machines. The coupling rules:
+
+- **All** container↔concrete transitions flow through `Document.SetContainerFlag`, which clears `IsSegmented`
+  (#378/#379 — the single choke point so the coupled invariant cannot leak).
+- `IsSegmented` is the **precise resume gate** (#377): set atomically with the segment rows on terminal SUCCESS;
+  do not infer completion from segment-row `Kind`.
+- A non-document slice (cover / index / transmittal) is **skipped, not persisted** — there is no terminal
+  "not a document" row state.
+
+Changes to these transitions must be covered by the cross-entity invariant tests (container→type→container round
+trips: assert segment-row + sub-document terminal states). When in doubt, this is a boundary — open an issue.

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -136,7 +136,7 @@ public class DocumentSegmentationJob
         }
     }
 
-    /// <summary>Load phase (short UoW): snapshot the source's tenant/uploader, Document.Markdown (with inline figure markers, #381), container flag, parent context, and whether the document is already marked segmented (#377, the precise resume gate).</summary>
+    /// <summary>Load phase (short UoW): snapshot the source's tenant, Document.Markdown (with inline figure markers, #381), container flag, parent context, and whether the document is already marked segmented (#377, the precise resume gate).</summary>
     protected virtual async Task<DetectionContext?> LoadAsync(Guid sourceDocumentId)
     {
         Document? source;
@@ -189,7 +189,6 @@ public class DocumentSegmentationJob
         return new DetectionContext(
             sourceDocumentId,
             source.TenantId,
-            source.FileOrigin?.UploadedByUserName ?? string.Empty,
             markdown,
             source.IsContainer,
             alreadySegmented,
@@ -422,7 +421,7 @@ public class DocumentSegmentationJob
 
         var snapshot = pending
             .OrderBy(s => s.Ordinal)
-            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.SliceText, s.Ordinal))
+            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Ordinal))
             .ToList();
 
         await uow.CompleteAsync();
@@ -619,11 +618,10 @@ public class DocumentSegmentationJob
     private static bool IsSchemaDeserializationError(Exception ex)
         => ex is JsonException || ex.GetBaseException() is JsonException;
 
-    /// <summary>Per-source detection context loaded once up front: provenance, the Document.Markdown to detect over (with inline figure markers, #381), the container flag, whether a prior split exists, and the parent context for the LLM.</summary>
+    /// <summary>Per-source detection context loaded once up front: the source id + tenant, the Document.Markdown to detect over (with inline figure markers, #381), the container flag, whether a prior split exists, and the parent context for the LLM.</summary>
     protected sealed record DetectionContext(
         Guid SourceDocumentId,
         Guid? TenantId,
-        string UploadedByUserName,
         string Markdown,
         bool IsContainer,
         bool AlreadySegmented,
@@ -632,8 +630,10 @@ public class DocumentSegmentationJob
     /// <summary>A standalone span prepared for persistence: its content key, clean slice text, kind, and figure page anchor.</summary>
     private sealed record PreparedSegment(string Key, string CleanText, DocumentSegmentKind Kind, int? PageNumber);
 
-    /// <summary>Detached snapshot of one still-Pending segment, carried across the per-segment external + UoW phases.</summary>
-    protected sealed record PendingSegment(Guid SegmentId, string SegmentKey, string SliceText, int Ordinal);
+    /// <summary>Detached snapshot of one still-Pending segment, carried across the per-segment external + UoW phases.
+    /// Carries no slice text: the spawn path keys off <see cref="SegmentKey"/>, and the derived document's Markdown
+    /// is seeded by <c>DocumentParseBackgroundJob</c> reading the segment's <c>SliceText</c> column fresh from the DB.</summary>
+    protected sealed record PendingSegment(Guid SegmentId, string SegmentKey, int Ordinal);
 }
 
 public class DocumentSegmentationJobArgs

--- a/core/src/Dignite.Extract.Domain.Shared/Documents/DocumentSegmentStatus.cs
+++ b/core/src/Dignite.Extract.Domain.Shared/Documents/DocumentSegmentStatus.cs
@@ -13,8 +13,5 @@ public enum DocumentSegmentStatus
     Pending = 0,
 
     /// <summary>Spawned into a derived <c>Document</c> (recorded in <see cref="DocumentSegment.RoutedDocumentId"/>).</summary>
-    Spawned = 1,
-
-    /// <summary>The LLM classified the slice as a non-document segment (cover / index / transmittal); not spawned.</summary>
-    NotADocument = 2
+    Spawned = 1
 }

--- a/core/src/Dignite.Extract.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.Extract.Domain/Documents/Segments/DocumentSegment.cs
@@ -82,10 +82,11 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
 
     /// <summary>
     /// Routing progress (#346): <see cref="DocumentSegmentStatus.Pending"/> until the job spawns this slice,
-    /// then <see cref="DocumentSegmentStatus.Spawned"/> (see <see cref="RoutedDocumentId"/>) or
-    /// <see cref="DocumentSegmentStatus.NotADocument"/> (the LLM marked the slice a cover / index / transmittal).
-    /// This is the durable, resumable work-queue marker that lets the job crash and resume from the remaining
+    /// then <see cref="DocumentSegmentStatus.Spawned"/> (see <see cref="RoutedDocumentId"/>). This is the durable,
+    /// resumable work-queue marker that lets the job crash and resume from the remaining
     /// <see cref="DocumentSegmentStatus.Pending"/> slices without duplicate-spawning or re-paying the LLM split.
+    /// A slice the LLM marks as a non-document span (cover / index / transmittal) is never persisted as a row —
+    /// the detection pass skips it rather than recording a terminal "not a document" state.
     /// </summary>
     public virtual DocumentSegmentStatus Status { get; private set; }
 

--- a/core/src/Dignite.Extract.EntityFrameworkCore/EntityFrameworkCore/ExtractDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Extract.EntityFrameworkCore/EntityFrameworkCore/ExtractDbContextModelCreatingExtensions.cs
@@ -142,9 +142,16 @@ public static class ExtractDbContextModelCreatingExtensions
             // SQL-Server-specific; the SQL-Server-only filtered-index portability limitation is intentionally
             // accepted for v0.2.0. No FK on OriginDocumentId: it is a soft provenance pointer, not a constraint,
             // so the derived document outlives the source (the source may be hard-deleted while derived ones remain).
+            // #391: the filter also excludes soft-deleted rows (IsDeleted = 0). A retracted (soft-deleted)
+            // sub-document is a recoverable archive (#349 DocumentDeletedEto), not a live constituent — leaving it in
+            // the index made a container→concrete→container round trip collide on re-spawn (Document.Markdown is
+            // immutable, so the re-split reuses the same OriginConstituentKey) and the job retried forever. Excluding
+            // IsDeleted keeps the slot free for the fresh child; concurrent double-spawn idempotency is preserved
+            // (two LIVE rows with the same key still collide). The new index covers a strict subset of the old one's
+            // rows, so the recreate is safe on populated tables.
             b.HasIndex(x => new { x.OriginDocumentId, x.OriginConstituentKey })
                 .IsUnique()
-                .HasFilter("[OriginDocumentId] IS NOT NULL");
+                .HasFilter("[OriginDocumentId] IS NOT NULL AND [IsDeleted] = 0");
         });
 
         builder.Entity<DocumentExtractedField>(b =>

--- a/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerLifecycleRoundTrip_Tests.cs
+++ b/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerLifecycleRoundTrip_Tests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Extract.Abstractions.Documents;
+using Dignite.Extract.Abstractions.Parse;
+using Dignite.Extract.Ai;
+using Dignite.Extract.Documents;
+using Dignite.Extract.Documents.Pipelines.Segmentation;
+using Dignite.Extract.Documents.Segments;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Volo.Abp.Uow;
+using Xunit;
+
+namespace Dignite.Extract.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(ExtractEntityFrameworkCoreTestModule))]
+public class ContainerLifecycleRoundTripTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<ExtractDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+
+        // Same split seam as DocumentSegmentationJob_Tests: a partial substitute whose RunAsync each test stubs to a
+        // chosen boundary set — no real LLM call. The real DocumentSegmentationJob, the real reclassify app service,
+        // and the real ContainerMarker{Set,Cleared}EventHandler all run against the real SQLite DB.
+        var workflow = Substitute.ForPartsOf<DocumentSegmentationWorkflow>(
+            Substitute.For<IChatClient>(),
+            Options.Create(new ExtractBehaviorOptions()),
+            new DefaultPromptProvider());
+        context.Services.AddSingleton(workflow);
+    }
+}
+
+/// <summary>
+/// Cross-entity invariant coverage for the FULL container lifecycle round trip (decision record #390): a single
+/// document driven container → concrete → container through the <b>real</b> segmentation job + reclassify app service +
+/// marker event handlers, asserting that the two coupled state machines (the <see cref="DocumentSegment"/> ledger's
+/// <c>Status</c>/<c>Kind</c> and the <see cref="Document"/>'s <c>IsContainer</c>/<c>IsSegmented</c>) stay consistent
+/// across the whole loop.
+/// <para>
+/// The existing per-leg tests each cover one transition in isolation (<c>IsSegmentedTransitionMatrix_Tests</c> is
+/// domain-only; <c>ContainerReclassifyRetraction_Tests</c> / <c>Concrete_Doc_..._Re_Recognized_As_Container</c>
+/// <b>pre-seed</b> a fabricated surviving-figure state). These tests instead verify the <b>composition seam</b>: that
+/// the state a real retraction <i>produces</i> is a valid input to a subsequent real re-split.
+/// </para>
+/// </summary>
+public class ContainerLifecycleRoundTrip_Tests
+    : ExtractTestBase<ContainerLifecycleRoundTripTestModule>
+{
+    private readonly DocumentSegmentationJob _job;
+    private readonly IDocumentAppService _appService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IRepository<DocumentType, Guid> _documentTypeRepository;
+    private readonly DocumentSegmentationWorkflow _workflow;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+
+    // A born-digital container Markdown carrying two text constituents with an inline figure (#301/#381) between them.
+    private const string FigureText = "INVOICE No 42 Total 100";
+    private static readonly string ContainerMarkdown =
+        $"Service A-B\n{ImageOcrMarkup.Wrap(FigureText, 1)}\nLease X-Y";
+
+    public ContainerLifecycleRoundTrip_Tests()
+    {
+        _job = GetRequiredService<DocumentSegmentationJob>();
+        _appService = GetRequiredService<IDocumentAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _segmentRepository = GetRequiredService<IRepository<DocumentSegment, Guid>>();
+        _documentTypeRepository = GetRequiredService<IRepository<DocumentType, Guid>>();
+        _workflow = GetRequiredService<DocumentSegmentationWorkflow>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
+    }
+
+    [Fact]
+    public async Task Real_Split_Then_Real_Reclassify_Retracts_Text_Keeps_Figure_And_Clears_IsSegmented()
+    {
+        // Leg 1 — the REAL segmentation job produces the post-split state (2 Text children + 1 Figure child),
+        // instead of the hand-seeded state the existing retraction test uses.
+        var containerId = await ArrangeContainerAsync();
+        StubSplit(("Service A-B", true), (ImageOcrMarkup.OpenPagePrefix + "1]*", true), ("Lease X-Y", true));
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
+
+        var figureKey = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(FigureText));
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetListByOriginAsync(containerId)).Count.ShouldBe(3);
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count.ShouldBe(3);
+            segments.Count(s => s.Kind == DocumentSegmentKind.Figure).ShouldBe(1);
+            (await _documentRepository.GetAsync(containerId)).IsSegmented.ShouldBeTrue();
+        });
+
+        // Leg 2 — the REAL reclassify app service drives container → concrete; the marker-cleared handler retracts
+        // only the Text children and keeps the Figure child, and SetContainerFlag clears IsSegmented.
+        var typeId = await SeedDocumentTypeAsync("invoice.general");
+        await _appService.ReclassifyAsync(containerId, new ReclassifyDocumentInput { DocumentTypeId = typeId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var doc = await _documentRepository.GetAsync(containerId);
+            doc.IsContainer.ShouldBeFalse();
+            doc.IsSegmented.ShouldBeFalse(); // cleared on the container→concrete transition (#378/#379)
+            doc.DocumentTypeId.ShouldBe(typeId);
+
+            // Only the figure child survives; the figure segment row is intact and re-split-ready (Spawned, pointing
+            // at its surviving child) — this is the exact state the existing #372/#377 tests fabricate by hand.
+            var survivors = await _documentRepository.GetListByOriginAsync(containerId);
+            survivors.Count.ShouldBe(1);
+
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count.ShouldBe(1);
+            segments[0].Kind.ShouldBe(DocumentSegmentKind.Figure);
+            segments[0].SegmentKey.ShouldBe(figureKey);
+            segments[0].Status.ShouldBe(DocumentSegmentStatus.Spawned);
+            segments[0].RoutedDocumentId.ShouldBe(survivors[0].Id);
+        });
+    }
+
+    [Fact(Skip = "Documents a latent defect discovered via the #390 round-trip probe (pending its own issue): a "
+        + "container→concrete→container loop cannot re-spawn its text children. Retraction SOFT-deletes them, but "
+        + "Document.Markdown is immutable, so the re-split produces the SAME OriginConstituentKey values and the spawn "
+        + "collides with the soft-deleted rows on the (OriginDocumentId, OriginConstituentKey) unique index (its "
+        + "filter is 'OriginDocumentId IS NOT NULL', not 'IsDeleted = 0'). The job then retries forever. Un-skip and "
+        + "assert clean re-spawn once the index/retraction interaction is fixed.")]
+    public async Task Re_Recognized_Container_Clears_IsSegmented_So_The_Split_Runs_Again()
+    {
+        // The full loop's third leg: after container→concrete, re-recognizing the document as a container again must
+        // clear IsSegmented so the segmentation job's Phase-A LLM split is NOT short-circuited by the stale marker.
+        var containerId = await ArrangeContainerAsync();
+        StubSplit(("Service A-B", true), (ImageOcrMarkup.OpenPagePrefix + "1]*", true), ("Lease X-Y", true));
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
+
+        var typeId = await SeedDocumentTypeAsync("invoice.general");
+        await _appService.ReclassifyAsync(containerId, new ReclassifyDocumentInput { DocumentTypeId = typeId });
+
+        // Re-recognize as a container (mirrors the classification job's container branch).
+        await MarkAsContainerInUowAsync(containerId);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var doc = await _documentRepository.GetAsync(containerId);
+            doc.IsContainer.ShouldBeTrue();
+            doc.IsSegmented.ShouldBeFalse(); // the re-recognition cleared the marker → a re-split is allowed
+            doc.DocumentTypeId.ShouldBeNull();
+        });
+
+        // Phase A re-runs (the marker no longer short-circuits it): assert the LLM split is invoked on re-enqueue.
+        _workflow.ClearReceivedCalls();
+        StubSplit(("Service A-B", true), (ImageOcrMarkup.OpenPagePrefix + "1]*", true), ("Lease X-Y", true));
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
+
+        await _workflow.Received().RunAsync(
+            Arg.Any<string>(), Arg.Any<SubDocumentDetectionContext>(), Arg.Any<CancellationToken>());
+
+        // The surviving figure constituent is idempotently kept (never duplicated) across the re-split.
+        var figureKey = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(FigureText));
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count(s => s.SegmentKey == figureKey).ShouldBe(1);
+        });
+    }
+
+    private async Task<Guid> ArrangeContainerAsync()
+    {
+        var containerId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var doc = new Document(
+                containerId,
+                tenantId: null,
+                fileOrigin: new FileOrigin(
+                    blobName: $"blobs/{containerId:N}.pdf",
+                    uploadedByUserName: "test-user",
+                    contentType: "application/pdf",
+                    contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                    fileSize: 2048,
+                    originalFileName: "bundle.pdf"));
+
+            typeof(Document)
+                .GetProperty(nameof(Document.Markdown))!
+                .GetSetMethod(nonPublic: true)!
+                .Invoke(doc, [ContainerMarkdown]);
+            typeof(Document)
+                .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(doc, null);
+
+            await _documentRepository.InsertAsync(doc, autoSave: true);
+        });
+
+        return containerId;
+    }
+
+    private async Task<Guid> SeedDocumentTypeAsync(string typeCode)
+    {
+        var typeId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+            await _documentTypeRepository.InsertAsync(
+                new DocumentType(typeId, tenantId: null, typeCode, typeCode), autoSave: true));
+        return typeId;
+    }
+
+    private async Task MarkAsContainerInUowAsync(Guid documentId)
+    {
+        using var uow = _unitOfWorkManager.Begin(requiresNew: true);
+        var document = await _documentRepository.GetAsync(documentId);
+        typeof(Document)
+            .GetMethod("MarkAsContainer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(document, null);
+        await _documentRepository.UpdateAsync(document, autoSave: true);
+        await uow.CompleteAsync();
+    }
+
+    private void StubSplit(params (string Marker, bool IsSubDocument)[] boundaries)
+    {
+        var outcome = new DocumentSegmentationOutcome();
+        foreach (var (marker, isSubDocument) in boundaries)
+        {
+            outcome.Boundaries.Add(new SegmentBoundary(marker, isSubDocument));
+        }
+
+        _workflow.RunAsync(Arg.Any<string>(), Arg.Any<SubDocumentDetectionContext>(), Arg.Any<CancellationToken>())
+            .Returns(outcome);
+    }
+}

--- a/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerLifecycleRoundTrip_Tests.cs
+++ b/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerLifecycleRoundTrip_Tests.cs
@@ -133,16 +133,15 @@ public class ContainerLifecycleRoundTrip_Tests
         });
     }
 
-    [Fact(Skip = "Documents a latent defect discovered via the #390 round-trip probe (pending its own issue): a "
-        + "container→concrete→container loop cannot re-spawn its text children. Retraction SOFT-deletes them, but "
-        + "Document.Markdown is immutable, so the re-split produces the SAME OriginConstituentKey values and the spawn "
-        + "collides with the soft-deleted rows on the (OriginDocumentId, OriginConstituentKey) unique index (its "
-        + "filter is 'OriginDocumentId IS NOT NULL', not 'IsDeleted = 0'). The job then retries forever. Un-skip and "
-        + "assert clean re-spawn once the index/retraction interaction is fixed.")]
-    public async Task Re_Recognized_Container_Clears_IsSegmented_So_The_Split_Runs_Again()
+    [Fact]
+    public async Task Re_Recognized_Container_Re_Splits_And_Re_Spawns_Text_Children_Without_Colliding()
     {
-        // The full loop's third leg: after container→concrete, re-recognizing the document as a container again must
-        // clear IsSegmented so the segmentation job's Phase-A LLM split is NOT short-circuited by the stale marker.
+        // The full loop's third leg + the #391 fix: after container→concrete, re-recognizing the document as a
+        // container again must clear IsSegmented so the Phase-A split re-runs, AND the re-split must cleanly re-spawn
+        // the text children. Retraction soft-deleted the original text children and Document.Markdown is immutable, so
+        // the re-split reuses the same OriginConstituentKey values — before #391 that collided with the soft-deleted
+        // rows on the (OriginDocumentId, OriginConstituentKey) unique index and the job retried forever. The index
+        // filter now excludes IsDeleted = 0, so the slot is free for the fresh child.
         var containerId = await ArrangeContainerAsync();
         StubSplit(("Service A-B", true), (ImageOcrMarkup.OpenPagePrefix + "1]*", true), ("Lease X-Y", true));
         await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
@@ -169,12 +168,25 @@ public class ContainerLifecycleRoundTrip_Tests
         await _workflow.Received().RunAsync(
             Arg.Any<string>(), Arg.Any<SubDocumentDetectionContext>(), Arg.Any<CancellationToken>());
 
-        // The surviving figure constituent is idempotently kept (never duplicated) across the re-split.
         var figureKey = ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(FigureText));
         await WithUnitOfWorkAsync(async () =>
         {
+            var doc = await _documentRepository.GetAsync(containerId);
+            doc.IsContainer.ShouldBeTrue();
+            doc.IsSegmented.ShouldBeTrue();                                    // the re-split completed
+            doc.ReviewReasons.ShouldBe(DocumentReviewReasons.None);           // no SegmentationIncomplete collision flag
+
+            // The surviving figure is idempotently kept (never duplicated) and the two text constituents are re-split,
+            // all reaching Spawned — no unique-index collision with the soft-deleted originals (#391).
             var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId);
+            segments.Count.ShouldBe(3);
+            segments.ShouldAllBe(s => s.Status == DocumentSegmentStatus.Spawned);
             segments.Count(s => s.SegmentKey == figureKey).ShouldBe(1);
+            segments.Count(s => s.Kind == DocumentSegmentKind.Text).ShouldBe(2);
+
+            // Three LIVE derived children (the figure that survived + two freshly re-spawned text children); the two
+            // originally-retracted text children remain only as soft-deleted archives, excluded by the ISoftDelete filter.
+            (await _documentRepository.GetListByOriginAsync(containerId)).Count.ShouldBe(3);
         });
     }
 

--- a/host/src/Migrations/20260620123853_SubDocumentUniqueIndexExcludesSoftDeleted.Designer.cs
+++ b/host/src/Migrations/20260620123853_SubDocumentUniqueIndexExcludesSoftDeleted.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.Extract.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.Extract.Host.Migrations
 {
     [DbContext(typeof(ExtractHostDbContext))]
-    partial class ExtractHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620123853_SubDocumentUniqueIndexExcludesSoftDeleted")]
+    partial class SubDocumentUniqueIndexExcludesSoftDeleted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260620123853_SubDocumentUniqueIndexExcludesSoftDeleted.cs
+++ b/host/src/Migrations/20260620123853_SubDocumentUniqueIndexExcludesSoftDeleted.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.Extract.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class SubDocumentUniqueIndexExcludesSoftDeleted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExtractDocuments_OriginDocumentId_OriginConstituentKey",
+                table: "ExtractDocuments");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExtractDocuments_OriginDocumentId_OriginConstituentKey",
+                table: "ExtractDocuments",
+                columns: new[] { "OriginDocumentId", "OriginConstituentKey" },
+                unique: true,
+                filter: "[OriginDocumentId] IS NOT NULL AND [IsDeleted] = 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExtractDocuments_OriginDocumentId_OriginConstituentKey",
+                table: "ExtractDocuments");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExtractDocuments_OriginDocumentId_OriginConstituentKey",
+                table: "ExtractDocuments",
+                columns: new[] { "OriginDocumentId", "OriginConstituentKey" },
+                unique: true,
+                filter: "[OriginDocumentId] IS NOT NULL");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Project-wide review follow-up to #390. The review found the channel core is clean and disciplined; the only subsystem accruing risky complexity is sub-document segmentation (13 issues, the densest code in the repo, and — until now — the only subsystem without its own `.claude/rules` file). This PR acts on that:

1. **Dead-code sweep** of the whole segmentation subsystem — systematic, not just the candidates #390 listed. Exactly three write-only / never-assigned members removed:
   - `DocumentSegmentStatus.NotADocument` (never assigned; non-document slices are skipped, not persisted)
   - `DetectionContext.UploadedByUserName` (loaded, never read)
   - `PendingSegment.SliceText` (projected, never read; the seed is read fresh from the DB by `DocumentParseBackgroundJob`)
   - Internal subsystem only (not on any REST/MCP/ETO egress); `NotADocument` was never persisted → no migration.

2. **New rules file** `.claude/rules/sub-document-segmentation.md` (auto-loaded for the subsystem) recording the #390 decisions as guardrails-before-code: the two-representation model (ledger + derived Document) and why it is intentional, the **two-Kind red line**, the field lifecycle contract, and the cross-entity invariant.

3. **Cross-entity round-trip test guardrail** through the *real* segmentation job + reclassify app service + marker handlers (existing per-leg tests hand-seed the surviving-figure state; this verifies the composition seam).

4. **Fix for #391** (discovered by the round-trip probe): the `(OriginDocumentId, OriginConstituentKey)` unique index was filtered only on `OriginDocumentId IS NOT NULL`, so a soft-deleted (retracted) sub-document still occupied the idempotency slot. A `container → concrete → container` round trip then collided on re-spawn and the job retried forever. Filter now also requires `IsDeleted = 0`; the round-trip test is un-skipped and asserts a clean re-spawn. Includes an EF Core migration.

## Decision record

The full architectural reasoning is posted as the resolution on #390.

Closes #391.

## Test plan

- `dotnet build` green.
- Segmentation subsystem tests green, including the new `ContainerLifecycleRoundTrip_Tests` (both round-trip legs now pass).
- New migration reviewed for SQL Server + multi-tenancy safety (the new filtered index covers a strict subset of the old one's rows → safe recreate on populated tables).
