### PR TITLE
feat(parse-pdf): carry inline bold/italic runs into Markdown emphasis (#403)

### DIFF
--- a/core/src/Dignite.Extract.Parse.Pdf/PdfHeadingScale.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfHeadingScale.cs
@@ -137,5 +137,11 @@ internal sealed class PdfHeadingScale
                || fontName.Contains("Heavy", StringComparison.OrdinalIgnoreCase)
                || fontName.Contains("Semibold", StringComparison.OrdinalIgnoreCase));
 
+    /// <summary>Whether <paramref name="fontName"/> denotes an italic / oblique face.</summary>
+    public static bool IsItalicFont(string? fontName)
+        => fontName is not null
+           && (fontName.Contains("Italic", StringComparison.OrdinalIgnoreCase)
+               || fontName.Contains("Oblique", StringComparison.OrdinalIgnoreCase));
+
     private static readonly IReadOnlyDictionary<int, int> EmptyLevels = new Dictionary<int, int>();
 }

--- a/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -49,9 +49,14 @@ internal static class PdfReadingOrder
     /// <summary>
     /// A reconstructed visual line of the text layer. <see cref="MaxFontSize"/> (largest glyph point size) and
     /// <see cref="Bold"/> (line is predominantly bold) carry the typographic signal used for heading detection
-    /// (#403); both default to neutral values so a line built without font data behaves as before.
+    /// (#403). <see cref="StyledText"/> is the line's Markdown text with inline emphasis already applied
+    /// (bold/italic runs wrapped and the rest inline-escaped) — used for rendering, while plain <see cref="Text"/>
+    /// stays the detection signal (header/footer dedup, caption matching); it is <c>null</c> when the line was
+    /// built without font data, in which case the renderer falls back to escaping <see cref="Text"/>. All
+    /// font-derived fields default to neutral values so a line built by a test still behaves as before.
     /// </summary>
-    public readonly record struct TextLine(PdfRectangle Bounds, string Text, double MaxFontSize = 0, bool Bold = false);
+    public readonly record struct TextLine(
+        PdfRectangle Bounds, string Text, double MaxFontSize = 0, bool Bold = false, string? StyledText = null);
 
     /// <summary>
     /// A reconstructed visual line plus the <see cref="Word"/> instances it was built from (left-to-right,
@@ -118,10 +123,93 @@ internal static class PdfReadingOrder
         var lines = new List<TextLine>(withWords.Count);
         foreach (var line in withWords)
         {
-            lines.Add(new TextLine(line.Bounds, line.Text, LineMaxFontSize(line.Words), IsLineBold(line.Words)));
+            lines.Add(new TextLine(
+                line.Bounds, line.Text, LineMaxFontSize(line.Words), IsLineBold(line.Words),
+                StyledLineText(line.Words)));
         }
 
         return lines;
+    }
+
+    /// <summary>
+    /// Builds the line's Markdown text with inline emphasis (#403): consecutive words of the same weight/slant
+    /// form a run that is wrapped in <c>**…**</c> (bold), <c>_…_</c> (italic), or <c>***…***</c> (both); each
+    /// run's content is inline-escaped exactly as the plain path would escape it, so only the deliberate
+    /// emphasis markers stay live. Runs are space-joined, matching the plain line's word join.
+    /// </summary>
+    private static string StyledLineText(IReadOnlyList<Word> words)
+    {
+        var runs = new List<string>();
+        var current = new List<string>();
+        var currentBold = false;
+        var currentItalic = false;
+
+        void FlushRun()
+        {
+            if (current.Count == 0)
+            {
+                return;
+            }
+
+            var escaped = MarkdownText.EscapeInline(string.Join(" ", current));
+            runs.Add((currentBold, currentItalic) switch
+            {
+                (true, true) => "***" + escaped + "***",
+                (true, false) => "**" + escaped + "**",
+                (false, true) => "_" + escaped + "_",
+                _ => escaped
+            });
+            current.Clear();
+        }
+
+        foreach (var word in words)
+        {
+            var bold = IsWordBold(word);
+            var italic = IsWordItalic(word);
+            if (current.Count > 0 && (bold != currentBold || italic != currentItalic))
+            {
+                FlushRun();
+            }
+
+            currentBold = bold;
+            currentItalic = italic;
+            current.Add(word.Text);
+        }
+
+        FlushRun();
+        return string.Join(" ", runs);
+    }
+
+    /// <summary>Whether the majority of a word's glyphs are bold.</summary>
+    private static bool IsWordBold(Word word)
+    {
+        long total = 0, bold = 0;
+        foreach (var letter in word.Letters)
+        {
+            total++;
+            if (PdfHeadingScale.IsBoldFont(letter.FontName))
+            {
+                bold++;
+            }
+        }
+
+        return total > 0 && bold * 2 >= total;
+    }
+
+    /// <summary>Whether the majority of a word's glyphs are italic.</summary>
+    private static bool IsWordItalic(Word word)
+    {
+        long total = 0, italic = 0;
+        foreach (var letter in word.Letters)
+        {
+            total++;
+            if (PdfHeadingScale.IsItalicFont(letter.FontName))
+            {
+                italic++;
+            }
+        }
+
+        return total > 0 && italic * 2 >= total;
     }
 
     /// <summary>The largest glyph point size on the line (its heading-candidate size, mirroring PyMuPDF4LLM's
@@ -313,9 +401,14 @@ internal static class PdfReadingOrder
                 // paragraph (FlushParagraph), since only a paragraph's first line sits at line start. A figure
                 // transcription is OCR-provider Markdown (intentional structure) and is never escaped.
                 // #403: classify the line as a heading from its font size + boldness (0 = body); a heading line
-                // is emitted as its own "# …" block in step 4, never folded into a paragraph.
+                // is emitted as its own "# …" block in step 4, never folded into a paragraph. Body lines carry
+                // inline emphasis (StyledText, bold/italic runs already wrapped + escaped); a heading is rendered
+                // plain (the "#" already signals it, so its text is not also bolded) via the inline-escaped Text.
                 var headingLevel = headingScale?.ClassifyLine(lines[i].MaxFontSize, lines[i].Bold) ?? 0;
-                items.Add(Item.ForText(lines[i].Bounds, MarkdownText.EscapeInline(lines[i].Text), headingLevel));
+                var text = headingLevel == 0 && lines[i].StyledText is not null
+                    ? lines[i].StyledText!
+                    : MarkdownText.EscapeInline(lines[i].Text);
+                items.Add(Item.ForText(lines[i].Bounds, text, headingLevel));
             }
         }
 

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -723,4 +723,37 @@ public class PdfExtractor_Tests
         result.Markdown.ShouldContain("First paragraph");
         result.Markdown.ShouldNotContain("#");
     }
+
+    [Fact]
+    public async Task Wraps_inline_bold_and_italic_runs_in_body_prose_but_not_in_a_heading()
+    {
+        // #403 inline emphasis: a bold / italic span *inside* a body line is wrapped (**…** / _…_), honoring the
+        // source's inline weight & slant. A bold *heading* line stays a heading only — no redundant ** inside the
+        // `#` (the heading already encodes the emphasis, and doubling it would be noise).
+        (string, bool, bool)[] Run(params (string Text, bool Bold, bool Italic)[] runs) => runs;
+        var pdf = PdfFixtures.BuildStyledLines(new (double, double, IReadOnlyList<(string, bool, bool)>)[]
+        {
+            // 16pt bold, alone on its line → heading.
+            (720.0, 16.0, Run(("Confidentiality", true, false))),
+
+            // One body line, mixed styles: regular → bold run → regular → italic run → regular.
+            (690.0, 11.0, Run(
+                ("The clause states the", false, false),
+                ("Confidential", true, false),          // inline bold
+                ("Information", false, false),
+                ("may", false, true),                   // inline italic
+                ("be protected.", false, false))),
+
+            (662.0, 11.0, Run(("A following paragraph of ordinary body weight for context.", false, false)))
+        });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        // The bold and italic spans inside the body line are wrapped; the surrounding prose is untouched.
+        result.Markdown.ShouldContain(
+            "The clause states the **Confidential** Information _may_ be protected.");
+        // The bold heading is a heading, not a bolded line: no ** inside the `#`.
+        result.Markdown.ShouldContain("# Confidentiality");
+        result.Markdown.ShouldNotContain("**Confidentiality**");
+    }
 }

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfFixtures.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfFixtures.cs
@@ -92,6 +92,46 @@ internal static class PdfFixtures
     }
 
     /// <summary>
+    /// Builds a single-page PDF from styled <b>lines</b>, where each line is a sequence of runs that each carry
+    /// their own weight and slant — needed to exercise inline emphasis (#403): a bold or italic run *inside* a body
+    /// line becomes <c>**…**</c> / <c>_…_</c>. Runs are auto-flowed left-to-right at the line's baseline, each
+    /// placed immediately after the previous run's pen position plus one space, so they read as a single continuous
+    /// line (a manual X gap wide enough to look like a column gutter would otherwise be split apart by the page
+    /// segmentation). Bold uses Helvetica-Bold, italic Helvetica-Oblique, both Helvetica-BoldOblique (the PostScript
+    /// names carry "Bold"/"Oblique", the run classifier's weight / slant signals).
+    /// </summary>
+    public static byte[] BuildStyledLines(
+        IReadOnlyList<(double BaselineY, double FontSize, IReadOnlyList<(string Text, bool Bold, bool Italic)> Runs)> lines)
+    {
+        var builder = new PdfDocumentBuilder();
+        var regular = builder.AddStandard14Font(Standard14Font.Helvetica);
+        var bold = builder.AddStandard14Font(Standard14Font.HelveticaBold);
+        var italic = builder.AddStandard14Font(Standard14Font.HelveticaOblique);
+        var boldItalic = builder.AddStandard14Font(Standard14Font.HelveticaBoldOblique);
+        var page = builder.AddPage(PageWidth, PageHeight);
+
+        foreach (var (baselineY, fontSize, runs) in lines)
+        {
+            var x = 50.0;
+            var spaceWidth = fontSize * 0.28; // ≈ Helvetica space advance (278/1000 em) — a word gap, not a gutter
+            foreach (var (text, isBold, isItalic) in runs)
+            {
+                var font = (isBold, isItalic) switch
+                {
+                    (true, true) => boldItalic,
+                    (true, false) => bold,
+                    (false, true) => italic,
+                    _ => regular
+                };
+                var letters = page.AddText(text, fontSize, new PdfPoint(x, baselineY), font);
+                x = letters[letters.Count - 1].EndBaseLine.X + spaceWidth;
+            }
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
     /// Builds a multi-page PDF — one page per inner list of (Text, baselineY) lines — needed to exercise the
     /// cross-page running header/footer detection (#383), which has no signal on a single page.
     /// </summary>

--- a/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfHeadingScale_Tests.cs
+++ b/core/test/Dignite.Extract.Parse.Pdf.Tests/PdfHeadingScale_Tests.cs
@@ -52,4 +52,13 @@ public class PdfHeadingScale_Tests
         PdfHeadingScale.IsBoldFont("BCDEEE+YuGothic-Regular").ShouldBeFalse();
         PdfHeadingScale.IsBoldFont(null).ShouldBeFalse();
     }
+
+    [Fact]
+    public void IsItalicFont_reads_the_slant_from_the_font_name()
+    {
+        PdfHeadingScale.IsItalicFont("Times-Italic").ShouldBeTrue();
+        PdfHeadingScale.IsItalicFont("Helvetica-Oblique").ShouldBeTrue();
+        PdfHeadingScale.IsItalicFont("BCDEEE+YuGothic-Regular").ShouldBeFalse();
+        PdfHeadingScale.IsItalicFont(null).ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## What

Second (and final) half of the #403 style-aware Markdown feature. PR #405 mapped **font size → heading levels**; this PR carries the source's **inline weight & slant** into the prose:

- A run of consecutive same-style words in a **body** line is wrapped `**bold**` / `_italic_` / `***both***`.
- **Heading** lines stay plain — the leading `#` already encodes the emphasis, so doubling it (`# **Title**`) would be noise.
- **Table cells** are unaffected: they never pass through the prose render path.

Concretely, the Japanese contract sample's bold draft-stamp now renders as `**契約書案**` instead of plain `契約書案`, while the title and `## 第1条…` headings stay clean.

## How

- `PdfHeadingScale.IsItalicFont(...)` — italic/oblique detection from the font name, mirroring the existing `IsBoldFont`.
- `PdfReadingOrder`:
  - `TextLine` gains a `StyledText` field — the line's Markdown with inline emphasis already applied.
  - `StyledLineText(words)` groups consecutive words of the same weight/slant into runs (weight/slant decided per word by a **majority-of-glyphs vote** on the font name), inline-escapes each run's content **exactly as the plain path would**, then wraps it in the emphasis markers. Runs are space-joined to match the plain line's word join — so only the *deliberate* markers stay live.
  - `Render` uses `StyledText` for body lines and the plain inline-escaped text for heading lines.

## Tests

- `PdfExtractor_Tests.Wraps_inline_bold_and_italic_runs_in_body_prose_but_not_in_a_heading` — end-to-end: a body line `regular → **bold** → regular → _italic_ → regular` round-trips through the real extractor; a bold heading line stays `# …` (no `**` inside). Verified to genuinely exercise the path (TEMP-VERIFY: disabling the styled-text branch makes it fail).
- New `PdfFixtures.BuildStyledLines(...)` auto-flows styled runs tightly along a baseline (measuring each run's pen end), so inline emphasis reads as one continuous line instead of being split into columns by page segmentation.
- `PdfHeadingScale_Tests.IsItalicFont_reads_the_slant_from_the_font_name`.

## Verification

- `Dignite.Extract.Parse.Pdf.Tests` — 79 passed
- `Dignite.Extract.Parse.Tests` — 82 passed
- `Dignite.Extract.Parse.Pdf` Release build — 0 warnings, 0 errors

Closes #403.
