### PR TITLE
feat(parse-pdf): map font size/weight to Markdown headings (#403)

### DIFF
--- a/core/src/Dignite.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfExtractor.cs
@@ -144,6 +144,11 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
             // document drops nothing.
             var runningContent = PdfRunningHeaderFooter.Detect(pages.ConvertAll(p => p.Words));
 
+            // #403: build the document-wide font-size → heading-level scale once (rank of the distinct sizes
+            // larger than the char-count-weighted body size), then pass it to each page render so larger/bold
+            // lines become Markdown headings. Built from all words; a single-size document yields no headings.
+            var headingScale = PdfHeadingScale.Build(pages.SelectMany(p => p.Words));
+
             for (var pageIndex = 0; pageIndex < pages.Count; pageIndex++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -270,7 +275,7 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     ? pageContent.Words
                     : pageContent.Words.Where(w => !droppable.Contains(w)).ToList();
 
-                var pageMarkdown = PdfReadingOrder.RenderPage(renderWords, figures, _options.ReconstructTables);
+                var pageMarkdown = PdfReadingOrder.RenderPage(renderWords, figures, _options.ReconstructTables, headingScale);
                 if (!string.IsNullOrWhiteSpace(pageMarkdown))
                 {
                     pageMarkdowns.Add(pageMarkdown);

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfHeadingScale.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfHeadingScale.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UglyToad.PdfPig.Content;
+
+namespace Dignite.Extract.Parse.Pdf;
+
+/// <summary>
+/// Maps a digital PDF's font sizes to Markdown heading levels (#403). Built once per document from the font-size
+/// histogram of all its words, then queried per visual line.
+/// <para>
+/// Follows the field-standard heuristic (PyMuPDF4LLM's <c>IdentifyHeaders</c>): the body font size is the most
+/// frequent rounded <see cref="Letter.PointSize"/> <b>weighted by character count</b> (body text wins by sheer
+/// volume); the <b>distinct</b> sizes larger than body are ranked descending and assigned levels 1..N (largest
+/// present size = H1), capped at <see cref="MaxLevels"/>. This is rank-of-distinct-sizes, not a fixed multiplier,
+/// so it adapts to each document's actual size palette.
+/// </para>
+/// <para>
+/// One refinement over the bare heuristic: because the gap between a body size and the next-larger heading size
+/// can be just 1pt (a contract's 11pt body vs. 12pt section headings), a candidate that is only marginally larger
+/// than body (&lt; <see cref="UnboldedHeadingMinGapPoints"/>) is accepted as a heading only when the line is also
+/// <b>bold</b> — the weight corroboration called for in #403. A clearly larger size needs no such corroboration.
+/// </para>
+/// </summary>
+internal sealed class PdfHeadingScale
+{
+    private const int MaxLevels = 6;
+
+    // A candidate heading size within this many points of the body size is too weak on size alone; require bold.
+    private const double UnboldedHeadingMinGapPoints = 2.0;
+
+    private readonly int _bodyLimit;
+    private readonly IReadOnlyDictionary<int, int> _levelBySize;
+
+    private PdfHeadingScale(int bodyLimit, IReadOnlyDictionary<int, int> levelBySize)
+    {
+        _bodyLimit = bodyLimit;
+        _levelBySize = levelBySize;
+    }
+
+    /// <summary>Whether any heading sizes were found (a document with no typographic hierarchy has none).</summary>
+    public bool HasHeadings => _levelBySize.Count > 0;
+
+    /// <summary>
+    /// The Markdown heading level (1 = largest = <c>#</c>) for a visual line whose largest glyph is
+    /// <paramref name="maxPointSize"/> and which is <paramref name="bold"/>, or 0 when the line is body text.
+    /// </summary>
+    public int ClassifyLine(double maxPointSize, bool bold)
+    {
+        var size = (int)Math.Round(maxPointSize);
+        if (size <= _bodyLimit || !_levelBySize.TryGetValue(size, out var level))
+        {
+            return 0;
+        }
+
+        // A heading only marginally larger than body is a weak signal — require bold to corroborate (#403).
+        if (size - _bodyLimit < UnboldedHeadingMinGapPoints && !bold)
+        {
+            return 0;
+        }
+
+        return level;
+    }
+
+    /// <summary>
+    /// Builds the scale from all of a document's words. Returns a scale with no headings when there are no
+    /// letters or no size exceeds the body size (a single-size document has no hierarchy).
+    /// </summary>
+    public static PdfHeadingScale Build(IEnumerable<Word> words)
+    {
+        var histogram = new Dictionary<int, long>(); // rounded point size -> character count
+        foreach (var word in words)
+        {
+            foreach (var letter in word.Letters)
+            {
+                var size = (int)Math.Round(letter.PointSize);
+                if (size <= 0)
+                {
+                    continue;
+                }
+
+                histogram[size] = histogram.GetValueOrDefault(size) + 1;
+            }
+        }
+
+        return FromSizeCounts(histogram.Select(kv => (kv.Key, kv.Value)));
+    }
+
+    /// <summary>
+    /// Builds the scale from a rounded-size → character-count histogram (the testable core of
+    /// <see cref="Build"/>). Body size = the most frequent size by character count (ties → the larger size, so
+    /// body is never under-estimated); the distinct larger sizes are ranked into heading levels.
+    /// </summary>
+    internal static PdfHeadingScale FromSizeCounts(IEnumerable<(int Size, long Count)> counts)
+    {
+        var histogram = new Dictionary<int, long>();
+        foreach (var (size, count) in counts)
+        {
+            if (size > 0 && count > 0)
+            {
+                histogram[size] = histogram.GetValueOrDefault(size) + count;
+            }
+        }
+
+        if (histogram.Count == 0)
+        {
+            return new PdfHeadingScale(int.MaxValue, EmptyLevels);
+        }
+
+        // No artificial floor: the char-count weighting makes the body text the mode for the prose-dominated
+        // target corpus, and a uniform-size document yields no sizes above body → no headings.
+        var bodyLimit = histogram
+            .OrderByDescending(kv => kv.Value)
+            .ThenByDescending(kv => kv.Key)
+            .First().Key;
+
+        var headingSizes = histogram.Keys
+            .Where(size => size > bodyLimit)
+            .OrderByDescending(size => size)
+            .Take(MaxLevels)
+            .ToList();
+
+        var levelBySize = new Dictionary<int, int>(headingSizes.Count);
+        for (var i = 0; i < headingSizes.Count; i++)
+        {
+            levelBySize[headingSizes[i]] = i + 1; // largest present size = level 1 (#)
+        }
+
+        return new PdfHeadingScale(bodyLimit, levelBySize);
+    }
+
+    /// <summary>Whether <paramref name="fontName"/> denotes a bold face (the standard digital-PDF heuristic).</summary>
+    public static bool IsBoldFont(string? fontName)
+        => fontName is not null
+           && (fontName.Contains("Bold", StringComparison.OrdinalIgnoreCase)
+               || fontName.Contains("Black", StringComparison.OrdinalIgnoreCase)
+               || fontName.Contains("Heavy", StringComparison.OrdinalIgnoreCase)
+               || fontName.Contains("Semibold", StringComparison.OrdinalIgnoreCase));
+
+    private static readonly IReadOnlyDictionary<int, int> EmptyLevels = new Dictionary<int, int>();
+}

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -46,8 +46,12 @@ internal static class PdfReadingOrder
     /// <summary>An embedded image with its page placement, source page number, and the OCR transcription of its content.</summary>
     public readonly record struct Figure(PdfRectangle Bounds, string Transcription, int? PageNumber = null);
 
-    /// <summary>A reconstructed visual line of the text layer.</summary>
-    public readonly record struct TextLine(PdfRectangle Bounds, string Text);
+    /// <summary>
+    /// A reconstructed visual line of the text layer. <see cref="MaxFontSize"/> (largest glyph point size) and
+    /// <see cref="Bold"/> (line is predominantly bold) carry the typographic signal used for heading detection
+    /// (#403); both default to neutral values so a line built without font data behaves as before.
+    /// </summary>
+    public readonly record struct TextLine(PdfRectangle Bounds, string Text, double MaxFontSize = 0, bool Bold = false);
 
     /// <summary>
     /// A reconstructed visual line plus the <see cref="Word"/> instances it was built from (left-to-right,
@@ -114,10 +118,49 @@ internal static class PdfReadingOrder
         var lines = new List<TextLine>(withWords.Count);
         foreach (var line in withWords)
         {
-            lines.Add(new TextLine(line.Bounds, line.Text));
+            lines.Add(new TextLine(line.Bounds, line.Text, LineMaxFontSize(line.Words), IsLineBold(line.Words)));
         }
 
         return lines;
+    }
+
+    /// <summary>The largest glyph point size on the line (its heading-candidate size, mirroring PyMuPDF4LLM's
+    /// "largest font size of the line"), or 0 when no glyph carries a size.</summary>
+    private static double LineMaxFontSize(IReadOnlyList<Word> words)
+    {
+        var max = 0.0;
+        foreach (var word in words)
+        {
+            foreach (var letter in word.Letters)
+            {
+                if (letter.PointSize > max)
+                {
+                    max = letter.PointSize;
+                }
+            }
+        }
+
+        return max;
+    }
+
+    /// <summary>Whether the majority of the line's glyphs are bold (a fully-bold heading / label line).</summary>
+    private static bool IsLineBold(IReadOnlyList<Word> words)
+    {
+        long total = 0;
+        long bold = 0;
+        foreach (var word in words)
+        {
+            foreach (var letter in word.Letters)
+            {
+                total++;
+                if (PdfHeadingScale.IsBoldFont(letter.FontName))
+                {
+                    bold++;
+                }
+            }
+        }
+
+        return total > 0 && bold * 2 >= total;
     }
 
     /// <summary>
@@ -216,7 +259,7 @@ internal static class PdfReadingOrder
     /// (and is close enough) consumes that line and renders it as the figure block's label, so the caption
     /// is not duplicated in the body text.
     /// </summary>
-    public static string Render(IReadOnlyList<TextLine> lines, IReadOnlyList<Figure> figures)
+    public static string Render(IReadOnlyList<TextLine> lines, IReadOnlyList<Figure> figures, PdfHeadingScale? headingScale = null)
     {
         var medianLineHeight = lines.Count > 0
             ? PdfGeometry.Median(lines.Select(l => l.Bounds.Height))
@@ -269,7 +312,10 @@ internal static class PdfReadingOrder
                 // emphasis / code / link span. The leading BLOCK marker is escaped later, once per folded
                 // paragraph (FlushParagraph), since only a paragraph's first line sits at line start. A figure
                 // transcription is OCR-provider Markdown (intentional structure) and is never escaped.
-                items.Add(Item.ForText(lines[i].Bounds, MarkdownText.EscapeInline(lines[i].Text)));
+                // #403: classify the line as a heading from its font size + boldness (0 = body); a heading line
+                // is emitted as its own "# …" block in step 4, never folded into a paragraph.
+                var headingLevel = headingScale?.ClassifyLine(lines[i].MaxFontSize, lines[i].Bold) ?? 0;
+                items.Add(Item.ForText(lines[i].Bounds, MarkdownText.EscapeInline(lines[i].Text), headingLevel));
             }
         }
 
@@ -333,6 +379,17 @@ internal static class PdfReadingOrder
                 continue;
             }
 
+            if (item.HeadingLevel > 0)
+            {
+                // #403: a heading line is its own block, never folded into a paragraph. Its text was already
+                // inline-escaped; the leading "#"s are intentional Markdown (so it is NOT line-start-escaped).
+                // Consecutive same-level heading blocks (a heading wrapped across lines / bands — e.g. the title
+                // and its trailing 「書」) are stitched back together by MergeAdjacentHeadings at the page level.
+                FlushParagraph();
+                blocks.Add(new string('#', item.HeadingLevel) + " " + item.Text);
+                continue;
+            }
+
             if (previousTop is double top && paragraphPitch > 0 && (top - item.Bounds.Top) > paragraphPitch)
             {
                 FlushParagraph();
@@ -345,6 +402,55 @@ internal static class PdfReadingOrder
         FlushParagraph();
 
         return string.Join("\n\n", blocks);
+    }
+
+    /// <summary>
+    /// Stitches consecutive same-level heading blocks into one heading (#403): a heading that wrapped across
+    /// visual lines / reading bands is rendered as adjacent <c>#…</c> blocks, and here they merge so e.g. the
+    /// title's trailing 「書」 rejoins its title line. Operates by splitting on the blank-line block separator
+    /// and re-joining it, so every non-heading block (paragraph, figure span) is returned unchanged.
+    /// </summary>
+    private static string MergeAdjacentHeadings(string pageMarkdown)
+    {
+        if (pageMarkdown.Length == 0)
+        {
+            return pageMarkdown;
+        }
+
+        var blocks = pageMarkdown.Split("\n\n");
+        var merged = new List<string>(blocks.Length);
+        foreach (var block in blocks)
+        {
+            var level = HeadingLevelOf(block);
+            if (level > 0 && merged.Count > 0 && HeadingLevelOf(merged[^1]) == level)
+            {
+                // Append this heading line's text (after its duplicate "#…<space>" prefix) to the open heading.
+                merged[^1] = merged[^1] + " " + block[(level + 1)..];
+            }
+            else
+            {
+                merged.Add(block);
+            }
+        }
+
+        return string.Join("\n\n", merged);
+    }
+
+    /// <summary>The heading level (1..6) of a single-line <c>"#… text"</c> heading block, or 0 otherwise.</summary>
+    private static int HeadingLevelOf(string block)
+    {
+        if (block.IndexOf('\n') >= 0)
+        {
+            return 0; // a heading block is always a single line
+        }
+
+        var hashes = 0;
+        while (hashes < block.Length && block[hashes] == '#')
+        {
+            hashes++;
+        }
+
+        return hashes is >= 1 and <= 6 && hashes < block.Length && block[hashes] == ' ' ? hashes : 0;
     }
 
     /// <summary>
@@ -379,7 +485,18 @@ internal static class PdfReadingOrder
     /// </para>
     /// </summary>
     public static string RenderPage(
-        IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables = true)
+        IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables = true,
+        PdfHeadingScale? headingScale = null)
+    {
+        var markdown = RenderPageCore(words, figures, reconstructTables, headingScale);
+        // #403: a heading that wrapped across lines / bands renders as adjacent same-level "# …" blocks; stitch
+        // them back into one heading (e.g. the title and its trailing 「書」). A no-op when no headings exist.
+        return headingScale is { HasHeadings: true } ? MergeAdjacentHeadings(markdown) : markdown;
+    }
+
+    private static string RenderPageCore(
+        IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables,
+        PdfHeadingScale? headingScale)
     {
         IReadOnlyList<DlaTextBlock> orderedBlocks;
         try
@@ -391,7 +508,7 @@ internal static class PdfReadingOrder
             // Any segmenter/reading-order fault degrades to the flat path: the page still renders and no
             // content is lost (the digital text layer is the channel's primary, non-negotiable payload).
             // A cancellation is NOT swallowed — it propagates so a host/job shutdown aborts promptly.
-            return Render(GroupWordsIntoLines(words), figures);
+            return Render(GroupWordsIntoLines(words), figures, headingScale);
         }
 
         // A single region (or no/one-block segmentation) is exactly the #301 behavior — render the whole
@@ -400,7 +517,7 @@ internal static class PdfReadingOrder
         // attempted here — an accepted #329 first-pass limitation.)
         if (orderedBlocks.Count <= 1)
         {
-            return Render(GroupWordsIntoLines(words), figures);
+            return Render(GroupWordsIntoLines(words), figures, headingScale);
         }
 
         // Non-lossy guard: RecursiveXYCut partitions every word into a leaf, so block words should account
@@ -411,7 +528,7 @@ internal static class PdfReadingOrder
             block => block.TextLines.Sum(line => line.Words.Count(w => !string.IsNullOrWhiteSpace(w.Text))));
         if (blockMeaningful < inputMeaningful)
         {
-            return Render(GroupWordsIntoLines(words), figures);
+            return Render(GroupWordsIntoLines(words), figures, headingScale);
         }
 
         // Attach each figure to the block it reads with (nearest block centroid) so figure inlining +
@@ -463,7 +580,7 @@ internal static class PdfReadingOrder
                 continue;
             }
 
-            var blockMarkdown = Render(blockLines, blockFigures);
+            var blockMarkdown = Render(blockLines, blockFigures, headingScale);
             if (!string.IsNullOrWhiteSpace(blockMarkdown))
             {
                 rendered.Add(blockMarkdown);
@@ -1065,11 +1182,12 @@ internal static class PdfReadingOrder
 
     private static double Sq(double v) => v * v;
 
-    private readonly record struct Item(PdfRectangle Bounds, string Text, bool IsFigure, string? Caption, int? PageNumber)
+    private readonly record struct Item(PdfRectangle Bounds, string Text, bool IsFigure, string? Caption, int? PageNumber, int HeadingLevel)
     {
-        public static Item ForText(PdfRectangle bounds, string text) => new(bounds, text, false, null, null);
+        public static Item ForText(PdfRectangle bounds, string text, int headingLevel = 0)
+            => new(bounds, text, false, null, null, headingLevel);
 
         public static Item ForFigure(PdfRectangle bounds, string text, string? caption, int? pageNumber)
-            => new(bounds, text, true, caption, pageNumber);
+            => new(bounds, text, true, caption, pageNumber, 0);
     }
 }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -673,4 +673,54 @@ public class PdfExtractor_Tests
         stamp.ShouldBeLessThan(table);
         result.Markdown.ShouldNotContain("| DRAFT"); // and it is not pulled into the table as a cell
     }
+
+    [Fact]
+    public async Task Maps_font_sizes_to_markdown_headings_and_merges_a_wrapped_title()
+    {
+        // #403: font size + weight encode hierarchy. Body (11pt, the bulk of the characters) is the mode; the
+        // distinct larger sizes are ranked into heading levels. A 20pt title wrapped across two lines becomes a
+        // single `#`; a 12pt BOLD section heading (only 1pt above body) becomes `##` via the weight corroboration;
+        // a 12pt NON-bold line stays body (the weak-gap guard); ordinary 11pt body is not headingified.
+        var pdf = PdfFixtures.BuildStyled(new[]
+        {
+            ("Annual Service Report For The", 50.0, 750.0, 20.0, true),       // title line 1 (H1)
+            ("Two Thousand Twenty Six Period", 50.0, 722.0, 20.0, true),      // title line 2 (wraps the title)
+
+            ("Overview Section", 50.0, 686.0, 12.0, true),                    // bold, 1pt above body → H2
+
+            ("This is the overview body paragraph and it carries enough", 50.0, 660.0, 11.0, false),
+            ("regular weight characters to be the dominant body font size.", 50.0, 638.0, 11.0, false),
+
+            ("Plain Twelve Point Line Not Bold", 50.0, 612.0, 12.0, false)    // 12pt but not bold → stays body
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // The two title lines merge into one H1.
+        result.Markdown.ShouldContain("# Annual Service Report For The Two Thousand Twenty Six Period");
+        // The bold section heading is H2.
+        result.Markdown.ShouldContain("## Overview Section");
+        // Body prose is present but not a heading.
+        result.Markdown.ShouldContain("This is the overview body paragraph");
+        result.Markdown.ShouldNotContain("# This is the overview");
+        // A 12pt non-bold line is body, not a heading (weak-gap guard rejects size alone).
+        result.Markdown.ShouldContain("Plain Twelve Point Line Not Bold");
+        result.Markdown.ShouldNotContain("# Plain Twelve Point Line");
+    }
+
+    [Fact]
+    public async Task Leaves_a_single_font_size_document_heading_free()
+    {
+        // No typographic hierarchy (one size throughout) → no headings invented.
+        var pdf = PdfFixtures.BuildStyled(new[]
+        {
+            ("First paragraph of a uniform document.", 50.0, 700.0, 11.0, false),
+            ("Second paragraph at the very same size.", 50.0, 660.0, 11.0, false)
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        result.Markdown.ShouldContain("First paragraph");
+        result.Markdown.ShouldNotContain("#");
+    }
 }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfFixtures.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfFixtures.cs
@@ -71,6 +71,27 @@ internal static class PdfFixtures
     }
 
     /// <summary>
+    /// Builds a single-page PDF with text at explicit (X, baseline) positions, each with its own font size and
+    /// weight — needed to exercise font-size → heading detection (#403). Bold uses Helvetica-Bold (font name
+    /// contains "Bold", which the heading detector reads as the weight signal).
+    /// </summary>
+    public static byte[] BuildStyled(
+        IReadOnlyList<(string Text, double X, double BaselineY, double FontSize, bool Bold)> texts)
+    {
+        var builder = new PdfDocumentBuilder();
+        var regular = builder.AddStandard14Font(Standard14Font.Helvetica);
+        var bold = builder.AddStandard14Font(Standard14Font.HelveticaBold);
+        var page = builder.AddPage(PageWidth, PageHeight);
+
+        foreach (var (text, x, baselineY, fontSize, isBold) in texts)
+        {
+            page.AddText(text, fontSize, new PdfPoint(x, baselineY), isBold ? bold : regular);
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
     /// Builds a multi-page PDF — one page per inner list of (Text, baselineY) lines — needed to exercise the
     /// cross-page running header/footer detection (#383), which has no signal on a single page.
     /// </summary>

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfHeadingScale_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfHeadingScale_Tests.cs
@@ -1,0 +1,55 @@
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Extract.Parse.Pdf;
+
+public class PdfHeadingScale_Tests
+{
+    [Fact]
+    public void Ranks_distinct_larger_sizes_as_heading_levels()
+    {
+        // The contract's size profile: body 11 wins on character count; the distinct larger sizes 18 and 12 are
+        // ranked H1 and H2 (rank of distinct sizes, not a fixed multiplier).
+        var scale = PdfHeadingScale.FromSizeCounts(new[] { (11, 1000L), (10, 200L), (12, 60L), (18, 30L) });
+
+        scale.HasHeadings.ShouldBeTrue();
+        scale.ClassifyLine(18, bold: false).ShouldBe(1);  // clearly larger than body → H1 (no bold needed)
+        scale.ClassifyLine(12, bold: true).ShouldBe(2);   // only 1pt above body, but bold → H2
+        scale.ClassifyLine(12, bold: false).ShouldBe(0);  // 1pt above body and NOT bold → body (weak-gap guard)
+        scale.ClassifyLine(11, bold: true).ShouldBe(0);   // body size
+        scale.ClassifyLine(10, bold: true).ShouldBe(0);   // below body
+    }
+
+    [Fact]
+    public void A_single_size_document_has_no_headings()
+    {
+        var scale = PdfHeadingScale.FromSizeCounts(new[] { (11, 500L) });
+
+        scale.HasHeadings.ShouldBeFalse();
+        scale.ClassifyLine(11, bold: true).ShouldBe(0);
+    }
+
+    [Fact]
+    public void Caps_heading_levels_at_six_and_drops_the_rest_to_body()
+    {
+        // Body 10; eight larger sizes — only the top six become headings, the smaller extras fall back to body.
+        var scale = PdfHeadingScale.FromSizeCounts(new[]
+        {
+            (10, 1000L), (11, 1L), (12, 1L), (13, 1L), (14, 1L), (15, 1L), (16, 1L), (17, 1L), (18, 1L)
+        });
+
+        scale.ClassifyLine(18, bold: false).ShouldBe(1);  // largest → H1
+        scale.ClassifyLine(13, bold: false).ShouldBe(6);  // sixth largest (18,17,16,15,14,13) → H6
+        scale.ClassifyLine(12, bold: false).ShouldBe(0);  // beyond the top six → body
+        scale.ClassifyLine(11, bold: false).ShouldBe(0);
+    }
+
+    [Fact]
+    public void IsBoldFont_reads_the_weight_from_the_font_name()
+    {
+        PdfHeadingScale.IsBoldFont("BCDGEE+YuGothic-Bold").ShouldBeTrue();
+        PdfHeadingScale.IsBoldFont("Helvetica-Bold").ShouldBeTrue();
+        PdfHeadingScale.IsBoldFont("BCDEEE+YuGothic-Regular").ShouldBeFalse();
+        PdfHeadingScale.IsBoldFont(null).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Implements the **headings** half of #403 (the rank-based mapping settled there). Inline emphasis (`**`/`_`) is the follow-up PR.

## What

Digital-born PDFs encode hierarchy with font size + weight (a contract's title = 18pt bold, `第N条` = 12pt bold, body = 10–11pt regular); the extractor flattened all of it. This adds heading detection following the field standard (PyMuPDF4LLM's approach, researched in #403):

- **Body size** = the **character-count-weighted mode** of rounded glyph point sizes (body prose wins by volume).
- **Heading sizes** = the **distinct** sizes larger than body, **ranked** descending → `#`, `##`, … (capped at 6). Rank of distinct sizes, *not* a fixed multiplier.
- **Per line**: its largest glyph size + boldness decide the level. A size only ~1pt above body (e.g. 12pt headings over 11pt body) is a weak signal, so it requires **bold** to corroborate (the #403 weight signal); a clearly larger size does not.
- **Multi-line heading merge**: a heading wrapped across lines / reading-bands renders as adjacent same-level `#…` blocks and is stitched back into one heading.

### Real contract → after

```
# ウェブサイト制作・ホスティング保守運用業務委託契約 書
…
## 第 1 条（委託業務）
…
## 第 2 条（仕様および納期）
```

The title is `#`, `第N条` are `##`, body/tables/lists are unchanged — and the title's wrapped **「書」 rejoins the title** (it's byte-identical 18pt-bold font), resolving the leftover from #402.

## How / safety

- Opt-in via a `PdfHeadingScale` built **once per document** in `PdfExtractor` and threaded through `RenderPage`/`Render`. A `null` scale or a **single-size document** produces no headings, so every existing rendering path is byte-for-byte unchanged.
- Tables / figure-OCR / bullet lists never go through the heading path (they're reconstructed separately), so they are not headingified.
- Internal to `Parse.Pdf`, non-lossy, no contract/egress change; output is still Markdown-first (richer Markdown, as the rules call for).

## Scope (per #403)

- **Colour** — ignored (Markdown has no colour syntax).
- **Inline emphasis** (`**`/`_` for bold/italic runs) — the next PR.
- **Body-paragraph reflow** — separate concern.

## Tests

- `PdfHeadingScale_Tests`: rank → levels, weak-gap-needs-bold, level cap at 6, single-size = none, bold-font detection.
- `PdfExtractor_Tests`: `Maps_font_sizes_to_markdown_headings_and_merges_a_wrapped_title` (end-to-end: title merge + bold `##` + non-bold-12pt stays body), `Leaves_a_single_font_size_document_heading_free`.
- Verified against the actual contract (title/第N条 headings, `書` merged, tables/lists intact).
- All **77** Parse.Pdf + **82** Parse tests pass; clean Release build, 0 warnings.