### PR TITLE
feat(text-extraction): lattice table detection — use a PDF's drawn ruling lines as the authoritative grid (#450)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
@@ -272,7 +272,27 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     ? pageContent.Words
                     : pageContent.Words.Where(w => !droppable.Contains(w)).ToList();
 
-                var pageMarkdown = PdfReadingOrder.RenderPage(renderWords, figures, _options.ReconstructTables, headingScale);
+                // #450 lattice: the page's vector ruling-line bounds (a table's drawn grid is the authoritative
+                // column/row model). Guarded — a page whose content stream faults on path access still renders
+                // its text; lattice detection is simply skipped for it (the stream table path still applies).
+                IReadOnlyList<PdfRectangle> rulingBounds;
+                try
+                {
+                    rulingBounds = pageContent.Page.Paths
+                        .SelectMany(path => path)
+                        .Select(subpath => subpath.GetBoundingRectangle())
+                        .Where(rect => rect.HasValue)
+                        .Select(rect => rect!.Value)
+                        .ToList();
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Logger.LogWarning(ex, "Failed to read vector paths on a PDF page; table lattice detection skipped for it.");
+                    rulingBounds = Array.Empty<PdfRectangle>();
+                }
+
+                var pageMarkdown = PdfReadingOrder.RenderPage(
+                    renderWords, figures, _options.ReconstructTables, headingScale, rulingBounds);
                 if (!string.IsNullOrWhiteSpace(pageMarkdown))
                 {
                     pageMarkdowns.Add(pageMarkdown);

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -656,6 +656,14 @@ internal static class PdfReadingOrder
             : 0.0;
         var paragraphModel = BuildParagraphModel(pageLines, medianLineHeight);
 
+        // #450 lattice: detect any drawn table grids from the page's vector ruling lines. This is authoritative
+        // (deterministic column/row boundaries), so it is detected up front and even keeps the single-block page
+        // out of the whitespace-only early return below when a grid is present. No rules -> empty -> the pure
+        // Phase A/B stream behaviour, unchanged.
+        var grids = reconstructTables && rulingBounds is { Count: > 0 }
+            ? PdfRulingLines.DetectGrids(rulingBounds)
+            : (IReadOnlyList<PdfRulingLines.Grid>)Array.Empty<PdfRulingLines.Grid>();
+
         IReadOnlyList<DlaTextBlock> orderedBlocks;
         try
         {
@@ -669,11 +677,11 @@ internal static class PdfReadingOrder
             return Render(pageLines, figures, headingScale, paragraphModel);
         }
 
-        // A single region (or no/one-block segmentation) is exactly the #301 behavior — render the whole
-        // page as one column. This is also the path the existing single-column fixtures take. (A table is
-        // almost always cut into several blocks, so single-block table reconstruction is not
-        // attempted here — an accepted #329 first-pass limitation.)
-        if (orderedBlocks.Count <= 1)
+        // A single region (or no/one-block segmentation) is the #301 behavior — render the whole page as one
+        // column — UNLESS a drawn grid is present: a small ruled table can land in a single segmentation block,
+        // and its grid still reconstructs it (the block path below claims it as a lattice table). Without a
+        // grid this stays the #329 single-block limitation (no whitespace table reconstruction on one block).
+        if (orderedBlocks.Count <= 1 && grids.Count == 0)
         {
             return Render(pageLines, figures, headingScale, paragraphModel);
         }
@@ -693,18 +701,11 @@ internal static class PdfReadingOrder
         // caption binding run within that block's single-region stream.
         var figuresByBlock = AssignFiguresToBlocks(orderedBlocks, figures);
 
-        // #450 lattice: if the page draws a table grid with vector rules, that grid is the authoritative
-        // column/row model. Detect it once from the ruling-line bounds; DetectTableClusters then prefers it for
-        // the blocks it covers and keeps the whitespace/stream path for everything else. No rules -> null -> the
-        // pure Phase A/B stream behaviour, unchanged.
-        var grid = reconstructTables && rulingBounds is { Count: > 0 }
-            ? PdfRulingLines.DetectGrid(rulingBounds)
-            : null;
-
-        // Phase B: re-aggregate neighbouring blocks into candidate table clusters and reconstruct the ones
-        // that confidently form a grid. A non-table page yields no clusters, so the loop below is exactly the
-        // Phase A per-block path; the host switch off -> empty maps -> identical to Phase A.
-        var tables = reconstructTables ? DetectTableClusters(orderedBlocks, grid) : TableClusters.Empty;
+        // Phase B: reconstruct tables — a drawn ruling grid as a deterministic lattice table (#450), and the
+        // remaining blocks via the whitespace/stream clustering. A non-table page yields no clusters, so the
+        // loop below is exactly the Phase A per-block path; the host switch off -> empty maps -> identical to
+        // Phase A.
+        var tables = reconstructTables ? DetectTableClusters(orderedBlocks, grids) : TableClusters.Empty;
 
         var rendered = new List<string>(orderedBlocks.Count);
         var emittedTables = new HashSet<int>();
@@ -816,47 +817,54 @@ internal static class PdfReadingOrder
     /// the reconstructor, which derives the grid from glyph geometry either way. A cluster that does not
     /// reconstruct as a table is absent from the result, so its blocks fall through to the Phase A paragraph path.
     /// </summary>
-    private static TableClusters DetectTableClusters(IReadOnlyList<DlaTextBlock> blocks, PdfRulingLines.Grid? grid)
+    private static TableClusters DetectTableClusters(
+        IReadOnlyList<DlaTextBlock> blocks, IReadOnlyList<PdfRulingLines.Grid> grids)
     {
         var result = new TableClusters();
 
-        // #450 lattice: a drawn ruling grid is the authoritative table — claim every block whose centre falls
+        // #450 lattice: each drawn ruling grid is an authoritative table — claim the blocks whose centre falls
         // inside it as ONE table, rendered deterministically from the drawn column/row boundaries (the case the
-        // whitespace path struggles with: tight gutters, sparse or empty columns). Blocks outside the grid (a
-        // title above it, a footnote below) are left for the stream path / paragraph flow. The table is placed
-        // at its topmost (lowest-index, earliest reading-order) block.
+        // whitespace path struggles with: tight gutters, sparse or empty columns). A block claimed by one grid
+        // is not re-claimed by another. Blocks outside every grid (a title above, a footnote below) are left for
+        // the stream path / paragraph flow; each table is placed at its topmost (earliest reading-order) block.
         var claimedByLattice = new HashSet<int>();
-        if (grid is { } g)
+        foreach (var g in grids)
         {
             var insideBlocks = new List<int>();
             for (var bi = 0; bi < blocks.Count; bi++)
             {
-                if (CentroidInsideGrid(blocks[bi].BoundingBox, g))
+                if (!claimedByLattice.Contains(bi) && CentroidInsideGrid(blocks[bi].BoundingBox, g))
                 {
                     insideBlocks.Add(bi);
                 }
             }
 
-            if (insideBlocks.Count >= 2)
+            if (insideBlocks.Count == 0)
             {
-                var latticeCells = insideBlocks
-                    .SelectMany(bi => blocks[bi].TextLines.SelectMany(line => line.Words))
-                    .Where(word => !string.IsNullOrWhiteSpace(word.Text))
-                    .Select(word => new PdfTableReconstruction.Cell(word.BoundingBox, word.Text))
-                    .ToList();
+                continue;
+            }
 
-                var lattice = PdfTableReconstruction.TryRenderLattice(latticeCells, g);
-                if (lattice is not null)
-                {
-                    var latticeLead = insideBlocks.Min();
-                    result.MarkdownByLead[latticeLead] = lattice;
-                    result.BlocksByLead[latticeLead] = insideBlocks;
-                    foreach (var bi in insideBlocks)
-                    {
-                        result.LeadByBlock[bi] = latticeLead;
-                        claimedByLattice.Add(bi);
-                    }
-                }
+            var latticeCells = insideBlocks
+                .SelectMany(bi => blocks[bi].TextLines.SelectMany(line => line.Words))
+                .Where(word => !string.IsNullOrWhiteSpace(word.Text))
+                .Select(word => new PdfTableReconstruction.Cell(word.BoundingBox, word.Text))
+                .ToList();
+
+            // TryRenderLattice returns null unless the claimed blocks fill a >= 2x2 grid, so a lone caption
+            // block that happens to sit inside a grid extent does not become a spurious table.
+            var lattice = PdfTableReconstruction.TryRenderLattice(latticeCells, g);
+            if (lattice is null)
+            {
+                continue;
+            }
+
+            var latticeLead = insideBlocks.Min();
+            result.MarkdownByLead[latticeLead] = lattice;
+            result.BlocksByLead[latticeLead] = insideBlocks;
+            foreach (var bi in insideBlocks)
+            {
+                result.LeadByBlock[bi] = latticeLead;
+                claimedByLattice.Add(bi);
             }
         }
 

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -636,9 +636,9 @@ internal static class PdfReadingOrder
     /// </summary>
     public static string RenderPage(
         IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables = true,
-        PdfHeadingScale? headingScale = null)
+        PdfHeadingScale? headingScale = null, IReadOnlyList<PdfRectangle>? rulingBounds = null)
     {
-        var markdown = RenderPageCore(words, figures, reconstructTables, headingScale);
+        var markdown = RenderPageCore(words, figures, reconstructTables, headingScale, rulingBounds);
         // #403: a heading that wrapped across lines / bands renders as adjacent same-level "# …" blocks; stitch
         // them back into one heading (e.g. the title and its trailing 「書」). A no-op when no headings exist.
         return headingScale is { HasHeadings: true } ? MergeAdjacentHeadings(markdown) : markdown;
@@ -646,7 +646,7 @@ internal static class PdfReadingOrder
 
     private static string RenderPageCore(
         IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables,
-        PdfHeadingScale? headingScale)
+        PdfHeadingScale? headingScale, IReadOnlyList<PdfRectangle>? rulingBounds)
     {
         // #407: build the page's justification-aware paragraph model once (right margin + measured wrap pitch)
         // and feed it to every Render call below, so a paragraph the segmenter cut into per-line blocks re-folds.
@@ -693,10 +693,18 @@ internal static class PdfReadingOrder
         // caption binding run within that block's single-region stream.
         var figuresByBlock = AssignFiguresToBlocks(orderedBlocks, figures);
 
+        // #450 lattice: if the page draws a table grid with vector rules, that grid is the authoritative
+        // column/row model. Detect it once from the ruling-line bounds; DetectTableClusters then prefers it for
+        // the blocks it covers and keeps the whitespace/stream path for everything else. No rules -> null -> the
+        // pure Phase A/B stream behaviour, unchanged.
+        var grid = reconstructTables && rulingBounds is { Count: > 0 }
+            ? PdfRulingLines.DetectGrid(rulingBounds)
+            : null;
+
         // Phase B: re-aggregate neighbouring blocks into candidate table clusters and reconstruct the ones
         // that confidently form a grid. A non-table page yields no clusters, so the loop below is exactly the
         // Phase A per-block path; the host switch off -> empty maps -> identical to Phase A.
-        var tables = reconstructTables ? DetectTableClusters(orderedBlocks) : TableClusters.Empty;
+        var tables = reconstructTables ? DetectTableClusters(orderedBlocks, grid) : TableClusters.Empty;
 
         var rendered = new List<string>(orderedBlocks.Count);
         var emittedTables = new HashSet<int>();
@@ -808,18 +816,72 @@ internal static class PdfReadingOrder
     /// the reconstructor, which derives the grid from glyph geometry either way. A cluster that does not
     /// reconstruct as a table is absent from the result, so its blocks fall through to the Phase A paragraph path.
     /// </summary>
-    private static TableClusters DetectTableClusters(IReadOnlyList<DlaTextBlock> blocks)
+    private static TableClusters DetectTableClusters(IReadOnlyList<DlaTextBlock> blocks, PdfRulingLines.Grid? grid)
     {
+        var result = new TableClusters();
+
+        // #450 lattice: a drawn ruling grid is the authoritative table — claim every block whose centre falls
+        // inside it as ONE table, rendered deterministically from the drawn column/row boundaries (the case the
+        // whitespace path struggles with: tight gutters, sparse or empty columns). Blocks outside the grid (a
+        // title above it, a footnote below) are left for the stream path / paragraph flow. The table is placed
+        // at its topmost (lowest-index, earliest reading-order) block.
+        var claimedByLattice = new HashSet<int>();
+        if (grid is { } g)
+        {
+            var insideBlocks = new List<int>();
+            for (var bi = 0; bi < blocks.Count; bi++)
+            {
+                if (CentroidInsideGrid(blocks[bi].BoundingBox, g))
+                {
+                    insideBlocks.Add(bi);
+                }
+            }
+
+            if (insideBlocks.Count >= 2)
+            {
+                var latticeCells = insideBlocks
+                    .SelectMany(bi => blocks[bi].TextLines.SelectMany(line => line.Words))
+                    .Where(word => !string.IsNullOrWhiteSpace(word.Text))
+                    .Select(word => new PdfTableReconstruction.Cell(word.BoundingBox, word.Text))
+                    .ToList();
+
+                var lattice = PdfTableReconstruction.TryRenderLattice(latticeCells, g);
+                if (lattice is not null)
+                {
+                    var latticeLead = insideBlocks.Min();
+                    result.MarkdownByLead[latticeLead] = lattice;
+                    result.BlocksByLead[latticeLead] = insideBlocks;
+                    foreach (var bi in insideBlocks)
+                    {
+                        result.LeadByBlock[bi] = latticeLead;
+                        claimedByLattice.Add(bi);
+                    }
+                }
+            }
+        }
+
         var medianHeight = PdfGeometry.Median(blocks.Select(b => b.BoundingBox.Height));
         if (medianHeight <= 0)
         {
-            return TableClusters.Empty;
+            return result;
         }
 
         var gutterThreshold = medianHeight * ColumnGutterScale;
-        var result = new TableClusters();
-        foreach (var clusterRows in ClusterTableCandidateBlocks(blocks, medianHeight))
+        foreach (var candidateRows in ClusterTableCandidateBlocks(blocks, medianHeight))
         {
+            // Drop any blocks already claimed by the lattice table so the stream path only reconstructs
+            // borderless tables (and never double-renders a ruled one).
+            var clusterRows = claimedByLattice.Count == 0
+                ? candidateRows
+                : candidateRows
+                    .Select(row => row.Where(bi => !claimedByLattice.Contains(bi)).ToList())
+                    .Where(row => row.Count > 0)
+                    .ToList();
+            if (clusterRows.Count == 0)
+            {
+                continue;
+            }
+
             // Peel leading heading / caption / intro rows (the "第3条（料金）" heading + "本業務の料金は…" intro
             // above the grid, the "別紙1 料金表" caption) before reconstruction. They enter the cluster from the
             // top — where no column structure is established yet, so the chaining bridge-guard cannot reject
@@ -866,6 +928,16 @@ internal static class PdfReadingOrder
         }
 
         return result;
+    }
+
+    /// <summary>Whether the box's centre falls within the drawn grid's outer extent (its column/row boundary
+    /// range) — i.e. the box is a cell of the ruled table rather than a title / footnote outside it (#450).</summary>
+    private static bool CentroidInsideGrid(PdfRectangle box, PdfRulingLines.Grid grid)
+    {
+        var centreX = (box.Left + box.Right) / 2.0;
+        var centreY = (box.Bottom + box.Top) / 2.0;
+        return centreX >= grid.ColumnBoundaries[0] && centreX <= grid.ColumnBoundaries[^1]
+            && centreY >= grid.RowBoundaries[0] && centreY <= grid.RowBoundaries[^1];
     }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfRulingLines.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfRulingLines.cs
@@ -6,23 +6,24 @@ using UglyToad.PdfPig.Core;
 namespace Dignite.Vault.Extract.Parse.Pdf;
 
 /// <summary>
-/// Detects a table's drawn ruling-line grid (#450 lattice path) from a page's vector subpath bounding
+/// Detects the drawn ruling-line grids on a page (#450 lattice path) from its vector subpath bounding
 /// rectangles. When a table draws its column/row separators as lines — bank statements, forms, financial
 /// reports — those lines are the <b>authoritative</b> column/row model: deterministic, unlike the whitespace
-/// heuristics of <see cref="PdfTableReconstruction"/>. Returns <c>null</c> when no grid of at least 2×2 cells
-/// is drawn, so the caller keeps the whitespace / stream path (a borderless table, or a table with only row
-/// rules and no column separators).
+/// heuristics of <see cref="PdfTableReconstruction"/>. Returns one <see cref="Grid"/> per drawn table; a page
+/// with no ruled grid (borderless tables, or a table with only row rules and no column separators) yields an
+/// empty list and the caller keeps the whitespace / stream path.
 /// <para>
 /// Robust to the two common encodings and their quirks: a ruling can be a thin filled rectangle OR a stroked
-/// line; a table border can be one stroked rectangle (contributing its four sides); and rulings are frequently
-/// <b>double-stroked</b> (two near-coincident segments ~a point apart). Every qualifying subpath contributes
-/// candidate boundary positions, and near-coincident candidates are clustered into a single boundary.
+/// line; a table border can be one stroked rectangle (its four sides); and rulings are frequently
+/// <b>double-stroked</b> (two near-coincident segments ~a point apart). Crucially, rules are grouped into
+/// SEPARATE tables by intersection (a connected component of mutually-crossing rules), so two distinct tables
+/// on one page are not merged into a single spurious grid.
 /// </para>
 /// </summary>
 internal static class PdfRulingLines
 {
     /// <summary>
-    /// The drawn grid: the ascending x of the vertical rules (column separators) and ascending y of the
+    /// One drawn table grid: the ascending x of the vertical rules (column separators) and ascending y of the
     /// horizontal rules (row separators). N boundaries delimit N-1 cells along that axis.
     /// </summary>
     public readonly record struct Grid(IReadOnlyList<double> ColumnBoundaries, IReadOnlyList<double> RowBoundaries)
@@ -32,20 +33,25 @@ internal static class PdfRulingLines
         public int RowCount => RowBoundaries.Count - 1;
     }
 
+    private readonly record struct HRule(double Y, double X1, double X2);
+
+    private readonly record struct VRule(double X, double Y1, double Y2);
+
     /// <summary>
-    /// Detects the ruling grid from the page's subpath bounding rectangles, or <c>null</c> when fewer than a
-    /// 2×2 grid of rules is present. <paramref name="minRuleLength"/> filters tick marks / glyph strokes,
+    /// Detects every drawn table grid on the page (top-to-bottom), or an empty list when none has at least a
+    /// 2×2 cell structure. <paramref name="minRuleLength"/> filters tick marks / glyph strokes,
     /// <paramref name="maxRuleThickness"/> separates a thin rule from a filled box, and
-    /// <paramref name="clusterTolerance"/> collapses double-stroked / near-coincident rules.
+    /// <paramref name="clusterTolerance"/> collapses double-stroked / near-coincident rules and sets the
+    /// intersection slack.
     /// </summary>
-    public static Grid? DetectGrid(
+    public static IReadOnlyList<Grid> DetectGrids(
         IReadOnlyList<PdfRectangle> subpathBounds,
         double minRuleLength = 18.0,
         double maxRuleThickness = 3.0,
         double clusterTolerance = 3.0)
     {
-        var verticalX = new List<double>();
-        var horizontalY = new List<double>();
+        var horizontals = new List<HRule>();
+        var verticals = new List<VRule>();
 
         foreach (var rect in subpathBounds)
         {
@@ -58,36 +64,102 @@ internal static class PdfRulingLines
 
             if (width >= minRuleLength && height <= maxRuleThickness)
             {
-                // A long, thin horizontal segment — one row rule at its centre line.
-                horizontalY.Add((top + bottom) / 2.0);
+                horizontals.Add(new HRule((top + bottom) / 2.0, left, right));
             }
             else if (height >= minRuleLength && width <= maxRuleThickness)
             {
-                // A long, thin vertical segment — one column rule at its centre line.
-                verticalX.Add((left + right) / 2.0);
+                verticals.Add(new VRule((left + right) / 2.0, bottom, top));
             }
             else if (width >= minRuleLength && height >= minRuleLength)
             {
-                // A large rectangle (a stroked table/cell border, or a shaded fill): contribute its four sides
-                // as candidate rules. Spurious sides from a fill fall out in clustering / the grid-shape check.
-                horizontalY.Add(top);
-                horizontalY.Add(bottom);
-                verticalX.Add(left);
-                verticalX.Add(right);
+                // A large rectangle (a stroked table/cell border, or a shaded fill): its four sides are rules.
+                horizontals.Add(new HRule(top, left, right));
+                horizontals.Add(new HRule(bottom, left, right));
+                verticals.Add(new VRule(left, bottom, top));
+                verticals.Add(new VRule(right, bottom, top));
             }
         }
 
-        var columns = Cluster(verticalX, clusterTolerance);
-        var rows = Cluster(horizontalY, clusterTolerance);
-
-        // A lattice needs >= 2 columns AND >= 2 rows (>= 3 boundaries on each axis). A page with only row rules
-        // (no vertical separators) is not a lattice here; the caller's whitespace path owns columns then.
-        if (columns.Count < 3 || rows.Count < 3)
+        // Group rules into separate tables: a table is a connected component of rules where a vertical and a
+        // horizontal cross. Union-find over [0..h) horizontals and [h..h+v) verticals.
+        var h = horizontals.Count;
+        var v = verticals.Count;
+        var parent = new int[h + v];
+        for (var i = 0; i < parent.Length; i++)
         {
-            return null;
+            parent[i] = i;
         }
 
-        return new Grid(columns, rows);
+        int Find(int x)
+        {
+            while (parent[x] != x)
+            {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+
+            return x;
+        }
+
+        for (var i = 0; i < h; i++)
+        {
+            for (var j = 0; j < v; j++)
+            {
+                if (Crosses(horizontals[i], verticals[j], clusterTolerance))
+                {
+                    parent[Find(i)] = Find(h + j);
+                }
+            }
+        }
+
+        var rowsByComponent = new Dictionary<int, List<double>>();
+        var columnsByComponent = new Dictionary<int, List<double>>();
+        for (var i = 0; i < h; i++)
+        {
+            AddTo(rowsByComponent, Find(i), horizontals[i].Y);
+        }
+
+        for (var j = 0; j < v; j++)
+        {
+            AddTo(columnsByComponent, Find(h + j), verticals[j].X);
+        }
+
+        var grids = new List<Grid>();
+        foreach (var (component, columnPositions) in columnsByComponent)
+        {
+            if (!rowsByComponent.TryGetValue(component, out var rowPositions))
+            {
+                continue; // vertical rules with no crossing horizontals — not a grid
+            }
+
+            var columns = Cluster(columnPositions, clusterTolerance);
+            var rows = Cluster(rowPositions, clusterTolerance);
+
+            // A lattice needs >= 2 columns AND >= 2 rows (>= 3 boundaries on each axis).
+            if (columns.Count >= 3 && rows.Count >= 3)
+            {
+                grids.Add(new Grid(columns, rows));
+            }
+        }
+
+        // Top-to-bottom (by the grid's top edge) for a stable, reading-order-ish sequence.
+        return grids.OrderByDescending(g => g.RowBoundaries[^1]).ToList();
+    }
+
+    /// <summary>Whether a horizontal and a vertical rule cross (within <paramref name="tolerance"/> slack).</summary>
+    private static bool Crosses(HRule horizontal, VRule vertical, double tolerance)
+        => vertical.X >= horizontal.X1 - tolerance && vertical.X <= horizontal.X2 + tolerance
+        && horizontal.Y >= vertical.Y1 - tolerance && horizontal.Y <= vertical.Y2 + tolerance;
+
+    private static void AddTo(Dictionary<int, List<double>> map, int key, double value)
+    {
+        if (!map.TryGetValue(key, out var list))
+        {
+            list = new List<double>();
+            map[key] = list;
+        }
+
+        list.Add(value);
     }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfRulingLines.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfRulingLines.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UglyToad.PdfPig.Core;
+
+namespace Dignite.Vault.Extract.Parse.Pdf;
+
+/// <summary>
+/// Detects a table's drawn ruling-line grid (#450 lattice path) from a page's vector subpath bounding
+/// rectangles. When a table draws its column/row separators as lines — bank statements, forms, financial
+/// reports — those lines are the <b>authoritative</b> column/row model: deterministic, unlike the whitespace
+/// heuristics of <see cref="PdfTableReconstruction"/>. Returns <c>null</c> when no grid of at least 2×2 cells
+/// is drawn, so the caller keeps the whitespace / stream path (a borderless table, or a table with only row
+/// rules and no column separators).
+/// <para>
+/// Robust to the two common encodings and their quirks: a ruling can be a thin filled rectangle OR a stroked
+/// line; a table border can be one stroked rectangle (contributing its four sides); and rulings are frequently
+/// <b>double-stroked</b> (two near-coincident segments ~a point apart). Every qualifying subpath contributes
+/// candidate boundary positions, and near-coincident candidates are clustered into a single boundary.
+/// </para>
+/// </summary>
+internal static class PdfRulingLines
+{
+    /// <summary>
+    /// The drawn grid: the ascending x of the vertical rules (column separators) and ascending y of the
+    /// horizontal rules (row separators). N boundaries delimit N-1 cells along that axis.
+    /// </summary>
+    public readonly record struct Grid(IReadOnlyList<double> ColumnBoundaries, IReadOnlyList<double> RowBoundaries)
+    {
+        public int ColumnCount => ColumnBoundaries.Count - 1;
+
+        public int RowCount => RowBoundaries.Count - 1;
+    }
+
+    /// <summary>
+    /// Detects the ruling grid from the page's subpath bounding rectangles, or <c>null</c> when fewer than a
+    /// 2×2 grid of rules is present. <paramref name="minRuleLength"/> filters tick marks / glyph strokes,
+    /// <paramref name="maxRuleThickness"/> separates a thin rule from a filled box, and
+    /// <paramref name="clusterTolerance"/> collapses double-stroked / near-coincident rules.
+    /// </summary>
+    public static Grid? DetectGrid(
+        IReadOnlyList<PdfRectangle> subpathBounds,
+        double minRuleLength = 18.0,
+        double maxRuleThickness = 3.0,
+        double clusterTolerance = 3.0)
+    {
+        var verticalX = new List<double>();
+        var horizontalY = new List<double>();
+
+        foreach (var rect in subpathBounds)
+        {
+            var left = Math.Min(rect.Left, rect.Right);
+            var right = Math.Max(rect.Left, rect.Right);
+            var bottom = Math.Min(rect.Bottom, rect.Top);
+            var top = Math.Max(rect.Bottom, rect.Top);
+            var width = right - left;
+            var height = top - bottom;
+
+            if (width >= minRuleLength && height <= maxRuleThickness)
+            {
+                // A long, thin horizontal segment — one row rule at its centre line.
+                horizontalY.Add((top + bottom) / 2.0);
+            }
+            else if (height >= minRuleLength && width <= maxRuleThickness)
+            {
+                // A long, thin vertical segment — one column rule at its centre line.
+                verticalX.Add((left + right) / 2.0);
+            }
+            else if (width >= minRuleLength && height >= minRuleLength)
+            {
+                // A large rectangle (a stroked table/cell border, or a shaded fill): contribute its four sides
+                // as candidate rules. Spurious sides from a fill fall out in clustering / the grid-shape check.
+                horizontalY.Add(top);
+                horizontalY.Add(bottom);
+                verticalX.Add(left);
+                verticalX.Add(right);
+            }
+        }
+
+        var columns = Cluster(verticalX, clusterTolerance);
+        var rows = Cluster(horizontalY, clusterTolerance);
+
+        // A lattice needs >= 2 columns AND >= 2 rows (>= 3 boundaries on each axis). A page with only row rules
+        // (no vertical separators) is not a lattice here; the caller's whitespace path owns columns then.
+        if (columns.Count < 3 || rows.Count < 3)
+        {
+            return null;
+        }
+
+        return new Grid(columns, rows);
+    }
+
+    /// <summary>
+    /// Merges ascending positions that sit within <paramref name="tolerance"/> of the running cluster into one
+    /// boundary (the cluster mean), collapsing double-stroked / near-coincident rules. Returns the boundaries
+    /// ascending. A real column gutter / row pitch is tens of points, far above the tolerance, so distinct
+    /// boundaries never merge.
+    /// </summary>
+    private static List<double> Cluster(List<double> values, double tolerance)
+    {
+        var result = new List<double>();
+        if (values.Count == 0)
+        {
+            return result;
+        }
+
+        values.Sort();
+        var clusterStart = values[0];
+        var sum = values[0];
+        var count = 1;
+        for (var i = 1; i < values.Count; i++)
+        {
+            if (values[i] - clusterStart <= tolerance)
+            {
+                sum += values[i];
+                count++;
+            }
+            else
+            {
+                result.Add(sum / count);
+                clusterStart = values[i];
+                sum = values[i];
+                count = 1;
+            }
+        }
+
+        result.Add(sum / count);
+        return result;
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfTableReconstruction.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfTableReconstruction.cs
@@ -196,6 +196,101 @@ internal static class PdfTableReconstruction
     }
 
     /// <summary>
+    /// Renders <paramref name="cells"/> against a table's <b>drawn ruling grid</b> (#450 lattice path): the
+    /// column/row boundaries come from the PDF's vector rules (<see cref="PdfRulingLines"/>), not from whitespace
+    /// heuristics, so the reconstruction is deterministic — the exact case where the stream path struggles (tight
+    /// gutters, sparse or empty columns). Each fragment is placed in the cell whose drawn boundaries contain its
+    /// centre; fragments outside the grid are ignored (they are not part of the table). Returns <c>null</c> when
+    /// the grid is smaller than 2×2 or no drawn row carries text, so the caller falls back to
+    /// <see cref="TryRender"/>.
+    /// </summary>
+    public static string? TryRenderLattice(IReadOnlyList<Cell> cells, PdfRulingLines.Grid grid)
+    {
+        var meaningful = cells.Where(c => !string.IsNullOrWhiteSpace(c.Text)).ToList();
+        if (meaningful.Count == 0 || grid.ColumnCount < MinColumns || grid.RowCount < MinRows)
+        {
+            return null;
+        }
+
+        var columns = grid.ColumnBoundaries; // ascending x
+        var rows = grid.RowBoundaries;       // ascending y (PDF user space is bottom-up)
+
+        // Bucket every fragment into its (row, column) cell by centre containment.
+        var buckets = new List<Cell>[grid.RowCount, grid.ColumnCount];
+        foreach (var cell in meaningful)
+        {
+            var column = BandIndex(columns, (cell.Bounds.Left + cell.Bounds.Right) / 2.0);
+            var bandFromBottom = BandIndex(rows, (cell.Bounds.Top + cell.Bounds.Bottom) / 2.0);
+            if (column < 0 || bandFromBottom < 0)
+            {
+                continue; // outside the drawn grid — not table content
+            }
+
+            var row = grid.RowCount - 1 - bandFromBottom; // ascending-y band -> top-to-bottom row
+            (buckets[row, column] ??= new List<Cell>()).Add(cell);
+        }
+
+        // Emit the rows that carry text (a drawn-but-blank spacer row is dropped, not rendered as an empty row).
+        var rendered = new List<IReadOnlyList<string>>(grid.RowCount);
+        for (var r = 0; r < grid.RowCount; r++)
+        {
+            var line = new string[grid.ColumnCount];
+            var hasText = false;
+            for (var c = 0; c < grid.ColumnCount; c++)
+            {
+                var bucket = buckets[r, c];
+                line[c] = bucket is null ? string.Empty : MarkdownText.EscapeInlineCell(JoinCellFragments(bucket));
+                hasText |= line[c].Length > 0;
+            }
+
+            if (hasText)
+            {
+                rendered.Add(line);
+            }
+        }
+
+        return rendered.Count < MinRows ? null : MarkdownText.RenderTable(rendered);
+    }
+
+    /// <summary>
+    /// Index of the cell band whose ascending <paramref name="boundaries"/> contain <paramref name="value"/>
+    /// (the largest <c>i</c> with <c>boundaries[i] &lt;= value</c>, in <c>[0, count-2]</c>), or <c>-1</c> when
+    /// the value falls outside the grid (left of the first boundary or at/after the last).
+    /// </summary>
+    private static int BandIndex(IReadOnlyList<double> boundaries, double value)
+    {
+        if (value < boundaries[0] || value >= boundaries[^1])
+        {
+            return -1;
+        }
+
+        int lo = 0, hi = boundaries.Count;
+        while (lo < hi)
+        {
+            var mid = (lo + hi) / 2;
+            if (boundaries[mid] <= value)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
+        }
+
+        return lo - 1;
+    }
+
+    /// <summary>
+    /// Joins the fragments that landed in one lattice cell in reading order. Fragments are first clustered into
+    /// visual lines (top-to-bottom, each left-to-right) via <see cref="GroupIntoVisualLines"/> — a raw
+    /// top-then-left sort mis-orders same-line words whose glyph boxes have slightly different tops (CJK
+    /// baselines / mixed sizes) — so a cell whose text wraps to several lines reads correctly.
+    /// </summary>
+    private static string JoinCellFragments(IReadOnlyList<Cell> cells)
+        => string.Join(" ", GroupIntoVisualLines(cells).SelectMany(line => line).Select(c => c.Text));
+
+    /// <summary>
     /// Splits the fragments into column bands. A flat x-projection of every fragment merges two columns whenever
     /// a single wide cell reaches across their gutter in even one row (#446: a 6-column bank statement whose
     /// 日付/摘要 and an empty メモ column collapsed into their neighbours, content bleeding across cells). Two

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfTableReconstruction.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfTableReconstruction.cs
@@ -223,7 +223,13 @@ internal static class PdfTableReconstruction
             var bandFromBottom = BandIndex(rows, (cell.Bounds.Top + cell.Bounds.Bottom) / 2.0);
             if (column < 0 || bandFromBottom < 0)
             {
-                continue; // outside the drawn grid — not table content
+                // A fragment whose centre is outside the drawn boundaries is deliberately dropped as non-table
+                // content. NOTE (#450 review): the caller claims a block by its CENTROID being inside the grid,
+                // so a block straddling the outer rule could contribute a fragment that lands here and is not
+                // re-rendered by the stream path — a narrow lossy edge, unlike the strict non-lossy guarantee
+                // RenderPageCore enforces around segmentation. It is bounded by real ruled tables enclosing their
+                // text, and by this method returning null (un-claiming the blocks) whenever the grid degrades.
+                continue;
             }
 
             var row = grid.RowCount - 1 - bandFromBottom; // ascending-y band -> top-to-bottom row

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfFixtures.cs
@@ -132,6 +132,38 @@ internal static class PdfFixtures
     }
 
     /// <summary>
+    /// Builds a single-page PDF with positioned text plus drawn ruling lines — a lattice table (#450). Vertical
+    /// rules are (X, Y1, Y2), horizontal rules (Y, X1, X2); each is stroked with <c>DrawLine</c>, so the page's
+    /// vector paths carry the table's drawn column/row grid that <see cref="PdfRulingLines"/> reads.
+    /// </summary>
+    public static byte[] BuildWithRules(
+        IReadOnlyList<(string Text, double X, double BaselineY)> texts,
+        IReadOnlyList<(double X, double Y1, double Y2)> verticalRules,
+        IReadOnlyList<(double Y, double X1, double X2)> horizontalRules)
+    {
+        var builder = new PdfDocumentBuilder();
+        var font = builder.AddStandard14Font(Standard14Font.Helvetica);
+        var page = builder.AddPage(PageWidth, PageHeight);
+
+        foreach (var (text, x, baselineY) in texts)
+        {
+            page.AddText(text, 12, new PdfPoint(x, baselineY), font);
+        }
+
+        foreach (var (x, y1, y2) in verticalRules)
+        {
+            page.DrawLine(new PdfPoint(x, y1), new PdfPoint(x, y2));
+        }
+
+        foreach (var (y, x1, x2) in horizontalRules)
+        {
+            page.DrawLine(new PdfPoint(x1, y), new PdfPoint(x2, y));
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
     /// Builds a multi-page PDF — one page per inner list of (Text, baselineY) lines — needed to exercise the
     /// cross-page running header/footer detection (#383), which has no signal on a single page.
     /// </summary>

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfLatticeIntegration_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfLatticeIntegration_Tests.cs
@@ -54,6 +54,54 @@ public class PdfLatticeIntegration_Tests
     }
 
     [Fact]
+    public void Reconstructs_two_ruled_tables_on_one_page_as_two_markdown_tables()
+    {
+        // #450 edge case: two stacked ruled tables with DIFFERENT column counts must be reconstructed as two
+        // separate tables (top-to-bottom), not merged into one spurious grid.
+        var pdf = PdfFixtures.BuildWithRules(
+            texts: new[]
+            {
+                // Top table (2 columns), band y 630..660 (header) / 600..630 (data).
+                ("A1", 60.0, 635.0), ("A2", 160.0, 635.0), ("a", 60.0, 605.0), ("b", 160.0, 605.0),
+                // Bottom table (3 columns), band y 430..460 (header) / 400..430 (data).
+                ("B1", 60.0, 435.0), ("B2", 160.0, 435.0), ("B3", 260.0, 435.0),
+                ("x", 60.0, 405.0), ("y", 160.0, 405.0), ("z", 260.0, 405.0)
+            },
+            verticalRules: new[]
+            {
+                (50.0, 600.0, 660.0), (150.0, 600.0, 660.0), (250.0, 600.0, 660.0),          // top: 2 columns
+                (50.0, 400.0, 460.0), (150.0, 400.0, 460.0), (250.0, 400.0, 460.0), (350.0, 400.0, 460.0) // bottom: 3 columns
+            },
+            horizontalRules: new[]
+            {
+                (600.0, 50.0, 250.0), (630.0, 50.0, 250.0), (660.0, 50.0, 250.0),
+                (400.0, 50.0, 350.0), (430.0, 50.0, 350.0), (460.0, 50.0, 350.0)
+            });
+
+        RenderFirstPage(pdf).ShouldBe(
+            "| A1 | A2 |\n| --- | --- |\n| a | b |\n\n" +
+            "| B1 | B2 | B3 |\n| --- | --- | --- |\n| x | y | z |");
+    }
+
+    [Fact]
+    public void Separates_columns_whose_gutter_is_too_tight_for_the_whitespace_path()
+    {
+        // A ruled table whose column gutter (~3pt) is narrower than the stream path's threshold and the
+        // segmenter's cut — the drawn rule at x=130 is the only column signal, and the lattice path honours it.
+        var pdf = PdfFixtures.BuildWithRules(
+            texts: new[]
+            {
+                ("Left", 55.0, 635.0), ("Right", 133.0, 635.0),
+                ("aaa", 55.0, 605.0), ("bbb", 133.0, 605.0)
+            },
+            verticalRules: new[] { (50.0, 600.0, 660.0), (130.0, 600.0, 660.0), (210.0, 600.0, 660.0) },
+            horizontalRules: new[] { (600.0, 50.0, 210.0), (630.0, 50.0, 210.0), (660.0, 50.0, 210.0) });
+
+        RenderFirstPage(pdf).ShouldBe(
+            "| Left | Right |\n| --- | --- |\n| aaa | bbb |");
+    }
+
+    [Fact]
     public void Falls_back_to_the_stream_path_when_no_grid_is_drawn()
     {
         // The same table with NO ruling lines: the lattice path finds no grid and the whitespace/stream path

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfLatticeIntegration_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfLatticeIntegration_Tests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using Shouldly;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Parse.Pdf;
+
+/// <summary>
+/// End-to-end tests for the #450 lattice path through <see cref="PdfReadingOrder.RenderPage"/> — a PDF whose
+/// table draws its grid with vector rules is reconstructed from that grid, exactly as <c>PdfExtractor</c> drives
+/// it (words + the page's ruling-line bounds).
+/// </summary>
+public class PdfLatticeIntegration_Tests
+{
+    private static string RenderFirstPage(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+        var words = page.GetWords().ToList();
+        var rulingBounds = page.Paths
+            .SelectMany(p => p)
+            .Select(sp => sp.GetBoundingRectangle())
+            .Where(r => r.HasValue)
+            .Select(r => r!.Value)
+            .ToList();
+
+        return PdfReadingOrder.RenderPage(
+            words, Array.Empty<PdfReadingOrder.Figure>(), true, PdfHeadingScale.Build(words), rulingBounds);
+    }
+
+    [Fact]
+    public void Reconstructs_a_ruled_table_from_its_drawn_grid()
+    {
+        // A 3-column x 2-row table whose grid is DRAWN. The middle column is empty on the data row — a sparse
+        // column the whitespace path could drop — but the drawn grid keeps all three columns.
+        var pdf = PdfFixtures.BuildWithRules(
+            texts: new[]
+            {
+                ("Name", 60.0, 635.0), ("Qty", 160.0, 635.0), ("Note", 260.0, 635.0), // header row (band 630..660)
+                ("Apple", 60.0, 605.0), ("red", 260.0, 605.0)                          // data row (band 600..630); Qty empty
+            },
+            verticalRules: new[]
+            {
+                (50.0, 600.0, 660.0), (150.0, 600.0, 660.0), (250.0, 600.0, 660.0), (350.0, 600.0, 660.0)
+            },
+            horizontalRules: new[]
+            {
+                (600.0, 50.0, 350.0), (630.0, 50.0, 350.0), (660.0, 50.0, 350.0)
+            });
+
+        RenderFirstPage(pdf).ShouldBe(
+            "| Name | Qty | Note |\n| --- | --- | --- |\n| Apple |  | red |");
+    }
+
+    [Fact]
+    public void Falls_back_to_the_stream_path_when_no_grid_is_drawn()
+    {
+        // The same table with NO ruling lines: the lattice path finds no grid and the whitespace/stream path
+        // reconstructs it (all columns filled here so it reads as a clean grid).
+        var pdf = PdfFixtures.BuildWithRules(
+            texts: new[]
+            {
+                ("Name", 60.0, 635.0), ("Qty", 160.0, 635.0), ("Note", 260.0, 635.0),
+                ("Apple", 60.0, 605.0), ("5", 160.0, 605.0), ("red", 260.0, 605.0)
+            },
+            verticalRules: Array.Empty<(double, double, double)>(),
+            horizontalRules: Array.Empty<(double, double, double)>());
+
+        RenderFirstPage(pdf).ShouldBe(
+            "| Name | Qty | Note |\n| --- | --- | --- |\n| Apple | 5 | red |");
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRulingLines_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRulingLines_Tests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using Shouldly;
+using UglyToad.PdfPig.Core;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Parse.Pdf;
+
+public class PdfRulingLines_Tests
+{
+    // PdfRectangle(left, bottom, right, top). A rule is a long, thin rectangle; a box is large in both axes.
+    private static PdfRectangle HRule(double y, double x1, double x2) => new(x1, y - 0.5, x2, y + 0.5);
+    private static PdfRectangle VRule(double x, double y1, double y2) => new(x - 0.5, y1, x + 0.5, y2);
+    private static PdfRectangle Box(double left, double bottom, double right, double top) => new(left, bottom, right, top);
+
+    // For lattice rendering fixtures: one PdfPig Word each, 12pt tall.
+    private static PdfTableReconstruction.Cell Cell(string text, double left, double right, double centreY)
+        => new(new PdfRectangle(left, centreY - 6, right, centreY + 6), text);
+
+    [Fact]
+    public void Detects_a_drawn_grid_of_columns_and_rows()
+    {
+        // 4 vertical rules (3 columns) x 3 horizontal rules (2 rows).
+        var bounds = new List<PdfRectangle>
+        {
+            VRule(50, 100, 300), VRule(150, 100, 300), VRule(250, 100, 300), VRule(350, 100, 300),
+            HRule(100, 50, 350), HRule(200, 50, 350), HRule(300, 50, 350)
+        };
+
+        var grid = PdfRulingLines.DetectGrid(bounds);
+
+        grid.ShouldNotBeNull();
+        grid!.Value.ColumnCount.ShouldBe(3);
+        grid.Value.RowCount.ShouldBe(2);
+        grid.Value.ColumnBoundaries.ShouldBe(new[] { 50.0, 150, 250, 350 });
+        grid.Value.RowBoundaries.ShouldBe(new[] { 100.0, 200, 300 });
+    }
+
+    [Fact]
+    public void Merges_double_stroked_rules_into_one_boundary()
+    {
+        // Each rule is drawn twice, ~0.8pt apart (a common encoding). They must collapse to one boundary each —
+        // three distinct positions per axis, not six.
+        var bounds = new List<PdfRectangle>
+        {
+            VRule(50, 100, 300), VRule(50.8, 100, 300), VRule(200, 100, 300), VRule(200.8, 100, 300), VRule(350, 100, 300), VRule(350.8, 100, 300),
+            HRule(100, 50, 350), HRule(100.8, 50, 350), HRule(200, 50, 350), HRule(200.8, 50, 350), HRule(300, 50, 350), HRule(300.8, 50, 350)
+        };
+
+        var grid = PdfRulingLines.DetectGrid(bounds);
+
+        grid.ShouldNotBeNull();
+        grid!.Value.ColumnBoundaries.Count.ShouldBe(3); // 50.4, 200.4, 350.4 — not six
+        grid.Value.RowBoundaries.Count.ShouldBe(3);
+        grid.Value.ColumnCount.ShouldBe(2);
+        grid.Value.RowCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Decomposes_a_stroked_box_into_its_four_sides()
+    {
+        // The table border is one stroked rectangle; interior rules add the middle column/row.
+        var bounds = new List<PdfRectangle>
+        {
+            Box(50, 100, 350, 300),   // outer border -> x{50,350}, y{100,300}
+            VRule(200, 100, 300),     // interior column rule
+            HRule(200, 50, 350)       // interior row rule
+        };
+
+        var grid = PdfRulingLines.DetectGrid(bounds);
+
+        grid.ShouldNotBeNull();
+        grid!.Value.ColumnBoundaries.ShouldBe(new[] { 50.0, 200, 350 });
+        grid.Value.RowBoundaries.ShouldBe(new[] { 100.0, 200, 300 });
+    }
+
+    [Fact]
+    public void Returns_null_without_column_rules()
+    {
+        // Only horizontal (row) rules — no vertical separators. Not a lattice; columns are left to the stream path.
+        var bounds = new List<PdfRectangle>
+        {
+            HRule(100, 50, 350), HRule(200, 50, 350), HRule(300, 50, 350)
+        };
+
+        PdfRulingLines.DetectGrid(bounds).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Ignores_short_segments_that_are_not_table_rules()
+    {
+        // Tick marks / underlines shorter than the min length must not create boundaries.
+        var bounds = new List<PdfRectangle>
+        {
+            VRule(50, 100, 105), VRule(150, 100, 104), // 4-5pt tall — too short
+            HRule(100, 50, 55)
+        };
+
+        PdfRulingLines.DetectGrid(bounds).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Renders_cells_against_a_drawn_grid()
+    {
+        // 2 columns x 2 rows. Ascending-y row boundaries: row 0 is the TOP band [200,300], row 1 is [100,200].
+        var grid = new PdfRulingLines.Grid(
+            new[] { 50.0, 150, 250 }, new[] { 100.0, 200, 300 });
+
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("Name", 60, 100, 250), Cell("Price", 160, 210, 250), // top row (header)
+            Cell("Apple", 60, 110, 150), Cell("10", 160, 185, 150)    // bottom row
+        };
+
+        PdfTableReconstruction.TryRenderLattice(cells, grid).ShouldBe(
+            "| Name | Price |\n| --- | --- |\n| Apple | 10 |");
+    }
+
+    [Fact]
+    public void Keeps_an_empty_drawn_column_and_ignores_fragments_outside_the_grid()
+    {
+        // 3 columns; the middle column has no content (a drawn-but-empty column, like メモ). A fragment whose
+        // centre is outside the grid extent is not table content and is dropped.
+        var grid = new PdfRulingLines.Grid(
+            new[] { 50.0, 150, 250, 350 }, new[] { 100.0, 200, 300 });
+
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("A", 60, 100, 250), Cell("C", 260, 300, 250),
+            Cell("x", 60, 100, 150), Cell("z", 260, 300, 150),
+            Cell("outside", 400, 480, 150) // right of the last boundary (350) -> ignored
+        };
+
+        PdfTableReconstruction.TryRenderLattice(cells, grid).ShouldBe(
+            "| A |  | C |\n| --- | --- | --- |\n| x |  | z |");
+    }
+
+    [Fact]
+    public void Joins_a_wrapped_and_multi_word_cell_in_reading_order()
+    {
+        // A description cell with several words on one visual line (slightly jittery tops) plus a wrapped second
+        // line must read left-to-right, top-to-bottom — not by raw top then left.
+        var grid = new PdfRulingLines.Grid(
+            new[] { 50.0, 300, 450 }, new[] { 100.0, 200, 300 });
+
+        var cells = new List<PdfTableReconstruction.Cell>
+        {
+            Cell("H", 60, 100, 250), Cell("H2", 310, 350, 250),
+            // one visual line, tops jitter by ~1pt; a raw top-sort would scramble them
+            new(new PdfRectangle(60, 144, 110, 156), "wire"),
+            new(new PdfRectangle(120, 144.6, 200, 156.6), "alpha"),
+            new(new PdfRectangle(210, 143.5, 260, 155.5), "beta"),
+            Cell("cont", 60, 100, 132), // wrapped continuation below
+            Cell("v", 310, 350, 150)
+        };
+
+        PdfTableReconstruction.TryRenderLattice(cells, grid).ShouldBe(
+            "| H | H2 |\n| --- | --- |\n| wire alpha beta cont | v |");
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRulingLines_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRulingLines_Tests.cs
@@ -27,13 +27,13 @@ public class PdfRulingLines_Tests
             HRule(100, 50, 350), HRule(200, 50, 350), HRule(300, 50, 350)
         };
 
-        var grid = PdfRulingLines.DetectGrid(bounds);
+        var grids = PdfRulingLines.DetectGrids(bounds);
 
-        grid.ShouldNotBeNull();
-        grid!.Value.ColumnCount.ShouldBe(3);
-        grid.Value.RowCount.ShouldBe(2);
-        grid.Value.ColumnBoundaries.ShouldBe(new[] { 50.0, 150, 250, 350 });
-        grid.Value.RowBoundaries.ShouldBe(new[] { 100.0, 200, 300 });
+        grids.Count.ShouldBe(1);
+        grids[0].ColumnCount.ShouldBe(3);
+        grids[0].RowCount.ShouldBe(2);
+        grids[0].ColumnBoundaries.ShouldBe(new[] { 50.0, 150, 250, 350 });
+        grids[0].RowBoundaries.ShouldBe(new[] { 100.0, 200, 300 });
     }
 
     [Fact]
@@ -47,13 +47,13 @@ public class PdfRulingLines_Tests
             HRule(100, 50, 350), HRule(100.8, 50, 350), HRule(200, 50, 350), HRule(200.8, 50, 350), HRule(300, 50, 350), HRule(300.8, 50, 350)
         };
 
-        var grid = PdfRulingLines.DetectGrid(bounds);
+        var grids = PdfRulingLines.DetectGrids(bounds);
 
-        grid.ShouldNotBeNull();
-        grid!.Value.ColumnBoundaries.Count.ShouldBe(3); // 50.4, 200.4, 350.4 — not six
-        grid.Value.RowBoundaries.Count.ShouldBe(3);
-        grid.Value.ColumnCount.ShouldBe(2);
-        grid.Value.RowCount.ShouldBe(2);
+        grids.Count.ShouldBe(1);
+        grids[0].ColumnBoundaries.Count.ShouldBe(3); // 50.4, 200.4, 350.4 — not six
+        grids[0].RowBoundaries.Count.ShouldBe(3);
+        grids[0].ColumnCount.ShouldBe(2);
+        grids[0].RowCount.ShouldBe(2);
     }
 
     [Fact]
@@ -67,15 +67,37 @@ public class PdfRulingLines_Tests
             HRule(200, 50, 350)       // interior row rule
         };
 
-        var grid = PdfRulingLines.DetectGrid(bounds);
+        var grids = PdfRulingLines.DetectGrids(bounds);
 
-        grid.ShouldNotBeNull();
-        grid!.Value.ColumnBoundaries.ShouldBe(new[] { 50.0, 200, 350 });
-        grid.Value.RowBoundaries.ShouldBe(new[] { 100.0, 200, 300 });
+        grids.Count.ShouldBe(1);
+        grids[0].ColumnBoundaries.ShouldBe(new[] { 50.0, 200, 350 });
+        grids[0].RowBoundaries.ShouldBe(new[] { 100.0, 200, 300 });
     }
 
     [Fact]
-    public void Returns_null_without_column_rules()
+    public void Separates_two_stacked_tables_into_two_grids()
+    {
+        // Two tables on one page, disjoint in x and y, with DIFFERENT column counts. They must NOT merge into
+        // one spurious grid — the intersection grouping keeps them apart (top-to-bottom order).
+        var bounds = new List<PdfRectangle>
+        {
+            // Top table: 2 columns x 2 rows.
+            VRule(50, 500, 560), VRule(150, 500, 560), VRule(250, 500, 560),
+            HRule(500, 50, 250), HRule(530, 50, 250), HRule(560, 50, 250),
+            // Bottom table: 3 columns x 2 rows, off to the right.
+            VRule(300, 300, 360), VRule(400, 300, 360), VRule(500, 300, 360), VRule(600, 300, 360),
+            HRule(300, 300, 600), HRule(330, 300, 600), HRule(360, 300, 600)
+        };
+
+        var grids = PdfRulingLines.DetectGrids(bounds);
+
+        grids.Count.ShouldBe(2);
+        grids[0].ColumnCount.ShouldBe(2); // top table first
+        grids[1].ColumnCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Returns_no_grid_without_column_rules()
     {
         // Only horizontal (row) rules — no vertical separators. Not a lattice; columns are left to the stream path.
         var bounds = new List<PdfRectangle>
@@ -83,7 +105,7 @@ public class PdfRulingLines_Tests
             HRule(100, 50, 350), HRule(200, 50, 350), HRule(300, 50, 350)
         };
 
-        PdfRulingLines.DetectGrid(bounds).ShouldBeNull();
+        PdfRulingLines.DetectGrids(bounds).ShouldBeEmpty();
     }
 
     [Fact]
@@ -96,7 +118,7 @@ public class PdfRulingLines_Tests
             HRule(100, 50, 55)
         };
 
-        PdfRulingLines.DetectGrid(bounds).ShouldBeNull();
+        PdfRulingLines.DetectGrids(bounds).ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #450. Follow-up to #446 (which hardened the whitespace/"stream" column detection); this adds the higher-fidelity **lattice** path.

## Why

Many real tables — bank statements, forms, financial reports — draw their column/row separators as vector lines. Those lines are the **authoritative, deterministic** grid; reconstructing them from whitespace is inherently heuristic. Until now the pipeline ignored vector graphics entirely. On the #446 customer statement (a 6-column JP bank statement) the drawn grid gives a deterministic 6 columns, where the stream path had to *guess* boundaries (within ~2pt of the real rules).

## What

- **`PdfRulingLines.DetectGrids`** (new) — from the page's vector subpath bounding rects, extracts thin horizontal/vertical rules (and a stroked box's four sides), collapses double-stroked / near-coincident rules, and groups rules into **separate tables by connected components of mutually-crossing rules** (so two tables on one page don't merge). Returns one `Grid` per drawn table, top-to-bottom.
- **`PdfTableReconstruction.TryRenderLattice`** — buckets each fragment into the cell whose drawn boundaries contain its centre, joins each cell in reading order (visual-line grouping, so a multi-word / wrapped 摘要 cell reads correctly), and renders the Markdown table.
- **Wiring** (`PdfReadingOrder` / `PdfExtractor`) — `RenderPage` gains an optional `rulingBounds`; a detected grid claims the blocks inside it as one lattice table (placed via the existing lead-block machinery), and everything else keeps the whitespace/stream path. A ruled table whose gutters are too tight to segment (single block) is still reconstructed (the grid keeps it out of the single-region early return).

## Result (the #446 statement, through `RenderPage`)

```
| 日付 | 摘要 | 入金金額 | 出金金額 | 残高 | メモ |
| 20251106 | 振込 ミツビシユ－エフジエイ オカノ トモキ |  | 104522 | 184805 |  |
| 20251101 | 普通預金 利息 | 57 |  | 1029207 |  |
```
Deterministic 6 columns from the drawn grid — no whitespace heuristics; correct word order; empty メモ / sparse 入金 preserved.

## Safety / scope

- **Non-lossy fallback preserved** — no rules on a page → no grid → identical prior stream/paragraph behaviour (`Falls_back_to_the_stream_path_when_no_grid_is_drawn`). The `blockMeaningful < inputMeaningful` and segmenter-fault guards are unchanged; the single-block early return is only *narrowed* (bypassed only when a grid is present).
- **Markdown-first intact** — output stays pure GFM Markdown; the grid is used transiently at render time and discarded (no new field on `TextExtractionResult`/`OcrResult`, no `Dictionary<string,object>` bag, no persisted spatial payload).
- **Dependency direction** — all inside the `Parse.Pdf` leaf Markdown provider; no `.csproj`/contract/DTO/`Document` changes.
- Reviewed by `abp-architecture-reviewer`: no blocking findings. One bounded lossy edge (a block straddling the outer rule) is documented in-code.

## Out of scope (per #450)

Colour/shaded tables with no rules (→ stream), rotated tables (PdfPig rects not rotation-aware), row/column spanning (#329).

## Tests

`dotnet test Dignite.Vault.Extract.Parse.Pdf.Tests` → **100 passed**, incl. `PdfRulingLines_Tests` (grid detection, double-stroke dedup, box decomposition, two-stacked-tables separation, rejection) and `PdfLatticeIntegration_Tests` (ruled table → lattice; two ruled tables → two Markdown tables; tight-gutter table; no-rules → stream fallback).