### PR TITLE
fix(text-extraction): unwrap stray markdown code fences from VisionLlm OCR so tables render (#448)

### DIFF
--- a/angular/packages/vault-extract/documents/src/lib/documents/document-detail/document-detail.component.ts
+++ b/angular/packages/vault-extract/documents/src/lib/documents/document-detail/document-detail.component.ts
@@ -36,6 +36,7 @@ import {
   PipelineRunStatus,
 } from '@dignite/vault-extract';
 import { formatExtractedFieldValue } from '../../shared/format-field-value';
+import { stripMarkdownCodeFences } from '../../shared/strip-code-fences';
 import { DocumentFileBlobService } from '../../shared/document-file-blob.service';
 import { isImageContentType, isPdfContentType } from '../../shared/content-type';
 
@@ -326,8 +327,13 @@ export class DocumentDetailComponent implements OnInit {
   // bind the result via [innerHTML] so Angular's DomSanitizer runs. Never bypassSecurityTrustHtml — a
   // LongText field value is attacker-influenced too (LLM extraction / VLM OCR can be prompt-injected), so
   // the sanitizer has to stay on end to end.
+  // #448: strip stray ```markdown code fences first. A vision-LLM OCR transcription is sometimes wrapped —
+  // wholly or partly — in a code fence despite the prompt forbidding it, which would make marked render the
+  // fenced table as literal <pre><code> (raw pipes) instead of a GFM table. The backend guard removes this at
+  // the source for new documents; stripping here also rescues documents already stored with the fence
+  // (Document.Markdown is write-once).
   private renderMarkdown(md: string): string {
-    return md ? (marked.parse(md, { gfm: true, async: false }) as string) : '';
+    return md ? (marked.parse(stripMarkdownCodeFences(md), { gfm: true, async: false }) as string) : '';
   }
 
   // Owning cabinet name for the document, cabinetId to name. Returns null when unclassified or

--- a/angular/packages/vault-extract/documents/src/lib/shared/strip-code-fences.spec.ts
+++ b/angular/packages/vault-extract/documents/src/lib/shared/strip-code-fences.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { marked } from 'marked';
+
+import { stripMarkdownCodeFences } from './strip-code-fences';
+
+// #448: a vision-LLM OCR transcription sometimes wraps its Markdown — wholly or partly — in a ```markdown code
+// fence despite the prompt forbidding it, so marked renders the fenced table as literal <pre><code> (raw pipes)
+// instead of a GFM table. stripMarkdownCodeFences removes the fence delimiters before parsing.
+describe('stripMarkdownCodeFences', () => {
+  const render = (md: string) => marked.parse(md, { gfm: true, async: false }) as string;
+  const rendersTable = (md: string) => /<table/i.test(render(md));
+
+  it('leaves plain Markdown untouched (no fence character)', () => {
+    const md = '# 普通預金通帳\n\n| 年月日 | 摘要 |\n| --- | --- |\n| 7-1-31 | 繰越 |';
+    expect(stripMarkdownCodeFences(md)).toBe(md);
+  });
+
+  it('returns empty / falsy input unchanged', () => {
+    expect(stripMarkdownCodeFences('')).toBe('');
+  });
+
+  it('unwraps a partial ```markdown fence so the table renders (the #448 bankbook case)', () => {
+    // The header sits outside the fence; the model fenced only the table + footnotes below it.
+    const ocr =
+      '普通預金通帳\n\n' +
+      '```markdown\n' +
+      '| 年月日 | 摘要 | 差引残高 |\n' +
+      '|---|---|---|\n' +
+      '| 7-1-31 | 繰越 | ¥4,181,159 |\n' +
+      '| 7-2-10 | カード支払 | ¥4,254,365 |\n' +
+      '```\n\n' +
+      '※証券類のご入金の場合は…';
+
+    // Before: the fenced block renders as a code block, NOT a table.
+    expect(rendersTable(ocr)).toBe(false);
+    // After stripping: a real GFM table.
+    const stripped = stripMarkdownCodeFences(ocr);
+    expect(stripped).not.toContain('```');
+    expect(rendersTable(stripped)).toBe(true);
+    // Content on both sides of the fence is preserved.
+    expect(stripped).toContain('普通預金通帳');
+    expect(stripped).toContain('※証券類のご入金の場合は…');
+  });
+
+  it('unwraps a whole-output fence', () => {
+    const stripped = stripMarkdownCodeFences('```markdown\n# Title\n\nBody.\n```');
+    expect(stripped).not.toContain('```');
+    expect(stripped).toContain('# Title');
+    expect(stripped).toContain('Body.');
+  });
+
+  it('unwraps an unmatched (never-closed) opening fence', () => {
+    const stripped = stripMarkdownCodeFences('```\n| a | b |\n| --- | --- |\n| c | d |');
+    expect(stripped).not.toContain('```');
+    expect(rendersTable(stripped)).toBe(true);
+  });
+
+  it('strips tilde fences and a language info string', () => {
+    expect(stripMarkdownCodeFences('~~~\ncontent\n~~~')).not.toContain('~~~');
+    expect(stripMarkdownCodeFences('```md\ncontent\n```')).not.toContain('`');
+  });
+
+  it('does not strip a line carrying an inline code span', () => {
+    const md = 'Run `dotnet build` then `nx serve`.';
+    expect(stripMarkdownCodeFences(md)).toBe(md);
+  });
+
+  it('does not strip a ```code``` inline span on its own line', () => {
+    const md = '```code```';
+    expect(stripMarkdownCodeFences(md)).toBe(md);
+  });
+});

--- a/angular/packages/vault-extract/documents/src/lib/shared/strip-code-fences.ts
+++ b/angular/packages/vault-extract/documents/src/lib/shared/strip-code-fences.ts
@@ -1,0 +1,43 @@
+/**
+ * Removes Markdown code-fence delimiter lines from LLM-produced Markdown, keeping the fenced content in place.
+ *
+ * A vision-LLM OCR transcription (and, defensively, any LLM Markdown rendered in the operator UI) sometimes
+ * arrives wrapped — wholly, or only partly — in a ```` ```markdown ```` fence despite the OCR prompt forbidding
+ * it (#448). `marked` then renders the fenced block (typically a table) as a literal `<pre><code>` block instead
+ * of Markdown, so the table shows as raw pipes. In this channel the payload is digitized DOCUMENT text
+ * (headings / tables / lists), never source code, so a triple-backtick / triple-tilde fence is always such an
+ * artifact: drop the fence delimiter lines (keeping their content) before parsing — this handles a whole-output
+ * fence, a partial fence, and an unmatched (never-closed) fence uniformly.
+ *
+ * The backend `VisionLlmOutputGuard.StripCodeFences` strips this at the source for newly extracted documents;
+ * this frontend twin also rescues documents already stored with the fence baked in (`Document.Markdown` is
+ * write-once, so they are never re-extracted).
+ *
+ * A fence delimiter is a line whose trimmed text is a run of >= 3 back-ticks or >= 3 tildes, optionally
+ * followed by an info string that contains no further back-tick — so an inline `` `code` `` / ```` ```code``` ````
+ * span sitting on its own line is not mistaken for a fence.
+ */
+export function stripMarkdownCodeFences(markdown: string): string {
+  // Fast path: no fence character at all (the overwhelming majority of documents) — return untouched.
+  if (!markdown || (markdown.indexOf('`') < 0 && markdown.indexOf('~') < 0)) {
+    return markdown;
+  }
+  return markdown
+    .split('\n')
+    .filter(line => !isCodeFenceLine(line))
+    .join('\n');
+}
+
+function isCodeFenceLine(line: string): boolean {
+  const s = line.trim();
+  const marker = s[0];
+  if (marker !== '`' && marker !== '~') {
+    return false;
+  }
+  let run = 0;
+  while (run < s.length && s[run] === marker) {
+    run++;
+  }
+  // >= 3 markers, and no back-tick after the run (a back-tick would make it an inline span, not a fence).
+  return run >= 3 && s.indexOf('`', run) < 0;
+}

--- a/core/src/Dignite.Vault.Extract.Ocr.VisionLlm/VisionLlmOcrProvider.cs
+++ b/core/src/Dignite.Vault.Extract.Ocr.VisionLlm/VisionLlmOcrProvider.cs
@@ -94,7 +94,12 @@ public class VisionLlmOcrProvider : IOcrProvider, ITransientDependency
         };
 
         var response = await _chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
-        var text = response.Text?.Trim() ?? string.Empty;
+        // #448: a chat vision LLM sometimes wraps all or part of its Markdown in a ```markdown code fence
+        // despite the prompt forbidding it, which makes the fenced block (typically a table) render as literal
+        // code downstream. Strip fence delimiters so the persisted transcription is clean Markdown for every
+        // consumer (preview / RAG / classification / egress). Trim again since removing a leading/trailing
+        // fence line can leave a blank edge.
+        var text = VisionLlmOutputGuard.StripCodeFences(response.Text).Trim();
 
         if (text.Length == 0)
         {

--- a/core/src/Dignite.Vault.Extract.Ocr.VisionLlm/VisionLlmOutputGuard.cs
+++ b/core/src/Dignite.Vault.Extract.Ocr.VisionLlm/VisionLlmOutputGuard.cs
@@ -5,7 +5,9 @@ using System.Linq;
 namespace Dignite.Vault.Extract.Ocr.VisionLlm;
 
 /// <summary>
-/// Heuristic guard against vision-LLM repetition / hallucination loops.
+/// Output sanitation for the vision-LLM OCR provider: a repetition-loop <b>detector</b>
+/// (<see cref="LooksLikeRepetitionLoop"/>, discard on a trip) plus a code-fence <b>stripper</b>
+/// (<see cref="StripCodeFences"/>, unwrap in place).
 /// <para>
 /// Traditional OCR can only mis-read characters; a vision LLM driven in chat mode can additionally fall
 /// into a repetition loop that fills the token budget with the same line/phrase over and over (the
@@ -113,6 +115,69 @@ public static class VisionLlmOutputGuard
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Removes Markdown code-fence delimiter lines from a vision-LLM transcription, keeping the fenced
+    /// content in place.
+    /// <para>
+    /// The OCR system prompt forbids wrapping the output in a code fence, but a chat vision LLM still
+    /// sometimes wraps all — or, worse, only <b>part</b> — of its Markdown in a <c>```markdown</c> fence
+    /// anyway (#448: a passbook page whose table and footnotes were fenced while the header above them was
+    /// not, so the whole fenced block rendered as literal <c>&lt;pre&gt;&lt;code&gt;</c> and the table never
+    /// became a GFM table — it showed as raw pipes). An OCR'd business document (receipt / passbook /
+    /// invoice / contract / form) never legitimately contains a fenced code block, so dropping every fence
+    /// delimiter line is safe and unwraps the content — handling a whole-output fence, a partial fence, and
+    /// an unmatched (never-closed) fence uniformly. Only the delimiter lines are removed; the content
+    /// between them is preserved verbatim.
+    /// </para>
+    /// </summary>
+    public static string StripCodeFences(string? markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return string.Empty;
+        }
+
+        // Fast path: no fence character at all (the overwhelming majority of transcriptions), so return the
+        // input untouched — including its original line endings.
+        if (markdown.IndexOf('`') < 0 && markdown.IndexOf('~') < 0)
+        {
+            return markdown;
+        }
+
+        // Split on '\n' only; a kept line keeps any trailing '\r', so original line endings survive.
+        var kept = markdown.Split('\n').Where(line => !IsCodeFenceLine(line));
+        return string.Join("\n", kept);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="line"/> is a Markdown code-fence delimiter: a run of at least three back-ticks
+    /// or three tildes at the start (leading indent tolerated), optionally followed by an info string that
+    /// contains no back-tick — so an inline <c>```code```</c> span sitting on its own line is not mistaken
+    /// for a fence.
+    /// </summary>
+    private static bool IsCodeFenceLine(string line)
+    {
+        var s = line.AsSpan().Trim();
+        if (s.Length < 3)
+        {
+            return false;
+        }
+
+        var marker = s[0];
+        if (marker != '`' && marker != '~')
+        {
+            return false;
+        }
+
+        var run = 0;
+        while (run < s.Length && s[run] == marker)
+        {
+            run++;
+        }
+
+        return run >= 3 && s[run..].IndexOf('`') < 0;
     }
 
     // Majority letters/digits → real content. Excludes Markdown table separators ("|---|---|"),

--- a/core/test/Dignite.Vault.Extract.Ocr.VisionLlm.Tests/VisionLlmOutputGuardTests.cs
+++ b/core/test/Dignite.Vault.Extract.Ocr.VisionLlm.Tests/VisionLlmOutputGuardTests.cs
@@ -109,4 +109,85 @@ public class VisionLlmOutputGuardTests
             MinDistinctRatio, MinLines, MinSegmentLength, MaxSegmentPeriod, MinSegmentRepeats)
             .ShouldBeTrue();
     }
+
+    // --- StripCodeFences (#448) ---
+
+    [Fact]
+    public void StripCodeFences_Leaves_Plain_Markdown_Untouched()
+    {
+        // Fast path: no fence character at all — returned byte-for-byte, line endings included.
+        const string markdown = "# 普通預金通帳\r\n\r\n| 年月日 | 摘要 |\r\n| --- | --- |\r\n| 7-1-31 | 繰越 |";
+        VisionLlmOutputGuard.StripCodeFences(markdown).ShouldBe(markdown);
+    }
+
+    [Fact]
+    public void StripCodeFences_Null_Or_Empty_Becomes_Empty()
+    {
+        VisionLlmOutputGuard.StripCodeFences(null).ShouldBe(string.Empty);
+        VisionLlmOutputGuard.StripCodeFences(string.Empty).ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void StripCodeFences_Unwraps_A_Partial_Markdown_Fence_And_Preserves_Every_Content_Line()
+    {
+        // The #448 case: the model fenced only the lower part of the page (```markdown … ```), while the
+        // header above it stayed outside. Both delimiter lines go; every content line (header, table rows,
+        // footnote) survives verbatim so the table becomes a real GFM table again.
+        const string fenced =
+            "普通預金通帳\n\n```markdown\n| 年月日 | 摘要 |\n| --- | --- |\n| 7-1-31 | 繰越 |\n```\n\n※脚注";
+
+        var result = VisionLlmOutputGuard.StripCodeFences(fenced);
+
+        result.ShouldNotContain("```");
+        result.ShouldContain("普通預金通帳");
+        result.ShouldContain("| 年月日 | 摘要 |");
+        result.ShouldContain("| --- | --- |");
+        result.ShouldContain("| 7-1-31 | 繰越 |");
+        result.ShouldContain("※脚注");
+    }
+
+    [Fact]
+    public void StripCodeFences_Unwraps_A_Whole_Output_Fence()
+    {
+        var result = VisionLlmOutputGuard.StripCodeFences("```markdown\n# Title\n\nBody.\n```");
+
+        result.ShouldNotContain("```");
+        result.ShouldContain("# Title");
+        result.ShouldContain("Body.");
+    }
+
+    [Fact]
+    public void StripCodeFences_Unwraps_An_Unmatched_Opening_Fence()
+    {
+        // A never-closed fence would otherwise swallow the rest of the document as code.
+        var result = VisionLlmOutputGuard.StripCodeFences("```\n| a | b |\n| --- | --- |");
+
+        result.ShouldNotContain("```");
+        result.ShouldContain("| a | b |");
+        result.ShouldContain("| --- | --- |");
+    }
+
+    [Fact]
+    public void StripCodeFences_Strips_Tilde_Fences_And_A_Language_Info_String()
+    {
+        VisionLlmOutputGuard.StripCodeFences("~~~\ncontent\n~~~").ShouldNotContain("~~~");
+        VisionLlmOutputGuard.StripCodeFences("```md\ncontent\n```").ShouldNotContain("`");
+    }
+
+    [Fact]
+    public void StripCodeFences_Does_Not_Strip_An_Inline_Code_Line()
+    {
+        // A line carrying an inline code span (a back-tick that also closes on the same line) is real content,
+        // not a fence delimiter — it must survive unchanged.
+        const string markdown = "Use `dotnet build` to compile.";
+        VisionLlmOutputGuard.StripCodeFences(markdown).ShouldBe(markdown);
+    }
+
+    [Fact]
+    public void StripCodeFences_Does_Not_Strip_A_Triple_Backtick_Inline_Span()
+    {
+        // "```code```" on its own line is an inline span (a back-tick follows the opening run), not a fence.
+        const string markdown = "```code```";
+        VisionLlmOutputGuard.StripCodeFences(markdown).ShouldBe(markdown);
+    }
 }


### PR DESCRIPTION
## Summary

Image-only PDFs go through the vision-LLM OCR path. The model sometimes wraps all — or only **part** — of its Markdown in a ` ```markdown ` code fence despite the system prompt forbidding it, so `marked` renders the fenced block (header + table + footnotes) as one literal `<pre><code>` and the table shows as **raw pipes** instead of a GFM table (#448, a 大阪シティ信用金庫 passbook page). Nothing stripped code fences on either side.

## Fix

- **Backend** — `VisionLlmOutputGuard.StripCodeFences` removes code-fence delimiter lines (≥3 back-ticks/tildes, with inline `` `code` `` spans preserved); the provider applies it before persisting, so `Document.Markdown` is clean Markdown for **every** consumer (preview / RAG / classification / egress). Fixes newly extracted documents.
- **Frontend** — `stripMarkdownCodeFences` runs in `renderMarkdown` before `marked`, which also **rescues documents already stored with the fence baked in** (`Document.Markdown` is write-once, so they are never re-extracted).

Both sides share the same fence-detection rule (whole-output, partial, and unmatched fences all unwrap uniformly).

## Tests

- **Backend**: 8 new `VisionLlmOutputGuardTests` cases (whole / partial / unmatched fence, tilde fence, info string, inline-code preserved). `VisionLlmOutputGuardTests` — 18 passed.
- **Frontend**: `strip-code-fences.spec.ts` — asserts the passbook case renders `<table>` after stripping, against real `marked@18`. 8 passed.

Closes #448
