### PR TITLE
chore(release): bump version to 0.2.0-preview.5

### DIFF
--- a/angular/packages/vault-extract/package.json
+++ b/angular/packages/vault-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignite/vault-extract",
-  "version": "0.2.0-preview.4",
+  "version": "0.2.0-preview.5",
   "description": "Angular UI library for Dignite Vault Extract — the IDP channel layer that converts documents into Markdown, metadata, and structured fields.",
   "author": "Dignite",
   "license": "Apache-2.0",

--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <Version>0.2.0-preview.4</Version>
+        <Version>0.2.0-preview.5</Version>
         <!-- Pinned explicitly: without this the SDK derives AssemblyVersion from <Version>,
              moving it on every MINOR/PATCH — see CONTRIBUTING.md "Where the version lives". -->
         <AssemblyVersion>0.1.0.0</AssemblyVersion>


### PR DESCRIPTION
Opens the next pre-release cycle: bumps `<Version>` in `common.props` and the npm `version` in `angular/packages/vault-extract/package.json` to `0.2.0-preview.5` (kept in lockstep). No code changes.

preview.4 is released — NuGet on GitHub Packages, Angular lib built + packed to `angular/dist/dignite-vault-extract-0.2.0-preview.4.tgz`.