### PR TITLE
fix(ocr-visionllm): keep document titles/headings out of the running-header exclusion (#409)

### DIFF
--- a/core/src/Dignite.Extract.Ocr.VisionLlm/VisionLlmOcrInstructions.cs
+++ b/core/src/Dignite.Extract.Ocr.VisionLlm/VisionLlmOcrInstructions.cs
@@ -13,14 +13,17 @@ internal static class VisionLlmOcrInstructions
     /// <summary>System role: defines the OCR transcription task and the anti-repetition rule.</summary>
     public const string SystemPrompt =
         "You are an OCR engine. Transcribe the text visible in the image into Markdown, exactly as it appears. " +
-        "Preserve document structure: Markdown headings for headings, Markdown tables for tabular data, and lists for lists. " +
+        "Preserve the document's visual structure in Markdown, using whichever constructs best fit what you see: Markdown headings for headings and titles, Markdown tables for tabular data, and lists for lists. " +
+        "Assign heading levels (#, ##, ###) that mirror the visual hierarchy — render the document's main title (a prominent, large, or centered title such as an invoice, report, or form name) as the top-level heading, with subordinate section titles beneath it. " +
         "For receipts, invoices, and forms, keep every line item, label, quantity, and amount — render line-item tables as a Markdown table (or list), aligning columns left to right. " +
         "Transcribe numbers, currency symbols, and dates verbatim. Do not compute totals, summarize, reorder, translate, or invent any content. " +
-        // #383: page chrome is mechanical noise that pollutes the body; drop it. This is a single-page,
-        // semantic judgment (the model sees one page at a time) — guarded by the explicit protection list
-        // below so body content at the page bottom is never sacrificed.
-        "Do NOT transcribe running page headers, running page footers, or standalone page numbers — for example a title or confidentiality/copyright line repeated at the very top or bottom edge of the page, or page numbering such as \"3\", \"- 3 -\", \"Page 3 of 10\", or \"第 3 页\". " +
-        "NEVER drop signatures, signature blocks, seals, stamps, company chops, total or subtotal amounts, or footnotes — these are body content and must be transcribed even when they sit at the very bottom of the page. " +
+        // #383 / #409: running page chrome (boilerplate repeated at the page edges) is mechanical noise that
+        // pollutes the body; drop it. This is a single-page, semantic judgment (the model sees one page at a
+        // time), so it must target only *repeated* boilerplate — never a one-off masthead. #409: the protection
+        // clause below now explicitly keeps the document title/headings, which a too-broad "drop the top line"
+        // reading was sacrificing on title-at-top forms (e.g. an invoice with 請求書 centered at the top edge).
+        "Do NOT transcribe running page headers, running page footers, or standalone page numbers — that is, boilerplate repeated at the very top or bottom edge of every page, for example a confidentiality, copyright, or filename line, or page numbering such as \"3\", \"- 3 -\", \"Page 3 of 10\", or \"第 3 页\". " +
+        "NEVER drop the document title or any heading, signatures, signature blocks, seals, stamps, company chops, total or subtotal amounts, or footnotes — these are body content: a one-off document title or heading is NOT a running header, so transcribe it as a Markdown heading even when it sits at the very top edge of the page, and keep content that sits at the very bottom. " +
         "Output ONLY the transcribed Markdown — no preamble, no commentary, no explanations, and do not wrap the whole output in a Markdown code fence. " +
         "Transcribe each piece of text exactly once; never repeat a line or block. " +
         "If the image contains no readable text, output nothing at all.";

--- a/core/test/Dignite.Extract.Ocr.VisionLlm.Tests/VisionLlmOcrInstructions_Tests.cs
+++ b/core/test/Dignite.Extract.Ocr.VisionLlm.Tests/VisionLlmOcrInstructions_Tests.cs
@@ -4,10 +4,12 @@ using Xunit;
 namespace Dignite.Extract.Ocr.VisionLlm;
 
 /// <summary>
-/// #383: guards the running header/footer + page-number exclusion in the OCR system prompt, and — more
-/// importantly — that it is paired with the explicit protection of page-bottom body content (signatures,
-/// seals, totals, footnotes). The prompt is the only lever on the VisionLlm path (single-page OCR cannot do
-/// cross-page detection), so the safety clause must not be silently dropped.
+/// #383 / #409: guards the running-header/footer + page-number exclusion in the OCR system prompt, and — more
+/// importantly — that it is paired with the explicit protection of the body content the exclusion must never
+/// eat: page-bottom content (signatures, seals, totals, footnotes) and, per #409, the document's own
+/// title/headings at the top edge (a one-off masthead is not a running header). #409 also pins the
+/// heading-level guidance that lets the model render visual hierarchy. The prompt is the only lever on the
+/// VisionLlm path (single-page OCR cannot do cross-page detection), so these clauses must not be silently dropped.
 /// </summary>
 public class VisionLlmOcrInstructions_Tests
 {
@@ -19,6 +21,9 @@ public class VisionLlmOcrInstructions_Tests
         prompt.ShouldContain("running page headers");
         prompt.ShouldContain("running page footers");
         prompt.ShouldContain("page numbers");
+        // #409: the exclusion must be framed as *repeated* (every-page) boilerplate, so it cannot be read as
+        // "drop the top line" and eat a one-off document title.
+        prompt.ShouldContain("edge of every page");
     }
 
     [Fact]
@@ -31,5 +36,28 @@ public class VisionLlmOcrInstructions_Tests
         prompt.ShouldContain("signature");
         prompt.ShouldContain("total");
         prompt.ShouldContain("footnotes");
+    }
+
+    [Fact]
+    public void System_prompt_protects_the_document_title_and_headings_at_the_top_edge()
+    {
+        var prompt = VisionLlmOcrInstructions.SystemPrompt;
+
+        // #409: a masthead title (e.g. 請求書 centered at the top of an invoice) must survive the running-header
+        // exclusion and be transcribed as a heading, not dropped as page chrome.
+        prompt.ShouldContain("NEVER drop the document title or any heading");
+        prompt.ShouldContain("very top edge of the page");
+    }
+
+    [Fact]
+    public void System_prompt_guides_the_model_to_assign_heading_levels()
+    {
+        var prompt = VisionLlmOcrInstructions.SystemPrompt;
+
+        // #409: let the model decide structure — but tell it to use heading levels reflecting visual hierarchy,
+        // with the main title as the top-level heading (the gap that left scanned-form titles as plain text).
+        prompt.ShouldContain("heading levels");
+        prompt.ShouldContain("#, ##, ###");
+        prompt.ShouldContain("top-level heading");
     }
 }


### PR DESCRIPTION
Fixes #409. OCR-path counterpart of #403 (which added heading detection on the digital PDF text path).

## Problem

A scanned, image-only invoice batch (Japanese 請求書) routes to the VisionLlm whole-page OCR fallback. Tables transcribe fine, but the **document title and form headings lose heading formatting** — the masthead `請求書` is dropped or flattened to plain text. For single-page OCR, `VisionLlmOcrInstructions.SystemPrompt` is the only lever, so this is a prompt defect:

1. The #383 running-header clause gave *"a title ... at the very top edge of the page"* as an example to drop, and the paired `NEVER drop` list omitted the title — so a one-off masthead was unprotected.
2. The heading instruction (*"Markdown headings for headings"*) was too thin: no heading-level guidance, under-triggers on scanned forms.

## Change (prompt only)

- Reframe the exclusion to target only **repeated** boilerplate (`edge of every page`; confidentiality / copyright / filename lines, page numbers) — the "a title" example is removed.
- Add **the document title / any heading** to the `NEVER drop` protection list, explicitly kept even at the very top edge of the page.
- Let the model **assign heading levels** (`#`, `##`, `###`) reflecting visual hierarchy, with the main title as the top-level heading (honours "let the AI decide the Markdown structure").

## Tests

`VisionLlmOcrInstructions_Tests` extended: existing #383 guards retained, plus new locks for (a) the title/heading protection at the top edge and (b) the heading-level guidance. Full project green (39/39).

## Boundaries

No change to `OcrResult` / `TextExtractionResult` / `Document` / egress DTOs; Markdown-first preserved (single text payload, no new field). The Parse.Pdf `PdfRunningHeaderFooter` mechanism is untouched.

## Validation note

`Document.Markdown` is write-once (no in-place re-OCR) — validating on a real document requires **re-uploading** a sample, not re-running extraction on the existing one.
