### PR TITLE
fix(parse-pdf): stop digital-PDF tables linearizing when wrapped by body text

### DIFF
--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -94,6 +94,11 @@ internal static class PdfReadingOrder
     // ClusterTableCandidateBlocks.
     private const double RowHeightSimilarityRatio = 0.4;
 
+    // Horizontal gutter scale for the structural break check (ClusterTableCandidateBlocks). Mirrors
+    // PdfTableReconstruction.ColumnGutterScale so the cluster's notion of a column gutter matches the
+    // reconstructor's: a horizontal gap wider than this many median-block-heights separates two columns.
+    private const double ColumnGutterScale = 0.8;
+
     /// <summary>
     /// Reconstructs visual lines from the page's words: clusters words whose vertical ranges overlap into
     /// one line, orders words left-to-right within a line, and returns lines top-to-bottom.
@@ -497,16 +502,32 @@ internal static class PdfReadingOrder
             return TableClusters.Empty;
         }
 
+        var gutterThreshold = medianHeight * ColumnGutterScale;
         var result = new TableClusters();
-        foreach (var cluster in ClusterTableCandidateBlocks(blocks, medianHeight))
+        foreach (var clusterRows in ClusterTableCandidateBlocks(blocks, medianHeight))
         {
+            // Peel leading heading / caption / intro rows (the "第3条（料金）" heading + "本業務の料金は…" intro
+            // above the grid, the "別紙1 料金表" caption) before reconstruction. They enter the cluster from the
+            // top — where no column structure is established yet, so the chaining bridge-guard cannot reject
+            // them — and then either become spurious leading table rows or, worse, a full-width intro line
+            // bridges and MERGES two real columns (the 料金表's 区分+内容). Trailing body text needs no peel: by
+            // the time the grid is below it, the column structure exists and the chaining bridge-guard already
+            // refuses to chain it in.
+            var coreRows = TrimLeadingNonGridRows(clusterRows, blocks, gutterThreshold);
+            if (coreRows.Count == 0)
+            {
+                continue;
+            }
+
+            var coreBlocks = coreRows.SelectMany(row => row).ToList();
+
             // Reconstruct from the cluster's WORDS, not its blocks: RecursiveXYCut's block granularity is not
             // stable for tables (#329 review) — a generous row pitch is cut into per-cell blocks, but a tight
             // row pitch is cut into per-COLUMN blocks (each column one tall block of stacked rows). Feeding
             // words lets TryRender derive the grid from real glyph geometry either way; its column x-projection
             // + visual-row clustering + wrapped-cell merge handle both, including a 備考 cell wrapping to two
             // lines (whether or not the segmenter pre-merged it).
-            var cells = cluster
+            var cells = coreBlocks
                 .SelectMany(bi => blocks[bi].TextLines.SelectMany(line => line.Words))
                 .Where(word => !string.IsNullOrWhiteSpace(word.Text))
                 .Select(word => new PdfTableReconstruction.Cell(word.BoundingBox, word.Text))
@@ -518,10 +539,13 @@ internal static class PdfReadingOrder
                 continue;
             }
 
-            var lead = cluster[0]; // cluster is sorted ascending, so [0] is the lead (lowest-index) block
+            // Lead = lowest-index core block: the table is emitted at its reading position, and any peeled
+            // (lower-index) heading/intro block falls through to the paragraph pass at its own earlier position,
+            // so the heading still renders above the table.
+            var lead = coreBlocks.Min();
             result.MarkdownByLead[lead] = table;
-            result.BlocksByLead[lead] = cluster;
-            foreach (var bi in cluster)
+            result.BlocksByLead[lead] = coreBlocks;
+            foreach (var bi in coreBlocks)
             {
                 result.LeadByBlock[bi] = lead;
             }
@@ -531,15 +555,106 @@ internal static class PdfReadingOrder
     }
 
     /// <summary>
-    /// Groups blocks into table-candidate clusters. RecursiveXYCut cuts a table into per-CELL blocks (its
-    /// column gutters and row gaps both exceed the cut threshold), so a cluster is built in two steps:
-    /// (1) union blocks whose vertical ranges overlap into <i>visual rows</i>; (2) chain vertically adjacent
-    /// rows (gap within <see cref="RowGroupGapScale"/> median-heights) into one cluster — which stops at the
-    /// larger gap to a title / body paragraph above or below. Each cluster's indices are sorted ascending so
-    /// the lead block is first; a lone row forms a singleton cluster (later rejected by
-    /// <see cref="PdfTableReconstruction.TryRender"/> for having too few rows).
+    /// Drops leading rows of a table-candidate cluster that are not grid rows — a section heading, a table
+    /// caption, or an introductory sentence sitting just above the grid — returning the remaining rows
+    /// (top to bottom). A leading row is peeled when it is <b>mono-column</b> (all its blocks fall in a single
+    /// column band: a heading / caption / title) or <b>gutter-bridging</b> (a block spans across a column
+    /// gutter: a full-width intro sentence). The column model is recomputed after each peel, so removing a
+    /// full-width intro that had merged two columns lets those columns re-separate for the rows below it.
+    /// Peeling stops at the first real grid row (the header or a data row, which spans ≥2 columns without
+    /// bridging). Only the leading edge is peeled: a mono-column row in the interior or at the bottom may be a
+    /// sparse data row or a wrapped-cell continuation and is kept. Peeled blocks are simply excluded from the
+    /// table, so they fall through to the paragraph path at their own reading position (non-lossy).
     /// </summary>
-    private static List<List<int>> ClusterTableCandidateBlocks(IReadOnlyList<DlaTextBlock> blocks, double medianHeight)
+    private static List<List<int>> TrimLeadingNonGridRows(
+        List<List<int>> clusterRows, IReadOnlyList<DlaTextBlock> blocks, double gutterThreshold)
+    {
+        var rows = new List<List<int>>(clusterRows);
+        while (rows.Count > 0)
+        {
+            var bands = ColumnBands(rows.SelectMany(row => row).Select(bi => blocks[bi].BoundingBox), gutterThreshold);
+            if (bands.Count < 2)
+            {
+                // No column structure across the remaining rows → not a grid; let TryRender reject it as a whole
+                // rather than peel every row one by one.
+                break;
+            }
+
+            if (IsLeadingNonGridRow(rows[0], bands, blocks))
+            {
+                rows.RemoveAt(0);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="row"/> reads as a heading / caption / intro rather than a grid row, given the
+    /// current column <paramref name="bands"/>: true when every block sits in one band (mono-column) or any
+    /// block bridges a gutter (a full-width line). A genuine header / data row spans ≥2 bands without bridging.
+    /// </summary>
+    private static bool IsLeadingNonGridRow(
+        IReadOnlyList<int> row, IReadOnlyList<(double Left, double Right)> bands, IReadOnlyList<DlaTextBlock> blocks)
+    {
+        var occupied = new HashSet<int>();
+        foreach (var bi in row)
+        {
+            var box = blocks[bi].BoundingBox;
+            if (BridgesAnyGutter(box, bands))
+            {
+                return true;
+            }
+
+            occupied.Add(BandOf(box, bands));
+        }
+
+        return occupied.Count <= 1;
+    }
+
+    /// <summary>Index of the column band containing the box's horizontal centre (nearest band as a fallback).</summary>
+    private static int BandOf(PdfRectangle box, IReadOnlyList<(double Left, double Right)> bands)
+    {
+        var centre = (box.Left + box.Right) / 2.0;
+        for (var i = 0; i < bands.Count; i++)
+        {
+            if (centre >= bands[i].Left && centre <= bands[i].Right)
+            {
+                return i;
+            }
+        }
+
+        var nearest = 0;
+        var best = double.MaxValue;
+        for (var i = 0; i < bands.Count; i++)
+        {
+            var d = Math.Min(Math.Abs(centre - bands[i].Left), Math.Abs(centre - bands[i].Right));
+            if (d < best)
+            {
+                best = d;
+                nearest = i;
+            }
+        }
+
+        return nearest;
+    }
+
+    /// <summary>
+    /// Groups blocks into table-candidate clusters, each returned as its list of <i>visual rows</i> (top to
+    /// bottom, every row a list of block indices). RecursiveXYCut cuts a table into per-CELL blocks (its column
+    /// gutters and row gaps both exceed the cut threshold), so a cluster is built in two steps: (1) union blocks
+    /// whose vertical ranges overlap into visual rows; (2) chain vertically adjacent rows (gap within
+    /// <see cref="RowGroupGapScale"/> median-heights, comparable height, no column-bridging) into one cluster —
+    /// which stops at the larger gap to a title / body paragraph above or below, and at a full-width body line
+    /// below the grid. The row structure is preserved (not flattened) so <see cref="DetectTableClusters"/> can
+    /// peel leading heading / caption / intro rows before reconstruction. A lone row forms a singleton cluster
+    /// (later rejected by <see cref="PdfTableReconstruction.TryRender"/> for having too few rows).
+    /// </summary>
+    private static List<List<List<int>>> ClusterTableCandidateBlocks(IReadOnlyList<DlaTextBlock> blocks, double medianHeight)
     {
         var n = blocks.Count;
 
@@ -590,14 +705,25 @@ internal static class PdfReadingOrder
             .OrderByDescending(group => group.Max(bi => blocks[bi].BoundingBox.Top))
             .ToList();
 
-        // 2. Chain rows whose vertical gap stays within the threshold AND whose height is comparable into one
-        // cluster. The height check stops a tall multi-line body / title block (a RecursiveXYCut paragraph
-        // leaf) from being chained onto a table's short cell rows even when it sits close, and keeps a
-        // paragraph-dominated page (large page-wide median -> large gap threshold) from over-merging (#329
-        // review). A wider gap, or a height mismatch, starts a new cluster.
+        // 2. Chain rows whose vertical gap stays within the threshold AND whose height is comparable AND whose
+        // blocks do not break the table's column structure, into one cluster. Three guards:
+        //   - gap: a wider vertical gap cuts the table off from a title / body paragraph farther above or below.
+        //   - height: a tall multi-line body / title block (a RecursiveXYCut paragraph leaf) is not chained onto
+        //     a table's short cell rows even when it sits close, and a paragraph-dominated page (large page-wide
+        //     median -> large gap threshold) cannot over-merge (#329 review).
+        //   - column structure (#310 follow-up): a row containing a block that BRIDGES the candidate's already
+        //     established column gutters (a full-page-width note / clause paragraph below the grid, e.g. the
+        //     日本語 料金表's "※上記金額…" / "本契約の成立を…" footnotes) is body text, not a table row — without
+        //     this guard those single-line full-width paragraphs are gap+height-comparable to the cell rows, so
+        //     they get chained in, collapse the column bands when the whole cluster is reconstructed, and sink
+        //     the entire table back to paragraph linearization. The gap/height guards alone cannot separate them
+        //     (the footnote sits one ordinary line-gap below the last cell row); only the column geometry can.
+        // Any guard failing starts a new cluster, so the trailing body text reconstructs (or degrades) on its own.
         var gapThreshold = medianHeight * RowGroupGapScale;
-        var clusters = new List<List<int>>();
-        var current = new List<int>(rows[0]);
+        var gutterThreshold = medianHeight * ColumnGutterScale;
+        var clusters = new List<List<List<int>>>();
+        var current = new List<List<int>> { rows[0] };
+        var currentFlat = new List<int>(rows[0]);
         var currentBottom = rows[0].Min(bi => blocks[bi].BoundingBox.Bottom);
         var currentRowHeight = PdfGeometry.Median(rows[0].Select(bi => blocks[bi].BoundingBox.Height));
         for (var i = 1; i < rows.Count; i++)
@@ -608,29 +734,119 @@ internal static class PdfReadingOrder
             var heightComparable = tallerHeight <= 0
                 || Math.Min(currentRowHeight, rowHeight) >= tallerHeight * RowHeightSimilarityRatio;
 
-            if (currentBottom - rowTop <= gapThreshold && heightComparable)
+            if (currentBottom - rowTop <= gapThreshold
+                && heightComparable
+                && !RowBridgesColumns(currentFlat, rows[i], blocks, gutterThreshold))
             {
-                current.AddRange(rows[i]);
+                current.Add(rows[i]);
+                currentFlat.AddRange(rows[i]);
                 currentBottom = Math.Min(currentBottom, rows[i].Min(bi => blocks[bi].BoundingBox.Bottom));
                 currentRowHeight = rowHeight;
             }
             else
             {
                 clusters.Add(current);
-                current = new List<int>(rows[i]);
+                current = new List<List<int>> { rows[i] };
+                currentFlat = new List<int>(rows[i]);
                 currentBottom = rows[i].Min(bi => blocks[bi].BoundingBox.Bottom);
                 currentRowHeight = rowHeight;
             }
         }
 
         clusters.Add(current);
+        return clusters;
+    }
 
-        foreach (var cluster in clusters)
+    /// <summary>
+    /// Whether any block of <paramref name="candidateRow"/> bridges a column gutter already established by the
+    /// blocks accumulated in <paramref name="clusterBlocks"/> — i.e. its horizontal extent spans across the
+    /// empty space that separates two of the candidate table's columns. Such a block is a full-width body line
+    /// (a footnote / clause paragraph / section heading), not a table cell, so the row must not be chained into
+    /// the table candidate. Returns <c>false</c> until at least two column bands exist (no gutter to bridge yet),
+    /// so the leading rows of a table still accumulate normally.
+    /// </summary>
+    private static bool RowBridgesColumns(
+        IReadOnlyList<int> clusterBlocks,
+        IReadOnlyList<int> candidateRow,
+        IReadOnlyList<DlaTextBlock> blocks,
+        double gutterThreshold)
+    {
+        var bands = ColumnBands(clusterBlocks.Select(bi => blocks[bi].BoundingBox), gutterThreshold);
+        if (bands.Count < 2)
         {
-            cluster.Sort();
+            return false;
         }
 
-        return clusters;
+        foreach (var bi in candidateRow)
+        {
+            if (BridgesAnyGutter(blocks[bi].BoundingBox, bands))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="box"/> straddles the empty gutter between any two adjacent column
+    /// <paramref name="bands"/> — i.e. it reaches into band k (or its left gutter) AND past the start of band
+    /// k+1. A real table cell never does (the gutter is empty by definition); a full-width body line (heading /
+    /// footnote / clause paragraph) does.
+    /// </summary>
+    private static bool BridgesAnyGutter(PdfRectangle box, IReadOnlyList<(double Left, double Right)> bands)
+    {
+        var left = Math.Min(box.Left, box.Right);
+        var right = Math.Max(box.Left, box.Right);
+        for (var k = 0; k < bands.Count - 1; k++)
+        {
+            if (left <= bands[k].Right && right >= bands[k + 1].Left)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Projects the boxes' horizontal extents onto the x-axis and splits them into column bands at gutters wider
+    /// than <paramref name="gutterThreshold"/> (overlapping/abutting extents merge into one band). Mirrors
+    /// <see cref="PdfTableReconstruction"/>'s own column detection so the cluster's column model matches the one
+    /// the reconstructor will later apply. Each band is the <c>[left, right]</c> extent of one column's content.
+    /// </summary>
+    private static List<(double Left, double Right)> ColumnBands(IEnumerable<PdfRectangle> boxes, double gutterThreshold)
+    {
+        var intervals = boxes
+            .Select(b => (Left: Math.Min(b.Left, b.Right), Right: Math.Max(b.Left, b.Right)))
+            .OrderBy(iv => iv.Left)
+            .ToList();
+
+        var bands = new List<(double Left, double Right)>();
+        if (intervals.Count == 0)
+        {
+            return bands;
+        }
+
+        var left = intervals[0].Left;
+        var right = intervals[0].Right;
+        for (var i = 1; i < intervals.Count; i++)
+        {
+            var iv = intervals[i];
+            if (iv.Left - right > gutterThreshold)
+            {
+                bands.Add((left, right));
+                left = iv.Left;
+                right = iv.Right;
+            }
+            else
+            {
+                right = Math.Max(right, iv.Right);
+            }
+        }
+
+        bands.Add((left, right));
+        return bands;
     }
 
     /// <summary>

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfTableReconstruction.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfTableReconstruction.cs
@@ -133,6 +133,13 @@ internal static class PdfTableReconstruction
 
         // 4. Fold wrapped-cell continuation lines into their parent row.
         var rows = MergeRows(visualLines, lineColumns, columns.Count, medianHeight * ContinuationPitchScale);
+
+        // 4b. Re-attach stray single-cell fragments: a cell taller than its row's single-line siblings wraps to a
+        // second visual line that falls OUTSIDE the row's y-band (above or below it), so step 4 — which only
+        // folds a continuation tight against the CURRENT row — leaves it as its own mono-column row interleaved
+        // with the data row (the #310 料金表 備考 cell "本契約に付随する無償提供。税別対象外", whose two lines
+        // bracket the "0円" row). Pull such a fragment into the adjacent data row's empty cell.
+        CoalesceStrayCellFragments(rows, medianHeight * ContinuationPitchScale);
         if (rows.Count < MinRows)
         {
             return null;
@@ -142,14 +149,14 @@ internal static class PdfTableReconstruction
         // whose cell wraps across several single-column continuation lines must not be diluted below the ratio
         // by those continuation lines — the fold in step 4 has already collapsed them into their parent row.
         // A multi-column BODY layout still fails here (each of its rows lives in one column).
-        var crossColumnRows = rows.Count(row => row.Count(cell => cell.Length > 0) >= 2);
+        var crossColumnRows = rows.Count(row => row.FilledCount >= 2);
         if ((double)crossColumnRows / rows.Count < MinCrossColumnRowRatio)
         {
             return null;
         }
 
         // 6. Fill ratio: reject a sparse scatter that lands in a few bands but isn't a real table.
-        var filled = rows.Sum(row => row.Count(cell => cell.Length > 0));
+        var filled = rows.Sum(row => row.FilledCount);
         if ((double)filled / (rows.Count * columns.Count) < MinFillRatio)
         {
             return null;
@@ -258,23 +265,43 @@ internal static class PdfTableReconstruction
         return lines;
     }
 
+    /// <summary>A reconstructed table row: its cells (one per column, empty string when unfilled) and y-band.</summary>
+    private sealed class GridRow
+    {
+        public GridRow(string[] cells, double top, double bottom)
+        {
+            Cells = cells;
+            Top = top;
+            Bottom = bottom;
+        }
+
+        public string[] Cells { get; }
+
+        /// <summary>Highest edge of the lines that formed the row (PDF user space: larger Y = higher).</summary>
+        public double Top { get; set; }
+
+        /// <summary>Lowest edge of the lines that formed the row.</summary>
+        public double Bottom { get; set; }
+
+        public int FilledCount => Cells.Count(c => c.Length > 0);
+    }
+
     /// <summary>
     /// Folds wrapped-cell continuation lines into their parent table row. A visual line is a continuation when
     /// it occupies a STRICT subset of the current row's columns (a wrapped cell only continues columns the row
     /// already has) AND sits within <paramref name="continuationPitch"/> below it; its text is appended to the
     /// matching columns (space-joined). Otherwise it starts a new row. Returns rectangular rows
-    /// (<paramref name="columnCount"/> cells each, empty string for an unfilled cell).
+    /// (<paramref name="columnCount"/> cells each, empty string for an unfilled cell), each carrying its y-band.
     /// </summary>
-    private static List<string[]> MergeRows(
+    private static List<GridRow> MergeRows(
         List<List<Cell>> visualLines,
         List<Dictionary<int, List<Cell>>> lineColumns,
         int columnCount,
         double continuationPitch)
     {
-        var rows = new List<string[]>();
-        string[]? current = null;
+        var rows = new List<GridRow>();
+        GridRow? current = null;
         HashSet<int>? currentColumns = null;
-        var currentBottom = 0.0;
 
         for (var i = 0; i < visualLines.Count; i++)
         {
@@ -291,17 +318,17 @@ internal static class PdfTableReconstruction
                 // rows is worse than splitting the rare all-cells-wrap case (#329 review; see class remarks).
                 && occupied.Count < currentColumns!.Count
                 && occupied.IsSubsetOf(currentColumns)     // and only columns the parent row already has
-                && currentBottom - lineTop <= continuationPitch; // and tight against it (a single-line wrap)
+                && current!.Bottom - lineTop <= continuationPitch; // and tight against it (a single-line wrap)
 
             if (isContinuation)
             {
                 foreach (var (column, list) in byColumn)
                 {
                     var text = JoinLineCells(list);
-                    current![column] = current[column].Length == 0 ? text : current[column] + " " + text;
+                    current!.Cells[column] = current.Cells[column].Length == 0 ? text : current.Cells[column] + " " + text;
                 }
 
-                currentBottom = lineBottom;
+                current!.Bottom = lineBottom;
                 continue;
             }
 
@@ -310,19 +337,19 @@ internal static class PdfTableReconstruction
                 rows.Add(current);
             }
 
-            current = new string[columnCount];
+            var cells = new string[columnCount];
             for (var c = 0; c < columnCount; c++)
             {
-                current[c] = string.Empty;
+                cells[c] = string.Empty;
             }
 
             foreach (var (column, list) in byColumn)
             {
-                current[column] = JoinLineCells(list);
+                cells[column] = JoinLineCells(list);
             }
 
+            current = new GridRow(cells, lineTop, lineBottom);
             currentColumns = occupied;
-            currentBottom = lineBottom;
         }
 
         if (current != null)
@@ -331,6 +358,91 @@ internal static class PdfTableReconstruction
         }
 
         return rows;
+    }
+
+    /// <summary>
+    /// Re-attaches stray single-cell fragment rows to the adjacent data row whose matching cell is empty. A cell
+    /// that is taller than its row's single-line siblings wraps to a second visual line whose y sits OUTSIDE the
+    /// row's band, so <see cref="MergeRows"/> (which folds only a continuation tight against the row it is
+    /// currently building) cannot capture it and leaves it as its own mono-column row interleaved next to the
+    /// data row. For every multi-cell row this pulls in the immediately adjacent (within
+    /// <paramref name="pitch"/>, above or below) mono-column rows that fill one of its empty columns, appending
+    /// their text top-to-bottom, and drops the consumed fragments. A fragment whose column the data row already
+    /// fills, or that sits a full row away, is left untouched — so a genuinely sparse row (the #329
+    /// "<c>|  | E |</c>" cases) is preserved.
+    /// </summary>
+    private static void CoalesceStrayCellFragments(List<GridRow> rows, double pitch)
+    {
+        var consumed = new bool[rows.Count];
+
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (consumed[i] || rows[i].FilledCount < 2)
+            {
+                continue; // only a substantial (multi-cell) data row attracts stray fragments
+            }
+
+            var host = rows[i];
+            for (var column = 0; column < host.Cells.Length; column++)
+            {
+                if (host.Cells[column].Length != 0)
+                {
+                    continue; // the magnet only fills an EMPTY cell of the host row
+                }
+
+                // Gather adjacent mono-column-`column` fragments above and below, nearest-first, while they stay
+                // within the host row's band expanded by `pitch`.
+                var fragments = new List<int>();
+                for (var j = i - 1; j >= 0 && IsStrayFragment(rows, consumed, j, column, host, pitch); j--)
+                {
+                    fragments.Add(j);
+                }
+
+                fragments.Reverse(); // above fragments now top-to-bottom
+                for (var j = i + 1; j < rows.Count && IsStrayFragment(rows, consumed, j, column, host, pitch); j++)
+                {
+                    fragments.Add(j);
+                }
+
+                foreach (var j in fragments)
+                {
+                    host.Cells[column] = host.Cells[column].Length == 0
+                        ? rows[j].Cells[column]
+                        : host.Cells[column] + " " + rows[j].Cells[column];
+                    host.Top = Math.Max(host.Top, rows[j].Top);
+                    host.Bottom = Math.Min(host.Bottom, rows[j].Bottom);
+                    consumed[j] = true;
+                }
+            }
+        }
+
+        for (var i = rows.Count - 1; i >= 0; i--)
+        {
+            if (consumed[i])
+            {
+                rows.RemoveAt(i);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Whether row <paramref name="j"/> is an unconsumed stray fragment that can fold into <paramref name="host"/>'s
+    /// <paramref name="column"/>: it fills exactly that one column and its y-band lies within the host's band
+    /// expanded by <paramref name="pitch"/> (immediately adjacent, not a full row away).
+    /// </summary>
+    private static bool IsStrayFragment(
+        List<GridRow> rows, bool[] consumed, int j, int column, GridRow host, double pitch)
+    {
+        if (consumed[j])
+        {
+            return false;
+        }
+
+        var row = rows[j];
+        return row.FilledCount == 1
+            && row.Cells[column].Length > 0
+            && row.Bottom <= host.Top + pitch
+            && row.Top >= host.Bottom - pitch;
     }
 
     /// <summary>Joins the fragments that landed in one cell of one visual line, left to right, with a single space.</summary>
@@ -344,10 +456,10 @@ internal static class PdfTableReconstruction
     /// as well as the pipe/newline — so table cells get the same #320 source-text protection the paragraph
     /// path has (a plain cell-escape would leave a literal <c>*</c>/<c>[</c> in a contract cell to be re-parsed).
     /// </summary>
-    private static string RenderGrid(List<string[]> rows)
+    private static string RenderGrid(List<GridRow> rows)
     {
         var escaped = rows
-            .Select(row => (IReadOnlyList<string>)row.Select(MarkdownText.EscapeInlineCell).ToArray())
+            .Select(row => (IReadOnlyList<string>)row.Cells.Select(MarkdownText.EscapeInlineCell).ToArray())
             .ToList();
         return MarkdownText.RenderTable(escaped);
     }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -528,4 +528,49 @@ public class PdfExtractor_Tests
             result.Markdown.ShouldContain(token);
         }
     }
+
+    [Fact]
+    public async Task Does_not_swallow_a_close_heading_or_full_width_note_into_the_table()
+    {
+        // The real 料金表 failure (#310 follow-up): the fee table is wrapped tightly by a section heading just
+        // above it and a full-width footnote just below — both within an ordinary line gap, so the gap/height
+        // guards alone cannot separate them. Before the fix the footnote was chained into the table cluster
+        // (collapsing the column bands -> the whole table degraded to column-by-column paragraphs), and the
+        // heading became a spurious leading table row. The grid must reconstruct with the proper header row, the
+        // heading must be peeled back out to its own line, and the footnote must stay OUTSIDE the table.
+        var pdf = PdfFixtures.BuildPositioned(new[]
+        {
+            ("Fee Schedule below", 50.0, 724.0), // section heading, one line gap above the grid -> chains in, peeled
+
+            ("Service", 50.0, 694.0), ("Charge", 210.0, 694.0), ("Remark", 380.0, 694.0),
+            ("Basic", 50.0, 666.0), ("100", 210.0, 666.0), ("standard", 380.0, 666.0),
+            ("Premium", 50.0, 638.0), ("200", 210.0, 638.0), ("priority", 380.0, 638.0),
+
+            // Full-width footnote one ordinary line gap below the last row — it bridges every column gutter.
+            ("All charges exclude consumption tax and are subject to change.", 50.0, 610.0)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // The grid reconstructs with the real header row (proves the heading was peeled, not promoted to the
+        // header row, and that the footnote did not collapse the columns).
+        result.Markdown.ShouldContain("| Service | Charge | Remark |");
+        result.Markdown.ShouldContain("| Basic | 100 | standard |");
+        result.Markdown.ShouldContain("| Premium | 200 | priority |");
+
+        // The footnote is present but NOT a table row (it stayed an ordinary paragraph).
+        result.Markdown.ShouldContain("All charges exclude consumption tax and are subject to change.");
+        result.Markdown.ShouldNotContain("| All charges");
+
+        // The heading is present but never became a table cell.
+        result.Markdown.ShouldContain("Fee Schedule below");
+        result.Markdown.ShouldNotContain("| Fee Schedule below");
+
+        // Reading order is preserved: heading above the table, footnote below it.
+        var heading = result.Markdown.IndexOf("Fee Schedule below", StringComparison.Ordinal);
+        var table = result.Markdown.IndexOf("| Service | Charge | Remark |", StringComparison.Ordinal);
+        var note = result.Markdown.IndexOf("All charges exclude", StringComparison.Ordinal);
+        heading.ShouldBeLessThan(table);
+        table.ShouldBeLessThan(note);
+    }
 }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfTableReconstruction_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfTableReconstruction_Tests.cs
@@ -205,6 +205,52 @@ public class PdfTableReconstruction_Tests
     }
 
     [Fact]
+    public void Reattaches_a_tall_cell_whose_wrap_lines_bracket_the_data_row()
+    {
+        // The #310 料金表 備考 failure: a cell taller than its single-line row siblings wraps to a second visual
+        // line, and the two lines sit ABOVE and BELOW the row's single-line cells (not tight under the row), so
+        // the step-4 continuation fold cannot capture them and they land as two stray mono-column rows
+        // interleaving the data row. The magnet pass (step 4b) must pull both fragments back into the row's
+        // empty Note cell, top-to-bottom.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Item", 50, 90, 700), Cell("Qty", 150, 190, 700), Cell("Note", 250, 290, 700),
+            Cell("note1", 250, 290, 668),                         // tall Note cell, upper line (above the data row)
+            Cell("Apple", 50, 90, 660), Cell("5", 150, 175, 660), // data row — Note cell empty on this line
+            Cell("note2", 250, 290, 652),                         // tall Note cell, lower line (below the data row)
+            Cell("Pear", 50, 90, 620), Cell("9", 150, 175, 620), Cell("plain", 250, 290, 620)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| Item | Qty | Note |\n" +
+            "| --- | --- | --- |\n" +
+            "| Apple | 5 | note1 note2 |\n" +
+            "| Pear | 9 | plain |");
+    }
+
+    [Fact]
+    public void Does_not_pull_a_sparse_cell_a_full_row_away_into_a_neighbor()
+    {
+        // The magnet only reaches an IMMEDIATELY adjacent mono-column fragment (within the continuation pitch).
+        // A genuinely sparse cell a full row away from the empty-Note row stays its own row — it is not a wrapped
+        // cell (the column-3-empty variant of the #329 "|  | E |" guard).
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Item", 50, 90, 700), Cell("Qty", 150, 190, 700), Cell("Note", 250, 290, 700),
+            Cell("Apple", 50, 90, 660), Cell("5", 150, 175, 660), // data row, Note empty
+            Cell("Pear", 50, 90, 620), Cell("9", 150, 175, 620), Cell("ok", 250, 290, 620),
+            Cell("late", 250, 290, 580) // col-3 only, a full row below the Pear row — not a wrap of the Apple row
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| Item | Qty | Note |\n" +
+            "| --- | --- | --- |\n" +
+            "| Apple | 5 |  |\n" +
+            "| Pear | 9 | ok |\n" +
+            "|  |  | late |");
+    }
+
+    [Fact]
     public void Escapes_inline_markdown_metacharacters_in_a_cell()
     {
         // #329 review: a cell is source text; literal * [ ] < ` must be escaped (like the paragraph path,


### PR DESCRIPTION
## Problem

Tested PDF text extraction on a real Japanese contract (ウェブサイト制作・ホスティング保守運用業務委託契約) and found the **fee tables (料金表) were not extracted as tables** — they came out fully linearized column-by-column (all 区分 values, then all 内容, then all 金額, then all 備考).

The digital-PDF table-reconstruction stack (#310 A/B, #326, #329) already exists and is enabled by default, and it works on an *isolated* table. The failure only appears on a *real* document, where the table is wrapped tightly by surrounding body text. Root cause: the table-candidate **clustering over-merged** the table with the heading/intro above it and the footnotes/signature below it; the merged cluster then failed the grid tests in `TryRender`, so the whole region degraded to paragraph linearization.

## Fix (all internal to `Parse.Pdf`, non-lossy, no contract change)

1. **Column-bridge guard when chaining rows** (`ClusterTableCandidateBlocks`) — a full-width footnote/clause paragraph one ordinary line-gap below the grid (`※上記金額…` / `本契約の成立を…`) is no longer chained into the table cluster. It used to collapse the column bands and sink the entire table; the gap/height guards alone cannot separate it, but the column geometry can.

2. **Leading non-grid row trim** (`TrimLeadingNonGridRows`) — a section heading / caption / intro just above the grid (`第3条（料金）` / `別紙1 料金表` / `本業務の料金は…`) is peeled back out before reconstruction, so it no longer becomes a spurious header row, and a full-width intro no longer **merges** two real columns (`区分`+`内容`). Peeled blocks fall through to the paragraph path at their reading position.

3. **Stray wrapped-cell re-attach** (`CoalesceStrayCellFragments`) — a cell taller than its single-line row siblings (`備考` = `本契約に付随する無償提供。税別対象外`) wraps to a second visual line that brackets the data row; its fragments are pulled back into the row's empty cell instead of stranding as separate rows.

### Before → After (別紙1 料金表)

Before: 30+ stray lines, no table. After:

| 区分 | 内容 | 金額 | 備考 |
| --- | --- | --- | --- |
| 初期費用 | ウェブサイト制作業務 | 100,000 円 | 税別 |
| … | … | … | … |
| 年額費用 | ドメインメールサービス 2 アカウント | 0 円／年 | 無償提供を継続 |

…and the heading renders above the table, the footnotes/signature below it, as ordinary paragraphs.

## Tests

- `PdfTableReconstruction_Tests`: `Reattaches_a_tall_cell_whose_wrap_lines_bracket_the_data_row`, `Does_not_pull_a_sparse_cell_a_full_row_away_into_a_neighbor`.
- `PdfExtractor_Tests`: `Does_not_swallow_a_close_heading_or_full_width_note_into_the_table` (end-to-end through `ExtractAsync`).
- Verified against the actual reported PDF (both fee tables reconstruct correctly).
- All **66** `Parse.Pdf` + **82** `Parse` tests pass; clean Release build, 0 warnings.

## Known remaining limitation

A literal full-width intro sentence spanning *every* column collapses the column model to a single band, defeating the leading-trim (degrades to the prior linearization, still non-lossy). Real intros usually leave ≥2 columns separable, as in this document. Wrapped CJK cells are joined with a space, matching the existing space-join convention.