### PR TITLE
fix(parse-pdf): reconstruct key-value tables under a title/stamp; render bullet lists

### DIFF
--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -572,7 +572,10 @@ internal static class PdfReadingOrder
         var rows = new List<List<int>>(clusterRows);
         while (rows.Count > 0)
         {
-            var bands = ColumnBands(rows.SelectMany(row => row).Select(bi => blocks[bi].BoundingBox), gutterThreshold);
+            // Seed the column model from the remaining MULTI-CELL rows only, so a leading full-width title or a
+            // centred stamp/watermark (both single-block rows) neither collapses the columns to one band nor
+            // injects a spurious one — the grid below stays visible and the title/watermark is then peeled.
+            var bands = ColumnBandsFromRows(rows, blocks, gutterThreshold);
             if (bands.Count < 2)
             {
                 // No column structure across the remaining rows → not a grid; let TryRender reject it as a whole
@@ -718,12 +721,14 @@ internal static class PdfReadingOrder
         //     they get chained in, collapse the column bands when the whole cluster is reconstructed, and sink
         //     the entire table back to paragraph linearization. The gap/height guards alone cannot separate them
         //     (the footnote sits one ordinary line-gap below the last cell row); only the column geometry can.
+        //     The column model is seeded only from the cluster's MULTI-CELL rows (see ColumnBandsFromRows), so a
+        //     full-width title or a centred stamp/watermark above the grid contributes no column and cannot
+        //     disable this guard.
         // Any guard failing starts a new cluster, so the trailing body text reconstructs (or degrades) on its own.
         var gapThreshold = medianHeight * RowGroupGapScale;
         var gutterThreshold = medianHeight * ColumnGutterScale;
         var clusters = new List<List<List<int>>>();
         var current = new List<List<int>> { rows[0] };
-        var currentFlat = new List<int>(rows[0]);
         var currentBottom = rows[0].Min(bi => blocks[bi].BoundingBox.Bottom);
         var currentRowHeight = PdfGeometry.Median(rows[0].Select(bi => blocks[bi].BoundingBox.Height));
         for (var i = 1; i < rows.Count; i++)
@@ -736,10 +741,9 @@ internal static class PdfReadingOrder
 
             if (currentBottom - rowTop <= gapThreshold
                 && heightComparable
-                && !RowBridgesColumns(currentFlat, rows[i], blocks, gutterThreshold))
+                && !RowBridgesColumns(current, rows[i], blocks, gutterThreshold))
             {
                 current.Add(rows[i]);
-                currentFlat.AddRange(rows[i]);
                 currentBottom = Math.Min(currentBottom, rows[i].Min(bi => blocks[bi].BoundingBox.Bottom));
                 currentRowHeight = rowHeight;
             }
@@ -747,7 +751,6 @@ internal static class PdfReadingOrder
             {
                 clusters.Add(current);
                 current = new List<List<int>> { rows[i] };
-                currentFlat = new List<int>(rows[i]);
                 currentBottom = rows[i].Min(bi => blocks[bi].BoundingBox.Bottom);
                 currentRowHeight = rowHeight;
             }
@@ -759,19 +762,19 @@ internal static class PdfReadingOrder
 
     /// <summary>
     /// Whether any block of <paramref name="candidateRow"/> bridges a column gutter already established by the
-    /// blocks accumulated in <paramref name="clusterBlocks"/> — i.e. its horizontal extent spans across the
-    /// empty space that separates two of the candidate table's columns. Such a block is a full-width body line
-    /// (a footnote / clause paragraph / section heading), not a table cell, so the row must not be chained into
-    /// the table candidate. Returns <c>false</c> until at least two column bands exist (no gutter to bridge yet),
-    /// so the leading rows of a table still accumulate normally.
+    /// rows accumulated in <paramref name="clusterRows"/> — i.e. its horizontal extent spans across the empty
+    /// space that separates two of the candidate table's columns. Such a block is a full-width body line (a
+    /// footnote / clause paragraph / section heading), not a table cell, so the row must not be chained into the
+    /// table candidate. Returns <c>false</c> until at least two column bands exist (no gutter to bridge yet), so
+    /// the leading rows of a table still accumulate normally.
     /// </summary>
     private static bool RowBridgesColumns(
-        IReadOnlyList<int> clusterBlocks,
+        IReadOnlyList<IReadOnlyList<int>> clusterRows,
         IReadOnlyList<int> candidateRow,
         IReadOnlyList<DlaTextBlock> blocks,
         double gutterThreshold)
     {
-        var bands = ColumnBands(clusterBlocks.Select(bi => blocks[bi].BoundingBox), gutterThreshold);
+        var bands = ColumnBandsFromRows(clusterRows, blocks, gutterThreshold);
         if (bands.Count < 2)
         {
             return false;
@@ -847,6 +850,26 @@ internal static class PdfReadingOrder
 
         bands.Add((left, right));
         return bands;
+    }
+
+    /// <summary>
+    /// Column bands for a table candidate, seeded <b>only from its multi-cell rows</b> (rows of ≥2 blocks). A
+    /// single-block row reveals no column structure — it is a title, a section heading, a table caption, a
+    /// stamp / watermark, or a full-width prose line, and its one box spans no gutter — so letting it seed the
+    /// model would either collapse the columns to one band (a full-width title masking the grid below it) or
+    /// inject a spurious column (a centred watermark like the 契約書案 draft stamp above the 委託者/受託者
+    /// key-value grid). Only a row that actually carries several cells shows where the columns and their gutters
+    /// are. The candidate row being tested for bridging is judged against this clean model, so a full-width body
+    /// line still bridges and is rejected, while the title/watermark simply contribute nothing.
+    /// </summary>
+    private static List<(double Left, double Right)> ColumnBandsFromRows(
+        IReadOnlyList<IReadOnlyList<int>> rows, IReadOnlyList<DlaTextBlock> blocks, double gutterThreshold)
+    {
+        var boxes = rows
+            .Where(row => row.Count >= 2)
+            .SelectMany(row => row)
+            .Select(bi => blocks[bi].BoundingBox);
+        return ColumnBands(boxes, gutterThreshold);
     }
 
     /// <summary>

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfTableReconstruction.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfTableReconstruction.cs
@@ -140,6 +140,16 @@ internal static class PdfTableReconstruction
         // with the data row (the #310 料金表 備考 cell "本契約に付随する無償提供。税別対象外", whose two lines
         // bracket the "0円" row). Pull such a fragment into the adjacent data row's empty cell.
         CoalesceStrayCellFragments(rows, medianHeight * ContinuationPitchScale);
+
+        // 4c. Merge a run of consecutive single-column lines that are tight against each other (within the
+        // continuation pitch) into one row. This catches a key-value row whose short label and multi-line value
+        // sit on SEPARATE visual lines in DIFFERENT columns (the 契約目的 row: label "契約目的" alone on one line,
+        // its value "甲の…定める。" wrapping across the line above and the line below it) — none of those lines is
+        // a multi-cell "host" for step 4b, so they would otherwise render as three half-empty rows that sever the
+        // label from its value. A run of single-column lines this tightly stacked is one record's cells, not
+        // several records (which sit a full row-pitch apart); a multi-cell record line breaks the run, so two
+        // real records are never merged.
+        CoalesceMonoColumnRuns(rows, medianHeight * ContinuationPitchScale);
         if (rows.Count < MinRows)
         {
             return null;
@@ -160,6 +170,16 @@ internal static class PdfTableReconstruction
         if ((double)filled / (rows.Count * columns.Count) < MinFillRatio)
         {
             return null;
+        }
+
+        // 7. Bullet list, not a table: a left column made entirely of list-bullet glyphs (•, ・, ‣, …) is a
+        // bullet list — "marker | item text" — that happens to be a clean 2-column grid geometrically. Render it
+        // as a real Markdown list instead of a table (and instead of letting it fall back to the paragraph path,
+        // where the column-wise reading order would strand every bullet away from its text). Only the leading
+        // column is checked — that is where a list marker sits.
+        if (IsBulletMarkerColumn(rows, 0))
+        {
+            return RenderBulletList(rows);
         }
 
         return RenderGrid(rows);
@@ -443,6 +463,119 @@ internal static class PdfTableReconstruction
             && row.Cells[column].Length > 0
             && row.Bottom <= host.Top + pitch
             && row.Top >= host.Bottom - pitch;
+    }
+
+    /// <summary>
+    /// Merges each maximal run of consecutive single-column rows that are tight against one another (each within
+    /// <paramref name="pitch"/> of the previous) into one row, concatenating per column top-to-bottom. Such a
+    /// run is one record whose cells (a short label, a wrapped value) landed on separate visual lines in
+    /// different columns; a multi-cell row breaks the run, so two genuine records — which sit a full row-pitch
+    /// apart, not within the continuation pitch — are never merged. Runs of length 1 are left untouched (a lone
+    /// sparse cell stays its own row, preserving the #329 "<c>|  | E |</c>" behavior).
+    /// </summary>
+    private static void CoalesceMonoColumnRuns(List<GridRow> rows, double pitch)
+    {
+        var i = 0;
+        while (i < rows.Count)
+        {
+            if (rows[i].FilledCount != 1)
+            {
+                i++;
+                continue;
+            }
+
+            // Extend the run while the next row is also single-column and sits within the pitch below this one.
+            var end = i;
+            while (end + 1 < rows.Count
+                   && rows[end + 1].FilledCount == 1
+                   && rows[end].Bottom - rows[end + 1].Top <= pitch)
+            {
+                end++;
+            }
+
+            if (end > i)
+            {
+                var host = rows[i];
+                for (var k = i + 1; k <= end; k++)
+                {
+                    for (var c = 0; c < host.Cells.Length; c++)
+                    {
+                        if (rows[k].Cells[c].Length == 0)
+                        {
+                            continue;
+                        }
+
+                        host.Cells[c] = host.Cells[c].Length == 0
+                            ? rows[k].Cells[c]
+                            : host.Cells[c] + " " + rows[k].Cells[c];
+                    }
+
+                    host.Bottom = Math.Min(host.Bottom, rows[k].Bottom);
+                }
+
+                rows.RemoveRange(i + 1, end - i);
+            }
+
+            i++;
+        }
+    }
+
+    /// <summary>
+    /// Single-glyph list bullets that mark a list item, never tabular data. Deliberately excludes the ASCII
+    /// <c>-</c> and <c>*</c>, which appear as legitimate cell content (a dash for "none", a footnote star).
+    /// </summary>
+    private static readonly char[] BulletMarkers =
+        { '•', '·', '・', '‣', '◦', '▪', '●', '○', '∙', '▸', '►', '∘', '⦁' };
+
+    /// <summary>
+    /// Whether column <paramref name="column"/> is a bullet-marker column: it has at least one non-empty cell and
+    /// every non-empty cell is a single list-bullet glyph (see <see cref="BulletMarkers"/>). Such a column is a
+    /// list marker, so the grid is a bullet list rather than a table.
+    /// </summary>
+    private static bool IsBulletMarkerColumn(List<GridRow> rows, int column)
+    {
+        var any = false;
+        foreach (var row in rows)
+        {
+            var cell = row.Cells[column];
+            if (cell.Length == 0)
+            {
+                continue;
+            }
+
+            var trimmed = cell.Trim();
+            if (trimmed.Length != 1 || Array.IndexOf(BulletMarkers, trimmed[0]) < 0)
+            {
+                return false;
+            }
+
+            any = true;
+        }
+
+        return any;
+    }
+
+    /// <summary>
+    /// Renders the rows as a GFM bullet list, one <c>- item</c> per row, where the item text is the row's
+    /// non-marker columns joined left to right (the leading column is the bullet glyph and is dropped). Item
+    /// text is source text, so it is inline-escaped like the paragraph path (#320); a row with no text beyond
+    /// the marker is skipped.
+    /// </summary>
+    private static string RenderBulletList(List<GridRow> rows)
+    {
+        var items = new List<string>();
+        foreach (var row in rows)
+        {
+            var text = string.Join(" ", row.Cells.Skip(1).Where(c => c.Length > 0));
+            if (text.Length == 0)
+            {
+                continue;
+            }
+
+            items.Add("- " + MarkdownText.EscapeInline(text));
+        }
+
+        return string.Join("\n", items);
     }
 
     /// <summary>Joins the fragments that landed in one cell of one visual line, left to right, with a single space.</summary>

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -573,4 +573,36 @@ public class PdfExtractor_Tests
         heading.ShouldBeLessThan(table);
         table.ShouldBeLessThan(note);
     }
+
+    [Fact]
+    public async Task Reconstructs_a_key_value_table_under_a_full_width_title()
+    {
+        // The page-1 委託者/受託者/契約目的/対象ドメイン key-value form: a clean 2-column label→value grid sitting
+        // one line below a FULL-WIDTH title. The title spans the whole content width, so if it were allowed to
+        // seed the column model it would collapse it to a single band and the grid would never be detected
+        // (the table would linearize). Because the column model is seeded only from multi-cell rows, the
+        // single-block title contributes nothing, the grid is found, and the title is peeled above it.
+        var pdf = PdfFixtures.BuildPositioned(new[]
+        {
+            // A long single-line title spanning the full content width, one line gap above the grid.
+            ("Master Services Agreement For The Provision Of Web Services", 50.0, 716.0),
+
+            ("Provider", 50.0, 690.0), ("Acme Corporation Limited", 230.0, 690.0),
+            ("Client", 50.0, 662.0), ("Beta Industries LLC", 230.0, 662.0),
+            ("Domain", 50.0, 634.0), ("example dot com", 230.0, 634.0)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // The key-value grid reconstructs (proves the full-width title did not collapse the column model).
+        result.Markdown.ShouldContain("| Provider | Acme Corporation Limited |");
+        result.Markdown.ShouldContain("| Client | Beta Industries LLC |");
+        result.Markdown.ShouldContain("| Domain | example dot com |");
+
+        // The title is present but is not a table row, and sits above the table.
+        result.Markdown.ShouldContain("Master Services Agreement");
+        result.Markdown.ShouldNotContain("| Master Services Agreement");
+        result.Markdown.IndexOf("Master Services Agreement", StringComparison.Ordinal)
+            .ShouldBeLessThan(result.Markdown.IndexOf("| Provider |", StringComparison.Ordinal));
+    }
 }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfTableReconstruction_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfTableReconstruction_Tests.cs
@@ -251,6 +251,47 @@ public class PdfTableReconstruction_Tests
     }
 
     [Fact]
+    public void Merges_a_key_value_row_whose_label_and_wrapped_value_are_on_separate_lines()
+    {
+        // The page-1 契約目的 row: the short label sits on its own visual line in column 0, and its long value
+        // wraps across the line ABOVE and the line BELOW the label, in column 1 — so no single line is a
+        // multi-cell "host" for the stray-fragment magnet. The three tightly-stacked single-column lines are one
+        // record and must merge into one row (label + the whole value), keeping the label bound to its value.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Party", 50, 100, 700), Cell("Acme Corporation", 200, 320, 700),
+
+            Cell("provides", 200, 280, 666),  // value line 1 (col 1), above the label
+            Cell("Purpose", 50, 110, 658),    // label (col 0), on its own line
+            Cell("the services", 200, 300, 650), // value line 2 (col 1), below the label
+
+            Cell("Domain", 50, 100, 600), Cell("example.com", 200, 290, 600)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "| Party | Acme Corporation |\n" +
+            "| --- | --- |\n" +
+            "| Purpose | provides the services |\n" +
+            "| Domain | example.com |");
+    }
+
+    [Fact]
+    public void Renders_a_bullet_first_column_grid_as_a_markdown_list()
+    {
+        // A left column of list-bullet glyphs ("• | item text") is a bullet list, not tabular data, even though
+        // it forms a clean 2-column grid. It must render as a real Markdown list, not a table.
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("•", 50, 56, 700), Cell("First item", 90, 200, 700),
+            Cell("•", 50, 56, 660), Cell("Second item", 90, 210, 660),
+            Cell("•", 50, 56, 620), Cell("Third item", 90, 205, 620)
+        };
+
+        PdfTableReconstruction.TryRender(cells).ShouldBe(
+            "- First item\n- Second item\n- Third item");
+    }
+
+    [Fact]
     public void Escapes_inline_markdown_metacharacters_in_a_cell()
     {
         // #329 review: a cell is source text; literal * [ ] < ` must be escaped (like the paragraph path,


### PR DESCRIPTION
Follow-up to #399. Same real contract — this fixes **page 1's key-value table** (the 委託者/受託者/契約目的/対象ドメイン form), which still linearized.

## Problem

The key-value block is a spatially clean 2-column grid (labels x78–138, values x198–528, 4 rows), but it failed to reconstruct because the table-candidate clustering builds its column model incrementally and was poisoned by two single-block neighbours:

1. The **full-width title** (`ウェブサイト制作・…委託契約`, spanning the whole width) collapsed the column model to a single band, disabling the bridge guard added in #399 — so the full-width preamble below chained in and the whole region linearized.
2. A centred **『契約書案』 draft stamp** (x286–326) injected a spurious middle column, so a value cell appeared to "bridge" it.

## Fix (all internal to `Parse.Pdf`, non-lossy, no contract change)

1. **Seed the column model only from a candidate's multi-cell rows** (`ColumnBandsFromRows`). A single-block row — title, heading, caption, stamp/watermark, full-width prose — spans no gutter and reveals no column structure, so it no longer collapses or pollutes the model. The grid stays visible; the title/stamp is peeled above it. (This also subsumes the special full-width handling the bridge guard needed.)

2. **Merge a run of consecutive tight single-column lines into one row** (`CoalesceMonoColumnRuns`). The `契約目的` row's short label and its multi-line value land on separate visual lines in different columns, so neither is a multi-cell "host" for the #399 stray-fragment magnet — they would render as three half-empty rows that sever the label from its value. A multi-cell row breaks the run, so two genuine records are never merged.

3. **Render a bullet-first-column grid as a Markdown list** (`RenderBulletList`). A `• | item` grid is a bullet list, not a table; it now renders as `- item` instead of a fake table (or stranded, column-wise-linearized bullets).

### Page 1 → after

| 委託者（甲） | 合同会社文創 |
| --- | --- |
| 受託者（乙） | 株式会社ディグナイト |
| 契約目的 | 甲のウェブサイト制作…基本条件を定める。 |
| 対象ドメイン | bunnsou.co.jp |

…then the 第1条 list renders as a proper Markdown bullet list, and the title / draft-stamp sit outside the table.

## Behaviour ripples (intended; accepted up front)

- **Bullet lists across contracts now render as Markdown lists** instead of linearized text — a quality improvement.
- **2-column signature blocks may now render as tables** (e.g. page 6's 甲/乙 signature block becomes a somewhat messy 5-column table from the date line). Non-lossy; flagged as the known trade-off of more aggressive table detection. Suppressing signature-block tabulation would be a separate change.

## Tests

- `PdfTableReconstruction_Tests`: `Merges_a_key_value_row_whose_label_and_wrapped_value_are_on_separate_lines`, `Renders_a_bullet_first_column_grid_as_a_markdown_list`.
- `PdfExtractor_Tests`: `Reconstructs_a_key_value_table_under_a_full_width_title` (end-to-end).
- Verified against the actual contract: page-1 KV table + bullet list correct, pages 2/6 料金表 unchanged.
- All **69** Parse.Pdf + **82** Parse tests pass; clean Release build, 0 warnings.