### PR TITLE
fix(parse-pdf): band-aware reading order so clause prose around tables isn't scrambled

### DIFF
--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -99,6 +99,12 @@ internal static class PdfReadingOrder
     // reconstructor's: a horizontal gap wider than this many median-block-heights separates two columns.
     private const double ColumnGutterScale = 0.8;
 
+    // A block at least this fraction of the page's content width is treated as a full-width "band separator"
+    // for reading order (SegmentIntoReadingOrder): it spans every column, so content above and below it are
+    // distinct horizontal bands. Sized to catch a full-width prose line (which reaches the right margin) while
+    // leaving a shorter wrapped continuation / a table cell inside its band.
+    private const double FullWidthReadingBandFraction = 0.7;
+
     /// <summary>
     /// Reconstructs visual lines from the page's words: clusters words whose vertical ranges overlap into
     /// one line, orders words left-to-right within a line, and returns lines top-to-bottom.
@@ -877,10 +883,18 @@ internal static class PdfReadingOrder
     /// <see cref="RecursiveXYCut"/> — a top-down "Manhattan layout" segmenter that cuts the page along
     /// whitespace valleys wider than the dominant font metrics, separating columns (vertical gutter cut)
     /// and paragraphs (horizontal line-gap cut). This fits the column/table-structured target corpus
-    /// (contracts / invoices) better than the bottom-up Docstrum clustering. Blocks are ordered by
-    /// <see cref="UnsupervisedReadingOrderDetector"/> in <see cref="UnsupervisedReadingOrderDetector.SpatialReasoningRules.ColumnWise"/>
-    /// mode (read each column top-to-bottom, then move right), which keeps a column's lines contiguous.
-    /// Returns an empty list when there are no meaningful words.
+    /// (contracts / invoices) better than the bottom-up Docstrum clustering.
+    /// <para>
+    /// <b>Band-aware reading order.</b> The blocks are first split into horizontal bands at full-width blocks
+    /// (a full-width prose line / footnote spans every column, so content above and below it reads separately),
+    /// and only <i>within</i> each band are blocks ordered column-wise
+    /// (<see cref="UnsupervisedReadingOrderDetector"/>, <see cref="UnsupervisedReadingOrderDetector.SpatialReasoningRules.ColumnWise"/>).
+    /// A plain page-wide column-wise pass (the prior behavior) reads each column top-to-bottom across the whole
+    /// page, which on a single-column page interleaved with a table reads the table's columns vertically and
+    /// captures the surrounding full-width clause prose into them — scrambling the clause text. Banding keeps a
+    /// genuine multi-column region (no full-width separator → one band) column-wise while reading single-column
+    /// prose between tables in true top-to-bottom order. Returns an empty list when there are no meaningful words.
+    /// </para>
     /// </summary>
     private static IReadOnlyList<DlaTextBlock> SegmentIntoReadingOrder(IReadOnlyList<Word> words)
     {
@@ -897,12 +911,70 @@ internal static class PdfReadingOrder
             return blocks;
         }
 
-        return new UnsupervisedReadingOrderDetector(
-                T: 5,
-                spatialReasoningRule: UnsupervisedReadingOrderDetector.SpatialReasoningRules.ColumnWise,
-                useRenderingOrder: false)
-            .Get(blocks)
-            .ToList();
+        return OrderByBandsThenColumns(blocks);
+    }
+
+    /// <summary>
+    /// Orders blocks into reading order by splitting them into horizontal bands at full-width separators and
+    /// ordering each band column-wise. A block whose width is at least
+    /// <see cref="FullWidthReadingBandFraction"/> of the page's content width spans every column and forms its
+    /// own band; each run of narrower blocks between separators forms a band; bands are read top-to-bottom.
+    /// Within a multi-block band, <see cref="UnsupervisedReadingOrderDetector"/> in column-wise mode keeps a
+    /// genuine column's lines contiguous (the multi-column case that has no full-width separator is a single
+    /// band, so its behavior is unchanged); the table cells of a band reconstruct independently of this order.
+    /// </summary>
+    private static IReadOnlyList<DlaTextBlock> OrderByBandsThenColumns(IReadOnlyList<DlaTextBlock> blocks)
+    {
+        var minLeft = blocks.Min(b => Math.Min(b.BoundingBox.Left, b.BoundingBox.Right));
+        var maxRight = blocks.Max(b => Math.Max(b.BoundingBox.Left, b.BoundingBox.Right));
+        var fullWidth = (maxRight - minLeft) * FullWidthReadingBandFraction;
+
+        // Walk top-to-bottom, flushing the accumulated narrow-block band whenever a full-width separator is hit
+        // (the separator is then its own band). This yields the bands already in top-to-bottom order.
+        var bands = new List<List<DlaTextBlock>>();
+        var current = new List<DlaTextBlock>();
+        foreach (var block in blocks.OrderByDescending(b => b.BoundingBox.Top))
+        {
+            if (Math.Abs(block.BoundingBox.Width) >= fullWidth)
+            {
+                if (current.Count > 0)
+                {
+                    bands.Add(current);
+                    current = new List<DlaTextBlock>();
+                }
+
+                bands.Add(new List<DlaTextBlock> { block });
+            }
+            else
+            {
+                current.Add(block);
+            }
+        }
+
+        if (current.Count > 0)
+        {
+            bands.Add(current);
+        }
+
+        var detector = new UnsupervisedReadingOrderDetector(
+            T: 5,
+            spatialReasoningRule: UnsupervisedReadingOrderDetector.SpatialReasoningRules.ColumnWise,
+            useRenderingOrder: false);
+
+        var result = new List<DlaTextBlock>(blocks.Count);
+        foreach (var band in bands)
+        {
+            if (band.Count == 1)
+            {
+                result.Add(band[0]);
+            }
+            else
+            {
+                result.AddRange(detector.Get(band));
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -605,4 +605,43 @@ public class PdfExtractor_Tests
         result.Markdown.IndexOf("Master Services Agreement", StringComparison.Ordinal)
             .ShouldBeLessThan(result.Markdown.IndexOf("| Provider |", StringComparison.Ordinal));
     }
+
+    [Fact]
+    public async Task Reads_full_width_clause_prose_below_a_table_in_top_to_bottom_order()
+    {
+        // The page-2 clause-scramble: a multi-column table followed by full-width clause prose whose sentences
+        // wrap across several lines. A page-wide column-wise reading order reads the table's columns vertically
+        // and captures the full-width prose lines into them, so a clause's later line is emitted before its
+        // earlier one (the sentence reads back-to-front). Banding the page at full-width separators makes each
+        // full-width prose line its own band, read strictly top-to-bottom, so the clause reads in order.
+        var pdf = PdfFixtures.BuildPositioned(new[]
+        {
+            ("Item", 50.0, 700.0), ("Qty", 230.0, 700.0), ("Remark", 380.0, 700.0),
+            ("Apple", 50.0, 672.0), ("5", 230.0, 672.0), ("fresh", 380.0, 672.0),
+            ("Pear", 50.0, 644.0), ("9", 230.0, 644.0), ("green", 380.0, 644.0),
+
+            // Two clauses below the table. Each clause is a full-width first line (a band separator) plus a
+            // SHORT continuation line at the left margin — exactly the x of the table's first column, which is
+            // what a page-wide column-wise pass captures into that column and reads out of order.
+            ("ALPHA the provider shall perform the work described in the written specification", 50.0, 600.0),
+            ("with due care here.", 50.0, 578.0),
+            ("BETA the client shall pay each invoice the provider issues by the stated final due", 50.0, 540.0),
+            ("date in full.", 50.0, 518.0)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // The table still reconstructs, and the two clauses read in document order: each clause's first line
+        // (ALPHA / BETA) before its own continuation, and ALPHA's clause entirely before BETA's.
+        result.Markdown.ShouldContain("| Item | Qty | Remark |");
+        var alpha = result.Markdown.IndexOf("ALPHA", StringComparison.Ordinal);
+        var alphaCont = result.Markdown.IndexOf("with due care here.", StringComparison.Ordinal);
+        var beta = result.Markdown.IndexOf("BETA", StringComparison.Ordinal);
+        var betaCont = result.Markdown.IndexOf("date in full.", StringComparison.Ordinal);
+        var table = result.Markdown.IndexOf("| Item | Qty | Remark |", StringComparison.Ordinal);
+        alpha.ShouldBeGreaterThan(table);
+        alphaCont.ShouldBeGreaterThan(alpha);
+        beta.ShouldBeGreaterThan(alphaCont);
+        betaCont.ShouldBeGreaterThan(beta);
+    }
 }


### PR DESCRIPTION
Follow-up to #399 / #400, same contract. Now that the tables extract correctly, the **clause body prose came out scrambled** — wrapped sentences read back-to-front.

## Problem

On a single-column page interleaved with a table (the clauses around the 料金表, the page-1 preamble around the key-value form), the page-wide **ColumnWise** reading order (#310 Phase A) reads each of the table's columns top-to-bottom and **captures the surrounding full-width clause prose into those columns**. So a clause's later (narrow, continuation) line is emitted before its full-width first line:

```
第 4 条（支払条件）
法により料金を支払う。振込手数料は甲の負担とする。      ← sentence END, emitted first
…
甲は、乙が発行する請求書に従い…乙指定の銀行口座へ振込   ← sentence START, emitted later
```

## Fix

**Band-aware reading order.** Split the page into horizontal bands at full-width blocks (a full-width prose line / footnote spans every column, so content above and below it reads separately) and order each band column-wise. Read bands top-to-bottom.

- Single-column clause prose between tables now reads strictly top-to-bottom (each full-width line is its own band).
- A genuine multi-column region has **no** full-width separator → it stays one band → its column-wise order is unchanged (the #310 `Two_column_label_body_page` case still passes).
- Table cells reconstruct independently of block order, so interleaving table cells within a band is harmless.

### After (page 2)

```
第 4 条（支払条件）
甲は、乙が発行する請求書に従い…乙指定の銀行口座へ振込送金の方
法により料金を支払う。振込手数料は甲の負担とする。
初期費用の支払時期…甲乙が別途合意する。別途合意がない場
合、乙は制作着手時または納品時に初期費用を請求できる。
…
```

…and page 1's preamble (`合同会社文創…は、ウ` → `ェブサイト制作…とい` → `う。）を締結する。`) now reads in order.

## Scope / notes

- Internal to `Parse.Pdf` (reading order only), non-lossy (reorders blocks, drops nothing), no contract/egress change, output is still Markdown-first.
- The line-per-paragraph format is unchanged/pre-existing (each loosely-spaced source line is its own RecursiveXYCut block); this PR fixes only the **order**. Reflowing wrapped lines into single paragraphs would be a separate change.

## Tests

- `PdfExtractor_Tests.Reads_full_width_clause_prose_below_a_table_in_top_to_bottom_order` — end-to-end; **verified it fails under the old ColumnWise order** and passes with banding.
- Verified against the actual contract: pages 1 & 2 clause prose now in correct order; tables (pages 1/2/6) unchanged.
- All **70** Parse.Pdf + **82** Parse tests pass (incl. the #310 multi-column test); clean Release build, 0 warnings.