### PR TITLE
fix(parse-pdf): order blocks within a reading band row-wise, not column-wise

### DIFF
--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -6,7 +6,6 @@ using Dignite.Extract.Abstractions.Parse;
 using UglyToad.PdfPig.Content;
 using UglyToad.PdfPig.Core;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
-using UglyToad.PdfPig.DocumentLayoutAnalysis.ReadingOrderDetector;
 using DlaTextBlock = UglyToad.PdfPig.DocumentLayoutAnalysis.TextBlock;
 
 namespace Dignite.Extract.Parse.Pdf;
@@ -21,13 +20,13 @@ namespace Dignite.Extract.Parse.Pdf;
 /// <see cref="PdfRectangle.Top"/>.
 /// </para>
 /// <para>
-/// <b>Column-aware reading order (#310 Phase A).</b> <see cref="RenderPage"/> uses PdfPig's
-/// <c>DocumentLayoutAnalysis</c> (<see cref="RecursiveXYCut"/> page segmenter +
-/// <see cref="UnsupervisedReadingOrderDetector"/>) to order blocks before linearizing, so a multi-column
-/// label/body page no longer splices a left-column label into the middle of a right-column sentence —
-/// the failure mode of a flat <c>Top</c>-descending sort. Within a single block the order is still
-/// <c>Top</c> descending then <c>Left</c> ascending (see <see cref="Render"/>), which is correct for one
-/// column.
+/// <b>Band-aware reading order (#310 Phase A).</b> <see cref="RenderPage"/> segments the page with PdfPig's
+/// <c>DocumentLayoutAnalysis</c> (<see cref="RecursiveXYCut"/>), then orders blocks band-aware
+/// (<see cref="SegmentIntoReadingOrder"/>): horizontal bands at full-width separators, visual rows within a
+/// band. A multi-column label/body row no longer splices a left-column label into the middle of a right-column
+/// sentence (the failure mode of a flat <c>Top</c>-descending sort), and single-column prose interleaved with a
+/// table reads top-to-bottom. Within a single block the order is still <c>Top</c> descending then <c>Left</c>
+/// ascending (see <see cref="Render"/>), which is correct for one column.
 /// </para>
 /// <para>
 /// <b>Table row reconstruction (#310 Phase B).</b> On a multi-block page <see cref="RenderPage"/> also
@@ -349,9 +348,9 @@ internal static class PdfReadingOrder
     }
 
     /// <summary>
-    /// Renders a page to Markdown with column-aware reading order (#310 Phase A): segments the page's
-    /// words into layout blocks (<see cref="RecursiveXYCut"/>), orders the blocks
-    /// (<see cref="UnsupervisedReadingOrderDetector"/>, column-wise), then renders each block in reading
+    /// Renders a page to Markdown with band-aware reading order (#310 Phase A): segments the page's
+    /// words into layout blocks (<see cref="RecursiveXYCut"/>), orders the blocks band-aware
+    /// (<see cref="SegmentIntoReadingOrder"/>: full-width bands, visual rows within a band), then renders each block in reading
     /// order through the single-region <see cref="Render(IReadOnlyList{TextLine}, IReadOnlyList{Figure})"/>
     /// path (line grouping + caption binding + paragraph folding) and joins the blocks. Embedded figures
     /// are merged into the block order by their placement bbox (nearest block by squared centroid
@@ -887,13 +886,13 @@ internal static class PdfReadingOrder
     /// <para>
     /// <b>Band-aware reading order.</b> The blocks are first split into horizontal bands at full-width blocks
     /// (a full-width prose line / footnote spans every column, so content above and below it reads separately),
-    /// and only <i>within</i> each band are blocks ordered column-wise
-    /// (<see cref="UnsupervisedReadingOrderDetector"/>, <see cref="UnsupervisedReadingOrderDetector.SpatialReasoningRules.ColumnWise"/>).
-    /// A plain page-wide column-wise pass (the prior behavior) reads each column top-to-bottom across the whole
-    /// page, which on a single-column page interleaved with a table reads the table's columns vertically and
-    /// captures the surrounding full-width clause prose into them — scrambling the clause text. Banding keeps a
-    /// genuine multi-column region (no full-width separator → one band) column-wise while reading single-column
-    /// prose between tables in true top-to-bottom order. Returns an empty list when there are no meaningful words.
+    /// and only <i>within</i> each band are blocks ordered by visual row (<see cref="OrderBandRowWise"/>:
+    /// top-to-bottom rows, left-to-right within a row). A plain page-wide column-wise pass reads each column
+    /// top-to-bottom across the whole page, which on a single-column page interleaved with a table reads the
+    /// table's columns vertically and captures the surrounding full-width clause prose into them — scrambling
+    /// the clause text. Banding plus row-wise ordering reads single-column prose between tables in true
+    /// top-to-bottom order while keeping a genuine side-by-side row (a label beside its body, the #310 case)
+    /// reading left-to-right. Returns an empty list when there are no meaningful words.
     /// </para>
     /// </summary>
     private static IReadOnlyList<DlaTextBlock> SegmentIntoReadingOrder(IReadOnlyList<Word> words)
@@ -916,12 +915,12 @@ internal static class PdfReadingOrder
 
     /// <summary>
     /// Orders blocks into reading order by splitting them into horizontal bands at full-width separators and
-    /// ordering each band column-wise. A block whose width is at least
+    /// ordering each band by <see cref="OrderBandRowWise">visual row</see>. A block whose width is at least
     /// <see cref="FullWidthReadingBandFraction"/> of the page's content width spans every column and forms its
     /// own band; each run of narrower blocks between separators forms a band; bands are read top-to-bottom.
-    /// Within a multi-block band, <see cref="UnsupervisedReadingOrderDetector"/> in column-wise mode keeps a
-    /// genuine column's lines contiguous (the multi-column case that has no full-width separator is a single
-    /// band, so its behavior is unchanged); the table cells of a band reconstruct independently of this order.
+    /// Within a multi-block band, blocks are grouped into visual rows read top-to-bottom (then left-to-right
+    /// within a row), so a stamp / wrapped title char that sits above a table but in a column to its side reads
+    /// before the table, not after it; the table cells of a band reconstruct independently of this order.
     /// </summary>
     private static IReadOnlyList<DlaTextBlock> OrderByBandsThenColumns(IReadOnlyList<DlaTextBlock> blocks)
     {
@@ -956,11 +955,6 @@ internal static class PdfReadingOrder
             bands.Add(current);
         }
 
-        var detector = new UnsupervisedReadingOrderDetector(
-            T: 5,
-            spatialReasoningRule: UnsupervisedReadingOrderDetector.SpatialReasoningRules.ColumnWise,
-            useRenderingOrder: false);
-
         var result = new List<DlaTextBlock>(blocks.Count);
         foreach (var band in bands)
         {
@@ -970,8 +964,52 @@ internal static class PdfReadingOrder
             }
             else
             {
-                result.AddRange(detector.Get(band));
+                result.AddRange(OrderBandRowWise(band));
             }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Orders the blocks of a single band in reading order: group them into visual rows by vertical overlap,
+    /// read the rows top-to-bottom, and read each row left-to-right. A row-wise order (rather than a page-wide
+    /// column-wise one) is correct here because a band has already been cut at its full-width separators, so its
+    /// remaining content reads top-to-bottom; ordering by column instead would place a block that sits in its
+    /// own x-column but higher up (e.g. the page-1 「契約書案」 draft stamp / the title's wrapped 「書」, which sit
+    /// above the key-value table but in a column to its right) AFTER the table rather than before it. A genuine
+    /// side-by-side row (a label beside its body, the #310 case) is a single visual row and still reads
+    /// left-to-right; a table's cells reconstruct independently of this order.
+    /// </summary>
+    private static IReadOnlyList<DlaTextBlock> OrderBandRowWise(IReadOnlyList<DlaTextBlock> band)
+    {
+        // Cluster blocks into visual rows: a block joins a row when it vertically overlaps that row's most
+        // recently added block (compared against the last block, not an accreted union, so a tall block cannot
+        // stretch a row and pull in a block from the next one — mirrors GroupWordsIntoLines).
+        var rows = new List<List<DlaTextBlock>>();
+        foreach (var block in band.OrderByDescending(b => b.BoundingBox.Top))
+        {
+            var placed = false;
+            foreach (var row in rows)
+            {
+                if (PdfGeometry.VerticalOverlapRatio(row[^1].BoundingBox, block.BoundingBox) >= RowConnectVerticalOverlap)
+                {
+                    row.Add(block);
+                    placed = true;
+                    break;
+                }
+            }
+
+            if (!placed)
+            {
+                rows.Add(new List<DlaTextBlock> { block });
+            }
+        }
+
+        var result = new List<DlaTextBlock>(band.Count);
+        foreach (var row in rows.OrderByDescending(r => r.Max(b => b.BoundingBox.Top)))
+        {
+            result.AddRange(row.OrderBy(b => b.BoundingBox.Left));
         }
 
         return result;

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -644,4 +644,33 @@ public class PdfExtractor_Tests
         beta.ShouldBeGreaterThan(alphaCont);
         betaCont.ShouldBeGreaterThan(beta);
     }
+
+    [Fact]
+    public async Task Reads_a_stamp_above_a_table_before_the_table_not_after_it()
+    {
+        // The page-1 「契約書案」 draft stamp + the title's wrapped 「書」: they sit ABOVE the key-value table but
+        // in an x-column to its side, inside the same horizontal band. A column-wise within-band order reads the
+        // table's columns first and so emits the stamp AFTER the table; row-wise within-band order reads it by
+        // its (higher) vertical position, before the table.
+        var pdf = PdfFixtures.BuildPositioned(new[]
+        {
+            ("Master Services Agreement Document Title Reaching The Right Margin", 50.0, 716.0), // full-width title (a band on its own)
+
+            ("DRAFT", 300.0, 688.0), // a stamp above the table, in a column to its right
+
+            ("Provider", 50.0, 650.0), ("Acme Corporation", 230.0, 650.0),
+            ("Client", 50.0, 622.0), ("Beta Industries", 230.0, 622.0)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        result.Markdown.ShouldContain("| Provider | Acme Corporation |");
+        var title = result.Markdown.IndexOf("Master Services Agreement", StringComparison.Ordinal);
+        var stamp = result.Markdown.IndexOf("DRAFT", StringComparison.Ordinal);
+        var table = result.Markdown.IndexOf("| Provider | Acme Corporation |", StringComparison.Ordinal);
+        // The stamp reads after the title but before the table — matching its vertical position on the page.
+        title.ShouldBeLessThan(stamp);
+        stamp.ShouldBeLessThan(table);
+        result.Markdown.ShouldNotContain("| DRAFT"); // and it is not pulled into the table as a cell
+    }
 }


### PR DESCRIPTION
Follow-up to #401, same contract. Two page-1 ordering issues the user reported:

1. The title's wrapped `書` (the title is `…業務委託契約書`, wrapping the last char) did not stay with the title.
2. The `契約書案` draft stamp, physically **above** the 委託者 key-value table, was emitted **below** it.

## Confirmed cause

Both share one cause. The band-aware reading order (#401) splits the page into horizontal bands at full-width lines. `書` (x≈297, y≈681) and `契約書案` (x≈286, y≈633) are narrow blocks between the full-width title and the first full-width preamble line, so they land in the **same band** as the key-value table's first rows. Within a band the blocks were ordered **column-wise**, and `書`/`契約書案` live in their own x-column to the **right** of the table's label/value columns — so they were read *after* the table's columns. The table then emits as a single unit at its first (lowest-index) cell, leaving `書`/`契約書案` as loose paragraphs rendered **after** the table.

(Confirmed by dumping the band structure: band 1 = `[書, 契約書案, 委託者, 合同会社文創, 受託者, 株式会社ディグナイト]`, column-wise ordered → stamps after the table cells.)

## Fix

Within a band, order blocks by **visual row** (group by vertical overlap, read rows top-to-bottom, left-to-right within a row) instead of column-wise (`OrderBandRowWise`). A block higher on the page now reads before a lower table even when it's in a side column. A genuine side-by-side row (a label beside its body — the #310 case) is a single visual row and still reads left-to-right; table cells reconstruct independently of block order. Removes the now-unused `UnsupervisedReadingOrderDetector`.

### Page 1 → after

```
ウェブサイト制作・ホスティング保守運用業務委託契約
書
契約書案
| 委託者（甲） | 合同会社文創 |
| --- | --- |
…
```

`書` now immediately follows the title and `契約書案` sits above the table.

## Notes

- `書` is still its own line (not joined into the title as `…契約書`); joining a wrapped line into its parent paragraph is the separate reflow concern noted in #401.
- Internal to `Parse.Pdf` (reading order only), non-lossy, no contract change.

## Tests

- `PdfExtractor_Tests.Reads_a_stamp_above_a_table_before_the_table_not_after_it` — end-to-end; **verified it fails under the old column-wise order**.
- Verified against the actual contract: page-1 `書`/`契約書案` now above the table; page-2 clause prose + all tables unchanged.
- All **71** Parse.Pdf + **82** Parse tests pass (incl. #310 multi-column and the #401 clause-prose test); clean Release build, 0 warnings.