### PR TITLE
fix(text-extraction): make OCR language provider-specific, remove dead VaultExtractOcrOptions (#441)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
@@ -121,8 +121,9 @@ public class DocumentParseBackgroundJob
                 var ctx = new TextExtractionContext
                 {
                     ContentType = workItem.ContentType!,
-                    FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty),
-                    LanguageHints = { "ja", "en" }
+                    FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty)
+                    // No language hints set: OCR language is provider-specific (#441). VisionLlm / Azure DI
+                    // auto-detect; PaddleOcr falls back to its own PaddleOcr:Languages config.
                 };
 
                 result = await _textExtractor.ExtractAsync(blobStream, ctx, _cancellationTokenProvider.Token);

--- a/core/src/Dignite.Vault.Extract.Ocr/VaultExtractOcrOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Ocr/VaultExtractOcrOptions.cs
@@ -1,9 +1,0 @@
-using System.Collections.Generic;
-
-namespace Dignite.Vault.Extract.Ocr;
-
-public class VaultExtractOcrOptions
-{
-    /// <summary>Default language hints applied to all OCR requests, in BCP 47 format.</summary>
-    public IList<string> DefaultLanguageHints { get; set; } = new List<string> { "ja", "en" };
-}

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -120,18 +120,15 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
 
     private readonly IOcrProvider _ocrProvider;
     private readonly OpenXmlExtractorOptions _options;
-    private readonly VaultExtractOcrOptions _ocrOptions;
 
     public ILogger<DocxExtractor> Logger { get; set; } = NullLogger<DocxExtractor>.Instance;
 
     public DocxExtractor(
         IOcrProvider ocrProvider,
-        IOptions<OpenXmlExtractorOptions> options,
-        IOptions<VaultExtractOcrOptions> ocrOptions)
+        IOptions<OpenXmlExtractorOptions> options)
     {
         _ocrProvider = ocrProvider;
         _options = options.Value;
-        _ocrOptions = ocrOptions.Value;
     }
 
     /// <inheritdoc/>
@@ -254,22 +251,22 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 break;
 
             case W.Table table:
-            {
-                // Native table -> Markdown table (pure structured extraction, no OCR). A null/empty render
-                // (layout-only or empty grid) is simply not added; a parse fault is caught by the caller's
-                // per-block try/catch and tripped as FailedBlocks.
-                var renderedTable = WordTableRenderer.Render(table);
-                if (!string.IsNullOrWhiteSpace(renderedTable))
                 {
-                    blocks.Add(renderedTable!);
-                }
+                    // Native table -> Markdown table (pure structured extraction, no OCR). A null/empty render
+                    // (layout-only or empty grid) is simply not added; a parse fault is caught by the caller's
+                    // per-block try/catch and tripped as FailedBlocks.
+                    var renderedTable = WordTableRenderer.Render(table);
+                    if (!string.IsNullOrWhiteSpace(renderedTable))
+                    {
+                        blocks.Add(renderedTable!);
+                    }
 
-                // A Markdown table cell can't host a multi-line transcription / chart block, so a figure
-                // inside a cell is extracted as its own block AFTER the table — content preserved (over its
-                // exact in-cell position), a failure still trips #268, rather than being silently dropped.
-                await ExtractContainerFiguresAsync(table, mainPart, blocks, state, cancellationToken);
-                break;
-            }
+                    // A Markdown table cell can't host a multi-line transcription / chart block, so a figure
+                    // inside a cell is extracted as its own block AFTER the table — content preserved (over its
+                    // exact in-cell position), a failure still trips #268, rather than being silently dropped.
+                    await ExtractContainerFiguresAsync(table, mainPart, blocks, state, cancellationToken);
+                    break;
+                }
 
             case W.SdtBlock sdt:
                 // Block-level content control (a form / template field wrapping paragraphs, tables, etc.).
@@ -763,12 +760,13 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     /// <summary>
-    /// Resolves the OCR language hints for embedded-image transcription, mirroring <c>DefaultTextExtractor</c>
-    /// and <see cref="PptxExtractor"/>: the per-document hints when present, otherwise the host's configured
-    /// defaults — so the figure path and the whole-page OCR path apply the same defaulting.
+    /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the
+    /// context, or empty. There is no central host default (#441 removed it); a provider that needs a
+    /// language default reads its own config (e.g. PaddleOcr:Languages). Kept <c>protected virtual</c> so a
+    /// consumer can override to supply hints (e.g. from per-tenant config).
     /// </summary>
     protected virtual IList<string> ResolveLanguageHints(TextExtractionContext context)
-        => context.LanguageHints?.Count > 0 ? context.LanguageHints : _ocrOptions.DefaultLanguageHints;
+        => context.LanguageHints ?? new List<string>();
 
     /// <summary>
     /// Builds the #268 incompleteness reason from the loss counters, or returns <c>null</c> when nothing was

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -63,18 +63,15 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
 
     private readonly IOcrProvider _ocrProvider;
     private readonly OpenXmlExtractorOptions _options;
-    private readonly VaultExtractOcrOptions _ocrOptions;
 
     public ILogger<PptxExtractor> Logger { get; set; } = NullLogger<PptxExtractor>.Instance;
 
     public PptxExtractor(
         IOcrProvider ocrProvider,
-        IOptions<OpenXmlExtractorOptions> options,
-        IOptions<VaultExtractOcrOptions> ocrOptions)
+        IOptions<OpenXmlExtractorOptions> options)
     {
         _ocrProvider = ocrProvider;
         _options = options.Value;
-        _ocrOptions = ocrOptions.Value;
     }
 
     /// <inheritdoc/>
@@ -246,34 +243,34 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             switch (child)
             {
                 case P.GroupShape group:
-                {
-                    var (gy, gx) = inGroup ? (groupY, groupX) : OffsetOf(group);
-                    await WalkShapesAsync(group, slidePart, inGroup: true, gy, gx, blocks, state, cancellationToken);
-                    break;
-                }
+                    {
+                        var (gy, gx) = inGroup ? (groupY, groupX) : OffsetOf(group);
+                        await WalkShapesAsync(group, slidePart, inGroup: true, gy, gx, blocks, state, cancellationToken);
+                        break;
+                    }
 
                 case P.Picture picture:
-                {
-                    var (y, x) = PositionFor(picture, inGroup, groupY, groupX);
-                    await HandlePictureAsync(picture, slidePart, y, x, blocks, state, cancellationToken);
-                    break;
-                }
+                    {
+                        var (y, x) = PositionFor(picture, inGroup, groupY, groupX);
+                        await HandlePictureAsync(picture, slidePart, y, x, blocks, state, cancellationToken);
+                        break;
+                    }
 
                 case P.GraphicFrame graphicFrame:
-                {
-                    var (y, x) = PositionFor(graphicFrame, inGroup, groupY, groupX);
-                    HandleGraphicFrame(graphicFrame, slidePart, y, x, blocks, state);
-                    break;
-                }
+                    {
+                        var (y, x) = PositionFor(graphicFrame, inGroup, groupY, groupX);
+                        HandleGraphicFrame(graphicFrame, slidePart, y, x, blocks, state);
+                        break;
+                    }
 
                 case P.Shape shape:
-                {
-                    var (y, x) = PositionFor(shape, inGroup, groupY, groupX);
-                    HandleTextShape(shape, y, x, blocks, state);
-                    break;
-                }
+                    {
+                        var (y, x) = PositionFor(shape, inGroup, groupY, groupX);
+                        HandleTextShape(shape, y, x, blocks, state);
+                        break;
+                    }
 
-                // ConnectionShape / non-visual property elements / unknown: nothing to extract.
+                    // ConnectionShape / non-visual property elements / unknown: nothing to extract.
             }
         }
     }
@@ -621,12 +618,13 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     /// <summary>
-    /// Resolves the OCR language hints for embedded-image transcription, mirroring
-    /// <c>DefaultTextExtractor</c>: the per-document hints when present, otherwise the host's configured
-    /// defaults — so the figure path and the whole-page OCR path apply the same defaulting.
+    /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the
+    /// context, or empty. There is no central host default (#441 removed it); a provider that needs a
+    /// language default reads its own config (e.g. PaddleOcr:Languages). Kept <c>protected virtual</c> so a
+    /// consumer can override to supply hints (e.g. from per-tenant config).
     /// </summary>
     protected virtual IList<string> ResolveLanguageHints(TextExtractionContext context)
-        => context.LanguageHints?.Count > 0 ? context.LanguageHints : _ocrOptions.DefaultLanguageHints;
+        => context.LanguageHints ?? new List<string>();
 
     /// <summary>
     /// Builds the #268 incompleteness reason from the loss counters, or returns <c>null</c> when nothing

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
@@ -43,18 +43,15 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
 
     private readonly IOcrProvider _ocrProvider;
     private readonly PdfExtractorOptions _options;
-    private readonly VaultExtractOcrOptions _ocrOptions;
 
     public ILogger<PdfExtractor> Logger { get; set; } = NullLogger<PdfExtractor>.Instance;
 
     public PdfExtractor(
         IOcrProvider ocrProvider,
-        IOptions<PdfExtractorOptions> options,
-        IOptions<VaultExtractOcrOptions> ocrOptions)
+        IOptions<PdfExtractorOptions> options)
     {
         _ocrProvider = ocrProvider;
         _options = options.Value;
-        _ocrOptions = ocrOptions.Value;
     }
 
     /// <inheritdoc/>
@@ -478,12 +475,13 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
         => !string.IsNullOrEmpty(text) && text.Any(char.IsLetterOrDigit);
 
     /// <summary>
-    /// Resolves the OCR language hints for embedded-image transcription, mirroring
-    /// <c>DefaultTextExtractor</c>: the per-document hints when present, otherwise the host's configured
-    /// defaults — so the figure path and the whole-page OCR path apply the same defaulting.
+    /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the
+    /// context, or empty. There is no central host default (#441 removed it); a provider that needs a
+    /// language default reads its own config (e.g. PaddleOcr:Languages). Kept <c>protected virtual</c> so a
+    /// consumer can override to supply hints (e.g. from per-tenant config).
     /// </summary>
     protected virtual IList<string> ResolveLanguageHints(TextExtractionContext context)
-        => context.LanguageHints?.Count > 0 ? context.LanguageHints : _ocrOptions.DefaultLanguageHints;
+        => context.LanguageHints ?? new List<string>();
 
     /// <summary>
     /// Builds the #268 incompleteness reason from the loss counters, or returns <c>null</c> when nothing

--- a/core/src/Dignite.Vault.Extract.Parse/DefaultTextExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse/DefaultTextExtractor.cs
@@ -8,7 +8,6 @@ using Dignite.Vault.Extract.Abstractions.Parse;
 using Dignite.Vault.Extract.Ocr;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 
 namespace Dignite.Vault.Extract.Parse;
@@ -17,18 +16,15 @@ public class DefaultTextExtractor : ITextExtractor, ITransientDependency
 {
     private readonly IOcrProvider _ocrProvider;
     private readonly IReadOnlyList<IMarkdownTextProvider> _markdownProviders;
-    private readonly VaultExtractOcrOptions _ocrOptions;
 
     public ILogger<DefaultTextExtractor> Logger { get; set; } = NullLogger<DefaultTextExtractor>.Instance;
 
     public DefaultTextExtractor(
         IOcrProvider ocrProvider,
-        IEnumerable<IMarkdownTextProvider> markdownProviders,
-        IOptions<VaultExtractOcrOptions> ocrOptions)
+        IEnumerable<IMarkdownTextProvider> markdownProviders)
     {
         _ocrProvider = ocrProvider;
         _markdownProviders = markdownProviders.ToList();
-        _ocrOptions = ocrOptions.Value;
     }
 
     public virtual async Task<TextExtractionResult> ExtractAsync(
@@ -135,15 +131,13 @@ public class DefaultTextExtractor : ITextExtractor, ITransientDependency
 
         try
         {
-            var languageHints = ctx.LanguageHints?.Count > 0
-                ? ctx.LanguageHints
-                : (IList<string>)_ocrOptions.DefaultLanguageHints;
-
             seekable.Position = 0;
             var result = await _ocrProvider.RecognizeAsync(seekable, new OcrOptions
             {
                 ContentType = ctx.ContentType ?? string.Empty,
-                LanguageHints = languageHints
+                // Per-document hints only (empty by default). The central host default was removed (#441);
+                // a provider that needs a language default reads its own config (e.g. PaddleOcr:Languages).
+                LanguageHints = ctx.LanguageHints ?? new List<string>()
             }, cancellationToken);
 
             Logger.LogDebug("OCR completed using {Provider}.", result.ProviderName ?? _ocrProvider.GetType().Name);

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DefaultTextExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DefaultTextExtractor_Tests.cs
@@ -49,8 +49,8 @@ public class DefaultTextExtractor_Tests : AbpIntegratedTest<DefaultTextExtractor
             Arg.Any<Stream>(),
             Arg.Is<OcrOptions>(o =>
                 o.ContentType == "image/jpeg" &&
-                o.LanguageHints.Contains("ja") &&
-                o.LanguageHints.Contains("en")),
+                // #441: no central host default; with no per-document hints the extractor passes empty hints.
+                o.LanguageHints.Count == 0),
             Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractorRegistration_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractorRegistration_Tests.cs
@@ -36,8 +36,7 @@ public class DocxExtractorRegistration_Tests
     {
         var extractor = new DocxExtractor(
             Substitute.For<IOcrProvider>(),
-            Options.Create(new OpenXmlExtractorOptions()),
-            Options.Create(new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            Options.Create(new OpenXmlExtractorOptions()));
 
         extractor.CanHandle(".docx").ShouldBeTrue();
         extractor.CanHandle(".DOCX").ShouldBeTrue();

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -20,8 +20,7 @@ public class DocxExtractor_Tests
     private DocxExtractor CreateExtractor(
         int minImagePixels = 0,
         int maxImages = 50,
-        long maxImageBytes = 16L * 1024 * 1024,
-        VaultExtractOcrOptions? ocrOptions = null)
+        long maxImageBytes = 16L * 1024 * 1024)
         => new(
             _ocr,
             Options.Create(new OpenXmlExtractorOptions
@@ -29,9 +28,7 @@ public class DocxExtractor_Tests
                 MinImagePixels = minImagePixels,
                 MaxImagesPerFile = maxImages,
                 MaxImageBytesPerImage = maxImageBytes
-            }),
-            // Default to empty hints so unrelated tests don't get defaults injected unexpectedly.
-            Options.Create(ocrOptions ?? new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            }));
 
     private static TextExtractionContext DocxContext()
         => new() { ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document", FileExtension = ".docx" };
@@ -417,7 +414,7 @@ public class DocxExtractor_Tests
     }
 
     [Fact]
-    public async Task Applies_default_language_hints_when_the_context_has_none()
+    public async Task Passes_empty_language_hints_to_figure_ocr_when_the_context_has_none()
     {
         StubOcr("FIGURE");
 
@@ -425,12 +422,14 @@ public class DocxExtractor_Tests
             .Paragraph("Body text")
             .Image(Png(alt: null)));
 
-        var extractor = CreateExtractor(ocrOptions: new VaultExtractOcrOptions());
+        // #441: no central host default. With no per-document hints, the figure path passes empty hints;
+        // a provider that needs a default reads its own config (e.g. PaddleOcr:Languages).
+        var extractor = CreateExtractor();
         await extractor.ExtractAsync(new MemoryStream(docx), DocxContext());
 
         await _ocr.Received(1).RecognizeAsync(
             Arg.Any<Stream>(),
-            Arg.Is<OcrOptions>(o => o.LanguageHints.Contains("ja") && o.LanguageHints.Contains("en")),
+            Arg.Is<OcrOptions>(o => o.LanguageHints.Count == 0),
             Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractorRegistration_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractorRegistration_Tests.cs
@@ -36,8 +36,7 @@ public class PptxExtractorRegistration_Tests
     {
         var extractor = new PptxExtractor(
             Substitute.For<IOcrProvider>(),
-            Options.Create(new OpenXmlExtractorOptions()),
-            Options.Create(new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            Options.Create(new OpenXmlExtractorOptions()));
 
         extractor.CanHandle(".pptx").ShouldBeTrue();
         extractor.CanHandle(".PPTX").ShouldBeTrue();

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -21,8 +21,7 @@ public class PptxExtractor_Tests
         int minImagePixels = 0,
         int maxImages = 50,
         bool includeNotes = true,
-        long maxImageBytes = 16L * 1024 * 1024,
-        VaultExtractOcrOptions? ocrOptions = null)
+        long maxImageBytes = 16L * 1024 * 1024)
         => new(
             _ocr,
             Options.Create(new OpenXmlExtractorOptions
@@ -31,9 +30,7 @@ public class PptxExtractor_Tests
                 MaxImagesPerFile = maxImages,
                 MaxImageBytesPerImage = maxImageBytes,
                 IncludeSpeakerNotes = includeNotes
-            }),
-            // Default to empty hints so unrelated tests don't get defaults injected unexpectedly.
-            Options.Create(ocrOptions ?? new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            }));
 
     private static TextExtractionContext PptxContext()
         => new() { ContentType = "application/vnd.openxmlformats-officedocument.presentationml.presentation", FileExtension = ".pptx" };
@@ -571,8 +568,7 @@ public class PptxExtractor_Tests
         // egress); a host has to opt in. Construct with default options to assert the shipped default.
         var extractor = new PptxExtractor(
             _ocr,
-            Options.Create(new OpenXmlExtractorOptions()),
-            Options.Create(new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            Options.Create(new OpenXmlExtractorOptions()));
 
         var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
             .Text("Visible content")
@@ -691,7 +687,7 @@ public class PptxExtractor_Tests
     }
 
     [Fact]
-    public async Task Applies_default_language_hints_when_the_context_has_none()
+    public async Task Passes_empty_language_hints_to_figure_ocr_when_the_context_has_none()
     {
         StubOcr("FIGURE");
 
@@ -699,12 +695,14 @@ public class PptxExtractor_Tests
             .Text("Body text")
             .Image(Png(alt: null, x: 100, y: 1_000_000)));
 
-        var extractor = CreateExtractor(ocrOptions: new VaultExtractOcrOptions());
+        // #441: no central host default. With no per-document hints, the figure path passes empty hints;
+        // a provider that needs a default reads its own config (e.g. PaddleOcr:Languages).
+        var extractor = CreateExtractor();
         await extractor.ExtractAsync(new MemoryStream(pptx), PptxContext());
 
         await _ocr.Received(1).RecognizeAsync(
             Arg.Any<Stream>(),
-            Arg.Is<OcrOptions>(o => o.LanguageHints.Contains("ja") && o.LanguageHints.Contains("en")),
+            Arg.Is<OcrOptions>(o => o.LanguageHints.Count == 0),
             Arg.Any<CancellationToken>());
     }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfExtractorRegistration_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfExtractorRegistration_Tests.cs
@@ -38,8 +38,7 @@ public class PdfExtractorRegistration_Tests
     {
         var extractor = new PdfExtractor(
             Substitute.For<IOcrProvider>(),
-            Options.Create(new PdfExtractorOptions()),
-            Options.Create(new VaultExtractOcrOptions()));
+            Options.Create(new PdfExtractorOptions()));
 
         extractor.CanHandle(".pdf").ShouldBeTrue();
         extractor.CanHandle(".PDF").ShouldBeTrue();

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -21,8 +21,7 @@ public class PdfExtractor_Tests
     private PdfExtractor CreateExtractor(
         int minImagePixels = 0,
         int maxImagesPerPdf = 50,
-        bool skipFullPageScanBackground = true,
-        VaultExtractOcrOptions? ocrOptions = null)
+        bool skipFullPageScanBackground = true)
         => new(
             _ocr,
             Options.Create(new PdfExtractorOptions
@@ -32,9 +31,7 @@ public class PdfExtractor_Tests
                 // Defaults to true in production; kept explicit here so each test states the behavior it
                 // exercises. The remaining FullPageScan* thresholds use their production defaults.
                 SkipFullPageScanBackground = skipFullPageScanBackground
-            }),
-            // Default to empty hints so unrelated tests don't get defaults injected unexpectedly.
-            Options.Create(ocrOptions ?? new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            }));
 
     // A full-page raster inset 10pt inside the fixture page — clears the coverage bar on both axes
     // (~0.97). Derived from PdfFixtures' page size so a fixture page-size change can't silently flip the
@@ -286,7 +283,7 @@ public class PdfExtractor_Tests
     }
 
     [Fact]
-    public async Task Applies_default_language_hints_when_the_context_has_none()
+    public async Task Passes_empty_language_hints_to_figure_ocr_when_the_context_has_none()
     {
         StubOcr("FIGURE");
 
@@ -295,13 +292,14 @@ public class PdfExtractor_Tests
             texts: new[] { ("Body text", 700.0) },
             images: new[] { (png, new PdfRectangle(50, 400, 200, 550)) });
 
-        // Context carries no hints; the host default {ja,en} must be applied (same as the whole-page path).
-        var extractor = CreateExtractor(ocrOptions: new VaultExtractOcrOptions());
+        // #441: no central host default. With no per-document hints, the figure path passes empty hints;
+        // a provider that needs a default reads its own config (e.g. PaddleOcr:Languages).
+        var extractor = CreateExtractor();
         await extractor.ExtractAsync(new MemoryStream(pdf), PdfContext());
 
         await _ocr.Received(1).RecognizeAsync(
             Arg.Any<Stream>(),
-            Arg.Is<OcrOptions>(o => o.LanguageHints.Contains("ja") && o.LanguageHints.Contains("en")),
+            Arg.Is<OcrOptions>(o => o.LanguageHints.Count == 0),
             Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRunningHeaderFooter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRunningHeaderFooter_Tests.cs
@@ -23,8 +23,7 @@ public class PdfRunningHeaderFooter_Tests
     private PdfExtractor CreateExtractor()
         => new(
             _ocr,
-            Options.Create(new PdfExtractorOptions()),
-            Options.Create(new VaultExtractOcrOptions { DefaultLanguageHints = new List<string>() }));
+            Options.Create(new PdfExtractorOptions()));
 
     private static TextExtractionContext PdfContext()
         => new() { ContentType = "application/pdf", FileExtension = ".pdf" };

--- a/core/test/Dignite.Vault.Extract.Parse.Tests/DefaultTextExtractorDispatch_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Tests/DefaultTextExtractorDispatch_Tests.cs
@@ -161,17 +161,19 @@ public class DefaultTextExtractorDispatch_Tests
     }
 
     [Fact]
-    public async Task Should_Fall_Back_To_Default_Language_Hints_When_Context_Has_None()
+    public async Task Should_Pass_Empty_Language_Hints_When_Context_Has_None()
     {
+        // #441: the central host default (VaultExtractOcrOptions) was removed. With no per-document hints
+        // the extractor passes empty hints; a provider that needs a default reads its own config
+        // (e.g. PaddleOcr:Languages), as proven by PaddleOcrProvider_Tests.
         var ocr = TestDoubles.OcrReturning();
-        var options = new VaultExtractOcrOptions { DefaultLanguageHints = new List<string> { "it", "es" } };
-        var sut = TestDoubles.Extractor(ocr, new[] { TestDoubles.MarkdownProvider(0, ".x") }, options);
+        var sut = TestDoubles.Extractor(ocr, new[] { TestDoubles.MarkdownProvider(0, ".x") });
 
         await sut.ExtractAsync(TestDoubles.Bytes(0xFF, 0xD8), Context(".jpg", "image/jpeg"));
 
         await ocr.Received(1).RecognizeAsync(
             Arg.Any<Stream>(),
-            Arg.Is<OcrOptions>(o => o.LanguageHints.SequenceEqual(new[] { "it", "es" })),
+            Arg.Is<OcrOptions>(o => o.LanguageHints.Count == 0),
             Arg.Any<CancellationToken>());
     }
 

--- a/core/test/Dignite.Vault.Extract.Parse.Tests/TestDoubles.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Tests/TestDoubles.cs
@@ -49,9 +49,8 @@ internal static class TestDoubles
 
     public static DefaultTextExtractor Extractor(
         IOcrProvider ocr,
-        IEnumerable<IMarkdownTextProvider> markdownProviders,
-        VaultExtractOcrOptions? ocrOptions = null)
-        => new(ocr, markdownProviders, Options.Create(ocrOptions ?? new VaultExtractOcrOptions()));
+        IEnumerable<IMarkdownTextProvider> markdownProviders)
+        => new(ocr, markdownProviders);
 
     public static MemoryStream Bytes(params byte[] content) => new(content);
 }


### PR DESCRIPTION
## What & why

OCR recognition language was effectively a hardcoded `{ja,en}` and **no appsettings-based OCR language config was reachable**:

- `DocumentParseBackgroundJob` set `TextExtractionContext.LanguageHints = {ja,en}` (the only `new TextExtractionContext` in `core/src`), which sat at the highest-precedence layer and shadowed everything below it.
- `VaultExtractOcrOptions.DefaultLanguageHints` was bound to **no** config section (dead config; `VaultExtractOcrModule` is empty).
- Because the parse job always supplied non-empty hints, even each provider's own bound config (`PaddleOcr:Languages`) was shadowed too.

Masked today only because the default provider (VisionLlm) ignores hints; it would silently bite the moment a deployment switched to PaddleOcr / Azure DI and tried to configure the language.

## Change (option B from #441 — remove the central default layer)

- **Delete** `VaultExtractOcrOptions` (the dead central default).
- **Stop hardcoding** `LanguageHints` in `DocumentParseBackgroundJob`.
- Each extractor's `ResolveLanguageHints` now passes `context.LanguageHints` through (empty by default); kept `protected virtual` as the override hook.
- **Kept** the per-request `OcrOptions.LanguageHints` contract param (L1) — the future per-tenant / per-document override hook.
- A provider that needs a language default reads **its own** config: PaddleOcr → `PaddleOcr:Languages`; VisionLlm / Azure DI auto-detect.

Rationale (full decision in #441): OCR providers are mutually exclusive (host enables exactly one), so a cross-provider central default serves no scenario; and a host knob the default provider silently ignores is the very "looks-live-but-isn't" trap being removed.

## Verification

- **294 tests pass** across the affected projects: Parse 82 / Pdf 85 / OpenXml 109 / **PaddleOcr 10** (confirms empty hints → falls back to `PaddleOcr:Languages`) / Application·DefaultTextExtractor 8.
- 4 tests that asserted the old `{ja,en}` default were rewritten to assert "empty hints passed through"; L1 pass-through and L3 PaddleOcr fallback both remain covered.
- Downstream consumer `vault-private` checked — **zero** references to `VaultExtractOcrOptions`; removal is safe (extractors are DI-resolved, ctor change is transparent).
- No Angular proxy regen needed (no AppService/DTO contract change).

## Note

Incidentally conforms `case`-block indentation in `DocxExtractor.cs` / `PptxExtractor.cs` to `.editorconfig` (`csharp_indent_case_contents_when_block` defaults true) — pure whitespace, no logic change.

Closes #441
