### PR TITLE
feat(documents): show title + upload date for duplicate candidates instead of #1 (#411)

### DIFF
--- a/angular/packages/extract/documents/src/lib/documents/document-detail/document-detail.component.html
+++ b/angular/packages/extract/documents/src/lib/documents/document-detail/document-detail.component.html
@@ -352,14 +352,19 @@
                           <span class="text-muted ms-1">{{ detail.missingFieldNames!.join('、') }}</span>
                         }
                         <!-- #411: suspected-duplicate candidates — open each to compare before allowing / discarding. -->
-                        @if (detail.duplicateCandidateDocumentIds?.length) {
-                          <span class="text-muted ms-1">
+                        @if (detail.duplicateCandidates?.length) {
+                          <div class="text-muted ms-1 mt-1">
                             {{ '::Document:ReviewReason:DuplicateCandidates' | abpLocalization }}
-                            @for (candidateId of detail.duplicateCandidateDocumentIds; track candidateId; let i = $index) {
-                              <button type="button" class="btn btn-link btn-sm p-0 ms-1 align-baseline"
-                                (click)="openDocument(candidateId)">#{{ i + 1 }}</button>
+                            @for (candidate of detail.duplicateCandidates; track candidate.id) {
+                              <button type="button" class="btn btn-link btn-sm p-0 ms-2 align-baseline text-start"
+                                (click)="openDocument(candidate.id!)">
+                                {{ candidate.title || candidate.fileName || candidate.id }}
+                                @if (candidate.creationTime) {
+                                  <span class="text-muted">· {{ candidate.creationTime | date:'yyyy-MM-dd' }}</span>
+                                }
+                              </button>
                             }
-                          </span>
+                          </div>
                         }
                       </div>
                     }

--- a/angular/packages/extract/src/lib/proxy/documents/models.ts
+++ b/angular/packages/extract/src/lib/proxy/documents/models.ts
@@ -66,6 +66,13 @@ export interface DocumentStatisticsDto {
   totalStorageBytes?: number;
 }
 
+export interface DuplicateCandidateDto {
+  id?: string;
+  title?: string | null;
+  fileName?: string | null;
+  creationTime?: string;
+}
+
 export interface FileOriginDto {
   uploadedByUserName?: string;
   originalFileName?: string | null;
@@ -100,7 +107,7 @@ export interface ReviewReasonDetailDto {
   reason?: DocumentReviewReasons;
   isBlocking?: boolean;
   missingFieldNames?: string[] | null;
-  duplicateCandidateDocumentIds?: string[] | null;
+  duplicateCandidates?: DuplicateCandidateDto[] | null;
 }
 
 export interface UpdateDocumentCabinetInput {

--- a/core/src/Dignite.Extract.Application.Contracts/Documents/DuplicateCandidateDto.cs
+++ b/core/src/Dignite.Extract.Application.Contracts/Documents/DuplicateCandidateDto.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Dignite.Extract.Documents;
+
+/// <summary>
+/// A duplicate-detection candidate surfaced to the operator (#411): another document suspected to be the same
+/// business entity (same layer + type + field fingerprint). Carries enough to recognize and open it — title (with
+/// <see cref="FileName"/> fallback when the title is empty) + upload time. Recomputed on read and hard-capped.
+/// </summary>
+public class DuplicateCandidateDto
+{
+    public Guid Id { get; set; }
+
+    public string? Title { get; set; }
+
+    public string? FileName { get; set; }
+
+    public DateTime CreationTime { get; set; }
+}

--- a/core/src/Dignite.Extract.Application.Contracts/Documents/ReviewReasonDetailDto.cs
+++ b/core/src/Dignite.Extract.Application.Contracts/Documents/ReviewReasonDetailDto.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Dignite.Extract.Documents;
@@ -9,7 +8,7 @@ namespace Dignite.Extract.Documents;
 /// <c>ReviewReasonPolicy</c>, so clients do not re-decide which reasons are blocking.
 /// <see cref="MissingFieldNames"/> is populated only for
 /// <see cref="DocumentReviewReasons.MissingRequiredFields"/> and contains display names of missing
-/// required fields. <see cref="DuplicateCandidateDocumentIds"/> is populated only for
+/// required fields. <see cref="DuplicateCandidates"/> is populated only for
 /// <see cref="DocumentReviewReasons.DuplicateSuspected"/> (#411).
 /// </summary>
 public class ReviewReasonDetailDto
@@ -24,9 +23,10 @@ public class ReviewReasonDetailDto
     public List<string>? MissingFieldNames { get; set; }
 
     /// <summary>
-    /// Ids of other documents suspected to be the same business entity (same layer + type + field fingerprint),
-    /// non-empty only for <see cref="DocumentReviewReasons.DuplicateSuspected"/> (#411). The operator follows these to
-    /// compare candidates side by side before allowing or discarding. Recomputed on read and hard-capped.
+    /// Other documents suspected to be the same business entity (same layer + type + field fingerprint), non-empty
+    /// only for <see cref="DocumentReviewReasons.DuplicateSuspected"/> (#411). Each carries a title / file name +
+    /// upload time so the operator can recognize and open it to compare before allowing or discarding. Recomputed on
+    /// read and hard-capped.
     /// </summary>
-    public List<Guid>? DuplicateCandidateDocumentIds { get; set; }
+    public List<DuplicateCandidateDto>? DuplicateCandidates { get; set; }
 }

--- a/core/src/Dignite.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Extract.Application/Documents/DocumentAppService.cs
@@ -906,7 +906,7 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
             {
                 Reason = DocumentReviewReasons.DuplicateSuspected,
                 IsBlocking = ReviewReasonPolicy.IsBlocking(DocumentReviewReasons.DuplicateSuspected),
-                DuplicateCandidateDocumentIds = await BuildDuplicateCandidateIdsAsync(document)
+                DuplicateCandidates = await BuildDuplicateCandidatesAsync(document)
             });
         }
 
@@ -944,24 +944,27 @@ public class DocumentAppService : ExtractAppService, IDocumentAppService
     }
 
     /// <summary>
-    /// #411: recomputes the duplicate-candidate document Ids for the detail page — other documents in the same layer +
-    /// type sharing this document's <see cref="Document.FieldFingerprint"/>. Computed on read (no separate storage),
-    /// hard-capped by <see cref="DocumentConsts.MaxDuplicateCandidates"/>, and tenant-/soft-delete-isolated by the
-    /// repository's ambient global filters. Returns empty when there is no fingerprint (defensive: a set
-    /// DuplicateSuspected reason normally implies one).
+    /// #411: recomputes the duplicate candidates for the detail page — other documents in the same layer + type
+    /// sharing this document's <see cref="Document.FieldFingerprint"/>, each projected with a title / file name +
+    /// upload time so the operator can recognize and open it. Computed on read (no separate storage), hard-capped by
+    /// <see cref="DocumentConsts.MaxDuplicateCandidates"/>, and tenant-/soft-delete-isolated by the repository's
+    /// ambient global filters. Returns empty when there is no fingerprint (defensive: a set DuplicateSuspected reason
+    /// normally implies one).
     /// </summary>
-    protected virtual async Task<List<Guid>> BuildDuplicateCandidateIdsAsync(Document document)
+    protected virtual async Task<List<DuplicateCandidateDto>> BuildDuplicateCandidatesAsync(Document document)
     {
         if (document.FieldFingerprint == null || !document.DocumentTypeId.HasValue)
         {
-            return new List<Guid>();
+            return new List<DuplicateCandidateDto>();
         }
 
-        return await _documentRepository.FindDuplicateCandidateIdsAsync(
+        var candidates = await _documentRepository.FindDuplicateCandidatesAsync(
             document.Id,
             document.DocumentTypeId.Value,
             document.FieldFingerprint,
             DocumentConsts.MaxDuplicateCandidates);
+
+        return ObjectMapper.Map<List<DuplicateCandidateModel>, List<DuplicateCandidateDto>>(candidates);
     }
 
     /// <summary>

--- a/core/src/Dignite.Extract.Application/Documents/Pipelines/FieldExtraction/FieldExtractionService.cs
+++ b/core/src/Dignite.Extract.Application/Documents/Pipelines/FieldExtraction/FieldExtractionService.cs
@@ -359,13 +359,13 @@ public class FieldExtractionService : ITransientDependency
             var duplicateSuspected = false;
             if (fingerprint != null && !document.DuplicateAllowed)
             {
-                var candidateIds = await _documentRepository.FindDuplicateCandidateIdsAsync(
+                var candidates = await _documentRepository.FindDuplicateCandidatesAsync(
                     document.Id,
                     documentTypeId,
                     fingerprint,
                     DocumentConsts.MaxDuplicateCandidates,
                     _cancellationTokenProvider.Token);
-                duplicateSuspected = candidateIds.Count > 0;
+                duplicateSuspected = candidates.Count > 0;
             }
 
             document.SetReviewReason(DocumentReviewReasons.DuplicateSuspected, duplicateSuspected);

--- a/core/src/Dignite.Extract.Application/ExtractApplicationMappers.cs
+++ b/core/src/Dignite.Extract.Application/ExtractApplicationMappers.cs
@@ -179,3 +179,14 @@ public partial class DocumentStatisticsToDtoMapper : MapperBase<DocumentStatisti
     public override partial DocumentStatisticsDto Map(DocumentStatisticsModel source);
     public override partial void Map(DocumentStatisticsModel source, DocumentStatisticsDto destination);
 }
+
+/// <summary>
+/// DuplicateCandidateModel -> DuplicateCandidateDto (#411). A flat scalar projection (Id / Title / FileName /
+/// CreationTime); all property names match 1:1 so Mapperly maps them directly with no lookup.
+/// </summary>
+[Mapper(RequiredMappingStrategy = RequiredMappingStrategy.Target)]
+public partial class DuplicateCandidateToDtoMapper : MapperBase<DuplicateCandidateModel, DuplicateCandidateDto>
+{
+    public override partial DuplicateCandidateDto Map(DuplicateCandidateModel source);
+    public override partial void Map(DuplicateCandidateModel source, DuplicateCandidateDto destination);
+}

--- a/core/src/Dignite.Extract.Domain/Documents/DuplicateCandidateModel.cs
+++ b/core/src/Dignite.Extract.Domain/Documents/DuplicateCandidateModel.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Dignite.Extract.Documents;
+
+/// <summary>
+/// Read-model for a duplicate-detection candidate (#411): a small Domain projection (not an entity) describing
+/// another document in the same layer + type that shares this document's <see cref="Document.FieldFingerprint"/>,
+/// returned by <see cref="IDocumentRepository.FindDuplicateCandidatesAsync"/>. Carries just enough for the operator
+/// to recognize and open the candidate — title (with file-name fallback) + upload time — without materializing the
+/// full Document row (notably <c>Markdown</c>). The Application layer maps it to <c>DuplicateCandidateDto</c>.
+/// </summary>
+public class DuplicateCandidateModel
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Display title (derived from Markdown); may be null for historical / not-yet-titled documents.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Original uploaded file name (from <c>FileOrigin</c>); null for derived sub-documents with no source blob.</summary>
+    public string? FileName { get; set; }
+
+    public DateTime CreationTime { get; set; }
+}

--- a/core/src/Dignite.Extract.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.Extract.Domain/Documents/IDocumentRepository.cs
@@ -17,19 +17,22 @@ public interface IDocumentRepository : IRepository<Document, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Duplicate-detection candidate query (#411): Ids of <b>other</b> documents in the current layer with the same
+    /// Duplicate-detection candidate query (#411): <b>other</b> documents in the current layer with the same
     /// <see cref="Document.DocumentTypeId"/> and the same <see cref="Document.FieldFingerprint"/> as the document
     /// being extracted. Two documents sharing a (type, fingerprint) are likely the same business entity re-uploaded.
+    /// Returns a lightweight <see cref="DuplicateCandidateModel"/> projection (Id + Title + file name + upload time)
+    /// so the operator can recognize each candidate without loading full rows; the field extraction stage uses only
+    /// the count to decide whether to flag <see cref="DocumentReviewReasons.DuplicateSuspected"/>.
     /// <para>
     /// <paramref name="documentId"/> (the document being checked) is excluded so a document never matches itself.
     /// <c>IMultiTenant</c> + <c>ISoftDelete</c> global filters apply automatically by ambient state, so the result
     /// stays within the document's own layer and excludes recycle-bin documents. The result is hard-capped at
     /// <paramref name="maxResults"/> (<c>DocumentConsts.MaxDuplicateCandidates</c>) — a fingerprint shared by many
-    /// documents never returns an unbounded set. Pure EF Core LINQ (equality on the indexed fingerprint column), no
-    /// raw SQL.
+    /// documents never returns an unbounded set. Pure EF Core LINQ (equality on the indexed fingerprint column,
+    /// projected with <c>AsNoTracking</c>), no raw SQL.
     /// </para>
     /// </summary>
-    Task<List<Guid>> FindDuplicateCandidateIdsAsync(
+    Task<List<DuplicateCandidateModel>> FindDuplicateCandidatesAsync(
         Guid documentId,
         Guid documentTypeId,
         string fieldFingerprint,

--- a/core/src/Dignite.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -51,7 +51,7 @@ public class EfCoreDocumentRepository
         }
     }
 
-    public virtual async Task<List<Guid>> FindDuplicateCandidateIdsAsync(
+    public virtual async Task<List<DuplicateCandidateModel>> FindDuplicateCandidatesAsync(
         Guid documentId,
         Guid documentTypeId,
         string fieldFingerprint,
@@ -61,7 +61,8 @@ public class EfCoreDocumentRepository
         // #411: other documents in the current layer sharing this (type, fingerprint). The default IMultiTenant +
         // ISoftDelete global filters are intentionally NOT disabled, so the result stays within the document's own
         // layer and excludes recycle-bin documents. Equality on the indexed FieldFingerprint column; AsNoTracking +
-        // Select(Id) avoids materializing rows / Markdown; Take is the fail-closed cap on a widely-shared fingerprint.
+        // a scalar projection (Id/Title/file name/upload time, no Markdown) keeps it light; Take is the fail-closed
+        // cap on a widely-shared fingerprint.
         var dbSet = await GetDbSetAsync();
         return await dbSet
             .AsNoTracking()
@@ -69,7 +70,13 @@ public class EfCoreDocumentRepository
                      && d.FieldFingerprint == fieldFingerprint
                      && d.Id != documentId)
             .OrderBy(d => d.CreationTime)
-            .Select(d => d.Id)
+            .Select(d => new DuplicateCandidateModel
+            {
+                Id = d.Id,
+                Title = d.Title,
+                FileName = d.FileOrigin != null ? d.FileOrigin.OriginalFileName : null,
+                CreationTime = d.CreationTime
+            })
             .Take(maxResults)
             .ToListAsync(GetCancellationToken(cancellationToken));
     }

--- a/core/test/Dignite.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionEventHandler_Tests.cs
+++ b/core/test/Dignite.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionEventHandler_Tests.cs
@@ -376,9 +376,9 @@ public class FieldExtractionEventHandler_Tests
         _workflow.ExtractAsync(Arg.Any<IReadOnlyList<FieldExtractionDescriptor>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<string, JsonElement?> { ["receipt_no"] = JsonDocument.Parse("\"R-001\"").RootElement });
         // A colliding document exists in the same layer + type.
-        _documentRepository.FindDuplicateCandidateIdsAsync(
+        _documentRepository.FindDuplicateCandidatesAsync(
                 doc.Id, TypeId("receipt.general"), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new List<Guid> { Guid.NewGuid() });
+            .Returns(new List<DuplicateCandidateModel> { new() { Id = Guid.NewGuid(), Title = "Existing receipt" } });
 
         await Extract(doc.Id, null, "receipt.general");
 
@@ -397,9 +397,9 @@ public class FieldExtractionEventHandler_Tests
             .Returns(new List<FieldDefinition> { CreateFieldDefinition("receipt.general", "receipt_no", FieldDataType.Text, isUniqueKey: true) });
         _workflow.ExtractAsync(Arg.Any<IReadOnlyList<FieldExtractionDescriptor>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<string, JsonElement?> { ["receipt_no"] = JsonDocument.Parse("\"R-001\"").RootElement });
-        _documentRepository.FindDuplicateCandidateIdsAsync(
+        _documentRepository.FindDuplicateCandidatesAsync(
                 doc.Id, TypeId("receipt.general"), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new List<Guid>());
+            .Returns(new List<DuplicateCandidateModel>());
 
         await Extract(doc.Id, null, "receipt.general");
 
@@ -424,7 +424,7 @@ public class FieldExtractionEventHandler_Tests
 
         (doc.ReviewReasons & DocumentReviewReasons.DuplicateSuspected).ShouldBe(DocumentReviewReasons.None);
         // The override short-circuits the collision query entirely.
-        await _documentRepository.DidNotReceive().FindDuplicateCandidateIdsAsync(
+        await _documentRepository.DidNotReceive().FindDuplicateCandidatesAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
@@ -453,7 +453,7 @@ public class FieldExtractionEventHandler_Tests
 
         doc.FieldFingerprint.ShouldBeNull();
         (doc.ReviewReasons & DocumentReviewReasons.DuplicateSuspected).ShouldBe(DocumentReviewReasons.None);
-        await _documentRepository.DidNotReceive().FindDuplicateCandidateIdsAsync(
+        await _documentRepository.DidNotReceive().FindDuplicateCandidatesAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryDuplicate_Tests.cs
+++ b/core/test/Dignite.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryDuplicate_Tests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace Dignite.Extract.EntityFrameworkCore.Documents;
 
 /// <summary>
-/// Real EF integration tests (SQLite) for <see cref="IDocumentRepository.FindDuplicateCandidateIdsAsync"/> (#411):
+/// Real EF integration tests (SQLite) for <see cref="IDocumentRepository.FindDuplicateCandidatesAsync"/> (#411):
 /// the duplicate-detection collision query. Verifies it matches other documents in the same layer + type sharing a
 /// fingerprint, excludes the document itself / different types / different fingerprints / soft-deleted documents, and
 /// honors the hard result cap.
@@ -48,9 +48,12 @@ public class EfCoreDocumentRepositoryDuplicate_Tests : ExtractEntityFrameworkCor
         });
 
         var candidates = await WithUnitOfWorkAsync(() =>
-            _documentRepository.FindDuplicateCandidateIdsAsync(self, TypeAId, "fp-1", maxResults: 20));
+            _documentRepository.FindDuplicateCandidatesAsync(self, TypeAId, "fp-1", maxResults: 20));
 
-        candidates.ShouldBe(new[] { collides });
+        candidates.Select(c => c.Id).ShouldBe(new[] { collides });
+        // The projection carries the recognizable fields the operator UI shows.
+        candidates[0].Title.ShouldBe("Title " + collides.ToString("N")[..8]);
+        candidates[0].FileName.ShouldBe("test.pdf");
     }
 
     [Fact]
@@ -70,7 +73,7 @@ public class EfCoreDocumentRepositoryDuplicate_Tests : ExtractEntityFrameworkCor
         await WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(collides));
 
         var candidates = await WithUnitOfWorkAsync(() =>
-            _documentRepository.FindDuplicateCandidateIdsAsync(self, TypeAId, "fp-1", maxResults: 20));
+            _documentRepository.FindDuplicateCandidatesAsync(self, TypeAId, "fp-1", maxResults: 20));
 
         candidates.ShouldBeEmpty();
     }
@@ -91,7 +94,7 @@ public class EfCoreDocumentRepositoryDuplicate_Tests : ExtractEntityFrameworkCor
         });
 
         var candidates = await WithUnitOfWorkAsync(() =>
-            _documentRepository.FindDuplicateCandidateIdsAsync(self, TypeAId, "fp-1", maxResults: 2));
+            _documentRepository.FindDuplicateCandidatesAsync(self, TypeAId, "fp-1", maxResults: 2));
 
         candidates.Count.ShouldBe(2);
     }
@@ -117,6 +120,7 @@ public class EfCoreDocumentRepositoryDuplicate_Tests : ExtractEntityFrameworkCor
                 fileSize: 1024,
                 originalFileName: "test.pdf"));
         doc.SetMarkdown("# Body");
+        doc.SetTitle("Title " + id.ToString("N")[..8]);
         // Assign the type first (ApplyAutomaticClassificationResult resets duplicate-detection state), then set the
         // fingerprint as the field extraction stage would.
         doc.ApplyAutomaticClassificationResult(documentTypeId, 0.99);


### PR DESCRIPTION
Follow-up UX polish for #411 (duplicate detection), merged in #412.

## Problem

In the duplicate-review panel, colliding documents were shown as opaque `#1 / #2` links — the operator couldn't tell which document each was without clicking through, because the review detail only carried candidate GUIDs.

## Change

Surface a recognizable label instead: **title (file-name fallback) + upload date**, e.g. `张三电子发票 · 06-24`.

- `IDocumentRepository.FindDuplicateCandidateIdsAsync` → `FindDuplicateCandidatesAsync`, returning a lightweight `DuplicateCandidateModel` projection `{ Id, Title, FileName, CreationTime }` (`AsNoTracking`, no Markdown loaded). The detection path in `FieldExtractionService` uses only `.Count` (unchanged behavior); the display path maps to a DTO.
- `ReviewReasonDetailDto.DuplicateCandidateDocumentIds` → `DuplicateCandidates` (`List<DuplicateCandidateDto>`); `DocumentAppService` maps via a new Mapperly mapper, following the existing `DocumentStatisticsModel → Dto` precedent.
- Angular: candidate links now render `{{ title || fileName || id }} · yyyy-MM-dd` and still open the document on click for side-by-side comparison.

## Tests

- EF `FindDuplicateCandidatesAsync` test now asserts the projection carries Title + FileName (plus the existing self/type/fingerprint/soft-delete/cap coverage).
- Service dup-detection test mocks return the model.

Local: Application 293 / EF Core 108 pass; Angular `nx build` + `nx lint` + `vitest` (5/5) pass.

> The review-detail DTO shape change is operator-UI-facing only (not an egress event contract), so no downstream consumer is affected.