### PR TITLE
feat(mcp): static API-key fallback auth for the /mcp egress (#428)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyAuthenticationMiddleware.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyAuthenticationMiddleware.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Security.Claims;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Optional static API-key fallback authentication for the <c>/mcp</c> egress (#428), for MCP clients that
+/// cannot run the #278 OAuth discovery flow (e.g. OpenAI Codex, ABP AI Management) but can send a static
+/// request header.
+///
+/// <para><b>Behaviour.</b> Read the configured header; on a constant-time match, set <c>context.User</c> to
+/// a synthetic authenticated principal for the mapped least-privilege service-account user. On a
+/// missing/invalid key, <b>do nothing</b> (fail open, leave the principal unauthenticated — never write 401
+/// or 403 here) so the request falls through to the OpenIddict Bearer chain and the #278 discovery
+/// challenge stay byte-for-byte intact. Emitting a 403 here would make
+/// <see cref="McpDiscoveryAuthorizationResultHandler"/> skip the <c>resource_metadata</c> pointer and break
+/// discovery for OAuth clients.</para>
+///
+/// <para><b>Pipeline placement.</b> Runs BEFORE <c>UseAuthentication</c>. Verified (ASP.NET Core +
+/// ABP 10.2.0): <c>AuthenticationMiddleware</c> only overwrites <c>context.User</c> when the default scheme
+/// returns a non-null principal, so a no-Bearer request (<c>NoResult</c>) preserves the key principal; a
+/// valid Bearer, when present, wins (acceptable). ABP <c>UseAbpOpenIddictValidation</c> is gated on
+/// <c>!IsAuthenticated</c> and no-ops over an already-authenticated principal.</para>
+///
+/// <para><b>Authorization.</b> The synthetic principal carries only <c>AbpClaimTypes.UserId</c> (+ tenant /
+/// label); permissions resolve from the permission store at the tools' <c>CheckPolicyAsync</c> (ABP does
+/// not read permissions from claims). The endpoint keeps the bare scheme-free <c>RequireAuthorization()</c>
+/// policy (the #278 invariant) which authorizes the ambient <c>context.User</c>.</para>
+///
+/// <para><b>Known limitation.</b> The key principal does NOT pass through <c>UseDynamicClaims</c> (it has no
+/// <c>IAuthenticateResultFeature</c>), so live dynamic-claims revocation does not apply — revoke by removing
+/// the key from config (or removing the service account's grant, which the permission cache picks up). A
+/// future upgrade to a real <c>AuthenticationHandler</c>/scheme would restore enrichment parity; see #428.</para>
+/// </summary>
+public sealed class McpApiKeyAuthenticationMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<McpApiKeyAuthenticationMiddleware> _logger;
+    private readonly string _headerName;
+    private readonly IReadOnlyList<CompiledKey> _keys;
+
+    public McpApiKeyAuthenticationMiddleware(
+        RequestDelegate next,
+        IOptions<McpApiKeyOptions> options,
+        ILogger<McpApiKeyAuthenticationMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+
+        var value = options.Value;
+        _headerName = value.HeaderName;
+
+        // Precompute SHA-256 digests once. Comparing fixed-length digests (not the raw keys) removes the
+        // length side-channel and lets FixedTimeEquals run over a constant-size buffer.
+        _keys = value.Keys
+            .Select(k => new CompiledKey(SHA256.HashData(Encoding.UTF8.GetBytes(k.Key)), k))
+            .ToList();
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Exactly one header instance is expected. An absent header (Count == 0) is the normal OAuth path;
+        // a duplicated header (Count > 1, e.g. a reverse proxy that appends instead of replaces) is
+        // ambiguous. In both cases do nothing and fall through to the Bearer chain (fail open) rather than
+        // matching a comma-joined StringValues that could never equal a real key.
+        var values = context.Request.Headers[_headerName];
+        if (values.Count == 1)
+        {
+            var presented = values[0];
+            if (!string.IsNullOrEmpty(presented))
+            {
+                var matched = Match(presented);
+                if (matched != null)
+                {
+                    context.User = BuildPrincipal(matched);
+                    _logger.LogDebug(
+                        "MCP request authenticated via API key (label: {Label}).",
+                        string.IsNullOrWhiteSpace(matched.Label) ? "<unlabeled>" : matched.Label);
+                }
+                else
+                {
+                    // Present-but-invalid key. Logged at Debug (not Warning) so an unauthenticated caller
+                    // cannot flood Warning-level logs / alerts; a rate-limited security event is the proper
+                    // signal (deferred, see #428). Never log the value.
+                    _logger.LogDebug(
+                        "An invalid MCP API key was presented in header '{Header}'; falling through to Bearer authentication.",
+                        _headerName);
+                }
+            }
+        }
+
+        await _next(context);
+    }
+
+    private McpApiKeyEntry? Match(string presented)
+    {
+        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+
+        // Compare against every configured key with no early-exit, so neither the match position nor the
+        // key count is timing-observable; SHA-256 digests are a fixed 32 bytes for FixedTimeEquals.
+        McpApiKeyEntry? matched = null;
+        foreach (var candidate in _keys)
+        {
+            if (CryptographicOperations.FixedTimeEquals(presentedHash, candidate.Hash))
+            {
+                matched = candidate.Entry;
+            }
+        }
+
+        return matched;
+    }
+
+    private static ClaimsPrincipal BuildPrincipal(McpApiKeyEntry entry)
+    {
+        var claims = new List<Claim>
+        {
+            new(AbpClaimTypes.UserId, entry.ServiceAccountUserId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(entry.TenantId))
+        {
+            claims.Add(new Claim(AbpClaimTypes.TenantId, entry.TenantId));
+        }
+
+        // Non-empty authenticationType => IsAuthenticated == true (load-bearing; see class remarks). The
+        // key's Label is used only for log attribution, NOT stamped as AbpClaimTypes.UserName: faking a
+        // user name would mislead audit correlation against the real Identity service-account user.
+        var identity = new ClaimsIdentity(claims, McpApiKeyDefaults.AuthenticationType);
+        return new ClaimsPrincipal(identity);
+    }
+
+    private sealed record CompiledKey(byte[] Hash, McpApiKeyEntry Entry);
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyAuthenticationMiddleware.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyAuthenticationMiddleware.cs
@@ -45,6 +45,7 @@ public sealed class McpApiKeyAuthenticationMiddleware
     private readonly RequestDelegate _next;
     private readonly ILogger<McpApiKeyAuthenticationMiddleware> _logger;
     private readonly string _headerName;
+    private readonly bool _requireHttps;
     private readonly IReadOnlyList<CompiledKey> _keys;
 
     public McpApiKeyAuthenticationMiddleware(
@@ -57,6 +58,7 @@ public sealed class McpApiKeyAuthenticationMiddleware
 
         var value = options.Value;
         _headerName = value.HeaderName;
+        _requireHttps = value.RequireHttps;
 
         // Precompute SHA-256 digests once. Comparing fixed-length digests (not the raw keys) removes the
         // length side-channel and lets FixedTimeEquals run over a constant-size buffer.
@@ -75,7 +77,7 @@ public sealed class McpApiKeyAuthenticationMiddleware
         if (values.Count == 1)
         {
             var presented = values[0];
-            if (!string.IsNullOrEmpty(presented))
+            if (!string.IsNullOrEmpty(presented) && !RejectInsecure(context))
             {
                 var matched = Match(presented);
                 if (matched != null)
@@ -98,6 +100,21 @@ public sealed class McpApiKeyAuthenticationMiddleware
         }
 
         await _next(context);
+    }
+
+    private bool RejectInsecure(HttpContext context)
+    {
+        if (!_requireHttps || context.Request.IsHttps)
+        {
+            return false;
+        }
+
+        // The key is a long-lived bearer-equivalent secret; refuse it over clear text and fall through to
+        // the Bearer chain. Never log the value. Disable via Mcp:ApiKey:RequireHttps only for a deliberate
+        // plain-HTTP deployment (e.g. local testing).
+        _logger.LogDebug(
+            "An MCP API key was presented over a non-HTTPS request; ignoring it (Mcp:ApiKey:RequireHttps=true).");
+        return true;
     }
 
     private McpApiKeyEntry? Match(string presented)

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyDefaults.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyDefaults.cs
@@ -1,0 +1,40 @@
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Constants for the optional static API-key fallback authentication channel on the <c>/mcp</c> egress
+/// (#428). The channel complements — never replaces — the OpenIddict Bearer chain and the #278 OAuth
+/// discovery flow; it exists for MCP clients that cannot run the dynamic OAuth flow but can send a static
+/// request header (OpenAI Codex, ABP AI Management). Claude's native custom connector is OAuth-only and
+/// keeps using #278; it is unaffected.
+/// </summary>
+public static class McpApiKeyDefaults
+{
+    /// <summary>
+    /// Default request header carrying the static key. Configurable via
+    /// <see cref="McpApiKeyOptions.HeaderName"/> for operability (reverse-proxy / WAF collisions, matching
+    /// a particular client's fixed header name).
+    /// </summary>
+    public const string DefaultHeaderName = "X-Api-Key";
+
+    /// <summary>Default endpoint path prefix the channel is scoped to (matches the host's <c>MapMcp("/mcp")</c>).</summary>
+    public const string DefaultPathPrefix = "/mcp";
+
+    /// <summary>
+    /// AuthenticationType stamped on the synthetic principal. MUST be non-empty so the identity is
+    /// <c>IsAuthenticated == true</c> — otherwise <c>RequireAuthorization</c> rejects it (401) and ABP's
+    /// <c>UseAbpOpenIddictValidation</c> <c>!IsAuthenticated</c> guard would re-run OpenIddict over it.
+    /// </summary>
+    public const string AuthenticationType = "McpApiKey";
+
+    /// <summary>
+    /// Committed-config placeholder, rejected fail-fast at startup (mirroring <c>ConfigureAI</c>'s
+    /// <c>YOUR_API_KEY</c> guard) so a real secret must be supplied out-of-band via env / user-secrets.
+    /// </summary>
+    public const string PlaceholderKey = "YOUR_MCP_API_KEY";
+
+    /// <summary>
+    /// Minimum accepted key length. The header check is unauthenticated, so a low-entropy key would be
+    /// brute-forceable; keys should be CSPRNG-generated (>= 256 bits, e.g. 32 random bytes base64url).
+    /// </summary>
+    public const int MinKeyLength = 32;
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyEntry.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyEntry.cs
@@ -1,0 +1,40 @@
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// One configured API key and the ABP identity it authenticates as (#428). This is host-owned deployment
+/// config — the key → service-account mapping is a deployment decision; the Mcp egress module only provides
+/// the matching + principal-construction mechanism. Each key SHOULD map to a dedicated, least-privilege
+/// service-account user granted <b>only</b> <c>ExtractPermissions.Documents.Default</c>
+/// (<c>"VaultExtract.Documents"</c>), with no roles, so an API-key caller can never exceed an OAuth user.
+/// </summary>
+public class McpApiKeyEntry
+{
+    /// <summary>
+    /// The shared secret. Supplied via environment variables / user-secrets, <b>never committed</b>;
+    /// at least <see cref="McpApiKeyDefaults.MinKeyLength"/> characters, CSPRNG-generated.
+    /// </summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The <c>Guid</c> of a real, provisioned ABP <c>IdentityUser</c> this key authenticates as; stamped as
+    /// <c>AbpClaimTypes.UserId</c>. Permissions resolve from the permission store by this id at the tools'
+    /// <c>CheckPolicyAsync</c> — ABP does not read permissions from principal claims.
+    /// </summary>
+    public string ServiceAccountUserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional tenant <c>Guid</c> (stamped as <c>AbpClaimTypes.TenantId</c>). Null/empty = host space.
+    /// <b>Only takes effect when the host runs multi-tenant</b> (i.e. <c>UseMultiTenancy</c> is in the
+    /// pipeline). While <c>ExtractHostModule.IsMultiTenant</c> is <c>false</c> the claim is inert and all
+    /// access resolves to the host space. When multi-tenancy is enabled this MUST be set so the ambient
+    /// <c>IMultiTenant</c> filter scopes LLM-triggered queries to the right layer.
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    /// Human label for audit attribution / rotation (e.g. <c>"codex-prod"</c>). Never the key value. Logged
+    /// on each successful authentication; it is NOT stamped onto the principal as a user name (that would
+    /// mislead audit correlation against the real Identity user).
+    /// </summary>
+    public string? Label { get; set; }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyOptions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Volo.Abp;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Options for the optional static API-key fallback auth channel on <c>/mcp</c> (#428). An empty
+/// <see cref="Keys"/> list (the shipped default) means the feature is <b>disabled</b> — an OAuth-only
+/// deployment — and the channel adds nothing to the request pipeline.
+/// </summary>
+public class McpApiKeyOptions
+{
+    /// <summary>Request header carrying the key. Default <see cref="McpApiKeyDefaults.DefaultHeaderName"/>.</summary>
+    public string HeaderName { get; set; } = McpApiKeyDefaults.DefaultHeaderName;
+
+    /// <summary>
+    /// Endpoint path prefix the channel is scoped to. Default <see cref="McpApiKeyDefaults.DefaultPathPrefix"/>.
+    /// MUST match the host's <c>MapMcp</c> path — if the host remaps the MCP endpoint, set this to match,
+    /// otherwise the channel silently stops matching (the middleware no-ops and key auth breaks).
+    /// </summary>
+    public string PathPrefix { get; set; } = McpApiKeyDefaults.DefaultPathPrefix;
+
+    /// <summary>Configured keys. Empty = feature disabled.</summary>
+    public List<McpApiKeyEntry> Keys { get; set; } = new();
+
+    /// <summary>
+    /// Fail-fast shape validation, mirroring <c>ConfigureAI</c>'s placeholder/empty guards. A no-op when no
+    /// keys are configured (the feature is simply off). When keys ARE present, every entry must be a real,
+    /// sufficiently-long, non-placeholder secret mapped to a parseable user id (and tenant id if given).
+    /// It does NOT verify the user exists or check its grants (there is no DB at config time) — that is
+    /// enforced fail-closed at call time by the tools' <c>CheckPolicyAsync</c>.
+    /// </summary>
+    public void Validate()
+    {
+        if (Keys is null || Keys.Count == 0)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(HeaderName))
+        {
+            throw new AbpException("Mcp:ApiKey:HeaderName must not be empty when API keys are configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(PathPrefix) || !PathPrefix.StartsWith('/'))
+        {
+            throw new AbpException(
+                "Mcp:ApiKey:PathPrefix must be a non-empty path starting with '/' and must match the host's " +
+                "MapMcp path (default \"/mcp\").");
+        }
+
+        for (var i = 0; i < Keys.Count; i++)
+        {
+            var entry = Keys[i];
+            var where = $"Mcp:ApiKey:Keys[{i}]";
+
+            if (string.IsNullOrWhiteSpace(entry.Key)
+                || entry.Key == McpApiKeyDefaults.PlaceholderKey
+                || entry.Key.Length < McpApiKeyDefaults.MinKeyLength)
+            {
+                throw new AbpException(
+                    $"{where}.Key is missing, the placeholder, or shorter than {McpApiKeyDefaults.MinKeyLength} characters. " +
+                    "Supply a CSPRNG-generated secret (>= 32 chars) via environment variables or user-secrets — never commit it. " +
+                    "Leave Mcp:ApiKey:Keys empty to disable the API-key channel (OAuth-only).");
+            }
+
+            if (!Guid.TryParse(entry.ServiceAccountUserId, out var userId) || userId == Guid.Empty)
+            {
+                throw new AbpException(
+                    $"{where}.ServiceAccountUserId must be the Guid of a provisioned ABP service-account user " +
+                    "granted only VaultExtract.Documents (least privilege, no roles).");
+            }
+
+            if (!string.IsNullOrWhiteSpace(entry.TenantId) && !Guid.TryParse(entry.TenantId, out _))
+            {
+                throw new AbpException($"{where}.TenantId, when set, must be a Guid.");
+            }
+        }
+
+        var duplicate = Keys.GroupBy(k => k.Key).FirstOrDefault(g => g.Count() > 1);
+        if (duplicate != null)
+        {
+            throw new AbpException(
+                "Mcp:ApiKey:Keys contains duplicate Key values; each key must be distinct so audit " +
+                "attribution and independent revocation stay meaningful.");
+        }
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyOptions.cs
@@ -22,6 +22,15 @@ public class McpApiKeyOptions
     /// </summary>
     public string PathPrefix { get; set; } = McpApiKeyDefaults.DefaultPathPrefix;
 
+    /// <summary>
+    /// When <c>true</c> (default), a key presented over a non-HTTPS request is ignored (the request falls
+    /// through to Bearer) — the key is a long-lived bearer-equivalent secret and must not travel in clear
+    /// text. Behind a TLS-terminating reverse proxy this relies on the host's forwarded-headers handling so
+    /// <c>Request.IsHttps</c> reflects the original scheme. Set <c>false</c> only for a deliberately
+    /// plain-HTTP deployment (e.g. local testing).
+    /// </summary>
+    public bool RequireHttps { get; set; } = true;
+
     /// <summary>Configured keys. Empty = feature disabled.</summary>
     public List<McpApiKeyEntry> Keys { get; set; } = new();
 

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyServiceCollectionExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyServiceCollectionExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Reusable wiring for the optional static API-key fallback auth channel on <c>/mcp</c> (#428), exported by
+/// the Mcp egress module so any host enables it with one <c>Add</c> + one <c>Use</c> call. Mirrors the #422
+/// <c>AddExtractMcpDiscovery</c> split: the deployment-agnostic MECHANISM (header matching, constant-time
+/// compare, synthetic-principal construction) lives in this module; the HOST owns all configuration and the
+/// key → service-account mapping, and calls <see cref="UseExtractMcpApiKey"/> from its
+/// <c>OnApplicationInitialization</c> — so the "middleware only wired in host" rule holds.
+/// </summary>
+public static class McpApiKeyServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers and fail-fast-validates the API-key options. A no-op feature when no keys are configured
+    /// (OAuth-only deployment). Pair with <see cref="UseExtractMcpApiKey"/> in the pipeline, before
+    /// <c>UseAuthentication</c>.
+    /// </summary>
+    public static IServiceCollection AddExtractMcpApiKey(
+        this IServiceCollection services,
+        Action<McpApiKeyOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Validate eagerly against a throwaway bound instance so misconfiguration fails fast at startup
+        // (mirroring ConfigureAI's placeholder guard); a no-op when no keys are configured.
+        var validation = new McpApiKeyOptions();
+        configure(validation);
+        validation.Validate();
+
+        // Register the SAME delegate so every option property binds to the DI instance — avoids a manual
+        // field-copy that a future property could silently drift out of.
+        services.Configure(configure);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Inserts the API-key middleware, scoped (segment-aware) to the configured <c>/mcp</c> path prefix so
+    /// it never runs for the admin UI / REST / Swagger. A no-op when no keys are configured. MUST be called
+    /// before <c>UseAuthentication</c>.
+    /// </summary>
+    public static IApplicationBuilder UseExtractMcpApiKey(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var options = app.ApplicationServices.GetRequiredService<IOptions<McpApiKeyOptions>>().Value;
+        var logger = app.ApplicationServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Dignite.Vault.Extract.Mcp.Authentication.McpApiKey");
+
+        if (options.Keys is null || options.Keys.Count == 0)
+        {
+            logger.LogInformation(
+                "MCP API-key channel is disabled (no Mcp:ApiKey:Keys configured); /mcp uses OpenIddict Bearer + #278 discovery only.");
+            return app; // disabled: OAuth-only deployment
+        }
+
+        logger.LogInformation(
+            "MCP API-key channel enabled with {KeyCount} key(s) on header '{Header}', scoped to '{Path}'.",
+            options.Keys.Count, options.HeaderName, options.PathPrefix);
+
+        var prefix = new PathString(options.PathPrefix);
+        return app.UseWhen(
+            context => context.Request.Path.StartsWithSegments(prefix),
+            branch => branch.UseMiddleware<McpApiKeyAuthenticationMiddleware>());
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpApiKeyAuthentication_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpApiKeyAuthentication_Tests.cs
@@ -148,6 +148,20 @@ public class McpApiKeyAuthentication_Tests
     }
 
     [Fact]
+    public async Task A_valid_key_over_plain_http_is_rejected_when_https_is_required()
+    {
+        using var server = await BuildServerAsync(requireHttps: true);
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, ValidKey);
+
+        // TestServer serves plain HTTP, so the RequireHttps gate ignores the key and the request falls
+        // through unauthenticated.
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public void Configuration_with_a_too_short_key_fails_fast()
     {
         var options = new McpApiKeyOptions
@@ -184,7 +198,7 @@ public class McpApiKeyAuthentication_Tests
         Should.NotThrow(() => options.Validate());
     }
 
-    private static async Task<TestServer> BuildServerAsync()
+    private static async Task<TestServer> BuildServerAsync(bool requireHttps = false)
     {
         var host = await new HostBuilder()
             .ConfigureWebHost(web =>
@@ -204,6 +218,9 @@ public class McpApiKeyAuthentication_Tests
                     {
                         options.HeaderName = HeaderName;
                         options.PathPrefix = "/mcp";
+                        // TestServer requests are plain HTTP; disable the HTTPS gate except where a test
+                        // explicitly exercises it.
+                        options.RequireHttps = requireHttps;
                         options.Keys = new List<McpApiKeyEntry>
                         {
                             new()

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpApiKeyAuthentication_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpApiKeyAuthentication_Tests.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.Security.Claims;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// #428 guard for the static API-key fallback auth channel on /mcp. Uses a minimal TestServer pipeline
+/// (no ABP host / DB / OpenIddict) that mirrors the host seam precisely: a default Bearer-stub scheme,
+/// <c>UseExtractMcpApiKey</c> BEFORE <c>UseAuthentication</c>, and the bare scheme-free
+/// <c>RequireAuthorization()</c> the host uses on /mcp.
+///
+/// The load-bearing behaviours locked here:
+///  - valid key => the request reaches the endpoint as the mapped service-account principal (proves the
+///    pre-UseAuthentication principal survives AuthenticationMiddleware's NoResult and that the scheme-free
+///    policy authorizes the ambient context.User);
+///  - missing key => falls through to 401 (Bearer chain + #278 discovery untouched);
+///  - invalid key => falls through to 401, never 403 (a 403 would suppress the #278 resource_metadata pointer);
+///  - the channel is segment-scoped to /mcp and does not authenticate other paths;
+///  - a valid Bearer still wins when no key is sent.
+/// </summary>
+public class McpApiKeyAuthentication_Tests
+{
+    private const string TokenScheme = "Token";
+    private const string RawClaim = "raw";
+    private const string HeaderName = "X-Api-Key";
+
+    // >= McpApiKeyDefaults.MinKeyLength (32). Test-only values, not real secrets.
+    private const string ValidKey = "test-mcp-api-key-0123456789abcdefghijklmnop";
+    private const string SecondKey = "second-mcp-api-key-zyxwvutsrqponmlkjihgfedcba";
+
+    private static readonly Guid ServiceAccountId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid SecondAccountId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public async Task Valid_api_key_authenticates_as_the_mapped_service_account()
+    {
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, ValidKey);
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        // The endpoint echoes the resolved AbpClaimTypes.UserId — proves the synthetic principal survived
+        // to authorization as the mapped service account.
+        (await response.Content.ReadAsStringAsync()).ShouldBe(ServiceAccountId.ToString());
+    }
+
+    [Fact]
+    public async Task Missing_api_key_falls_through_to_401()
+    {
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Invalid_api_key_falls_through_to_401_not_403()
+    {
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, "wrong-but-long-enough-key-aaaaaaaaaaaaaaaa");
+
+        var response = await client.GetAsync("/mcp");
+
+        // Must be 401 (unauthenticated challenge), NOT 403 — a 403 would make the #278 discovery handler
+        // skip the resource_metadata pointer and break OAuth-client discovery.
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Api_key_channel_is_scoped_to_the_mcp_path()
+    {
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, ValidKey);
+
+        // Same valid key on a non-/mcp protected path: the middleware branch must not run, so no principal
+        // is established and the request is rejected.
+        var response = await client.GetAsync("/other");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task A_second_configured_key_authenticates_as_its_own_service_account()
+    {
+        // Proves the no-early-exit match loop resolves a non-first key to its own mapped account.
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, SecondKey);
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldBe(SecondAccountId.ToString());
+    }
+
+    [Fact]
+    public async Task A_valid_bearer_wins_when_both_a_key_and_a_bearer_are_sent()
+    {
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, ValidKey);
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        // The middleware sets the api-key principal first, then UseAuthentication's Bearer success overwrites
+        // context.User — so the Bearer principal (no UserId claim, "stage"=raw) wins, as documented.
+        (await response.Content.ReadAsStringAsync()).ShouldBe(RawClaim);
+    }
+
+    [Fact]
+    public async Task Valid_bearer_still_authenticates_when_no_api_key_is_sent()
+    {
+        using var server = await BuildServerAsync();
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Bearer test-token");
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        // The Bearer stub principal (not the API-key path) handled it.
+        (await response.Content.ReadAsStringAsync()).ShouldBe(RawClaim);
+    }
+
+    [Fact]
+    public void Configuration_with_a_too_short_key_fails_fast()
+    {
+        var options = new McpApiKeyOptions
+        {
+            Keys = new List<McpApiKeyEntry>
+            {
+                new() { Key = "short", ServiceAccountUserId = ServiceAccountId.ToString() }
+            }
+        };
+
+        Should.Throw<AbpException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void Configuration_with_the_placeholder_key_fails_fast()
+    {
+        var options = new McpApiKeyOptions
+        {
+            Keys = new List<McpApiKeyEntry>
+            {
+                new() { Key = McpApiKeyDefaults.PlaceholderKey, ServiceAccountUserId = ServiceAccountId.ToString() }
+            }
+        };
+
+        Should.Throw<AbpException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void Empty_key_list_is_valid_and_disables_the_feature()
+    {
+        var options = new McpApiKeyOptions();
+
+        // No throw: an OAuth-only deployment.
+        Should.NotThrow(() => options.Validate());
+    }
+
+    private static async Task<TestServer> BuildServerAsync()
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+
+                    services
+                        .AddAuthentication(TokenScheme)
+                        .AddScheme<AuthenticationSchemeOptions, StubTokenHandler>(TokenScheme, null);
+
+                    services.AddAuthorization();
+
+                    services.AddExtractMcpApiKey(options =>
+                    {
+                        options.HeaderName = HeaderName;
+                        options.PathPrefix = "/mcp";
+                        options.Keys = new List<McpApiKeyEntry>
+                        {
+                            new()
+                            {
+                                Key = ValidKey,
+                                ServiceAccountUserId = ServiceAccountId.ToString(),
+                                Label = "codex-test"
+                            },
+                            new()
+                            {
+                                Key = SecondKey,
+                                ServiceAccountUserId = SecondAccountId.ToString(),
+                                Label = "abp-ai-test"
+                            }
+                        };
+                    });
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseExtractMcpApiKey();   // before authentication, mirroring the host
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints
+                            .MapGet("/mcp", (HttpContext context) => Echo(context))
+                            .RequireAuthorization();
+
+                        endpoints
+                            .MapGet("/other", (HttpContext context) => Echo(context))
+                            .RequireAuthorization();
+                    });
+                });
+            })
+            .StartAsync();
+
+        return host.GetTestServer();
+    }
+
+    private static string Echo(HttpContext context)
+    {
+        // API-key path stamps AbpClaimTypes.UserId; the Bearer stub stamps a "stage"=raw claim.
+        return context.User.FindFirst(AbpClaimTypes.UserId)?.Value
+            ?? context.User.FindFirst("stage")?.Value
+            ?? "anon";
+    }
+
+    // Bearer stub: an Authorization header authenticates with a raw principal; otherwise NoResult so the
+    // request stays unauthenticated (mirroring OpenIddict validation finding no token).
+    private sealed class StubTokenHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public StubTokenHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey("Authorization"))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var identity = new ClaimsIdentity(TokenScheme);
+            identity.AddClaim(new Claim("stage", RawClaim));
+            return Task.FromResult(AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(identity), TokenScheme)));
+        }
+    }
+}

--- a/docs/en/egress/mcp-server.md
+++ b/docs/en/egress/mcp-server.md
@@ -123,6 +123,7 @@ Some MCP clients cannot run the OAuth flow above but can send a **static custom 
 "Mcp": {
   "ApiKey": {
     "HeaderName": "X-Api-Key",                       // configurable; match it to the client's header
+    "RequireHttps": true,                            // ignore a key presented over plain HTTP (default true)
     "Keys": [
       {
         "Key": "<a CSPRNG secret, >= 32 chars>",     // env / user-secrets only
@@ -142,7 +143,7 @@ Some MCP clients cannot run the OAuth flow above but can send a **static custom 
 
 **Operational notes.**
 
-- **TLS only.** The key is a long-lived, bearer-equivalent secret: use the channel over HTTPS only, and configure the reverse proxy to strip any inbound copy of the header before forwarding.
+- **TLS only.** The key is a long-lived, bearer-equivalent secret. `Mcp:ApiKey:RequireHttps` (default `true`) makes the server **ignore a key presented over a non-HTTPS request** (it falls through to Bearer), so a key never travels in clear text; behind a TLS-terminating proxy this relies on the host's forwarded-headers handling. Also configure the proxy to strip any inbound copy of the header before forwarding. Set `RequireHttps: false` only for a deliberate plain-HTTP deployment (e.g. local testing).
 - **Rotation / revocation.** Multiple keys are supported, each with its own `Label` for audit attribution. Rotate with an overlap window (add the new key → migrate clients → remove the old). Revoke by removing the key from config (or removing the service account's grant). The API-key principal does **not** pass through ABP dynamic claims, so *disabling the underlying user is not an instant revocation path* — remove the key.
 - **Generation / fail-fast.** Generate keys from a CSPRNG (≥ 256 bits, e.g. 32 random bytes base64url); the host refuses to start on a placeholder value or a key shorter than 32 characters when keys are configured.
 

--- a/docs/en/egress/mcp-server.md
+++ b/docs/en/egress/mcp-server.md
@@ -17,11 +17,11 @@ The transport is **Streamable HTTP** at `/mcp`. (The legacy SSE transport is not
 
 ## Authentication
 
-The `/mcp` endpoint reuses the host's existing **OpenIddict Bearer** auth — the same scheme as the REST API (audience `VaultExtract`). There is no separate API-key system in v1.
+The `/mcp` endpoint's primary authentication is the host's existing **OpenIddict Bearer** auth — the same scheme as the REST API (audience `VaultExtract`). An **optional static API-key channel** (a custom request header) can be enabled alongside it for clients that cannot run the OAuth flow — see [§3 *Static API key*](#3-static-api-key-custom-header--fallback-for-non-oauth-clients) below. It is **disabled by default**.
 
 Every request to `/mcp` requires a valid Bearer token (`RequireAuthorization` on the endpoint). In addition, each tool/resource call performs an explicit server-side permission assertion: the caller must be granted **`VaultExtract.Documents`** (`ExtractPermissions.Documents.Default`). A token without that permission gets an authorization error even though the endpoint accepted the connection (fail-closed, defense in depth).
 
-There are two ways for a client to present that token. Both end at the same Bearer validation — they differ only in **how the client obtains the token**.
+There are two ways for a client to present that token (a third, non-OAuth option — a static API key — is covered separately in §3). Both end at the same Bearer validation — they differ only in **how the client obtains the token**.
 
 ### 1. Manual token (static `Authorization` header)
 
@@ -111,7 +111,58 @@ Native desktop clients bind a **random loopback port**, so the seeded client is 
 
 `RedirectUris` **replaces** the built-in defaults (it does not merge), so list every URI you still need. Re-run the host with `--migrate-database` to re-seed after changing it. A client's exact callback path can be captured from the `redirect_uri` query parameter on the `/authorize` request during a connect attempt.
 
-> Multi-tenancy is currently disabled (`ExtractHostModule.IsMultiTenant = false`), so all access resolves to the host document space. Tenant isolation is still enforced fail-closed in code (explicit `TenantId` predicate), so it stays correct if multi-tenancy is later enabled.
+> Multi-tenancy is currently disabled (`ExtractHostModule.IsMultiTenant = false`), so all access resolves to the host document space. Tenant isolation is enforced by ABP's ambient `IMultiTenant` global query filter — driven by the authenticated principal's tenant claim, not a hand-written `TenantId` predicate (see `.claude/rules/llm-call-anti-patterns.md`, anti-pattern B) — so it stays correct if multi-tenancy is later enabled, **provided every credential (including an API-key principal) carries the correct tenant claim**.
+
+### 3. Static API key (custom header) — fallback for non-OAuth clients
+
+Some MCP clients cannot run the OAuth flow above but can send a **static custom header** — e.g. **OpenAI Codex** (Streamable-HTTP MCP with arbitrary headers) and **ABP AI Management** (auth type *Custom Header* / *API Key*). For them the host can enable an optional **API-key channel** parallel to the Bearer chain. Claude's native custom connector is OAuth-only and keeps using discovery — it does not use this. (Introduced in #428.)
+
+**Disabled by default.** The shipped `appsettings.json` carries an empty `Mcp:ApiKey:Keys`, so OAuth-only deployments are unaffected. Configure keys via environment variables / user-secrets — **never commit a real key** (the same discipline as `Vault:Extract:ApiKey`):
+
+```jsonc
+"Mcp": {
+  "ApiKey": {
+    "HeaderName": "X-Api-Key",                       // configurable; match it to the client's header
+    "Keys": [
+      {
+        "Key": "<a CSPRNG secret, >= 32 chars>",     // env / user-secrets only
+        "ServiceAccountUserId": "<guid of a provisioned service-account user>",
+        "TenantId": null,                            // host space; set a tenant Guid once multi-tenant
+        "Label": "codex-prod"                        // audit attribution; never the key value
+      }
+    ]
+  }
+}
+```
+
+**How it maps to permissions.** A request carrying a valid key is authenticated as the mapped **service-account user**; a missing or invalid key is ignored — the request falls through to the Bearer chain + discovery `401`, never a `403`. The key grants *authentication* only; actual access is still gated by the same fail-closed `CheckPolicyAsync(VaultExtract.Documents)` the Bearer path hits. So you must:
+
+1. **Provision a dedicated service-account user** (ABP admin UI or your own seed), then
+2. **Grant it only `VaultExtract.Documents`** (`ExtractPermissions.Documents.Default`) — directly at the user level, **no roles**. That single permission covers every MCP path (`search_documents`, `get_document`, `list_document_types`, the document and document-type resources). Granting anything more — or via a shared role — would let an API-key caller exceed an OAuth user; don't.
+
+**Operational notes.**
+
+- **TLS only.** The key is a long-lived, bearer-equivalent secret: use the channel over HTTPS only, and configure the reverse proxy to strip any inbound copy of the header before forwarding.
+- **Rotation / revocation.** Multiple keys are supported, each with its own `Label` for audit attribution. Rotate with an overlap window (add the new key → migrate clients → remove the old). Revoke by removing the key from config (or removing the service account's grant). The API-key principal does **not** pass through ABP dynamic claims, so *disabling the underlying user is not an instant revocation path* — remove the key.
+- **Generation / fail-fast.** Generate keys from a CSPRNG (≥ 256 bits, e.g. 32 random bytes base64url); the host refuses to start on a placeholder value or a key shorter than 32 characters when keys are configured.
+
+#### Connect OpenAI Codex
+
+Add a Streamable-HTTP MCP server pointing at `/mcp` and send the key as a custom header. In `config.toml`:
+
+```toml
+[mcp_servers.extract]
+url = "https://your-extract-host/mcp"
+http_headers = { "X-Api-Key" = "<your-key>" }
+# or read it from the environment instead of inlining the secret:
+# env_http_headers = { "X-Api-Key" = "EXTRACT_MCP_API_KEY" }
+```
+
+(Equivalently, in Codex's UI: transport **Streamable HTTP**, the `/mcp` URL, and a header `X-Api-Key` = `<your-key>`.)
+
+#### Connect ABP AI Management
+
+In *edit MCP server → Auth*, choose **Custom Header**, set the header name to `X-Api-Key` (matching the server's `Mcp:ApiKey:HeaderName`) and the value to your key. If you use the **API Key** auth mode instead and it sends a fixed header name, set `Mcp:ApiKey:HeaderName` on the server to match it.
 
 ## Connect Claude Desktop
 

--- a/host/src/ExtractHostModule.cs
+++ b/host/src/ExtractHostModule.cs
@@ -331,6 +331,26 @@ public class ExtractHostModule : AbpModule
         });
 
         ConfigureMcpAuthentication(context);
+        ConfigureMcpApiKey(context);
+    }
+
+    // #428: optional static API-key fallback auth for the /mcp egress, parallel to the OpenIddict Bearer
+    // chain and the #278 OAuth discovery flow. It exists for MCP clients that cannot run the dynamic OAuth
+    // flow but can send a static request header (OpenAI Codex, ABP AI Management); Claude's native custom
+    // connector is OAuth-only and keeps using #278, unaffected. The shipped appsettings.json ships an empty
+    // Mcp:ApiKey:Keys, so the channel is DISABLED by default and OAuth-only deployments are untouched. Real
+    // keys + the key -> service-account mapping are host deployment config (env / user-secrets), never
+    // committed. The channel mechanism (matching, constant-time compare, synthetic-principal construction)
+    // lives in the Mcp egress module (AddExtractMcpApiKey, mirroring #422's AddExtractMcpDiscovery); the
+    // middleware is wired into the pipeline in OnApplicationInitialization via UseExtractMcpApiKey, before
+    // UseAuthentication. See docs/en/egress/mcp-server.md.
+    private void ConfigureMcpApiKey(ServiceConfigurationContext context)
+    {
+        var configuration = context.Services.GetConfiguration();
+        context.Services.AddExtractMcpApiKey(options =>
+        {
+            configuration.GetSection("Mcp:ApiKey").Bind(options);
+        });
     }
 
     // #278: add OAuth Protected Resource Metadata discovery for the /mcp export endpoint (RFC 9728). This is additive
@@ -733,6 +753,12 @@ public class ExtractHostModule : AbpModule
         app.UseAbpStudioLink();
         app.UseAbpSecurityHeaders();
         app.UseCors();
+        // #428: static API-key fallback auth for /mcp, inserted before the OpenIddict Bearer chain. No-op
+        // unless Mcp:ApiKey:Keys is configured. A valid key sets an authenticated least-privilege
+        // service-account principal that the bare RequireAuthorization() on /mcp accepts; a missing/invalid
+        // key falls through unauthenticated, so the Bearer chain and the #278 discovery challenge are
+        // unaffected. Scoped (segment-aware) to the /mcp path inside UseExtractMcpApiKey.
+        app.UseExtractMcpApiKey();
         app.UseAuthentication();
         app.UseAbpOpenIddictValidation();
 

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -59,6 +59,12 @@
       "MaxTextLengthPerExtraction": 8000
     }
   },
+  "Mcp": {
+    "ApiKey": {
+      "HeaderName": "X-Api-Key",
+      "Keys": []
+    }
+  },
   "VisionLlmOcr": {
     "MaxOutputTokens": 4096,
     "MaxPdfPages": 30

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -62,6 +62,7 @@
   "Mcp": {
     "ApiKey": {
       "HeaderName": "X-Api-Key",
+      "RequireHttps": true,
       "Keys": []
     }
   },


### PR DESCRIPTION
## What & why

Implements the static **API-key fallback authentication channel** for the `/mcp` MCP egress designed in #428, for MCP clients that cannot run the dynamic OAuth flow but can send a static request header — **OpenAI Codex** (arbitrary `http_headers`) and **ABP AI Management** (auth type *Custom Header* / *API Key*). It is **parallel to, never a replacement for**, the OpenIddict Bearer chain and the #278 OAuth discovery flow. Claude's native custom connector is OAuth-only and is unaffected.

Closes #428. This changes the **MCP egress security contract** and reverses the documented v1 decision *"no separate API-key system in v1"*, so it wants maintainer sign-off before merge (per CLAUDE.md working-rule #3). Docs are updated in lockstep.

## Design decision

Two shapes were considered (see #428). This PR implements the **path-scoped middleware** (Option A), not the auth-scheme (Option B):

- **Why middleware:** isolated, doesn't perturb ABP's existing `ForwardIdentityAuthenticationForBearer` / OpenIddict / McpAuth wiring, and its load-bearing behaviour is verified against this exact pipeline + ABP 10.2.0 (decompiled `UseAbpOpenIddictValidation` is gated on `!IsAuthenticated`; `AuthenticationMiddleware` only overwrites `context.User` on a non-null principal; the scheme-free `RequireAuthorization()` authorizes the ambient `context.User`).
- **Accepted trade-off:** the key principal does **not** pass through `UseDynamicClaims`, so live dynamic-claims revocation does not apply — revocation is by removing the key from config (or removing the service account's grant). A future `AuthenticationHandler`/scheme upgrade would restore enrichment parity; tracked as a #428 follow-up.

## What's in it

- **Mechanism (Mcp egress module, `core/.../Mcp/Authentication/`, mirrors #422 `AddExtractMcpDiscovery`):** `McpApiKeyAuthenticationMiddleware` + `McpApiKeyOptions`/`McpApiKeyEntry`/`McpApiKeyDefaults` + `AddExtractMcpApiKey` / `UseExtractMcpApiKey`. Segment-scoped to `/mcp`, runs before `UseAuthentication`. On a constant-time match (SHA-256 + `CryptographicOperations.FixedTimeEquals`, no early-exit) it sets an authenticated principal for the mapped least-privilege service-account user (`AbpClaimTypes.UserId` only, + tenant). On a missing/invalid key it **fails open** (never 401/403) so the Bearer chain + #278 discovery `401` stay intact. `RequireHttps` (default `true`) ignores a key over plain HTTP.
- **Host (`ExtractHostModule`):** `ConfigureMcpApiKey` binds `Mcp:ApiKey`; `UseExtractMcpApiKey` wired before `UseAuthentication`. **Disabled by default** (shipped `appsettings.json` has empty `Keys`); fail-fast on placeholder/short keys, non-Guid ids, duplicate keys when configured.
- **Permissions stay fail-closed:** the key grants *authentication* only; the tools' `CheckPolicyAsync(VaultExtract.Documents)` remains the real authorization gate. Minimal grant is exactly `VaultExtract.Documents`.
- **Docs (`docs/en/egress/mcp-server.md`):** new *Static API key* section + Codex / ABP AI Management setup; reverses the *"no separate API-key system in v1"* note; fixes the tenant-isolation doc drift (ambient `IMultiTenant` filter, not a hand-written `TenantId` predicate).

## Testing

- `dotnet test core/test/Dignite.Vault.Extract.Mcp.Tests` → **41/41 pass** (incl. the existing #278 discovery regression suite — unbroken). 11 new TestServer cases cover: valid key → authorized as the service account; missing → 401; invalid → **401 not 403** (protects the discovery pointer); path-scoping (`/other` not matched); multi-key resolution; key-vs-Bearer precedence; `RequireHttps` rejection over plain HTTP; and config fail-fast (placeholder / short key / empty-list).
- `dotnet build host/src/Dignite.Vault.Extract.Host.csproj` → **0 errors** (only pre-existing warnings).
- A finding round (architecture + security adversarial reviewers) was applied: multi-valued-header guard, single config-bind path, Debug-level invalid-key logging, no fake username claim, `PathPrefix` validation, startup enabled/disabled log, `RequireHttps` enforcement, softened tenant docs.

## To enable (operator steps, documented)

1. Provision a dedicated ABP service-account user.
2. Grant it **only** `VaultExtract.Documents` — directly at the user level, **no roles**.
3. Set `Mcp:ApiKey:Keys` via env / user-secrets: a CSPRNG key (≥ 32 chars) + that user's Guid.
4. Configure the client (`X-Api-Key: <key>`).

## Deferred (tracked under #428)

- `AuthenticationHandler`/scheme upgrade for live dynamic-claims revocation.
- Full ABP integration test (real `CheckPolicyAsync` pass/deny + tenant scoping); current tests are TestServer-level.
- Rate limiting on `/mcp`; service-account auto-provisioning seed; key hash-at-rest in config; multi-tenant end-to-end test.

