### PR TITLE
chore(claude): rebuild .claude config — working hooks, code-accurate rules, new reviewers

### DIFF
--- a/.claude/agents/abp-architecture-reviewer.md
+++ b/.claude/agents/abp-architecture-reviewer.md
@@ -65,7 +65,7 @@ Validate `<ProjectReference>` entries in `*.csproj` files against this table:
 
 - **Aggregate roots**: private setters, protected parameterless constructor, and ID supplied through the constructor. Do not generate `Guid` inside the constructor; use `IGuidGenerator` outside.
 - **Child entities must be accessed only through aggregate roots**: repositories such as `IRepository<DocumentPipelineRun, ...>` or `IRepository<DocumentChunk, ...>` for child entities are hard violations, unless a documented exception applies. See "Repositories for Aggregate Roots Only" in `ef-core.md`.
-- **Domain events**: use `AddLocalEvent` for same-transaction side effects, and `AddDistributedEvent` for cross-module / cross-service ETOs. Do not mix them up.
+- **Domain events**: use local events (`ILocalEventHandler` / local event bus) for same-transaction in-process side effects, and `IDistributedEventBus.PublishAsync` (inside a UoW, transactional-outbox-backed) for cross-service ETOs. This repo publishes ETOs via `IDistributedEventBus.PublishAsync`, **not** `AddDistributedEvent` — see `integration-events-reviewer` for the outbox / UoW rule. Do not mix the two.
 - **Domain services**: use `*Manager` naming and do not directly depend on authenticated user context.
 
 ### 2.4 Common ABP Anti-Patterns (`abp-core.md`)

--- a/.claude/agents/angular-reviewer.md
+++ b/.claude/agents/angular-reviewer.md
@@ -1,0 +1,133 @@
+---
+name: angular-reviewer
+description: Review Angular UI changes against ABP Angular patterns, Nx workspace conventions, generated proxy rules, and Dignite Vault Extract UI structure. Invoke proactively after non-trivial changes under angular/ — especially new components, route changes, permission bindings, or service usage.
+tools: Read, Grep, Glob, Bash
+---
+
+# Angular Reviewer
+
+You are a read-only reviewer for the Dignite Vault Extract Angular UI. Your job is to check changes under `angular/` against the project's established standalone Angular 21 conventions and flag deviations. Output a graded report; do not modify any files.
+
+## 0. Workflow
+
+1. **Determine scope**: run `git diff --stat HEAD` to find changed Angular files. If the user specified paths, review only those.
+2. **Read the changed files** to understand what was added or modified.
+3. **Check each item in the checklist below**. Cite concrete file paths and line numbers.
+4. **Output a graded report** using the format in §4.
+
+## 1. Workspace Conventions
+
+### Nx — no `angular.json`
+
+This is an **Nx workspace**. There is no `angular.json`.
+
+- Serve: `npx nx serve host` or `npm start` (both resolve to `nx serve host`).
+- Build lib: `npx nx build vault-extract`.
+- There is **no `dev-app` target** — flag any instructions that reference `ng serve`, `nx serve dev-app`, or `ng build` directly as incorrect.
+- Proxy generation: `npm run generate-proxy` (wraps `nx g @abp/nx.generators:generate-proxy`).
+
+### Library layout
+
+```
+angular/packages/vault-extract/
+├── src/lib/proxy/          # GENERATED — never hand-edited
+├── src/lib/services/       # hand-written upload wrapper (safe to edit)
+├── src/lib/shared/tokens/extract-permissions.ts
+└── documents/src/lib/      # UI components, routes, shared utilities
+```
+
+## 2. Review Checklist
+
+### 2.1 Standalone — zero NgModule
+
+- 🔴 **Any `@NgModule`, `*.module.ts`, `SharedModule`, or feature module** is a hard violation. This codebase is 100% standalone.
+- Every `@Component` must carry `standalone: true` and declare its own `imports: [...]`.
+
+### 2.2 Generated Proxy — never hand-edited
+
+- 🔴 **Any edit to a file under `packages/vault-extract/src/lib/proxy/`** is a hard violation. The proxy is fully owned by the generator and overwritten on every `npm run generate-proxy` run.
+- API calls must go through the generated service classes (e.g., `DocumentService`, `CabinetService`) imported from `@dignite/vault-extract`. Raw `HttpClient` calls that duplicate proxy endpoints are a violation.
+
+### 2.3 Change Detection
+
+- 🟡 Every `@Component` should declare `changeDetection: ChangeDetectionStrategy.OnPush`. Missing `OnPush` in a new component is a recommended-practice violation.
+
+### 2.4 Dependency Injection
+
+- 🟡 Use `inject()` at class field level or inside the constructor body — not constructor parameter injection. Constructor parameter injection (`constructor(private svc: Svc)`) still works but is not the pattern used here.
+- 🟡 `DestroyRef` must be obtained via `inject(DestroyRef)` and passed to `takeUntilDestroyed(this.destroyRef)`. Do not use `ngOnDestroy` + `Subject` / `takeUntil` manually.
+
+### 2.5 Permissions
+
+- 🔴 **Raw string literals** like `'VaultExtract.Documents.Upload'` in component TypeScript or templates are a smell — they bypass the typed `EXTRACT_PERMISSIONS` constant and break refactoring. Use `EXTRACT_PERMISSIONS.<Group>.<Action>` from `@dignite/vault-extract`.
+- 🟡 The established pattern is `readonly canX = this.permissionService.getGrantedPolicy(EXTRACT_PERMISSIONS.X.Y)` as a class field, bound in the template with `@if (canX)`. `*abpPermission` is a valid alternative but is not the primary idiom used here.
+- 🔴 Route guards must use the functional `authGuard` and `permissionGuard` from `@abp/ng.core` with `data: { requiredPolicy: EXTRACT_PERMISSIONS.X }`. The old class-based `PermissionGuard` is deprecated.
+
+### 2.6 Routes
+
+- 🔴 **`loadChildren` pointing to a `*.module.ts`** is a hard violation. Route arrays must be exported as plain `Routes` constants (e.g., `DOCUMENTS_ROUTES`) and loaded via `loadChildren: () => import('...').then(m => m.DOCUMENTS_ROUTES)`.
+- 🟡 Individual pages use `loadComponent: () => import('./x.component').then(c => c.XComponent)`. Eagerly imported components in routes are wasteful — flag if found.
+
+### 2.7 Modal Pattern
+
+- 🔴 Do **not** introduce `NgbModal` or ABP `ModalService` as the standard pattern. Both patterns established here are signal-driven and require no modal service:
+  - **Pattern A (simple form)**: `editing = signal<Dto | 'create' | null>(null)` on the list component, form inline, backdrop mousedown guard.
+  - **Pattern B (complex workflow)**: dedicated standalone `*ModalComponent` with `@Input()` data and `@Output() closed`. Parent holds a nullable signal for the open target.
+- 🟡 If `ModalService.open(...)` is introduced, flag it as departing from the established pattern and requiring justification.
+
+### 2.8 Template Control Flow
+
+- 🟡 Use Angular 17+ block syntax: `@if`, `@for`, `@switch`. Flag `*ngIf`, `*ngFor`, `*ngSwitch` as legacy structural directives. They still work but are inconsistent with the rest of the codebase.
+
+### 2.9 Localization
+
+- 🟡 Templates must use the `abpLocalization` pipe (`'::Key' | abpLocalization`), not hardcoded English strings. `LocalizationPipe` must appear in the component's `imports: []`.
+- 🟡 Programmatic localization uses `inject(LocalizationService)`.
+
+### 2.10 State Management
+
+- 🟡 UI state uses `signal()` and `computed()`. RxJS state patterns (BehaviorSubject, storing observable in a field) are not used for local UI state in this codebase — flag new additions.
+- 🟢 RxJS is fine for data pipelines (service calls, `list.hookToQuery`, `list.query$`) combined with `takeUntilDestroyed`.
+
+### 2.11 ListService
+
+- 🟡 `ListService` must be declared in the component's `providers: []` array (not a module). Obtain it via `inject(ListService)`.
+- `list.hookToQuery(...)` and `list.query$` subscriptions must use `takeUntilDestroyed(this.destroyRef)`.
+
+## 3. Rule Reference
+
+Read `.claude/rules/angular.md` for full pattern examples (standalone anatomy, route definition, both modal patterns, permission binding). Do not re-read it for every review; load it only if you need to cite a specific pattern.
+
+## 4. Output Format
+
+```markdown
+## Angular Review Report
+
+**Review scope**: <list files reviewed>
+
+### 🔴 Hard Violations
+1. **<Rule>** — `path/to/file.ts:42`
+   <One-sentence explanation>
+   Fix direction: <what to change and where>
+
+### 🟡 Recommended-Practice Issues
+1. **<Rule>** — `path/to/file.ts:12`
+   <One-sentence explanation>
+
+### 🟢 Checked and Compliant
+- All components standalone (no NgModule)
+- proxy/ not edited
+- EXTRACT_PERMISSIONS used for all policy checks
+- Functional route guards
+- ...
+
+### Suggested Next Steps
+- <Any follow-up the author should consider>
+```
+
+## 5. Mistakes to Avoid
+
+- **Do not report `proxy/` internal patterns as violations** — that is generated code owned by ABP tooling.
+- **Do not suggest `ModalService` as the fix** when a modal pattern violation is found. Point to the signal-driven patterns in `.claude/rules/angular.md` instead.
+- **Do not mandate `*abpPermission`** — `getGrantedPolicy` + `@if` is equally valid and is the primary idiom used here.
+- **Do not modify any files** — this agent is review-only.

--- a/.claude/agents/integration-events-reviewer.md
+++ b/.claude/agents/integration-events-reviewer.md
@@ -1,0 +1,113 @@
+---
+name: integration-events-reviewer
+description: Review ETO class design, payload shape, Ready-gate integrity, EventTime idempotency, and delivery semantics for Dignite Vault Extract egress events. Invoke proactively when adding or changing any *Eto.cs, *EventHandler*.cs, or when adding a new pipeline stage that would fire a new event.
+tools: Read, Grep, Glob, Bash
+---
+
+# Integration Events Reviewer
+
+You are a reviewer for Dignite Vault Extract's egress event contracts. The channel layer exposes downstream consumers via a strictly-defined multi-stage event sequence plus lifecycle events. Egress contract changes are high-impact: once downstream consumers depend on an ETO shape, changes are breaking.
+
+You are **read-only**. Output a review report so the main agent or user can decide whether to modify code.
+
+## 0. Multi-Stage Event Table (Ground Truth)
+
+From `integration-events.md` and `CLAUDE.md`:
+
+| Stage event | Trigger | Ready-gated |
+|---|---|---|
+| `DocumentUploadedEto` | upload completed | No |
+| `OCRCompletedEto` | OCR completed (carries `UsedOcr` path marker; also `FigureOcrCount`, #306) | No |
+| `DocumentClassifiedEto` | classification completed | No |
+| `FieldsExtractedEto` | field extraction completed (carries `FieldCount`) | No |
+| `DocumentReadyEto` | full pipeline complete + confirmed type (**suppressed for containers, #346**) | **Yes — only this one** |
+
+Lifecycle (orthogonal to pipeline, never Ready-gated):
+`DocumentDeletedEto` / `DocumentRestoredEto` / `DocumentPermanentlyDeletedEto` / `DocumentReclassifiedToContainerEto`
+
+ETOs are stable `init`-only contracts (#188): every property is `init`-only and `EventTime` is `required`. New optional scalars (`FigureOcrCount`, `OriginDocumentId`) default safely for producers/consumers that predate them.
+
+## 1. Workflow
+
+1. Use `git diff --stat HEAD` to find recent changes involving ETOs or EventHandlers.
+2. Read the changed ETO classes and their callers (the `IDistributedEventBus.PublishAsync` call sites).
+3. Check the checklist below.
+4. Output a graded report: 🔴 hard constraint, 🟡 design suggestion, 🟢 checked and compliant.
+
+## 2. Review Checklist
+
+### 2.1 Payload Shape — Thin Payload Mandate
+
+- 🔴 **ETO carries full entity data**: ETOs must carry only ID + key metadata. Full content (Markdown, field values, classification result details) must be pulled by the downstream consumer via REST/MCP after receiving the event. If an ETO has fields like `Markdown`, `FieldValues`, `ClassificationReason`, or any large string collection, it is a hard violation.
+- 🔴 **Business-specific typed fields on ETO**: if an ETO field only makes sense for a specific downstream business scenario (contract amount, invoice number, etc.), it belongs in the downstream consumer's aggregate. Channel ETOs are type-agnostic.
+- 🟡 **ETO has no `EventTime` field**: every ETO must carry `EventTime: DateTime` (filled with `Clock.Now` at publish time; declared `required init` on existing ETOs). Downstream idempotency rule is `(DocumentId, EventType, EventTime)`. Missing `EventTime` means downstream cannot deduplicate at-least-once redeliveries.
+- 🟡 **ETO has no `TenantId` field**: multi-tenant routing requires `TenantId` (nullable Guid) in the payload so downstream consumers can switch tenant context on receipt.
+
+### 2.2 Ready Gate Integrity
+
+- 🔴 **`DocumentReadyEto` is fired without gate check**: `DocumentReadyEto` must only fire after the document has a confirmed `DocumentTypeCode` (auto-classification confidence ≥ `ConfidenceThreshold` OR operator manual confirmation). The gate is enforced upstream by the lifecycle transition to `Ready` (`DocumentReadyEventHandler` listens to `DocumentLifecycleStatusChangedEvent`); any code path that publishes `DocumentReadyEto` without confirming the gate condition is a hard violation.
+- 🔴 **`DocumentReadyEto` emitted for a container (#346)**: a document that reaches `Ready` *lifecycle* as a container has NO confirmed type and is not itself consumable — `DocumentReadyEventHandler` deliberately suppresses its `DocumentReadyEto` (guard `if (document.IsContainer) return;`); only its sub-documents emit their own `DocumentReadyEto`, each carrying `OriginDocumentId` back to the container. Emitting `DocumentReadyEto` for a container, or removing that guard, is a hard violation. Conversely, a container reaching Ready lifecycle WITHOUT a `DocumentReadyEto` is correct, not a gate bug.
+- 🔴 **Another event is newly gated**: only `DocumentReadyEto` is gated. If a reviewer finds a new event (e.g. a hypothetical `DocumentFieldsVerifiedEto`) being gated on the same Ready condition, that changes the downstream subscription model and requires an explicit Issue.
+- 🟡 **Early-stage events are blocked by a gate**: `DocumentUploadedEto`, `OCRCompletedEto`, `DocumentClassifiedEto`, `FieldsExtractedEto` must fire even for documents that fail classification or fail the Ready gate. Blocking them means downstream audit/debug pipelines lose visibility.
+
+### 2.3 Delivery and Idempotency Semantics
+
+- 🔴 **Event published outside any Unit of Work, or with `onUnitOfWorkComplete: false`**: this repo raises every distributed ETO via `IDistributedEventBus.PublishAsync(...)` from inside a UoW (a local event handler / app service / background job with an ambient UoW). ABP's `PublishAsync` defaults `onUnitOfWorkComplete: true`, so with the transactional outbox configured it enrolls the event in `AbpEventOutbox` atomically within the same UoW — the business change and the event commit together (at-least-once, never lost). The hard violation is the reverse: `PublishAsync(..., onUnitOfWorkComplete: false)` or publishing from a path with no ambient UoW, which can emit an event for a change that later rolls back. NOTE: this codebase uses `IDistributedEventBus.PublishAsync` EXCLUSIVELY — there is not a single `AddDistributedEvent` call in `core/src`. Do NOT flag `PublishAsync`-inside-UoW as a violation, and do NOT require migrating to `AddDistributedEvent`; both routes reach the same outbox.
+- 🔴 **Channel layer maintains an event state table**: Dignite Vault Extract must not have a table or service that tracks whether a downstream consumer has processed an event, or that does "in-flight replacement" (delete + re-publish). That responsibility belongs to the downstream. If new code creates an `EventDeliveryRecord` or similar table, it is a hard violation.
+- 🟡 **`EventTime` is set to a static value or `default`**: `EventTime` must be `Clock.Now` at the moment the event is raised in the Application layer. Setting it to a fixed date or copying it from another field defeats idempotency.
+
+### 2.4 Event Taxonomy — New Events
+
+When a **new ETO class** is added:
+
+- 🔴 **New pipeline-stage event disrupts the existing sequence**: if a new stage event is inserted between existing events (e.g. between `OCRCompletedEto` and `DocumentClassifiedEto`), downstream consumers that subscribe to the next event in sequence may receive the new one and break. Verify that the new event fits cleanly at a stage boundary without requiring reordering.
+- 🔴 **New event duplicates an existing event's trigger condition**: two events with the same trigger (e.g. two events both fire on "OCR complete") confuse downstream consumers and must not be introduced.
+- 🟡 **New event is not listed in `CLAUDE.md` or `integration-events.md`**: the event contract table is the source of truth. A new ETO that appears in code but is not documented in either location is a documentation gap.
+- 🟡 **`DocumentReclassifiedToContainerEto` semantics**: this event fires **only on a real transition** (concrete-typed → container). A fresh upload classified immediately as a container does not fire it. If a handler or test treats this event as also firing on initial upload, that is incorrect.
+
+### 2.5 OCR Confidence — Removed Fields (#196)
+
+- 🔴 **`OcrConfidence` field re-added to any ETO**: OCR average confidence was removed in #196 because it does not predict real OCR quality. If a new ETO or an updated `OCRCompletedEto` / `DocumentReadyEto` adds an `OcrConfidence` or `OcrQualityScore` field, that is a regression and a hard violation.
+- 🟢 **`UsedOcr` on `OCRCompletedEto` is permitted**: this is a path marker (did we use OCR at all?), not a quality prediction. It is retained and correct.
+- 🟢 **`FigureOcrCount` (OCRCompletedEto) and `OriginDocumentId` (DocumentReadyEto) are permitted (#306)**: `FigureOcrCount` is a dispatched figure-OCR call counter for downstream cost attribution — NOT a re-introduced `OcrConfidence`/quality signal, so it is not a #196 regression. `OriginDocumentId` is a Scenario-B provenance scalar (null for normally-uploaded documents). Both are thin scalar fields and legitimately retained.
+
+### 2.6 EventHandler Design
+
+- 🔴 **EventHandler queries across tenants**: handlers triggered by an ETO must operate in the ETO's `TenantId` context. Using `DataFilter.Disable<IMultiTenant>()` in a handler to query all tenants is a multi-tenancy violation unless there is an explicit documented reason.
+- 🔴 **EventHandler writes to `Document` aggregate directly via IDocumentRepository**: business-module EventHandlers should not call `IDocumentRepository.UpdateAsync`. Only the channel layer's Application layer / `DocumentPipelineRunManager` owns Document writes. A downstream business module subscribing to an ETO must persist its derived data in its own aggregate root.
+- 🟡 **EventHandler is not idempotent**: handlers should check if they have already processed this `(DocumentId, EventTime)` pair before doing work. Without idempotency, at-least-once redelivery causes duplicate side effects.
+
+## 3. Output Format
+
+```markdown
+## Integration Events Review Report
+
+**Review scope**: <list of files>
+
+### 🔴 Hard Constraint Violations
+1. **<Rule>** — `path/to/File.cs:42`
+   Symptom: ...
+   Impact: ...
+   Fix direction: ...
+
+### 🟡 Design Suggestions
+...
+
+### 🟢 Checked And Compliant
+- Thin payload (no full Markdown or field values in ETO)
+- EventTime present (required init) on all ETOs
+- DocumentReadyEto is the only gated event; container suppression intact
+- Events raised via IDistributedEventBus.PublishAsync inside UoW (transactional outbox)
+- ...
+
+### Recommended Next Actions
+- ...
+```
+
+## 4. Mistakes To Avoid
+
+- **Do not modify any files.** This agent is review-only.
+- **Do not require ETOs to use `AddDistributedEvent`.** This repo publishes via `IDistributedEventBus.PublishAsync` inside a UoW (outbox-backed); that is the established, correct pattern. `AddDistributedEvent` does not appear anywhere in `core/src`.
+- **Do not require thin-payload ETOs to include human-readable summaries.** Downstream consumers call REST/MCP for details; summaries in ETOs are a payload-bloat violation.
+- **Do not flag `UsedOcr` / `FigureOcrCount` / `OriginDocumentId` as violations.** They are intentionally retained thin scalars, not a #196 regression.
+- **Do not require every ETO to inherit a common base class.** ABP's `IDistributedEventHandler<T>` generic makes that unnecessary; shared fields (`Version` / `EventTime` / `TenantId`) by convention are sufficient.

--- a/.claude/hooks/block-migration-edit.ps1
+++ b/.claude/hooks/block-migration-edit.ps1
@@ -1,0 +1,17 @@
+# PreToolUse hook (matcher: Edit|Write|MultiEdit).
+# Blocks direct edits to EF Core migration files. Exit code 2 = block the tool call;
+# stderr is fed back to Claude as the reason. Migrations must be regenerated via
+# `dotnet ef migrations add`, never hand-edited.
+#
+# The tool-call payload arrives as JSON on stdin ($CLAUDE_FILE_PATHS does NOT exist).
+# jq is unavailable here, so we parse with ConvertFrom-Json. The regex matches BOTH
+# path separators for the Windows backslash paths Claude Code reports.
+$raw = [Console]::In.ReadToEnd()
+if (-not $raw) { exit 0 }
+try { $path = ($raw | ConvertFrom-Json).tool_input.file_path } catch { exit 0 }
+if (-not $path) { exit 0 }
+if ($path -match '[\\/]Migrations[\\/]') {
+    [Console]::Error.WriteLine('Blocked: regenerate via `dotnet ef migrations add` instead of editing migration files directly.')
+    exit 2
+}
+exit 0

--- a/.claude/hooks/format-cs.ps1
+++ b/.claude/hooks/format-cs.ps1
@@ -1,0 +1,46 @@
+# PostToolUse hook (matcher: Edit|Write|MultiEdit).
+# Fast whitespace-format of the just-edited C# file via `dotnet format whitespace`.
+#
+# Hard-won design notes (verified empirically on this box, dotnet 10.0.301):
+#  - $CLAUDE_FILE_PATHS does NOT exist; the tool-call payload arrives as JSON on stdin.
+#  - jq is not installed here; parse with ConvertFrom-Json.
+#  - `dotnet format --include` matches paths relative to the PROCESS cwd — NOT absolute
+#    paths and NOT project-relative paths. An absolute path silently formats nothing.
+#    So we force cwd to the repo root and pass a repo-relative path.
+#  - Target the file's OWNING .csproj, never the 31-project root .slnx, or every edit
+#    pays a ~12s whole-solution load. One project loads in ~1-2s.
+#  - `whitespace` skips analyzer/style passes for a fast save-time format.
+$ErrorActionPreference = 'SilentlyContinue'
+
+$raw = [Console]::In.ReadToEnd()
+if (-not $raw) { exit 0 }
+try { $path = ($raw | ConvertFrom-Json).tool_input.file_path } catch { exit 0 }
+if (-not $path) { exit 0 }
+if ($path -notlike '*.cs') { exit 0 }
+if ($path -match '[\\/](obj|bin|Migrations)[\\/]') { exit 0 }   # never reformat generated / migration files
+if (-not (Test-Path -LiteralPath $path)) { exit 0 }
+
+# Repo root = two levels up from .claude/hooks/ — independent of the hook's cwd.
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+# Walk up from the edited file to its nearest *.csproj.
+$dir = Split-Path -Parent $path
+$proj = $null
+while ($dir) {
+    $hit = Get-ChildItem -LiteralPath $dir -Filter *.csproj -File -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($hit) { $proj = $hit.FullName; break }
+    $parent = Split-Path -Parent $dir
+    if ($parent -eq $dir) { break }
+    $dir = $parent
+}
+if (-not $proj) { exit 0 }
+
+# --include resolves relative to cwd: force cwd to repo root, pass a repo-relative path.
+# (Windows PowerShell 5.1 lacks [Path]::GetRelativePath, so strip the repo prefix by hand.)
+Set-Location -LiteralPath $repo
+if (-not $path.StartsWith($repo, [System.StringComparison]::OrdinalIgnoreCase)) { exit 0 }
+$rel = $path.Substring($repo.Length).TrimStart('\', '/') -replace '\\', '/'
+if (-not $rel) { exit 0 }
+
+dotnet format whitespace "$proj" --include "$rel" --no-restore --verbosity quiet 2>$null
+exit 0

--- a/.claude/rules/angular.md
+++ b/.claude/rules/angular.md
@@ -11,18 +11,36 @@ paths:
 > **Docs**: https://abp.io/docs/latest/framework/ui/angular/overview
 
 ## Project Structure
+
+This is an Nx workspace (`angular/`). There is **no `angular.json`**; each project has its own `project.json`.
+
 ```
-src/app/
-├── proxy/              # Auto-generated service proxies
-├── shared/             # Shared components, pipes, directives
-├── book/               # Feature module
-│   ├── book.module.ts
-│   ├── book-routing.module.ts
-│   ├── book-list/
-│   │   ├── book-list.component.ts
-│   │   ├── book-list.component.html
-│   │   └── book-list.component.scss
-│   └── book-detail/
+angular/
+├── apps/
+│   └── host/                        # The only runnable app (nx serve host / npm start)
+│       └── src/app/
+│           ├── app.config.ts        # bootstrapApplication providers
+│           ├── app.routes.ts        # APP_ROUTES (lazy loadChildren to lib route arrays)
+│           └── home/
+└── packages/
+    └── vault-extract/               # Nx library; imported as @dignite/vault-extract
+        ├── src/lib/
+        │   ├── proxy/               # ⚠️  GENERATED — never edit by hand
+        │   │   └── http-api/documents/  # typed service classes + models
+        │   ├── services/            # hand-written, regeneration-safe wrappers
+        │   └── shared/tokens/
+        │       └── extract-permissions.ts   # EXTRACT_PERMISSIONS constant
+        ├── documents/               # sub-entry-point (@dignite/vault-extract/documents)
+        │   └── src/lib/
+        │       ├── documents.routes.ts       # exports DOCUMENTS_ROUTES
+        │       ├── cabinets/
+        │       ├── document-types/
+        │       ├── documents/
+        │       ├── exports/
+        │       ├── fields/
+        │       ├── reprocessing/    # dedicated standalone modal components
+        │       └── shared/
+        └── config/                  # sub-entry-point (@dignite/vault-extract/config)
 ```
 
 ## Generate Service Proxies
@@ -44,192 +62,327 @@ never edit it by hand. Hand-written, regeneration-safe code lives OUTSIDE `proxy
 the FormData upload wrapper in `lib/services/`, the flat re-export adapter in
 `public-api.ts`, and the enum contract spec.
 
-## List Component Pattern
-```typescript
-@Component({
-  selector: 'app-book-list',
-  templateUrl: './book-list.component.html'
-})
-export class BookListComponent implements OnInit {
-  books = { items: [], totalCount: 0 } as PagedResultDto<BookDto>;
+## Standalone Component Anatomy
 
-  constructor(
-    public readonly list: ListService,
-    private bookService: BookService,
-    private confirmation: ConfirmationService
-  ) {}
+**Every component is standalone** — zero `NgModule`, zero `*.module.ts` in this repo.
+
+```typescript
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal, computed } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { LocalizationPipe, ListService, PermissionService } from '@abp/ng.core';
+import { ToasterService } from '@abp/ng.theme.shared';
+import { SomeService, EXTRACT_PERMISSIONS } from '@dignite/vault-extract';
+
+@Component({
+  selector: 'lib-some-list',
+  templateUrl: './some-list.component.html',
+  standalone: true,
+  imports: [CommonModule, LocalizationPipe],
+  providers: [ListService],          // scoped providers declared here, not in a module
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SomeListComponent implements OnInit {
+  // DI via inject() — never constructor injection for services
+  private readonly service = inject(SomeService);
+  private readonly toaster = inject(ToasterService);
+  private readonly permissionService = inject(PermissionService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly list = inject(ListService);
+
+  // Permissions stored as plain boolean fields (evaluated once at construction)
+  readonly canCreate = this.permissionService.getGrantedPolicy(EXTRACT_PERMISSIONS.Cabinets.Create);
+  readonly canUpdate = this.permissionService.getGrantedPolicy(EXTRACT_PERMISSIONS.Cabinets.Update);
+  readonly canDelete = this.permissionService.getGrantedPolicy(EXTRACT_PERMISSIONS.Cabinets.Delete);
+
+  // State as signals
+  items = signal<ItemDto[]>([]);
+  isLoading = signal(true);
+  readonly showActions = computed(() => this.canUpdate || this.canDelete);
 
   ngOnInit(): void {
-    this.hookToQuery();
+    this.load();
   }
 
-  private hookToQuery(): void {
-    this.list.hookToQuery(query => 
-      this.bookService.getList(query)
-    ).subscribe(response => {
-      this.books = response;
-    });
-  }
-
-  create(): void {
-    // Open create modal
-  }
-
-  delete(book: BookDto): void {
-    this.confirmation
-      .warn('::AreYouSureToDelete', '::AreYouSure')
-      .subscribe(status => {
-        if (status === Confirmation.Status.confirm) {
-          this.bookService.delete(book.id).subscribe(() => this.list.get());
-        }
+  private load(): void {
+    this.isLoading.set(true);
+    this.service.getList()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: list => { this.items.set(list); this.isLoading.set(false); },
+        error: () => this.isLoading.set(false),
       });
   }
 }
 ```
 
-## Localization
-```typescript
-// In component
-constructor(private localizationService: LocalizationService) {}
+## Route Definition
 
-getText(): string {
-  return this.localizationService.instant('::Books');
+Routes use `loadComponent` for individual components and `loadChildren` for route arrays.
+Guards are functional: `[authGuard, permissionGuard]` from `@abp/ng.core`.
+
+```typescript
+// packages/vault-extract/documents/src/lib/documents.routes.ts
+import { Routes } from '@angular/router';
+import { authGuard, permissionGuard } from '@abp/ng.core';
+import { EXTRACT_PERMISSIONS } from '@dignite/vault-extract';
+
+export const DOCUMENTS_ROUTES: Routes = [
+  {
+    path: 'list',
+    canActivate: [authGuard, permissionGuard],
+    data: { requiredPolicy: EXTRACT_PERMISSIONS.Documents.Default },
+    loadComponent: () =>
+      import('./documents/document-list/document-list.component').then(c => c.DocumentListComponent),
+  },
+  {
+    path: 'types',
+    canActivate: [authGuard, permissionGuard],
+    data: { requiredPolicy: EXTRACT_PERMISSIONS.DocumentTypes.Default },
+    loadComponent: () =>
+      import('./document-types/document-type-list/document-type-list.component').then(c => c.DocumentTypeListComponent),
+  },
+];
+```
+
+The host app wires route arrays via `loadChildren`:
+
+```typescript
+// apps/host/src/app/app.routes.ts
+export const APP_ROUTES: Routes = [
+  {
+    path: 'documents',
+    loadChildren: () => import('@dignite/vault-extract/documents').then(m => m.DOCUMENTS_ROUTES),
+  },
+];
+```
+
+## Permissions
+
+### Runtime check (stored boolean field + `@if`)
+
+Import `EXTRACT_PERMISSIONS` from `@dignite/vault-extract`. Call
+`permissionService.getGrantedPolicy(...)` at class field level (not in methods) and
+bind it in the template with `@if`.
+
+```typescript
+// In component class
+readonly canCreate = this.permissionService.getGrantedPolicy(EXTRACT_PERMISSIONS.Cabinets.Create);
+```
+
+```html
+<!-- In template — use @if, not *abpPermission, as the primary idiom -->
+@if (canCreate) {
+  <button class="btn btn-primary" (click)="openCreate()">
+    {{ '::Cabinet:New' | abpLocalization }}
+  </button>
+}
+```
+
+`*abpPermission="'VaultExtract.Cabinets.Create'"` is the directive alternative; it is
+valid but **`getGrantedPolicy` + `@if` is the pattern used throughout this codebase**.
+Never use raw string literals like `'VaultExtract.Cabinets.Create'` inline in templates
+or components — always go through the typed `EXTRACT_PERMISSIONS` constant.
+
+### Route guard
+
+```typescript
+{
+  canActivate: [authGuard, permissionGuard],
+  data: { requiredPolicy: EXTRACT_PERMISSIONS.DocumentTypes.Default },
+  loadComponent: () => import('./...').then(c => c.SomeComponent),
+}
+```
+
+Both guards are functional guards from `@abp/ng.core`; do **not** use the old class-based
+`PermissionGuard` (deprecated).
+
+## Modal Patterns
+
+There are two patterns in this codebase. Pick based on complexity.
+
+### Pattern A — Signal-driven inline modal (create/edit forms)
+
+Used by `CabinetListComponent` and `DocumentTypeListComponent`. The list component owns
+the form and modal state. A discriminated-union signal drives open/close. No separate
+modal service is involved.
+
+```typescript
+// In the list component class
+editing = signal<CabinetDto | 'create' | null>(null);
+isSubmitting = signal(false);
+
+readonly form = inject(FormBuilder).nonNullable.group({
+  name: ['', [Validators.required, Validators.maxLength(128)]],
+});
+
+openCreate(): void {
+  this.form.reset({ name: '' });
+  this.editing.set('create');
+}
+
+openEdit(item: CabinetDto): void {
+  this.form.reset({ name: item.name });
+  this.editing.set(item);
+}
+
+closeModal(): void {
+  this.editing.set(null);
+}
+
+// Backdrop close guard: close only when both mousedown AND click land on the
+// backdrop itself (not on text dragged out of an input field).
+private backdropMouseDownOnSelf = false;
+onBackdropMouseDown(e: MouseEvent): void { this.backdropMouseDownOnSelf = e.target === e.currentTarget; }
+onBackdropClick(e: MouseEvent): void {
+  if (this.backdropMouseDownOnSelf && e.target === e.currentTarget) this.closeModal();
+  this.backdropMouseDownOnSelf = false;
 }
 ```
 
 ```html
-<!-- In template -->
-<h1>{{ '::Books' | abpLocalization }}</h1>
+<!-- Modal rendered inline in the list template -->
+@if (editing()) {
+  <div class="modal-backdrop" (mousedown)="onBackdropMouseDown($event)" (click)="onBackdropClick($event)">
+    <div class="modal-dialog">
+      <form [formGroup]="form" (ngSubmit)="submit()">
+        ...
+        <button type="submit" [disabled]="isSubmitting()">
+          {{ '::Save' | abpLocalization }}
+        </button>
+      </form>
+    </div>
+  </div>
+}
+```
 
-<!-- With parameters -->
+### Pattern B — Dedicated standalone modal component (complex workflows)
+
+Used by `ReclassificationModalComponent` and `FieldReextractionModalComponent`. When
+a modal has enough logic to warrant its own class (preview calls, scoped loading state,
+multi-step form), extract it as a dedicated standalone component. The parent holds a
+nullable signal for the open target and imports the component.
+
+```typescript
+// The dedicated modal component
+@Component({
+  selector: 'lib-field-reextraction-modal',
+  templateUrl: './field-reextraction-modal.component.html',
+  standalone: true,
+  imports: [CommonModule, LocalizationPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FieldReextractionModalComponent implements OnInit {
+  private readonly service = inject(DocumentReprocessingService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  @Input({ required: true }) documentTypeId!: string;
+  @Output() closed = new EventEmitter<void>();
+
+  readonly isSubmitting = signal(false);
+  // ... preview signals, loadPreview(), confirm(), close()
+}
+```
+
+```typescript
+// In the parent list component
+// 1. Import the dedicated component
+imports: [FieldReextractionModalComponent],
+
+// 2. Signal for open target (null = closed)
+reextractTarget = signal<DocumentTypeDto | null>(null);
+
+openReextractFields(type: DocumentTypeDto): void {
+  this.reextractTarget.set(type);
+}
+```
+
+```html
+<!-- In the parent list template -->
+@if (reextractTarget(); as t) {
+  <lib-field-reextraction-modal
+    [documentTypeId]="t.id!"
+    [documentTypeDisplayName]="t.displayName ?? ''"
+    (closed)="reextractTarget.set(null)"
+  />
+}
+```
+
+ABP `ModalService` is available as an alternative but is **not** the established pattern
+in this codebase. Do not introduce it unless a genuine need arises (e.g., opening a modal
+from a non-template context).
+
+## ListService with Signals
+
+`ListService` is provided in the component's `providers: []` array and obtained via
+`inject()`. Subscribe to `query$` and `hookToQuery` with `takeUntilDestroyed`.
+
+```typescript
+providers: [ListService],
+// ...
+readonly list = inject(ListService);
+
+ngOnInit(): void {
+  this.list.requestStatus$
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(status => this.isLoading.set(status === 'loading'));
+
+  this.list
+    .hookToQuery(query => this.service.getList({ ...query }))
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(result => this.items.set(result.items ?? []));
+}
+```
+
+## Localization
+
+Import `LocalizationPipe` from `@abp/ng.core` in the component's `imports` array.
+
+```html
+<h1>{{ '::Cabinet:Title' | abpLocalization }}</h1>
 <p>{{ '::WelcomeMessage' | abpLocalization: userName }}</p>
 ```
 
-## Authorization
+For programmatic access inject `LocalizationService`:
 
-### Permission Directive
-```html
-<button *abpPermission="'BookStore.Books.Create'">Create</button>
-```
-
-### Permission Guard
 ```typescript
-const routes: Routes = [
-  {
-    path: '',
-    component: BookListComponent,
-    canActivate: [PermissionGuard],
-    data: {
-      requiredPolicy: 'BookStore.Books'
-    }
-  }
-];
-```
-
-### Programmatic Check
-```typescript
-constructor(private permissionService: PermissionService) {}
-
-canCreate(): boolean {
-  return this.permissionService.getGrantedPolicy('BookStore.Books.Create');
-}
-```
-
-## Forms with Validation
-```typescript
-@Component({...})
-export class BookFormComponent {
-  form: FormGroup;
-
-  constructor(private fb: FormBuilder) {
-    this.buildForm();
-  }
-
-  buildForm(): void {
-    this.form = this.fb.group({
-      name: ['', [Validators.required, Validators.maxLength(128)]],
-      price: [0, [Validators.required, Validators.min(0)]]
-    });
-  }
-
-  save(): void {
-    if (this.form.invalid) return;
-    
-    this.bookService.create(this.form.value).subscribe(() => {
-      // Handle success
-    });
-  }
-}
-```
-
-```html
-<form [formGroup]="form" (ngSubmit)="save()">
-  <div class="form-group">
-    <label for="name">{{ '::Name' | abpLocalization }}</label>
-    <input type="text" id="name" formControlName="name" class="form-control" />
-  </div>
-  
-  <button type="submit" class="btn btn-primary" [disabled]="form.invalid">
-    {{ '::Save' | abpLocalization }}
-  </button>
-</form>
-```
-
-## Configuration API
-```typescript
-constructor(private configService: ConfigStateService) {}
-
-getCurrentUser(): CurrentUserDto {
-  return this.configService.getOne('currentUser');
-}
-
-getSettings(): void {
-  const setting = this.configService.getSetting('MyApp.MaxItemCount');
-}
-```
-
-## Modal Service
-```typescript
-constructor(private modalService: ModalService) {}
-
-openCreateModal(): void {
-  const modalRef = this.modalService.open(BookFormComponent, {
-    size: 'lg'
-  });
-
-  modalRef.result.then(result => {
-    if (result) {
-      this.list.get();
-    }
-  });
-}
+private readonly localization = inject(LocalizationService);
+getText(): string { return this.localization.instant('::Cabinet:Title'); }
 ```
 
 ## Toast Notifications
+
 ```typescript
-constructor(private toaster: ToasterService) {}
+private readonly toaster = inject(ToasterService);
 
-showSuccess(): void {
-  this.toaster.success('::BookCreatedSuccessfully', '::Success');
-}
-
-showError(error: string): void {
-  this.toaster.error(error, '::Error');
-}
+onSuccess(): void { this.toaster.success('::Cabinet:CreatedSuccessfully', '::Success'); }
+onError(): void   { this.toaster.error('::Cabinet:DeleteFailed', '::Error'); }
 ```
 
-## Lazy Loading Modules
-```typescript
-// app-routing.module.ts
-const routes: Routes = [
-  {
-    path: 'books',
-    loadChildren: () => import('./book/book.module').then(m => m.BookModule)
-  }
-];
+## Template Control Flow
+
+Use Angular 17+ block syntax — NOT `*ngIf` / `*ngFor`:
+
+```html
+@if (canCreate) {
+  <button>Create</button>
+}
+
+@for (item of items(); track item.id) {
+  <tr>...</tr>
+}
+
+@if (isLoading()) {
+  <div class="spinner-border"></div>
+} @else {
+  <!-- content -->
+}
 ```
 
 ## Theme & Styling
-- Use Bootstrap classes
-- ABP provides theme variables via CSS custom properties
+
+- Bootstrap utility classes for layout/spacing
+- ABP LeptonX theme variables via CSS custom properties
 - Component-specific styles in `.component.scss`
+- Icons: Font Awesome (`fas fa-*`)

--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -1,8 +1,7 @@
 ---
 description: "ABP testing patterns - unit tests and integration tests"
 paths:
-  - "test/**/*.cs"
-  - "tests/**/*.cs"
+  - "**/test/**/*.cs"
   - "**/*Tests*/**/*.cs"
   - "**/*Test*.cs"
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,24 +1,34 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
-    "PostToolUse": [
+    "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$CLAUDE_FILE_PATHS\" == *.cs ]]; then dotnet format core/Dignite.Vault.Extract.slnx --include \"$CLAUDE_FILE_PATHS\" --no-restore --verbosity quiet 2>/dev/null || true; fi"
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-migration-edit.ps1"
           }
         ]
       }
     ],
-    "PreToolUse": [
+    "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$CLAUDE_FILE_PATHS\" == */Migrations/* ]]; then echo 'Blocked: regenerate via dotnet ef migrations add instead of editing migration files directly' >&2; exit 2; fi"
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/format-cs.ps1"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -c \"[console]::beep(880,200); [console]::beep(1100,200)\""
           }
         ]
       }

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: run
+description: Start the Vault Extract dev environment — SQL Server reachability check, .NET host at https://localhost:44348, Angular SPA at http://localhost:4200 — and verify both are healthy. Also covers stopping the stack and regenerating Angular client proxies.
+---
+
+# Run: Start and Verify the Vault Extract Dev Stack
+
+## Connection targets (read from real appsettings files)
+
+| Environment | `ConnectionStrings:Default` |
+|---|---|
+| Base (`appsettings.json`) | `Server=(LocalDb)\MSSQLLocalDB;Database=Extract;Trusted_Connection=True;TrustServerCertificate=true` |
+| Development (`appsettings.Development.json`) | `Server=43.130.249.65;User ID=developer;...;Database=VaultExtract-Dev;Trusted_Connection=False;TrustServerCertificate=true` |
+
+`launchSettings.json` sets `ASPNETCORE_ENVIRONMENT=Development`, so the **Development override is always active** during `dotnet run`. The active target is the remote SQL Server at `43.130.249.65:1433`.
+
+The base appsettings LocalDB target (`(LocalDb)\MSSQLLocalDB`) is only used when the `Development` override is absent (e.g. custom `--environment` flag or a CI environment that does not load the Development file).
+
+---
+
+## Step 1 — Verify SQL Server reachability
+
+**Development environment (normal case): remote SQL Server**
+
+```powershell
+Test-NetConnection 43.130.249.65 -Port 1433
+```
+
+Expect `TcpTestSucceeded : True`. If this fails, check VPN/network access before proceeding — the host will fail to start with a DB connection error.
+
+**Base fallback: LocalDB**
+
+If running without the Development override (unusual), the target is `(LocalDb)\MSSQLLocalDB`. LocalDB uses a local named pipe; there is no TCP port to check. Verify the instance exists with:
+
+```powershell
+sqllocaldb info MSSQLLocalDB
+```
+
+---
+
+## Step 2 — Start the .NET host
+
+The host project lives at `host/src/Dignite.Vault.Extract.Host.csproj` (directly inside `host/src/`).
+
+```powershell
+dotnet run --project host/src
+```
+
+Or, to pin the environment explicitly:
+
+```powershell
+$env:ASPNETCORE_ENVIRONMENT = "Development"
+dotnet run --project host/src
+```
+
+The host binds to `https://localhost:44348` (confirmed in both `launchSettings.json` and `appsettings.json` `App.SelfUrl`).
+
+**Wait for readiness.** Poll until the health endpoint responds HTTP 200:
+
+```powershell
+do {
+    Start-Sleep -Seconds 2
+    try { $r = Invoke-WebRequest -Uri "https://localhost:44348/health-status" -SkipCertificateCheck -UseBasicParsing -ErrorAction Stop }
+    catch { $r = $null }
+} until ($r -and $r.StatusCode -eq 200)
+Write-Host "Host is up."
+```
+
+Swagger UI is available at `https://localhost:44348/swagger` (served via `UseAbpSwaggerUI`).
+
+---
+
+## Step 3 — Start the Angular SPA
+
+The workspace root is `angular/`. The Nx app name is `host`. The `package.json` `start` script runs `nx serve host`.
+
+```powershell
+Set-Location angular
+npm start
+```
+
+Alternative (equivalent, bypasses the npm script wrapper):
+
+```powershell
+npx nx serve host
+```
+
+The SPA dev server listens on `http://localhost:4200`.
+
+**TLS note.** The Angular dev server calls the host directly (via `environment.ts` — there is no Angular proxy config file). Node-side tooling skips TLS verification via `NODE_TLS_REJECT_UNAUTHORIZED=0`, which is already set in `.claude/settings.local.json`. Do not add a proxy config file to work around TLS; the env var is the correct mechanism.
+
+**Verify Angular is up:**
+
+```powershell
+Invoke-WebRequest -Uri "http://localhost:4200" -UseBasicParsing -ErrorAction Stop
+```
+
+---
+
+## Stopping the stack
+
+**Kill the host by port (Windows PowerShell):**
+
+```powershell
+Get-NetTCPConnection -LocalPort 44348 -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty OwningProcess |
+    ForEach-Object { Stop-Process -Id $_ -Force }
+```
+
+**Kill the Angular dev server by port:**
+
+```powershell
+Get-NetTCPConnection -LocalPort 4200 -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty OwningProcess |
+    ForEach-Object { Stop-Process -Id $_ -Force }
+```
+
+Do not use `pkill` — it is not available on Windows / Git Bash.
+
+---
+
+## Regenerating Angular client proxies
+
+Requires the host running at `https://localhost:44348`.
+
+```powershell
+Set-Location angular
+npm run generate-proxy
+```
+
+This runs:
+
+```
+nx g @abp/nx.generators:generate-proxy --module=vault-extract --apiName=Default --source=host --target=vault-extract --url=https://localhost:44348 --serviceType=application --no-interactive
+```
+
+(exact script from `angular/package.json`)
+
+---
+
+## Quick-reference checklist
+
+| Step | Command | Expected result |
+|---|---|---|
+| DB reachability (Dev) | `Test-NetConnection 43.130.249.65 -Port 1433` | `TcpTestSucceeded : True` |
+| Start host | `dotnet run --project host/src` | Binds `https://localhost:44348` |
+| Health check | `GET https://localhost:44348/health-status` | HTTP 200 |
+| Swagger | `https://localhost:44348/swagger` | Swagger UI loads |
+| Start Angular | `cd angular && npm start` | `http://localhost:4200` |
+| Generate proxies | `cd angular && npm run generate-proxy` | Proxy files updated |
+| Stop host | `Get-NetTCPConnection -LocalPort 44348 …` | Process killed |
+| Stop Angular | `Get-NetTCPConnection -LocalPort 4200 …` | Process killed |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ Fields are organized into two kinds: **system common fields** (auto-produced by 
 
 > Full system-field table, text-extraction provenance (#210), and mechanism-B implementation form (`FieldDefinition` / `DocumentExtractedField` / unique index / composite key): see `.claude/rules/field-architecture.md` (auto-loaded when editing Document / field code).
 
+> Sub-document segmentation (a **container** document → derived sub-documents): the two-representation model (`DocumentSegment` ledger + derived `Document`), the two-`Kind` red line, and the field lifecycle contract — see `.claude/rules/sub-document-segmentation.md` (decision record #390, auto-loaded when editing Segmentation / `DerivedDocumentSpawner` / `ContainerMarker*` / `DocumentSegment*` code). Relevant to egress too: a container is suppressed from `DocumentReadyEto` (#346); only its sub-documents fire it, each carrying `OriginDocumentId`.
+
 ## Egress contracts
 
 Three live egress channels: **REST API** (HTTP, generic programmatic access) / **MCP server** (Claude Desktop / Cursor / any MCP client) / **EventBus** (ABP DistributedEventBus, business systems / custom consumers); plus **Webhook** (legacy systems) — **planned, not yet implemented**.


### PR DESCRIPTION
## What

Rebuilds the `.claude/` Claude Code config. The hook layer was silently non-functional and several rule/agent docs had drifted from the codebase; this fixes them and adds two reviewers + a run skill. Everything was verified against the real code (hooks were runtime-tested).

## Why it mattered

- All three hooks used `$CLAUDE_FILE_PATHS`, which Claude Code does not set — so they never ran. The "block migration edits" guard gave false safety.
- The format hook pointed at a non-existent `core/*.slnx` with an absolute `--include` path; even fixed, it loaded the 31-project solution (~12s/edit).
- `angular.md` taught NgModule patterns; the app is 100% standalone Angular 21 (zero `@NgModule`).
- `abp-architecture-reviewer` required `AddDistributedEvent`; the repo publishes ETOs via `IDistributedEventBus.PublishAsync` (zero `AddDistributedEvent` in `core/src`).
- `testing-patterns.md` path globs never matched (tests live under `core/test/`).

## Changes

**Hooks** (`.claude/settings.json`, `.claude/hooks/`)
- Parse tool-call JSON from stdin (`ConvertFrom-Json`; `jq` unavailable here).
- `format-cs.ps1`: format the edited file against its **owning `.csproj`** with a repo-relative `--include`; PS 5.1 compatible (no `Path.GetRelativePath`); `whitespace` subcommand for speed.
- `block-migration-edit.ps1`: block `*/Migrations/*` edits (regex matches both separators), exit 2.
- `Stop`: completion beep.

**Rules / agents**
- `angular.md` → standalone Angular 21 (proxy-generation section preserved verbatim).
- `abp-architecture-reviewer.md` → correct ABP event-raising (PublishAsync + outbox).
- `testing-patterns.md` → working globs (`**/test/**`).
- add `integration-events-reviewer` (ETO contracts; #346 container suppression, #306 scalars) and `angular-reviewer` (standalone conventions).

**Docs / skill**
- `CLAUDE.md`: pointer to the sub-document-segmentation rule.
- `run` skill: start the dev stack (SQL Server, host `:44348`, Angular).

## Verification

- Hook scripts runtime-tested via simulated stdin JSON: migration block → exit 2; format actually reformats a scratch `.cs` (trailing whitespace + indent); non-`.cs` skipped.
- Rule/agent claims grounded by grep/read against the codebase.

## Note (not in this diff)

`settings.local.json` (gitignored) sets `NODE_TLS_REJECT_UNAUTHORIZED=0` for `generate-proxy` against the self-signed dev cert. I tried to replace it with `NODE_EXTRA_CA_CERTS` and `--use-system-ca` but **verified both fail** (`DEPTH_ZERO_SELF_SIGNED_CERT` — node won't trust the dotnet dev leaf cert), so it was left as-is rather than break proxy generation.