### PR TITLE
OpenXML text-extraction fast-follows (#317 #319 #321 #316 #315 #322 #318 #313)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/ChartRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/ChartRenderer.cs
@@ -234,12 +234,18 @@ internal static class ChartRenderer
         var result = new Dictionary<int, string>();
         foreach (var idx in indices)
         {
-            // Outermost (last authored) to innermost (first authored); forward-fill each level so a position
-            // inside an outer group inherits the label cached at that group's first index.
+            // Outermost (last authored) to innermost (first authored).
             var parts = new List<string>();
             for (var lvl = levelMaps.Count - 1; lvl >= 0; lvl--)
             {
-                var label = ForwardFill(levelMaps[lvl], idx);
+                // Forward-fill only OUTER grouping levels: an outer category caches its label at its group's
+                // first index and spans the rest of the group. The innermost (leaf, lvl 0) is NOT a span — a
+                // leaf position with no pt is a genuinely blank cell, so read it exactly rather than carrying
+                // the previous leaf's label (which would fabricate e.g. "2024 / Q2" for a blank leaf that opens
+                // a new outer group, whose correct label is just "2024").
+                var label = lvl == 0
+                    ? (levelMaps[0].TryGetValue(idx, out var leaf) ? leaf : string.Empty)
+                    : ForwardFill(levelMaps[lvl], idx);
                 if (label.Length > 0)
                 {
                     parts.Add(label);

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/ChartRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/ChartRenderer.cs
@@ -65,7 +65,7 @@ internal static class ChartRenderer
             //    wide table would silently hang values under the wrong category. Bail to null; the caller
             //    counts it as a chart failure (#268) — an honest "could not be rendered as a table" signal
             //    instead of misaligned data.
-            foreach (var (idx, label) in ReadCache(FirstChildByLocalName(ser, "cat")))
+            foreach (var (idx, label) in ReadCategoryLabels(FirstChildByLocalName(ser, "cat")))
             {
                 if (!categories.TryGetValue(idx, out var existing))
                 {
@@ -190,6 +190,82 @@ internal static class ChartRenderer
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Reads a <c>c:cat</c> container's cached category labels into an index → label map. A single-level axis
+    /// (<c>c:strCache</c> / <c>c:numCache</c>) reads through <see cref="ReadCache"/> unchanged. A
+    /// <b>multi-level</b> axis (<c>c:multiLvlStrRef</c> with several <c>c:lvl</c> blocks) repeats <c>idx</c>
+    /// values per level, so a flat <c>Descendants("pt")</c> read would collide the levels and mislabel rows
+    /// (#321) — instead compose one compound label per position from outermost to innermost (e.g.
+    /// <c>"2024 / Q1"</c>). Per ECMA-376 the first <c>c:lvl</c> is the innermost level, and an outer level
+    /// caches its label only at each group's first index, so each level is forward-filled across its span.
+    /// </summary>
+    private static IReadOnlyDictionary<int, string> ReadCategoryLabels(OpenXmlElement? catContainer)
+    {
+        if (catContainer is null)
+        {
+            return new Dictionary<int, string>();
+        }
+
+        var levels = catContainer
+            .Descendants<OpenXmlElement>()
+            .Where(e => e.LocalName == "lvl")
+            .ToList();
+
+        if (levels.Count == 0)
+        {
+            // Single-level (or no) category cache: the flat index → label read is correct.
+            return ReadCache(catContainer);
+        }
+
+        // Each c:lvl is its own index → label map, authored innermost-first.
+        var levelMaps = levels.Select(ReadCache).ToList();
+
+        var indices = new SortedSet<int>();
+        foreach (var map in levelMaps)
+        {
+            foreach (var idx in map.Keys)
+            {
+                indices.Add(idx);
+            }
+        }
+
+        var result = new Dictionary<int, string>();
+        foreach (var idx in indices)
+        {
+            // Outermost (last authored) to innermost (first authored); forward-fill each level so a position
+            // inside an outer group inherits the label cached at that group's first index.
+            var parts = new List<string>();
+            for (var lvl = levelMaps.Count - 1; lvl >= 0; lvl--)
+            {
+                var label = ForwardFill(levelMaps[lvl], idx);
+                if (label.Length > 0)
+                {
+                    parts.Add(label);
+                }
+            }
+
+            result[idx] = string.Join(" / ", parts);
+        }
+
+        return result;
+    }
+
+    /// <summary>The label at the greatest index &lt;= <paramref name="idx"/> present in <paramref name="level"/>,
+    /// or empty — so an outer category label cached only at its group's first position fills the rest of the group.</summary>
+    private static string ForwardFill(IReadOnlyDictionary<int, string> level, int idx)
+    {
+        var best = -1;
+        foreach (var key in level.Keys)
+        {
+            if (key <= idx && key > best)
+            {
+                best = key;
+            }
+        }
+
+        return best >= 0 ? level[best] : string.Empty;
     }
 
     private static OpenXmlElement? FirstChildByLocalName(OpenXmlElement parent, string localName)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -100,24 +100,6 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// </summary>
     private const int MaxListIndentLevels = 9;
 
-    /// <summary>
-    /// Open settings that collapse OOXML markup-compatibility (<c>mc:AlternateContent</c>) to its single
-    /// selected branch <b>before</b> parsing. Under the default <see cref="MarkupCompatibilityProcessMode.NoProcess"/>
-    /// both branches stay in the tree, so a <c>Descendants</c> walk would read the SAME content twice: a
-    /// modern Word text box stores its text in both the <c>mc:Choice</c> (DrawingML <c>wps:txbx</c>) and the
-    /// <c>mc:Fallback</c> (legacy VML that Word auto-writes), and an <c>AlternateContent</c>-wrapped picture
-    /// can carry a blip in both branches — duplicating text and double-OCR-ing (and double-charging the image
-    /// budget for) one logical figure. <see cref="FileFormatVersions.Office2019"/> is recent enough that the
-    /// SDK understands the modern (<c>wps</c> / DrawingML) namespaces, so it keeps the richer Choice branch
-    /// (the one whose <c>w:drawing</c> the image path can read) and drops the VML fallback.
-    /// </summary>
-    private static readonly OpenSettings McCollapsingOpenSettings = new()
-    {
-        MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(
-            MarkupCompatibilityProcessMode.ProcessAllParts,
-            DocumentFormat.OpenXml.FileFormatVersions.Office2019)
-    };
-
     private readonly IOcrProvider _ocrProvider;
     private readonly OpenXmlExtractorOptions _options;
 
@@ -148,7 +130,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         WordprocessingDocument document;
         try
         {
-            document = WordprocessingDocument.Open(new MemoryStream(bytes, writable: false), isEditable: false, McCollapsingOpenSettings);
+            document = WordprocessingDocument.Open(new MemoryStream(bytes, writable: false), isEditable: false, OpenXmlPackageSettings.McCollapsing);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -290,7 +290,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         OpenXmlExtractionState state,
         CancellationToken cancellationToken)
     {
-        var headingLevel = WordStyleMap.HeadingLevel(paragraph);
+        var headingLevel = WordStyleMap.HeadingLevel(paragraph, mainPart);
         if (headingLevel is int level)
         {
             // Headings render as plain collapsed text (no inline emphasis markup inside an ATX heading).

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -46,7 +46,8 @@ namespace Dignite.Vault.Extract.Parse.OpenXml;
 /// <b>Tracked changes: accepted view.</b> Inserted-revision text lives in <c>w:t</c> (read normally);
 /// deleted-revision text lives in <c>w:delText</c> (LocalName "delText", not "t"). Reading only <c>w:t</c>
 /// therefore yields the accepted view of tracked changes for free (#308 decision). Comments and
-/// headers/footers are excluded (author-private / page boilerplate); footnotes/endnotes are deferred.
+/// headers/footers are excluded (author-private / page boilerplate); footnotes/endnotes are surfaced as
+/// Markdown-footnote definitions at the end of the document (#315).
 /// </para>
 /// <para>
 /// <b>Relationship to ElBruno.</b> Unlike <c>.pptx</c>, the catch-all ElBruno provider <i>can</i> convert
@@ -155,7 +156,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
             var mainPart = document.MainDocumentPart;
             var body = mainPart?.Document?.Body;
 
-            var state = new OpenXmlExtractionState
+            var state = new DocxExtractionState
             {
                 ImageBudget = _options.MaxImagesPerFile,
                 LanguageHints = ResolveLanguageHints(context)
@@ -183,11 +184,16 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 }
             }
 
+            // Footnotes / endnotes: markers were emitted inline during the body walk (WordParagraphRenderer
+            // collected each reference); resolve their bodies from the notes parts and append them as a
+            // Markdown-footnote-style notes section at the end of the document (#315).
+            await AppendNotesAsync(mainPart, blocks, state, cancellationToken);
+
             // Single source of truth for the #268 signal: the reason is built from the counters and is
             // null iff nothing was lost; completeness derives from it (no parallel hand-synced predicate).
             var incompleteReason = BuildIncompleteReason(
                 state.FailedContainers, state.DroppedByCap, state.Undecodable, state.OversizedImages,
-                state.TruncatedOcr, state.FailedFigureOcr, state.ChartFailures);
+                state.TruncatedOcr, state.FailedFigureOcr, state.ChartFailures, state.FailedNotes);
             var complete = incompleteReason is null;
             if (!complete)
             {
@@ -222,7 +228,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocumentFormat.OpenXml.OpenXmlElement element,
         MainDocumentPart mainPart,
         List<string> blocks,
-        OpenXmlExtractionState state,
+        DocxExtractionState state,
         int depth,
         CancellationToken cancellationToken)
     {
@@ -287,7 +293,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         W.Paragraph paragraph,
         MainDocumentPart mainPart,
         List<string> blocks,
-        OpenXmlExtractionState state,
+        DocxExtractionState state,
         CancellationToken cancellationToken)
     {
         var headingLevel = WordStyleMap.HeadingLevel(paragraph, mainPart);
@@ -309,7 +315,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         else
         {
             // Body paragraphs render with inline formatting (bold/italic) and hyperlinks.
-            var markdown = WordParagraphRenderer.Render(paragraph, mainPart);
+            var markdown = WordParagraphRenderer.Render(paragraph, mainPart, state.NoteReferences);
             if (!string.IsNullOrWhiteSpace(markdown))
             {
                 // A list item (w:numPr) gets a Markdown bullet / ordered marker, indented by nesting level.
@@ -366,7 +372,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocumentFormat.OpenXml.OpenXmlElement container,
         MainDocumentPart mainPart,
         List<string> blocks,
-        OpenXmlExtractionState state,
+        DocxExtractionState state,
         CancellationToken cancellationToken)
     {
         // Skip drawings nested inside a text box (txbxContent): the text box's own (outer) drawing is
@@ -397,12 +403,125 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         }
     }
 
+    /// <summary>
+    /// Resolves the footnote / endnote references collected during the body walk (#315) and appends each note
+    /// body as a Markdown-footnote definition (<c>[^fn{id}]: body</c>) at the end of the document, in
+    /// first-reference order and de-duplicated (a note referenced twice is defined once). The auto-inserted
+    /// separator / continuation notes are excluded (no author content). A reference that cannot be resolved —
+    /// a dangling id, or a missing FootnotesPart / EndnotesPart — trips the #268 signal via
+    /// <see cref="DocxExtractionState.FailedNotes"/> rather than being silently dropped.
+    /// </summary>
+    private async Task AppendNotesAsync(
+        MainDocumentPart? mainPart,
+        List<string> blocks,
+        DocxExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        if (mainPart is null || state.NoteReferences.Count == 0)
+        {
+            return;
+        }
+
+        var footnotes = BuildNoteBodyMap(mainPart.FootnotesPart?.Footnotes?.Elements<W.Footnote>());
+        var endnotes = BuildNoteBodyMap(mainPart.EndnotesPart?.Endnotes?.Elements<W.Endnote>());
+
+        var seen = new HashSet<NoteReference>();
+        foreach (var reference in state.NoteReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // A note referenced more than once is defined a single time.
+            if (!seen.Add(reference))
+            {
+                continue;
+            }
+
+            var map = reference.Kind == NoteKind.Footnote ? footnotes : endnotes;
+            if (map is null || !map.TryGetValue(reference.Id, out var note))
+            {
+                // Dangling reference, or the notes part is missing entirely — surface the loss (#268).
+                Logger.LogWarning(
+                    "A {Kind} reference (id {Id}) could not be resolved to a note body.", reference.Kind, reference.Id);
+                state.FailedNotes++;
+                continue;
+            }
+
+            var body = await RenderNoteBodyAsync(note, mainPart, state, cancellationToken);
+            blocks.Add(string.IsNullOrWhiteSpace(body) ? $"{reference.Marker}:" : $"{reference.Marker}: {body}");
+        }
+    }
+
+    /// <summary>
+    /// Indexes footnote / endnote definitions by <c>w:id</c>, excluding the auto-inserted
+    /// <c>separator</c> / <c>continuationSeparator</c> notes (they carry no author content). Returns
+    /// <c>null</c> when the part is absent, so the caller distinguishes "no notes part" (a reference is
+    /// therefore dangling) from an empty part.
+    /// </summary>
+    private static IReadOnlyDictionary<long, W.FootnoteEndnoteType>? BuildNoteBodyMap(
+        IEnumerable<W.FootnoteEndnoteType>? notes)
+    {
+        if (notes is null)
+        {
+            return null;
+        }
+
+        var map = new Dictionary<long, W.FootnoteEndnoteType>();
+        foreach (var note in notes)
+        {
+            if (note.Id?.Value is not { } id)
+            {
+                continue;
+            }
+
+            var type = note.Type?.Value;
+            if (type == W.FootnoteEndnoteValues.Separator || type == W.FootnoteEndnoteValues.ContinuationSeparator)
+            {
+                continue;
+            }
+
+            map[id] = note;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Renders a footnote / endnote body to Markdown by reusing the body paragraph/run renderer (so a note
+    /// that carries formatting / links is handled consistently) and transcribing any embedded image in the
+    /// note through the shared <see cref="OpenXmlFigureTranscriber"/> (#315 red line: notes go through the
+    /// host <see cref="IOcrProvider"/>, no new LLM call site). Paragraphs are joined with blank lines. A
+    /// nested note reference inside a note is not followed (no collector is passed), so it does not recurse.
+    /// </summary>
+    private async Task<string> RenderNoteBodyAsync(
+        W.FootnoteEndnoteType note,
+        MainDocumentPart mainPart,
+        DocxExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        var parts = new List<string>();
+        foreach (var paragraph in note.Elements<W.Paragraph>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var text = WordParagraphRenderer.Render(paragraph, mainPart);
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                parts.Add(text);
+            }
+
+            // A figure inside a note (rare) is transcribed via the same host OCR path, appended after its text.
+            await ExtractContainerFiguresAsync(paragraph, mainPart, parts, state, cancellationToken);
+        }
+
+        return string.Join("\n\n", parts);
+    }
+
     /// <summary>Recursively renders the block-level children of a content-control / custom-XML wrapper.</summary>
     private async Task RenderChildBlocksAsync(
         DocumentFormat.OpenXml.OpenXmlElement? container,
         MainDocumentPart mainPart,
         List<string> blocks,
-        OpenXmlExtractionState state,
+        DocxExtractionState state,
         int depth,
         CancellationToken cancellationToken)
     {
@@ -435,7 +554,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         W.Drawing drawing,
         MainDocumentPart mainPart,
         List<string> blocks,
-        OpenXmlExtractionState state,
+        DocxExtractionState state,
         CancellationToken cancellationToken)
     {
         var embed = drawing.Descendants<A.Blip>().FirstOrDefault()?.Embed?.Value;
@@ -471,7 +590,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         string? caption,
         MainDocumentPart mainPart,
         List<string> blocks,
-        OpenXmlExtractionState state,
+        DocxExtractionState state,
         CancellationToken cancellationToken)
     {
         var block = await OpenXmlFigureTranscriber.TranscribeAsync(
@@ -514,7 +633,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// renderable category/value cache (e.g. scatter/bubble) or an unreadable part trips the completeness
     /// signal (#268); a non-chart drawing with no blip (SmartArt / diagram / OLE) is an accepted blind spot.
     /// </summary>
-    private void HandleChart(W.Drawing drawing, MainDocumentPart mainPart, List<string> blocks, OpenXmlExtractionState state)
+    private void HandleChart(W.Drawing drawing, MainDocumentPart mainPart, List<string> blocks, DocxExtractionState state)
     {
         var chartId = drawing.Descendants<C.ChartReference>().FirstOrDefault()?.Id?.Value;
         if (string.IsNullOrEmpty(chartId))
@@ -672,7 +791,21 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// path lands in a later #308 build-order step.
     /// </summary>
     internal static string? BuildIncompleteReason(
-        int failedBlocks, int droppedByCap, int undecodable, int oversizedImages, int truncatedOcr, int failedFigureOcr, int chartFailures)
+        int failedBlocks, int droppedByCap, int undecodable, int oversizedImages, int truncatedOcr, int failedFigureOcr, int chartFailures, int failedNotes = 0)
         => OpenXmlIncompleteReason.Build(
-            "document block", failedBlocks, droppedByCap, undecodable, oversizedImages, truncatedOcr, failedFigureOcr, chartFailures);
+            "document block", failedBlocks, droppedByCap, undecodable, oversizedImages, truncatedOcr, failedFigureOcr, chartFailures, failedNotes);
+
+    /// <summary>
+    /// DOCX-specific per-extraction accumulator: extends the shared <see cref="OpenXmlExtractionState"/> with
+    /// the footnote / endnote references collected during the body walk (in reading order) and the count of
+    /// references that could not be resolved to a note body (#315).
+    /// </summary>
+    protected sealed class DocxExtractionState : OpenXmlExtractionState
+    {
+        /// <summary>Footnote / endnote references seen in the body, in reading order (#315).</summary>
+        internal List<NoteReference> NoteReferences { get; } = new();
+
+        /// <summary>References whose note body could not be resolved — dangling id / missing notes part (#268).</summary>
+        public int FailedNotes;
+    }
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
+using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
@@ -397,6 +398,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         // in a style attribute, not wp:extent), so a tiny VML icon may be transcribed; VML in modern DOCX is
         // rare, so this is accepted.
         var pictures = new List<Pic.Picture>();
+        var fillDrawings = new List<W.Drawing>();
         var chartDrawings = new List<W.Drawing>();
         var vmlImages = new List<DocumentFormat.OpenXml.OpenXmlElement>();
 
@@ -409,7 +411,23 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                     break;
 
                 case W.Drawing drawing when !HasTextBoxAncestor(drawing):
-                    chartDrawings.Add(drawing);
+                    // A drawing that contains a pic:pic is already covered by the Pic.Picture case above. One
+                    // WITHOUT a pic:pic but WITH an a:blip is a shape/group whose fill is a picture
+                    // (wps:wsp/a:blipFill/a:blip) — real image content the picture walk misses, so transcribe
+                    // it rather than dropping it silently (#322 fill-image regression). Anything else is a
+                    // chart (c:chart) or a SmartArt/diagram/OLE blind spot.
+                    if (!drawing.Descendants<Pic.Picture>().Any())
+                    {
+                        if (drawing.Descendants<A.Blip>().Any())
+                        {
+                            fillDrawings.Add(drawing);
+                        }
+                        else
+                        {
+                            chartDrawings.Add(drawing);
+                        }
+                    }
+
                     break;
 
                 default:
@@ -427,6 +445,15 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         {
             cancellationToken.ThrowIfCancellationRequested();
             await HandlePictureAsync(picture, mainPart, blocks, state, cancellationToken);
+        }
+
+        // Shape/group picture fills (a:blipFill on a wps:wsp / wpg, no pic:pic): transcribe via the shape's
+        // own extent / alt-text. Emitted after the pictures; these were previously dropped entirely, so no
+        // prior output ordering is disturbed (#322).
+        foreach (var drawing in fillDrawings)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await HandleFillDrawingAsync(drawing, mainPart, blocks, state, cancellationToken);
         }
 
         // Charts: a w:drawing referencing a c:chart renders as a table; HandleChart self-filters non-charts.
@@ -656,6 +683,37 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     /// <summary>
+    /// Transcribes a shape / group picture-fill drawing — a <c>wps:wsp</c> / <c>wpg</c> whose fill is an
+    /// <c>a:blipFill</c> with no <c>pic:pic</c> for the picture walk to catch. Judges the decorative-size
+    /// filter on the drawing's OWN <c>wp:extent</c> and reads its caption from the drawing's <c>wp:docPr</c>.
+    /// Restores the pre-#322 blip-anywhere behavior for fill images that the pic:pic walk otherwise dropped
+    /// silently (#322).
+    /// </summary>
+    private async Task HandleFillDrawingAsync(
+        W.Drawing drawing,
+        MainDocumentPart mainPart,
+        List<string> blocks,
+        DocxExtractionState state,
+        CancellationToken cancellationToken)
+    {
+        var embed = drawing.Descendants<A.Blip>().FirstOrDefault()?.Embed?.Value;
+        if (string.IsNullOrEmpty(embed))
+        {
+            return;
+        }
+
+        // No pic:pic, so IsDecorative(Pic.Picture) does not apply — judge the drawing's own wp:extent (the
+        // outermost inline/anchor extent; no extent => cannot judge => keep).
+        if (IsDecorativeExtent(drawing.Descendants<DW.Extent>().FirstOrDefault()))
+        {
+            return;
+        }
+
+        var caption = CaptionFromDocProperties(drawing.Descendants<DW.DocProperties>().FirstOrDefault());
+        await TranscribeEmbeddedImageAsync(embed, caption, mainPart, blocks, state, cancellationToken);
+    }
+
+    /// <summary>
     /// Resolves an embedded image relationship and transcribes it via the host-selected
     /// <see cref="IOcrProvider"/>, appending the (optionally captioned) transcription as a block. Shared by
     /// the DrawingML (<c>a:blip</c>) and legacy VML (<c>v:imagedata</c>) image paths. The figure-OCR pipeline
@@ -748,8 +806,14 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// image is judged by its own size rather than the text box's.
     /// </summary>
     protected virtual bool IsDecorative(Pic.Picture picture)
+        => IsDecorativeExtent(NearestDrawingExtent(picture));
+
+    /// <summary>
+    /// Whether a <c>wp:extent</c> is below the decorative threshold (skipped silently). Shared by the picture
+    /// path (its nearest inline/anchor extent) and the shape-fill path (the drawing's own extent, #322).
+    /// </summary>
+    private bool IsDecorativeExtent(DW.Extent? extent)
     {
-        var extent = NearestDrawingExtent(picture);
         if (extent?.Cx is null || extent.Cy is null)
         {
             // No display extents: cannot judge — do not skip.
@@ -895,8 +959,12 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     private static string? AltTextOf(Pic.Picture picture)
+        => CaptionFromDocProperties(NearestDocProperties(picture));
+
+    /// <summary>The caption from a <c>wp:docPr</c>: its description (<c>@descr</c>), or its title as a fallback.
+    /// Shared by the picture path (nearest docPr) and the shape-fill path (the drawing's own docPr, #322).</summary>
+    private static string? CaptionFromDocProperties(DW.DocProperties? props)
     {
-        var props = NearestDocProperties(picture);
         var description = props?.Description?.Value;
         return !string.IsNullOrWhiteSpace(description) ? description : props?.Title?.Value;
     }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -485,8 +485,38 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
             }
 
             var body = await RenderNoteBodyAsync(note, mainPart, state, cancellationToken);
-            blocks.Add(string.IsNullOrWhiteSpace(body) ? $"{reference.Marker}:" : $"{reference.Marker}: {body}");
+            blocks.Add(FormatNoteDefinition(reference.Marker, body));
         }
+    }
+
+    /// <summary>
+    /// Formats one Markdown-footnote definition: the label, then the body with every line AFTER the first
+    /// indented four spaces (blank separators kept blank). The indent is required by the Markdown footnote
+    /// syntax (Pandoc / cmark-gfm) so a multi-paragraph or figure note body stays attached to the definition;
+    /// without it the second paragraph is flush-left and escapes as an ordinary document-level paragraph (and
+    /// can wedge between two definitions), corrupting the output structure (#315).
+    /// </summary>
+    private static string FormatNoteDefinition(string marker, string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return $"{marker}:";
+        }
+
+        var lines = body.Replace("\r\n", "\n").Split('\n');
+        var sb = new System.Text.StringBuilder();
+        sb.Append(marker).Append(": ").Append(lines[0]);
+        for (var i = 1; i < lines.Length; i++)
+        {
+            sb.Append('\n');
+            // Keep a blank separator blank; indent every content continuation line so it attaches to the note.
+            if (lines[i].Length > 0)
+            {
+                sb.Append("    ").Append(lines[i]);
+            }
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -11,8 +11,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
-using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
+using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
@@ -363,10 +363,13 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     /// <summary>
-    /// Transcribes a container's (paragraph or table) embedded images and renders its chart drawings.
-    /// Covers both DrawingML images (<c>a:blip</c> in <c>w:drawing</c>) and legacy VML raster images
-    /// (<c>v:imagedata</c> in <c>w:pict</c>), so a compatibility-mode / legacy DOCX does not silently drop
-    /// figures. Used for both body paragraphs and table cells (a Markdown cell can't host a transcription).
+    /// Transcribes a container's (paragraph, table cell, or note) embedded images and renders its chart
+    /// drawings. Images are walked as <b>picture instances</b> (<c>pic:pic</c>) rather than <c>w:drawing</c>
+    /// elements (#322), so a grouped drawing's several pictures are each transcribed once, a text-box image is
+    /// transcribed once with its OWN extent / caption (read from the picture's nearest <c>wp:inline</c> /
+    /// <c>wp:anchor</c>), and the previous grouped-multi-image loss and double-OCR special-case both go away.
+    /// Charts ride the <c>c:chart</c> reference on a <c>w:drawing</c>; legacy VML raster images ride
+    /// <c>v:imagedata</c> — neither is a <c>pic:pic</c>, so each keeps its own pass.
     /// </summary>
     private async Task ExtractContainerFiguresAsync(
         DocumentFormat.OpenXml.OpenXmlElement container,
@@ -375,19 +378,26 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocxExtractionState state,
         CancellationToken cancellationToken)
     {
-        // Skip drawings nested inside a text box (txbxContent): the text box's own (outer) drawing is
-        // processed once and its recursive blip lookup transcribes the inner image a single time. Without
-        // this skip the recursive Descendants walk visits BOTH the outer text-box drawing AND the nested
-        // image drawing and OCRs the same image twice (double cost + double budget + duplicate block).
+        // Images: one transcription per picture instance. A pic:pic appears exactly once in the tree, so a
+        // grouped drawing's images and a text-box image are each handled once with no double-OCR guard needed.
+        foreach (var picture in container.Descendants<Pic.Picture>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await HandlePictureAsync(picture, mainPart, blocks, state, cancellationToken);
+        }
+
+        // Charts: a w:drawing referencing a c:chart renders its backing data as a table (no pic:pic).
+        // HandleChart self-filters non-chart drawings, so image / SmartArt / diagram / OLE drawings fall
+        // through untouched. A chart nested in a text box stays skipped (an accepted blind spot, unchanged).
         foreach (var drawing in container.Descendants<W.Drawing>().Where(d => !HasTextBoxAncestor(d)))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await HandleDrawingAsync(drawing, mainPart, blocks, state, cancellationToken);
+            HandleChart(drawing, mainPart, blocks, state);
         }
 
-        // Legacy VML raster images (w:pict/v:imagedata) are not W.Drawing, so the DrawingML walk above
-        // misses them. They reference PNG/JPEG bytes via an r:id (or o:relid) relationship — transcribe them
-        // too rather than silently dropping the figure. (A vector-only VML shape has no imagedata relationship.)
+        // Legacy VML raster images (w:pict/v:imagedata) are not pic:pic, so the picture walk above misses
+        // them. They reference PNG/JPEG bytes via an r:id (or o:relid) relationship — transcribe them too
+        // rather than silently dropping the figure. (A vector-only VML shape has no imagedata relationship.)
         // Known limitation: VML images are NOT decorative-size-filtered (a VML shape's size lives in its style
         // attribute, not wp:extent), so a tiny VML icon may be transcribed where its DrawingML equivalent
         // would be skipped by IsDecorative. VML in modern DOCX is rare, so this is accepted (see #318-area).
@@ -550,23 +560,26 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         }
     }
 
-    private async Task HandleDrawingAsync(
-        W.Drawing drawing,
+    /// <summary>
+    /// Transcribes one embedded picture (<c>pic:pic</c>) via the host OCR path, reading its decorative-size
+    /// threshold and caption from the picture's own <c>wp:inline</c> / <c>wp:anchor</c> ancestor so a grouped
+    /// or text-box image uses its OWN extent / alt-text rather than the group's / text box's (#322).
+    /// </summary>
+    private async Task HandlePictureAsync(
+        Pic.Picture picture,
         MainDocumentPart mainPart,
         List<string> blocks,
         DocxExtractionState state,
         CancellationToken cancellationToken)
     {
-        var embed = drawing.Descendants<A.Blip>().FirstOrDefault()?.Embed?.Value;
+        var embed = picture.BlipFill?.Blip?.Embed?.Value;
         if (string.IsNullOrEmpty(embed))
         {
-            // No image blip: a chart (render its backing data as a table) or SmartArt/diagram/OLE (an
-            // accepted blind spot). Charts go through the format-agnostic ChartRenderer — no OCR / vision.
-            HandleChart(drawing, mainPart, blocks, state);
+            // A picture with no embedded blip (e.g. a linked / external image) — nothing to transcribe.
             return;
         }
 
-        if (IsDecorative(drawing))
+        if (IsDecorative(picture))
         {
             // Icon / bullet / logo / spacer — not figure content, not counted against completeness.
             return;
@@ -574,7 +587,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
 
         // Native alt-text (wp:docPr/@descr, fallback @title) is a real caption signal — strictly better than
         // PDF's nearest-text heuristic.
-        await TranscribeEmbeddedImageAsync(embed, AltTextOf(drawing), mainPart, blocks, state, cancellationToken);
+        await TranscribeEmbeddedImageAsync(embed, AltTextOf(picture), mainPart, blocks, state, cancellationToken);
     }
 
     /// <summary>
@@ -664,10 +677,14 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         blocks.Add(table!);
     }
 
-    /// <summary>Whether the drawing's display size is below the decorative threshold (skipped silently).</summary>
-    protected virtual bool IsDecorative(W.Drawing drawing)
+    /// <summary>
+    /// Whether the picture's display size is below the decorative threshold (skipped silently). The extent is
+    /// read from the picture's nearest <c>wp:inline</c> / <c>wp:anchor</c> ancestor (#322), so a text-box
+    /// image is judged by its own size rather than the text box's.
+    /// </summary>
+    protected virtual bool IsDecorative(Pic.Picture picture)
     {
-        var extent = drawing.Descendants<DW.Extent>().FirstOrDefault();
+        var extent = NearestDrawingExtent(picture);
         if (extent?.Cx is null || extent.Cy is null)
         {
             // No display extents: cannot judge — do not skip.
@@ -691,6 +708,16 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         var pixelArea = cx * cy / (EmuPerPixel96 * EmuPerPixel96);
         return pixelArea < _options.MinImagePixels;
     }
+
+    /// <summary>The nearest inline (<c>wp:inline</c>) or floating (<c>wp:anchor</c>) drawing-wrapper ancestor
+    /// of the picture, or <c>null</c> — the source of the picture's own extent + docPr (#322). For a text-box
+    /// image this is the inner drawing (the image's), not the outer text-box drawing.</summary>
+    private static DocumentFormat.OpenXml.OpenXmlElement? NearestDrawingWrapper(Pic.Picture picture)
+        => picture.Ancestors().FirstOrDefault(a => a is DW.Inline or DW.Anchor);
+
+    /// <summary>The <c>wp:extent</c> of the picture's nearest inline / floating drawing ancestor, or <c>null</c>.</summary>
+    private static DW.Extent? NearestDrawingExtent(Pic.Picture picture)
+        => NearestDrawingWrapper(picture)?.GetFirstChild<DW.Extent>();
 
     /// <summary>
     /// Concatenates a paragraph's visible run text in document order: run text (<c>w:t</c>), tabs
@@ -768,12 +795,17 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         return MarkdownText.EscapeBlockText(sb.ToString().Trim());
     }
 
-    private static string? AltTextOf(W.Drawing drawing)
+    private static string? AltTextOf(Pic.Picture picture)
     {
-        var props = drawing.Descendants<DW.DocProperties>().FirstOrDefault();
+        var props = NearestDocProperties(picture);
         var description = props?.Description?.Value;
         return !string.IsNullOrWhiteSpace(description) ? description : props?.Title?.Value;
     }
+
+    /// <summary>The <c>wp:docPr</c> of the picture's nearest inline / floating drawing ancestor — the image's
+    /// own caption source, not the group's / text box's (#322).</summary>
+    private static DW.DocProperties? NearestDocProperties(Pic.Picture picture)
+        => NearestDrawingWrapper(picture)?.GetFirstChild<DW.DocProperties>();
 
     /// <summary>
     /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -173,7 +173,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
             var mainPart = document.MainDocumentPart;
             var body = mainPart?.Document?.Body;
 
-            var state = new ExtractionState
+            var state = new OpenXmlExtractionState
             {
                 ImageBudget = _options.MaxImagesPerFile,
                 LanguageHints = ResolveLanguageHints(context)
@@ -196,7 +196,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                         // OpenXML parses lazily, so a malformed block can fault here on access. Skip it and
                         // mark the result incomplete rather than failing the whole document.
                         Logger.LogWarning(ex, "Failed to process a document block; skipping it.");
-                        state.FailedBlocks++;
+                        state.FailedContainers++;
                     }
                 }
             }
@@ -204,7 +204,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
             // Single source of truth for the #268 signal: the reason is built from the counters and is
             // null iff nothing was lost; completeness derives from it (no parallel hand-synced predicate).
             var incompleteReason = BuildIncompleteReason(
-                state.FailedBlocks, state.DroppedByCap, state.Undecodable, state.OversizedImages,
+                state.FailedContainers, state.DroppedByCap, state.Undecodable, state.OversizedImages,
                 state.TruncatedOcr, state.FailedFigureOcr, state.ChartFailures);
             var complete = incompleteReason is null;
             if (!complete)
@@ -240,7 +240,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocumentFormat.OpenXml.OpenXmlElement element,
         MainDocumentPart mainPart,
         List<string> blocks,
-        ExtractionState state,
+        OpenXmlExtractionState state,
         int depth,
         CancellationToken cancellationToken)
     {
@@ -254,7 +254,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 {
                     // Native table -> Markdown table (pure structured extraction, no OCR). A null/empty render
                     // (layout-only or empty grid) is simply not added; a parse fault is caught by the caller's
-                    // per-block try/catch and tripped as FailedBlocks.
+                    // per-block try/catch and tripped as FailedContainers.
                     var renderedTable = WordTableRenderer.Render(table);
                     if (!string.IsNullOrWhiteSpace(renderedTable))
                     {
@@ -286,7 +286,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 if (!string.IsNullOrWhiteSpace(element.InnerText))
                 {
                     Logger.LogWarning("Skipping an unsupported body block <{Name}> that carries text.", element.LocalName);
-                    state.FailedBlocks++;
+                    state.FailedContainers++;
                 }
 
                 break;
@@ -305,7 +305,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         W.Paragraph paragraph,
         MainDocumentPart mainPart,
         List<string> blocks,
-        ExtractionState state,
+        OpenXmlExtractionState state,
         CancellationToken cancellationToken)
     {
         var headingLevel = WordStyleMap.HeadingLevel(paragraph);
@@ -384,7 +384,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocumentFormat.OpenXml.OpenXmlElement container,
         MainDocumentPart mainPart,
         List<string> blocks,
-        ExtractionState state,
+        OpenXmlExtractionState state,
         CancellationToken cancellationToken)
     {
         // Skip drawings nested inside a text box (txbxContent): the text box's own (outer) drawing is
@@ -420,7 +420,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocumentFormat.OpenXml.OpenXmlElement? container,
         MainDocumentPart mainPart,
         List<string> blocks,
-        ExtractionState state,
+        OpenXmlExtractionState state,
         int depth,
         CancellationToken cancellationToken)
     {
@@ -436,7 +436,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
             Logger.LogWarning("Content-control nesting exceeded depth {Max}; skipping the remaining subtree.", MaxBlockNestingDepth);
             if (!string.IsNullOrWhiteSpace(container.InnerText))
             {
-                state.FailedBlocks++;
+                state.FailedContainers++;
             }
 
             return;
@@ -453,7 +453,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         W.Drawing drawing,
         MainDocumentPart mainPart,
         List<string> blocks,
-        ExtractionState state,
+        OpenXmlExtractionState state,
         CancellationToken cancellationToken)
     {
         var embed = drawing.Descendants<A.Blip>().FirstOrDefault()?.Embed?.Value;
@@ -477,112 +477,27 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     /// <summary>
-    /// Resolves an embedded image relationship to its bytes and transcribes it via the host-selected
-    /// <see cref="IOcrProvider"/>, appending the transcription (optionally captioned) as a block. Shared by
-    /// the DrawingML (<c>a:blip</c>) and legacy VML (<c>v:imagedata</c>) image paths. Honors the per-file
-    /// image budget and trips the #268 counters on cap / oversize / undecodable / OCR-failure / truncation.
+    /// Resolves an embedded image relationship and transcribes it via the host-selected
+    /// <see cref="IOcrProvider"/>, appending the (optionally captioned) transcription as a block. Shared by
+    /// the DrawingML (<c>a:blip</c>) and legacy VML (<c>v:imagedata</c>) image paths. The figure-OCR pipeline
+    /// itself — budget guard, resolve, image-outcome switch, OCR, truncation signal, caption — lives in the
+    /// shared <see cref="OpenXmlFigureTranscriber"/> (#317, shared with <see cref="PptxExtractor"/>); this
+    /// wrapper only supplies the DOCX part container + caption and sinks the finished block in flow order.
     /// </summary>
     private async Task TranscribeEmbeddedImageAsync(
         string relationshipId,
         string? caption,
         MainDocumentPart mainPart,
         List<string> blocks,
-        ExtractionState state,
+        OpenXmlExtractionState state,
         CancellationToken cancellationToken)
     {
-        if (state.ImageBudget <= 0)
+        var block = await OpenXmlFigureTranscriber.TranscribeAsync(
+            mainPart, relationshipId, caption, state, _options, _ocrProvider, Logger, cancellationToken);
+        if (block is not null)
         {
-            state.DroppedByCap++;
-            return;
+            blocks.Add(block);
         }
-
-        OpenXmlImagePayload.ResolvedImage resolved;
-        try
-        {
-            var part = mainPart.GetPartById(relationshipId);
-            resolved = part is ImagePart imagePart
-                ? OpenXmlImagePayload.TryResolve(imagePart, _options.MaxImageBytesPerImage)
-                // A dangling relationship / non-image part: treat as undecodable.
-                : new OpenXmlImagePayload.ResolvedImage(OpenXmlImagePayload.ImageOutcome.Undecodable, null, null);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Logger.LogWarning(ex, "Failed to resolve/decode an embedded DOCX image; skipping it.");
-            resolved = new OpenXmlImagePayload.ResolvedImage(OpenXmlImagePayload.ImageOutcome.Undecodable, null, null);
-        }
-
-        switch (resolved.Outcome)
-        {
-            case OpenXmlImagePayload.ImageOutcome.Oversized:
-                // A single image larger than the per-image byte cap (e.g. a ZIP-decompression bomb). Skipped
-                // before full materialization; trips the completeness signal but never OOMs the worker.
-                Logger.LogWarning("Skipped an embedded image exceeding the {Cap}-byte per-image cap.", _options.MaxImageBytesPerImage);
-                state.OversizedImages++;
-                return;
-
-            case OpenXmlImagePayload.ImageOutcome.Undecodable:
-                // Vector (EMF/WMF), dangling relationship, or undecodable/mislabeled bytes.
-                state.Undecodable++;
-                return;
-
-            case OpenXmlImagePayload.ImageOutcome.Ok:
-                break;
-
-            default:
-                // A future outcome added to the enum must not silently fall through to RecognizeAsync with
-                // possibly-null bytes — fail closed by treating it as undecodable.
-                Logger.LogWarning("Unhandled image outcome {Outcome}; treating as undecodable.", resolved.Outcome);
-                state.Undecodable++;
-                return;
-        }
-
-        state.ImageBudget--;
-
-        OcrResult ocr;
-        try
-        {
-            using var imageStream = new MemoryStream(resolved.Bytes!, writable: false);
-            ocr = await _ocrProvider.RecognizeAsync(
-                imageStream,
-                new OcrOptions
-                {
-                    ContentType = resolved.ContentType!,
-                    LanguageHints = state.LanguageHints
-                },
-                cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // A single figure's OCR failing (provider timeout / rate-limit / auth / one bad image) must NOT
-            // discard the document text already extracted — figure OCR is an auxiliary augmentation, not the
-            // document's primary payload (the #210/#268 "auxiliary step must not break the main pipeline"
-            // principle). Skip this figure and mark the result incomplete. OperationCanceledException still
-            // propagates so a host/job shutdown aborts promptly.
-            Logger.LogWarning(ex, "Embedded-image OCR failed; keeping the document text, skipping this figure.");
-            state.FailedFigureOcr++;
-            return;
-        }
-
-        if (!ocr.IsComplete)
-        {
-            // OCR truncated at the token limit or discarded by the repetition guard.
-            state.TruncatedOcr++;
-        }
-
-        var transcription = ocr.Markdown?.Trim() ?? string.Empty;
-        if (transcription.Length == 0)
-        {
-            return;
-        }
-
-        // Caption (alt-text) is author-controlled free text (often multi-line), so collapse newlines via
-        // MarkdownText.InlineLabel AND inline-escape via MarkdownText.EscapeInline so the bold caption can't
-        // break the OCR block (often a table) below it, nor inject a link/emphasis from a literal [..](..)/*.
-        var markdown = string.IsNullOrWhiteSpace(caption)
-            ? transcription
-            : "**" + MarkdownText.EscapeInline(MarkdownText.InlineLabel(caption)) + "**\n\n" + transcription;
-
-        blocks.Add(markdown);
     }
 
     /// <summary>
@@ -617,7 +532,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// renderable category/value cache (e.g. scatter/bubble) or an unreadable part trips the completeness
     /// signal (#268); a non-chart drawing with no blip (SmartArt / diagram / OLE) is an accepted blind spot.
     /// </summary>
-    private void HandleChart(W.Drawing drawing, MainDocumentPart mainPart, List<string> blocks, ExtractionState state)
+    private void HandleChart(W.Drawing drawing, MainDocumentPart mainPart, List<string> blocks, OpenXmlExtractionState state)
     {
         var chartId = drawing.Descendants<C.ChartReference>().FirstOrDefault()?.Id?.Value;
         if (string.IsNullOrEmpty(chartId))
@@ -766,7 +681,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// consumer can override to supply hints (e.g. from per-tenant config).
     /// </summary>
     protected virtual IList<string> ResolveLanguageHints(TextExtractionContext context)
-        => context.LanguageHints ?? new List<string>();
+        => OpenXmlExtractionState.ResolveLanguageHints(context);
 
     /// <summary>
     /// Builds the #268 incompleteness reason from the loss counters, or returns <c>null</c> when nothing was
@@ -776,57 +691,6 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     /// </summary>
     internal static string? BuildIncompleteReason(
         int failedBlocks, int droppedByCap, int undecodable, int oversizedImages, int truncatedOcr, int failedFigureOcr, int chartFailures)
-    {
-        var parts = new List<string>();
-        if (failedBlocks > 0)
-        {
-            parts.Add($"{failedBlocks} document block(s) could not be parsed and were skipped");
-        }
-
-        if (undecodable > 0)
-        {
-            parts.Add($"{undecodable} embedded image(s) could not be decoded to a supported raster format (e.g. EMF/WMF vector)");
-        }
-
-        if (oversizedImages > 0)
-        {
-            parts.Add($"{oversizedImages} embedded image(s) exceeded the per-image size cap and were skipped");
-        }
-
-        if (failedFigureOcr > 0)
-        {
-            parts.Add($"{failedFigureOcr} embedded image(s) failed OCR (provider error)");
-        }
-
-        if (truncatedOcr > 0)
-        {
-            parts.Add($"{truncatedOcr} image transcription(s) were truncated or discarded by the OCR provider");
-        }
-
-        if (chartFailures > 0)
-        {
-            parts.Add($"{chartFailures} chart(s) could not be rendered as a table");
-        }
-
-        if (droppedByCap > 0)
-        {
-            parts.Add($"{droppedByCap} image(s) were skipped after reaching the per-file image cap");
-        }
-
-        return parts.Count == 0 ? null : string.Join("; ", parts) + ".";
-    }
-
-    /// <summary>Mutable per-extraction accumulator: image budget and #268 loss counters.</summary>
-    protected sealed class ExtractionState
-    {
-        public int ImageBudget;
-        public int FailedBlocks;
-        public int DroppedByCap;
-        public int Undecodable;
-        public int OversizedImages;
-        public int TruncatedOcr;
-        public int FailedFigureOcr;
-        public int ChartFailures;
-        public IList<string> LanguageHints = new List<string>();
-    }
+        => OpenXmlIncompleteReason.Build(
+            "document block", failedBlocks, droppedByCap, undecodable, oversizedImages, truncatedOcr, failedFigureOcr, chartFailures);
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -246,8 +246,9 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 {
                     // Native table -> Markdown table (pure structured extraction, no OCR). A null/empty render
                     // (layout-only or empty grid) is simply not added; a parse fault is caught by the caller's
-                    // per-block try/catch and tripped as FailedContainers.
-                    var renderedTable = WordTableRenderer.Render(table);
+                    // per-block try/catch and tripped as FailedContainers. The note collector is threaded in so
+                    // a footnote/endnote reference inside a cell is captured, not silently dropped (#315).
+                    var renderedTable = WordTableRenderer.Render(table, state.NoteReferences);
                     if (!string.IsNullOrWhiteSpace(renderedTable))
                     {
                         blocks.Add(renderedTable!);
@@ -305,15 +306,21 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         {
             // Headings render as plain collapsed text (no inline emphasis markup inside an ATX heading).
             var text = ParagraphText(paragraph);
-            if (!string.IsNullOrWhiteSpace(text))
+            // A footnote/endnote reference inside a heading is real content. The plain-text heading path does
+            // not go through WordParagraphRenderer (which collects markers for body paragraphs), so collect
+            // the references here and append their markers — otherwise the marker and the note body were
+            // silently dropped and the loss bypassed the #268 signal (#315).
+            var noteMarkers = CollectNoteMarkers(paragraph, state.NoteReferences);
+            if (!string.IsNullOrWhiteSpace(text) || noteMarkers.Length > 0)
             {
                 // Collapse internal line breaks so a multi-line heading renders as one clean ATX heading.
                 var oneLine = string.Join(
                     " ",
                     text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
                 // Escape the heading text so a literal "#"/"[...]"/"*" in it does not extend the ATX run or
-                // inject a link/emphasis (the "# " prefix we add is generated structure, kept intact).
-                blocks.Add(new string('#', level) + " " + MarkdownText.EscapeBlockText(oneLine));
+                // inject a link/emphasis (the "# " prefix we add is generated structure, kept intact). Note
+                // markers are generated structure too, so they are appended past the escape.
+                blocks.Add(new string('#', level) + " " + MarkdownText.EscapeBlockText(oneLine) + noteMarkers);
             }
         }
         else
@@ -814,6 +821,40 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         }
 
         return sb.ToString().Trim();
+    }
+
+    /// <summary>
+    /// Appends a Markdown marker (<c>[^fn{id}]</c> / <c>[^en{id}]</c>) for each footnote/endnote reference in
+    /// the paragraph, in reading order, and records the reference on <paramref name="sink"/> so its body is
+    /// resolved and defined at the document end (#315). Used by the plain-text heading path, which — unlike
+    /// the body path via <see cref="WordParagraphRenderer"/> — would otherwise drop the reference silently.
+    /// Text-box references are excluded (a text box is emitted as its own block).
+    /// </summary>
+    private static string CollectNoteMarkers(W.Paragraph paragraph, ICollection<NoteReference> sink)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var element in paragraph.Descendants<DocumentFormat.OpenXml.OpenXmlElement>())
+        {
+            if (HasTextBoxAncestor(element))
+            {
+                continue;
+            }
+
+            var reference = element switch
+            {
+                W.FootnoteReference fn when fn.Id?.Value is { } fnId => new NoteReference(NoteKind.Footnote, fnId),
+                W.EndnoteReference en when en.Id?.Value is { } enId => new NoteReference(NoteKind.Endnote, enId),
+                _ => (NoteReference?)null
+            };
+
+            if (reference is { } note)
+            {
+                sb.Append(note.Marker);
+                sink.Add(note);
+            }
+        }
+
+        return sb.ToString();
     }
 
     private static bool HasTextBoxAncestor(DocumentFormat.OpenXml.OpenXmlElement element)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -162,6 +162,10 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 LanguageHints = ResolveLanguageHints(context)
             };
 
+            // Build the per-document hyperlink id -> uri cache once (#318) so a link resolves in O(1) rather
+            // than scanning HyperlinkRelationships per hyperlink during the body render.
+            state.HyperlinkUris = mainPart is null ? null : BuildHyperlinkUris(mainPart);
+
             var blocks = new List<string>();
 
             if (body is not null)
@@ -315,11 +319,11 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         else
         {
             // Body paragraphs render with inline formatting (bold/italic) and hyperlinks.
-            var markdown = WordParagraphRenderer.Render(paragraph, mainPart, state.NoteReferences);
+            var markdown = WordParagraphRenderer.Render(paragraph, mainPart, state.NoteReferences, state.HyperlinkUris);
             if (!string.IsNullOrWhiteSpace(markdown))
             {
                 // A list item (w:numPr) gets a Markdown bullet / ordered marker, indented by nesting level.
-                var list = WordListNumbering.Resolve(paragraph, mainPart.NumberingDefinitionsPart);
+                var list = WordListNumbering.Resolve(paragraph, mainPart.NumberingDefinitionsPart, state.NumberingFormatCache);
                 if (list is { } listInfo)
                 {
                     // Clamp the nesting level: a malformed / attacker w:ilvl would otherwise allocate a huge
@@ -378,31 +382,55 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocxExtractionState state,
         CancellationToken cancellationToken)
     {
-        // Images: one transcription per picture instance. A pic:pic appears exactly once in the tree, so a
-        // grouped drawing's images and a text-box image are each handled once with no double-OCR guard needed.
-        foreach (var picture in container.Descendants<Pic.Picture>())
+        // One subtree traversal (#318): collect the pictures, chart drawings, and legacy VML images in a
+        // single Descendants() pass, then emit in the established order (pictures, then charts, then VML) so
+        // the Markdown output is byte-for-byte unchanged. A pic:pic is transcribed regardless of a text-box
+        // ancestor (#322 — the text-box image is real content), while a chart / VML inside a text box stays
+        // skipped (an accepted blind spot). Known VML limitation: not decorative-size-filtered (its size lives
+        // in a style attribute, not wp:extent), so a tiny VML icon may be transcribed; VML in modern DOCX is
+        // rare, so this is accepted.
+        var pictures = new List<Pic.Picture>();
+        var chartDrawings = new List<W.Drawing>();
+        var vmlImages = new List<DocumentFormat.OpenXml.OpenXmlElement>();
+
+        foreach (var element in container.Descendants())
+        {
+            switch (element)
+            {
+                case Pic.Picture picture:
+                    pictures.Add(picture);
+                    break;
+
+                case W.Drawing drawing when !HasTextBoxAncestor(drawing):
+                    chartDrawings.Add(drawing);
+                    break;
+
+                default:
+                    if (element.LocalName == "imagedata" && !HasTextBoxAncestor(element))
+                    {
+                        vmlImages.Add(element);
+                    }
+
+                    break;
+            }
+        }
+
+        // Images: one transcription per picture instance, with metadata from the picture's own inline/anchor.
+        foreach (var picture in pictures)
         {
             cancellationToken.ThrowIfCancellationRequested();
             await HandlePictureAsync(picture, mainPart, blocks, state, cancellationToken);
         }
 
-        // Charts: a w:drawing referencing a c:chart renders its backing data as a table (no pic:pic).
-        // HandleChart self-filters non-chart drawings, so image / SmartArt / diagram / OLE drawings fall
-        // through untouched. A chart nested in a text box stays skipped (an accepted blind spot, unchanged).
-        foreach (var drawing in container.Descendants<W.Drawing>().Where(d => !HasTextBoxAncestor(d)))
+        // Charts: a w:drawing referencing a c:chart renders as a table; HandleChart self-filters non-charts.
+        foreach (var drawing in chartDrawings)
         {
             cancellationToken.ThrowIfCancellationRequested();
             HandleChart(drawing, mainPart, blocks, state);
         }
 
-        // Legacy VML raster images (w:pict/v:imagedata) are not pic:pic, so the picture walk above misses
-        // them. They reference PNG/JPEG bytes via an r:id (or o:relid) relationship — transcribe them too
-        // rather than silently dropping the figure. (A vector-only VML shape has no imagedata relationship.)
-        // Known limitation: VML images are NOT decorative-size-filtered (a VML shape's size lives in its style
-        // attribute, not wp:extent), so a tiny VML icon may be transcribed where its DrawingML equivalent
-        // would be skipped by IsDecorative. VML in modern DOCX is rare, so this is accepted (see #318-area).
-        foreach (var imageData in container.Descendants()
-                     .Where(e => e.LocalName == "imagedata" && !HasTextBoxAncestor(e)))
+        // Legacy VML raster images (v:imagedata), not pic:pic — transcribe via their r:id relationship.
+        foreach (var imageData in vmlImages)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var relationshipId = VmlImageRelationshipId(imageData);
@@ -808,6 +836,21 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         => NearestDrawingWrapper(picture)?.GetFirstChild<DW.DocProperties>();
 
     /// <summary>
+    /// Builds the per-document hyperlink relationship-id → URI map once (#318). Relationship ids are unique,
+    /// so a plain dictionary suffices; a relationship with no target maps to <c>null</c> (an internal anchor).
+    /// </summary>
+    private static IReadOnlyDictionary<string, string?> BuildHyperlinkUris(MainDocumentPart mainPart)
+    {
+        var map = new Dictionary<string, string?>();
+        foreach (var relationship in mainPart.HyperlinkRelationships)
+        {
+            map[relationship.Id] = relationship.Uri?.ToString();
+        }
+
+        return map;
+    }
+
+    /// <summary>
     /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the
     /// context, or empty. There is no central host default (#441 removed it); a provider that needs a
     /// language default reads its own config (e.g. PaddleOcr:Languages). Kept <c>protected virtual</c> so a
@@ -839,5 +882,11 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
 
         /// <summary>References whose note body could not be resolved — dangling id / missing notes part (#268).</summary>
         public int FailedNotes;
+
+        /// <summary>Per-document hyperlink relationship-id → URI cache, built once (#318); null until built.</summary>
+        public IReadOnlyDictionary<string, string?>? HyperlinkUris;
+
+        /// <summary>Per-document <c>(numId, level) → numbering-format</c> memo, populated lazily (#318).</summary>
+        public Dictionary<(int NumId, int Level), W.NumberFormatValues?> NumberingFormatCache { get; } = new();
     }
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/NoteReference.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/NoteReference.cs
@@ -1,0 +1,19 @@
+namespace Dignite.Vault.Extract.Parse.OpenXml;
+
+/// <summary>Whether a note reference targets a footnote or an endnote (#315). The two id spaces are separate.</summary>
+internal enum NoteKind
+{
+    Footnote,
+    Endnote
+}
+
+/// <summary>
+/// A footnote / endnote reference found in the body at its reading position (#315): the kind and the
+/// <c>w:id</c> that keys its body in the <c>FootnotesPart</c> / <c>EndnotesPart</c>. <see cref="Marker"/> is
+/// the stable Markdown-footnote label used both for the in-text marker and the appended definition
+/// (<c>[^fn2]</c> / <c>[^en1]</c>); the <c>fn</c> / <c>en</c> prefix disambiguates the two separate id spaces.
+/// </summary>
+internal readonly record struct NoteReference(NoteKind Kind, long Id)
+{
+    public string Marker => $"[^{(Kind == NoteKind.Footnote ? "fn" : "en")}{Id}]";
+}

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlExtractionState.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlExtractionState.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Dignite.Vault.Extract.Abstractions.Parse;
+
+namespace Dignite.Vault.Extract.Parse.OpenXml;
+
+/// <summary>
+/// Mutable per-extraction accumulator shared by <see cref="DocxExtractor"/> and <see cref="PptxExtractor"/>:
+/// the remaining per-file image budget, the resolved OCR language hints, and the #268 loss counters that
+/// <see cref="OpenXmlIncompleteReason"/> turns into the completeness signal. Extracted from the two formerly
+/// duplicated (and inconsistently <c>protected</c>/<c>private</c>) nested <c>ExtractionState</c> classes
+/// (#317) so a new counter is declared in exactly one place. The "failed container" counter is
+/// format-neutral (<see cref="FailedContainers"/> — a Word document block or a PowerPoint slide); the format
+/// supplies the noun when building the reason. PPTX adds a reading-order <c>Sequence</c> in its own
+/// <c>PptxExtractionState</c> subclass; DOCX emits in flow (document) order and needs no such field.
+/// </summary>
+public class OpenXmlExtractionState
+{
+    /// <summary>Remaining per-file image-transcription budget (decremented once per real figure sent to OCR).</summary>
+    public int ImageBudget;
+
+    /// <summary>Top-level containers (DOCX body blocks / PPTX slides) that faulted on parse and were skipped.</summary>
+    public int FailedContainers;
+
+    /// <summary>Images skipped after the per-file image cap was reached.</summary>
+    public int DroppedByCap;
+
+    /// <summary>Images that could not be decoded to a supported raster format (vector / corrupt / mislabeled).</summary>
+    public int Undecodable;
+
+    /// <summary>Images that exceeded the per-image byte cap and were skipped before materialization.</summary>
+    public int OversizedImages;
+
+    /// <summary>Image transcriptions truncated at the token limit or discarded by the OCR repetition guard.</summary>
+    public int TruncatedOcr;
+
+    /// <summary>Images whose OCR failed with a provider error (the figure was skipped, the text kept).</summary>
+    public int FailedFigureOcr;
+
+    /// <summary>Charts whose backing data could not be rendered as a Markdown table.</summary>
+    public int ChartFailures;
+
+    /// <summary>OCR language hints for embedded-image transcription (resolved once per extraction).</summary>
+    public IList<string> LanguageHints = new List<string>();
+
+    /// <summary>
+    /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the
+    /// context, or empty. There is no central host default (#441 removed it); a provider that needs a
+    /// language default reads its own config (e.g. <c>PaddleOcr:Languages</c>). Shared by both OpenXML
+    /// extractors' <c>protected virtual ResolveLanguageHints</c> override seam (#317) so the resolution rule
+    /// lives in one place while each extractor keeps its overridable entry point.
+    /// </summary>
+    public static IList<string> ResolveLanguageHints(TextExtractionContext context)
+        => context.LanguageHints ?? new List<string>();
+}

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlFigureTranscriber.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlFigureTranscriber.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Ocr;
+using DocumentFormat.OpenXml.Packaging;
+using Microsoft.Extensions.Logging;
+
+namespace Dignite.Vault.Extract.Parse.OpenXml;
+
+/// <summary>
+/// Resolves an embedded OpenXML image relationship to bytes, transcribes it through the host-selected
+/// <see cref="IOcrProvider"/>, and returns the (optionally captioned) Markdown block — or <c>null</c> when
+/// there is nothing to emit. This is the figure-OCR pipeline formerly copy-pasted between
+/// <c>DocxExtractor.TranscribeEmbeddedImageAsync</c> and <c>PptxExtractor.HandlePictureAsync</c>: the budget
+/// guard, <see cref="OpenXmlImagePayload.TryResolve"/> call, the image-outcome switch, the OCR call, the
+/// truncation signal, and the caption formatting were character-for-character identical, so a future change
+/// (a new <c>ImageOutcome</c>, a new #268 counter, a cap-ordering or security tightening) had to be applied
+/// in two places and compiled cleanly if one was missed (#317).
+/// <para>
+/// It honors the per-file image budget and trips the #268 loss counters on
+/// cap / oversize / undecodable / OCR-failure / truncation, mutating them on the passed
+/// <see cref="OpenXmlExtractionState"/>. The caller owns everything format-specific: the pre-checks
+/// (decorative-size filtering, blip/embed presence), the caption source (Word <c>wp:docPr</c> vs PPTX
+/// <c>p:cNvPr</c>), the part container to resolve the relationship against (<c>MainDocumentPart</c> vs
+/// <c>SlidePart</c>), and how the returned block is sunk (DOCX appends the string in flow order; PPTX wraps
+/// it in a positioned <c>SlideBlock</c> for reading-order sorting).
+/// </para>
+/// <para>
+/// <b>Transcription only</b> — the figure's bytes are the OCR input, so no user free-text enters a prompt
+/// (no <c>PromptBoundary</c> concern), and <c>UsedOcr</c> ("scan vs digital") stays the caller's <c>false</c>
+/// because figure OCR is auxiliary to a digital extraction (same contract reasoning as PdfExtractor #301).
+/// </para>
+/// </summary>
+internal static class OpenXmlFigureTranscriber
+{
+    public static async Task<string?> TranscribeAsync(
+        OpenXmlPartContainer partContainer,
+        string relationshipId,
+        string? caption,
+        OpenXmlExtractionState state,
+        OpenXmlExtractorOptions options,
+        IOcrProvider ocrProvider,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (state.ImageBudget <= 0)
+        {
+            state.DroppedByCap++;
+            return null;
+        }
+
+        OpenXmlImagePayload.ResolvedImage resolved;
+        try
+        {
+            var part = partContainer.GetPartById(relationshipId);
+            resolved = part is ImagePart imagePart
+                ? OpenXmlImagePayload.TryResolve(imagePart, options.MaxImageBytesPerImage)
+                // A dangling relationship / non-image part: treat as undecodable.
+                : new OpenXmlImagePayload.ResolvedImage(OpenXmlImagePayload.ImageOutcome.Undecodable, null, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Failed to resolve/decode an embedded OpenXML image; skipping it.");
+            resolved = new OpenXmlImagePayload.ResolvedImage(OpenXmlImagePayload.ImageOutcome.Undecodable, null, null);
+        }
+
+        switch (resolved.Outcome)
+        {
+            case OpenXmlImagePayload.ImageOutcome.Oversized:
+                // A single image larger than the per-image byte cap (e.g. a ZIP-decompression bomb). Skipped
+                // before full materialization; trips the completeness signal but never OOMs the worker.
+                logger.LogWarning("Skipped an embedded image exceeding the {Cap}-byte per-image cap.", options.MaxImageBytesPerImage);
+                state.OversizedImages++;
+                return null;
+
+            case OpenXmlImagePayload.ImageOutcome.Undecodable:
+                // Vector (EMF/WMF), dangling relationship, or undecodable/mislabeled bytes.
+                state.Undecodable++;
+                return null;
+
+            case OpenXmlImagePayload.ImageOutcome.Ok:
+                break;
+
+            default:
+                // A future outcome added to the enum must not silently fall through to RecognizeAsync with
+                // possibly-null bytes — fail closed by treating it as undecodable.
+                logger.LogWarning("Unhandled image outcome {Outcome}; treating as undecodable.", resolved.Outcome);
+                state.Undecodable++;
+                return null;
+        }
+
+        state.ImageBudget--;
+
+        OcrResult ocr;
+        try
+        {
+            using var imageStream = new MemoryStream(resolved.Bytes!, writable: false);
+            ocr = await ocrProvider.RecognizeAsync(
+                imageStream,
+                new OcrOptions
+                {
+                    ContentType = resolved.ContentType!,
+                    LanguageHints = state.LanguageHints
+                },
+                cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A single figure's OCR failing (provider timeout / rate-limit / auth / one bad image) must NOT
+            // discard the text already extracted — figure OCR is an auxiliary augmentation, not the primary
+            // payload (the #210/#268 "auxiliary step must not break the main pipeline" principle). Skip this
+            // figure and trip the signal. OperationCanceledException still propagates so a host/job shutdown
+            // aborts promptly.
+            logger.LogWarning(ex, "Embedded-image OCR failed; keeping the extracted text, skipping this figure.");
+            state.FailedFigureOcr++;
+            return null;
+        }
+
+        if (!ocr.IsComplete)
+        {
+            // OCR truncated at the token limit or discarded by the repetition guard.
+            state.TruncatedOcr++;
+        }
+
+        var transcription = ocr.Markdown?.Trim() ?? string.Empty;
+        if (transcription.Length == 0)
+        {
+            return null;
+        }
+
+        // Caption (alt-text) is author-controlled free text (often multi-line), so collapse newlines via
+        // MarkdownText.InlineLabel AND inline-escape via MarkdownText.EscapeInline so the bold caption can't
+        // break the OCR block (often a table) below it, nor inject a link/emphasis from a literal [..](..)/*.
+        return string.IsNullOrWhiteSpace(caption)
+            ? transcription
+            : "**" + MarkdownText.EscapeInline(MarkdownText.InlineLabel(caption)) + "**\n\n" + transcription;
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlIncompleteReason.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlIncompleteReason.cs
@@ -22,7 +22,8 @@ internal static class OpenXmlIncompleteReason
         int oversizedImages,
         int truncatedOcr,
         int failedFigureOcr,
-        int chartFailures)
+        int chartFailures,
+        int failedNotes = 0)
     {
         var parts = new List<string>();
         if (failedContainers > 0)
@@ -53,6 +54,11 @@ internal static class OpenXmlIncompleteReason
         if (chartFailures > 0)
         {
             parts.Add($"{chartFailures} chart(s) could not be rendered as a table");
+        }
+
+        if (failedNotes > 0)
+        {
+            parts.Add($"{failedNotes} footnote/endnote reference(s) could not be resolved to a note body");
         }
 
         if (droppedByCap > 0)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlIncompleteReason.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlIncompleteReason.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+namespace Dignite.Vault.Extract.Parse.OpenXml;
+
+/// <summary>
+/// Builds the #268 extraction-incompleteness reason shared by <see cref="DocxExtractor"/> and
+/// <see cref="PptxExtractor"/> from their loss counters, or returns <c>null</c> when nothing was lost.
+/// Single source of truth for both the reason text and completeness (<c>IsComplete = reason is null</c>),
+/// so a new counter cannot drift out of sync with a separate boolean predicate — and, being shared, a change
+/// to the wording / branch set / ordering now applies to <b>both</b> OpenXML extractors at once (#317,
+/// extracted from the two formerly character-for-character-identical <c>BuildIncompleteReason</c> bodies).
+/// Only the first cause differs per format — a Word <c>document block</c> vs a PowerPoint <c>slide</c> —
+/// supplied by the caller as <paramref name="failedContainerNoun"/>.
+/// </summary>
+internal static class OpenXmlIncompleteReason
+{
+    public static string? Build(
+        string failedContainerNoun,
+        int failedContainers,
+        int droppedByCap,
+        int undecodable,
+        int oversizedImages,
+        int truncatedOcr,
+        int failedFigureOcr,
+        int chartFailures)
+    {
+        var parts = new List<string>();
+        if (failedContainers > 0)
+        {
+            parts.Add($"{failedContainers} {failedContainerNoun}(s) could not be parsed and were skipped");
+        }
+
+        if (undecodable > 0)
+        {
+            parts.Add($"{undecodable} embedded image(s) could not be decoded to a supported raster format (e.g. EMF/WMF vector)");
+        }
+
+        if (oversizedImages > 0)
+        {
+            parts.Add($"{oversizedImages} embedded image(s) exceeded the per-image size cap and were skipped");
+        }
+
+        if (failedFigureOcr > 0)
+        {
+            parts.Add($"{failedFigureOcr} embedded image(s) failed OCR (provider error)");
+        }
+
+        if (truncatedOcr > 0)
+        {
+            parts.Add($"{truncatedOcr} image transcription(s) were truncated or discarded by the OCR provider");
+        }
+
+        if (chartFailures > 0)
+        {
+            parts.Add($"{chartFailures} chart(s) could not be rendered as a table");
+        }
+
+        if (droppedByCap > 0)
+        {
+            parts.Add($"{droppedByCap} image(s) were skipped after reaching the per-file image cap");
+        }
+
+        return parts.Count == 0 ? null : string.Join("; ", parts) + ".";
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlPackageSettings.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlPackageSettings.cs
@@ -1,0 +1,37 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Dignite.Vault.Extract.Parse.OpenXml;
+
+/// <summary>
+/// Shared OpenXML package open settings for the DOCX/PPTX extractors (#319).
+/// </summary>
+internal static class OpenXmlPackageSettings
+{
+    /// <summary>
+    /// Open settings that collapse OOXML markup-compatibility (<c>mc:AlternateContent</c>) to its single
+    /// selected branch <b>before</b> parsing. Under the default <see cref="MarkupCompatibilityProcessMode.NoProcess"/>
+    /// both branches stay in the tree, which harms the two extractors in opposite ways:
+    /// <list type="bullet">
+    /// <item><b>DOCX</b> walks with <c>Descendants</c>, so it would read the SAME content twice — a modern Word
+    /// text box stores its text in both the <c>mc:Choice</c> (DrawingML <c>wps:txbx</c>) and the
+    /// <c>mc:Fallback</c> (legacy VML Word auto-writes), and an <c>AlternateContent</c>-wrapped picture can
+    /// carry a blip in both branches, duplicating text and double-OCR-ing (and double-charging the image
+    /// budget for) one logical figure.</item>
+    /// <item><b>PPTX</b> dispatches by strong shape type, so an <c>mc:AlternateContent</c> node — which is none
+    /// of <c>P.Picture</c> / <c>P.Shape</c> / <c>P.GraphicFrame</c> / <c>P.GroupShape</c> — is silently skipped
+    /// by the typed walk, dropping any shape / picture / text that PowerPoint 2016+ wraps in a compatibility
+    /// fork, with no #268 signal (#319).</item>
+    /// </list>
+    /// Collapsing on open resolves each fork to one real element before either walk runs.
+    /// <see cref="FileFormatVersions.Office2019"/> is recent enough that the SDK understands the modern
+    /// (<c>wps</c> / DrawingML) namespaces, so it keeps the richer Choice branch (whose <c>w:drawing</c> the
+    /// DOCX image path can read) and drops the legacy fallback.
+    /// </summary>
+    public static readonly OpenSettings McCollapsing = new()
+    {
+        MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(
+            MarkupCompatibilityProcessMode.ProcessAllParts,
+            FileFormatVersions.Office2019)
+    };
+}

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -225,9 +225,9 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     /// <summary>
     /// Walks a shape container (the slide's shape tree or a grouped shape) in document order, dispatching
     /// pictures to OCR, charts/tables to structured rendering, and text shapes to Markdown. Recurses into
-    /// grouped shapes; for items inside a group, the group's own offset anchors their reading position and
-    /// document-encounter order (<see cref="PptxExtractionState.Sequence"/>) breaks ties within the group —
-    /// avoiding the child-coordinate-space math a precise absolute position would require.
+    /// grouped shapes; each shape's absolute slide position is its own offset plus the accumulated group
+    /// translation (<paramref name="groupY"/>/<paramref name="groupX"/> — the running sum of each enclosing
+    /// group's <c>a:off − a:chOff</c>, #313), with <see cref="PptxExtractionState.Sequence"/> breaking ties.
     /// </summary>
     private async Task WalkShapesAsync(
         DocumentFormat.OpenXml.OpenXmlElement container,
@@ -247,28 +247,36 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             {
                 case P.GroupShape group:
                     {
-                        var (gy, gx) = inGroup ? (groupY, groupX) : OffsetOf(group);
-                        await WalkShapesAsync(group, slidePart, inGroup: true, gy, gx, blocks, state, cancellationToken);
+                        // Descend with the group's translation composed in (#313): a child's absolute slide
+                        // position is its own offset plus the accumulated (group a:off − a:chOff) of every
+                        // enclosing group. Group scale is uniform per axis, so it preserves the per-axis order
+                        // and the translation alone is enough for reading order.
+                        var (offY, offX) = OffsetOf(group) ?? (0, 0);
+                        var (childOffY, childOffX) = GroupChildOffset(group);
+                        await WalkShapesAsync(
+                            group, slidePart, inGroup: true,
+                            groupY + offY - childOffY, groupX + offX - childOffX,
+                            blocks, state, cancellationToken);
                         break;
                     }
 
                 case P.Picture picture:
                     {
-                        var (y, x) = PositionFor(picture, inGroup, groupY, groupX);
+                        var (y, x) = AbsolutePosition(picture, slidePart, inGroup, groupY, groupX);
                         await HandlePictureAsync(picture, slidePart, y, x, blocks, state, cancellationToken);
                         break;
                     }
 
                 case P.GraphicFrame graphicFrame:
                     {
-                        var (y, x) = PositionFor(graphicFrame, inGroup, groupY, groupX);
+                        var (y, x) = AbsolutePosition(graphicFrame, slidePart, inGroup, groupY, groupX);
                         HandleGraphicFrame(graphicFrame, slidePart, y, x, blocks, state);
                         break;
                     }
 
                 case P.Shape shape:
                     {
-                        var (y, x) = PositionFor(shape, inGroup, groupY, groupX);
+                        var (y, x) = AbsolutePosition(shape, slidePart, inGroup, groupY, groupX);
                         HandleTextShape(shape, y, x, blocks, state);
                         break;
                     }
@@ -456,12 +464,30 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         return parts.Count == 0 ? null : string.Join("\n\n", parts);
     }
 
-    private static (long Y, long X) PositionFor(
-        DocumentFormat.OpenXml.OpenXmlElement shape, bool inGroup, long groupY, long groupX)
-        => inGroup ? (groupY, groupX) : OffsetOf(shape);
+    /// <summary>
+    /// The absolute slide position (EMU) of a shape for reading-order sorting (#313): the shape's own offset
+    /// translated by the accumulated group offset (<paramref name="groupY"/>/<paramref name="groupX"/>). A
+    /// top-level placeholder that omits its own <c>a:xfrm</c> inherits its position from the slide layout /
+    /// master rather than collapsing to (0,0); an in-group shape without an xfrm falls back to the group origin.
+    /// </summary>
+    private static (long Y, long X) AbsolutePosition(
+        DocumentFormat.OpenXml.OpenXmlElement shape, SlidePart slidePart, bool inGroup, long groupY, long groupX)
+    {
+        if (OffsetOf(shape) is { } own)
+        {
+            return (groupY + own.Y, groupX + own.X);
+        }
 
-    /// <summary>The shape's own top-left offset in EMU, or (0,0) when it inherits position from the layout.</summary>
-    private static (long Y, long X) OffsetOf(DocumentFormat.OpenXml.OpenXmlElement shape)
+        if (!inGroup && ResolveInheritedOffset(shape, slidePart) is { } inherited)
+        {
+            return inherited;
+        }
+
+        return (groupY, groupX);
+    }
+
+    /// <summary>The shape's own top-left offset in EMU, or <c>null</c> when it carries no explicit <c>a:xfrm</c>.</summary>
+    private static (long Y, long X)? OffsetOf(DocumentFormat.OpenXml.OpenXmlElement shape)
     {
         var offset = shape switch
         {
@@ -472,9 +498,87 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             _ => null
         };
 
-        // A shape with no explicit xfrm inherits its position from the slide layout/master; we cannot
-        // resolve that here, so it sorts to the top by position and keeps document order via Sequence.
-        return offset is null ? (0, 0) : (offset.Y?.Value ?? 0, offset.X?.Value ?? 0);
+        return offset is null ? null : (offset.Y?.Value ?? 0, offset.X?.Value ?? 0);
+    }
+
+    /// <summary>A group's child coordinate-space origin (<c>a:chOff</c>), or (0,0).</summary>
+    private static (long Y, long X) GroupChildOffset(P.GroupShape group)
+    {
+        var childOffset = group.GroupShapeProperties?.TransformGroup?.ChildOffset;
+        return childOffset is null ? (0, 0) : (childOffset.Y?.Value ?? 0, childOffset.X?.Value ?? 0);
+    }
+
+    /// <summary>
+    /// The position a slide-level placeholder inherits from its slide layout (then master) when it omits its
+    /// own <c>a:xfrm</c> (#313): match the layout / master placeholder by <c>idx</c> (the stable key) then
+    /// type, and read its offset. Returns <c>null</c> when the shape is not a placeholder or no match carries
+    /// an offset — the caller then keeps (0,0), preserving prior behavior.
+    /// </summary>
+    private static (long Y, long X)? ResolveInheritedOffset(DocumentFormat.OpenXml.OpenXmlElement shape, SlidePart slidePart)
+    {
+        if (shape is not P.Shape placeholderShape)
+        {
+            return null;
+        }
+
+        var ph = placeholderShape.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape;
+        if (ph is null)
+        {
+            return null;
+        }
+
+        var type = ph.Type?.Value;
+        var index = ph.Index?.Value;
+
+        return MatchingPlaceholderOffset(slidePart.SlideLayoutPart?.SlideLayout?.CommonSlideData?.ShapeTree, type, index)
+            ?? MatchingPlaceholderOffset(slidePart.SlideLayoutPart?.SlideMasterPart?.SlideMaster?.CommonSlideData?.ShapeTree, type, index);
+    }
+
+    /// <summary>The offset of the placeholder in <paramref name="shapeTree"/> matching the given idx + type.</summary>
+    private static (long Y, long X)? MatchingPlaceholderOffset(P.ShapeTree? shapeTree, P.PlaceholderValues? type, uint? index)
+    {
+        if (shapeTree is null)
+        {
+            return null;
+        }
+
+        foreach (var candidate in shapeTree.Elements<P.Shape>())
+        {
+            var ph = candidate.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape;
+            if (ph is null)
+            {
+                continue;
+            }
+
+            // idx is the primary placeholder key; when the slide placeholder carries one, require the same
+            // idx. Otherwise fall back to a type match (title / body placeholders often omit idx).
+            var indexMatches = index is null ? ph.Index?.Value is null : ph.Index?.Value == index;
+            if (indexMatches
+                && PlaceholderTypesMatch(ph.Type?.Value, type)
+                && candidate.ShapeProperties?.Transform2D?.Offset is { } offset)
+            {
+                return (offset.Y?.Value ?? 0, offset.X?.Value ?? 0);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Whether two placeholder types are equivalent for inheritance — an absent type defaults to
+    /// Body, and CenteredTitle counts as Title.</summary>
+    private static bool PlaceholderTypesMatch(P.PlaceholderValues? a, P.PlaceholderValues? b)
+    {
+        static P.PlaceholderValues Normalize(P.PlaceholderValues? type)
+        {
+            if (type is null)
+            {
+                return P.PlaceholderValues.Body;
+            }
+
+            return type.Value == P.PlaceholderValues.CenteredTitle ? P.PlaceholderValues.Title : type.Value;
+        }
+
+        return Normalize(a) == Normalize(b);
     }
 
     private static string ShapeText(P.Shape shape)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -225,7 +225,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
 
         if (shapeTree is not null)
         {
-            await WalkShapesAsync(shapeTree, slidePart, inGroup: false, groupY: 0, groupX: 0, blocks, state, cancellationToken);
+            await WalkShapesAsync(shapeTree, slidePart, inGroup: false, GroupTransform.Identity, blocks, state, cancellationToken);
         }
 
         var body = SlideReadingOrder.Render(blocks);
@@ -246,16 +246,15 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     /// <summary>
     /// Walks a shape container (the slide's shape tree or a grouped shape) in document order, dispatching
     /// pictures to OCR, charts/tables to structured rendering, and text shapes to Markdown. Recurses into
-    /// grouped shapes; each shape's absolute slide position is its own offset plus the accumulated group
-    /// translation (<paramref name="groupY"/>/<paramref name="groupX"/> — the running sum of each enclosing
-    /// group's <c>a:off − a:chOff</c>, #313), with <see cref="PptxExtractionState.Sequence"/> breaking ties.
+    /// grouped shapes; each shape's absolute slide position is the accumulated group transform
+    /// (<paramref name="transform"/> — every enclosing group's translation AND <c>ext/chExt</c> scale, #313 /
+    /// #456) applied to its own offset, with <see cref="PptxExtractionState.Sequence"/> breaking ties.
     /// </summary>
     private async Task WalkShapesAsync(
         DocumentFormat.OpenXml.OpenXmlElement container,
         SlidePart slidePart,
         bool inGroup,
-        long groupY,
-        long groupX,
+        GroupTransform transform,
         List<SlideReadingOrder.SlideBlock> blocks,
         PptxExtractionState state,
         CancellationToken cancellationToken)
@@ -268,36 +267,33 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             {
                 case P.GroupShape group:
                     {
-                        // Descend with the group's translation composed in (#313): a child's absolute slide
-                        // position is its own offset plus the accumulated (group a:off − a:chOff) of every
-                        // enclosing group. Group scale is uniform per axis, so it preserves the per-axis order
-                        // and the translation alone is enough for reading order.
-                        var (offY, offX) = OffsetOf(group) ?? (0, 0);
-                        var (childOffY, childOffX) = GroupChildOffset(group);
+                        // Descend with the group's full transform composed in (#313 / #456): the child frame is
+                        // mapped to slide coordinates by the group's translation (a:off − a:chOff) AND its scale
+                        // (a:ext / a:chExt). A resized group has ext ≠ chExt, so translation alone would place
+                        // its children at the wrong slide position for the slide-global reading-order sort.
                         await WalkShapesAsync(
-                            group, slidePart, inGroup: true,
-                            groupY + offY - childOffY, groupX + offX - childOffX,
+                            group, slidePart, inGroup: true, ComposeGroup(transform, group),
                             blocks, state, cancellationToken);
                         break;
                     }
 
                 case P.Picture picture:
                     {
-                        var (y, x) = AbsolutePosition(picture, slidePart, inGroup, groupY, groupX);
+                        var (y, x) = AbsolutePosition(picture, slidePart, inGroup, transform);
                         await HandlePictureAsync(picture, slidePart, y, x, blocks, state, cancellationToken);
                         break;
                     }
 
                 case P.GraphicFrame graphicFrame:
                     {
-                        var (y, x) = AbsolutePosition(graphicFrame, slidePart, inGroup, groupY, groupX);
+                        var (y, x) = AbsolutePosition(graphicFrame, slidePart, inGroup, transform);
                         HandleGraphicFrame(graphicFrame, slidePart, y, x, blocks, state);
                         break;
                     }
 
                 case P.Shape shape:
                     {
-                        var (y, x) = AbsolutePosition(shape, slidePart, inGroup, groupY, groupX);
+                        var (y, x) = AbsolutePosition(shape, slidePart, inGroup, transform);
                         HandleTextShape(shape, y, x, blocks, state);
                         break;
                     }
@@ -486,17 +482,17 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     }
 
     /// <summary>
-    /// The absolute slide position (EMU) of a shape for reading-order sorting (#313): the shape's own offset
-    /// translated by the accumulated group offset (<paramref name="groupY"/>/<paramref name="groupX"/>). A
-    /// top-level placeholder that omits its own <c>a:xfrm</c> inherits its position from the slide layout /
-    /// master rather than collapsing to (0,0); an in-group shape without an xfrm falls back to the group origin.
+    /// The absolute slide position (EMU) of a shape for reading-order sorting (#313 / #456): the accumulated
+    /// group <paramref name="transform"/> applied to the shape's own offset. A top-level placeholder that omits
+    /// its own <c>a:xfrm</c> inherits its position from the slide layout / master rather than collapsing to
+    /// (0,0); an in-group shape without an xfrm falls back to the group frame's mapped origin.
     /// </summary>
     private static (long Y, long X) AbsolutePosition(
-        DocumentFormat.OpenXml.OpenXmlElement shape, SlidePart slidePart, bool inGroup, long groupY, long groupX)
+        DocumentFormat.OpenXml.OpenXmlElement shape, SlidePart slidePart, bool inGroup, GroupTransform transform)
     {
         if (OffsetOf(shape) is { } own)
         {
-            return (groupY + own.Y, groupX + own.X);
+            return transform.Apply(own.Y, own.X);
         }
 
         if (!inGroup && ResolveInheritedOffset(shape, slidePart) is { } inherited)
@@ -504,7 +500,48 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             return inherited;
         }
 
-        return (groupY, groupX);
+        return transform.Origin;
+    }
+
+    /// <summary>
+    /// The accumulated affine map from the current shape container's coordinate frame to slide coordinates
+    /// (#313 / #456): <c>slide = Offset + Scale · local</c>, per axis. Identity at the slide root; each
+    /// enclosing group composes its translation and its <c>ext/chExt</c> scale (see <see cref="ComposeGroup"/>)
+    /// so a resized group places its children at their real slide position for cross-group reading order.
+    /// </summary>
+    private readonly record struct GroupTransform(double OffY, double OffX, double ScaleY, double ScaleX)
+    {
+        public static GroupTransform Identity => new(0, 0, 1, 1);
+
+        /// <summary>Maps a shape's own child-frame offset (EMU) to an absolute slide position (EMU).</summary>
+        public (long Y, long X) Apply(long localY, long localX)
+            => ((long)(OffY + ScaleY * localY), (long)(OffX + ScaleX * localX));
+
+        /// <summary>This frame's mapped origin — where an in-group shape with no explicit xfrm is placed.</summary>
+        public (long Y, long X) Origin => ((long)OffY, (long)OffX);
+    }
+
+    /// <summary>
+    /// Composes an enclosing group's transform onto <paramref name="t"/>. A child at child-frame coordinate
+    /// <c>c</c> maps to the parent frame as <c>off + (c − chOff)·(ext/chExt)</c>; folding that through the
+    /// incoming affine <c>t</c> keeps the result affine. A missing / zero child extent means no scaling
+    /// information → scale 1 (translation only), preserving the pre-#456 behavior for such groups.
+    /// </summary>
+    private static GroupTransform ComposeGroup(GroupTransform t, P.GroupShape group)
+    {
+        var xfrm = group.GroupShapeProperties?.TransformGroup;
+        long offY = xfrm?.Offset?.Y ?? 0, offX = xfrm?.Offset?.X ?? 0;
+        long chOffY = xfrm?.ChildOffset?.Y ?? 0, chOffX = xfrm?.ChildOffset?.X ?? 0;
+        var sY = xfrm?.Extents?.Cy is { } ey && xfrm.ChildExtents?.Cy is { } cey && cey != 0 ? (double)ey / cey : 1.0;
+        var sX = xfrm?.Extents?.Cx is { } ex && xfrm.ChildExtents?.Cx is { } cex && cex != 0 ? (double)ex / cex : 1.0;
+
+        // slide = t.Off + t.Scale·(off + (local − chOff)·s)
+        //       = [t.Off + t.Scale·off − t.Scale·chOff·s] + [t.Scale·s]·local
+        return new GroupTransform(
+            t.OffY + t.ScaleY * offY - t.ScaleY * chOffY * sY,
+            t.OffX + t.ScaleX * offX - t.ScaleX * chOffX * sX,
+            t.ScaleY * sY,
+            t.ScaleX * sX);
     }
 
     /// <summary>The shape's own top-left offset in EMU, or <c>null</c> when it carries no explicit <c>a:xfrm</c>.</summary>
@@ -520,13 +557,6 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         };
 
         return offset is null ? null : (offset.Y?.Value ?? 0, offset.X?.Value ?? 0);
-    }
-
-    /// <summary>A group's child coordinate-space origin (<c>a:chOff</c>), or (0,0).</summary>
-    private static (long Y, long X) GroupChildOffset(P.GroupShape group)
-    {
-        var childOffset = group.GroupShapeProperties?.TransformGroup?.ChildOffset;
-        return childOffset is null ? (0, 0) : (childOffset.Y?.Value ?? 0, childOffset.X?.Value ?? 0);
     }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -114,7 +114,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             var presentation = document.PresentationPart?.Presentation;
             var slideIds = presentation?.SlideIdList?.Elements<P.SlideId>().ToList() ?? new List<P.SlideId>();
 
-            var state = new ExtractionState
+            var state = new PptxExtractionState
             {
                 ImageBudget = _options.MaxImagesPerFile,
                 LanguageHints = ResolveLanguageHints(context)
@@ -140,7 +140,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     Logger.LogWarning(ex, "Could not resolve a slide part; skipping the slide.");
-                    state.FailedSlides++;
+                    state.FailedContainers++;
                     continue;
                 }
 
@@ -154,7 +154,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
                     // OpenXML parses lazily, so a malformed slide can fault here on access. Skip it and
                     // mark the result incomplete rather than failing the whole deck.
                     Logger.LogWarning(ex, "Failed to process a slide; skipping it.");
-                    state.FailedSlides++;
+                    state.FailedContainers++;
                     continue;
                 }
 
@@ -167,7 +167,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             // Single source of truth for the #268 signal: the reason is built from the counters and is
             // null iff nothing was lost; completeness derives from it (no parallel hand-synced predicate).
             var incompleteReason = BuildIncompleteReason(
-                state.FailedSlides, state.DroppedByCap, state.Undecodable, state.OversizedImages,
+                state.FailedContainers, state.DroppedByCap, state.Undecodable, state.OversizedImages,
                 state.TruncatedOcr, state.FailedFigureOcr, state.ChartFailures);
             var complete = incompleteReason is null;
             if (!complete)
@@ -194,7 +194,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
 
     /// <summary>Builds one slide's Markdown: ordered shape blocks, then the optional speaker-notes block.</summary>
     private async Task<string> ProcessSlideAsync(
-        SlidePart slidePart, ExtractionState state, CancellationToken cancellationToken)
+        SlidePart slidePart, PptxExtractionState state, CancellationToken cancellationToken)
     {
         var shapeTree = slidePart.Slide?.CommonSlideData?.ShapeTree;
         var blocks = new List<SlideReadingOrder.SlideBlock>();
@@ -223,7 +223,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     /// Walks a shape container (the slide's shape tree or a grouped shape) in document order, dispatching
     /// pictures to OCR, charts/tables to structured rendering, and text shapes to Markdown. Recurses into
     /// grouped shapes; for items inside a group, the group's own offset anchors their reading position and
-    /// document-encounter order (<see cref="ExtractionState.Sequence"/>) breaks ties within the group —
+    /// document-encounter order (<see cref="PptxExtractionState.Sequence"/>) breaks ties within the group —
     /// avoiding the child-coordinate-space math a precise absolute position would require.
     /// </summary>
     private async Task WalkShapesAsync(
@@ -233,7 +233,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         long groupY,
         long groupX,
         List<SlideReadingOrder.SlideBlock> blocks,
-        ExtractionState state,
+        PptxExtractionState state,
         CancellationToken cancellationToken)
     {
         foreach (var child in container.ChildElements)
@@ -281,7 +281,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         long y,
         long x,
         List<SlideReadingOrder.SlideBlock> blocks,
-        ExtractionState state,
+        PptxExtractionState state,
         CancellationToken cancellationToken)
     {
         if (IsDecorative(picture))
@@ -297,102 +297,16 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             return;
         }
 
-        if (state.ImageBudget <= 0)
+        // Native alt-text (p:cNvPr/@descr, fallback @title) is a real caption signal — strictly better than
+        // PDF's nearest-text heuristic. The shared figure pipeline (budget → resolve → outcome switch → OCR →
+        // truncation → caption, #317) returns the finished block; PPTX sinks it as a positioned SlideBlock so
+        // reading-order sorting can place it by shape offset (state.Sequence breaks ties in document order).
+        var block = await OpenXmlFigureTranscriber.TranscribeAsync(
+            slidePart, embed, AltTextOf(picture), state, _options, _ocrProvider, Logger, cancellationToken);
+        if (block is not null)
         {
-            state.DroppedByCap++;
-            return;
+            blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, block));
         }
-
-        OpenXmlImagePayload.ResolvedImage resolved;
-        try
-        {
-            var part = slidePart.GetPartById(embed);
-            resolved = part is ImagePart imagePart
-                ? OpenXmlImagePayload.TryResolve(imagePart, _options.MaxImageBytesPerImage)
-                // A dangling relationship / non-image part: treat as undecodable.
-                : new OpenXmlImagePayload.ResolvedImage(OpenXmlImagePayload.ImageOutcome.Undecodable, null, null);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Logger.LogWarning(ex, "Failed to resolve/decode an embedded PPTX image; skipping it.");
-            resolved = new OpenXmlImagePayload.ResolvedImage(OpenXmlImagePayload.ImageOutcome.Undecodable, null, null);
-        }
-
-        switch (resolved.Outcome)
-        {
-            case OpenXmlImagePayload.ImageOutcome.Oversized:
-                // A single image larger than the per-image byte cap (e.g. a ZIP-decompression bomb). Skipped
-                // before full materialization; trips the completeness signal but never OOMs the worker.
-                Logger.LogWarning("Skipped an embedded image exceeding the {Cap}-byte per-image cap.", _options.MaxImageBytesPerImage);
-                state.OversizedImages++;
-                return;
-
-            case OpenXmlImagePayload.ImageOutcome.Undecodable:
-                // Vector (EMF/WMF), dangling relationship, or undecodable/mislabeled bytes.
-                state.Undecodable++;
-                return;
-
-            case OpenXmlImagePayload.ImageOutcome.Ok:
-                break;
-
-            default:
-                // A future outcome added to the enum must not silently fall through to RecognizeAsync with
-                // possibly-null bytes — fail closed by treating it as undecodable.
-                Logger.LogWarning("Unhandled image outcome {Outcome}; treating as undecodable.", resolved.Outcome);
-                state.Undecodable++;
-                return;
-        }
-
-        state.ImageBudget--;
-
-        OcrResult ocr;
-        try
-        {
-            using var imageStream = new MemoryStream(resolved.Bytes!, writable: false);
-            ocr = await _ocrProvider.RecognizeAsync(
-                imageStream,
-                new OcrOptions
-                {
-                    ContentType = resolved.ContentType!,
-                    LanguageHints = state.LanguageHints
-                },
-                cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // A single figure's OCR failing (provider timeout / rate-limit / auth / one bad image) must
-            // NOT discard the slide text already extracted — figure OCR is an auxiliary augmentation, not
-            // the deck's primary payload (the #210/#268 "auxiliary step must not break the main pipeline"
-            // principle). Skip this figure and mark the result incomplete. OperationCanceledException
-            // still propagates so a host/job shutdown aborts promptly.
-            Logger.LogWarning(ex, "Embedded-image OCR failed; keeping the slide text, skipping this figure.");
-            state.FailedFigureOcr++;
-            return;
-        }
-
-        if (!ocr.IsComplete)
-        {
-            // OCR truncated at the token limit or discarded by the repetition guard.
-            state.TruncatedOcr++;
-        }
-
-        var transcription = ocr.Markdown?.Trim() ?? string.Empty;
-        if (transcription.Length == 0)
-        {
-            return;
-        }
-
-        // Native alt-text (p:cNvPr/@descr, fallback @title) is a real caption signal — strictly better
-        // than PDF's nearest-text heuristic. Render it as the figure block's label. Alt-text is
-        // author-controlled free text (often multi-line), so collapse newlines via MarkdownText.InlineLabel
-        // AND inline-escape via MarkdownText.EscapeInline so the bold caption can't break the OCR block (often
-        // a table) below it, nor inject a link/emphasis from a literal [..](..)/*.
-        var caption = AltTextOf(picture);
-        var markdown = string.IsNullOrWhiteSpace(caption)
-            ? transcription
-            : "**" + MarkdownText.EscapeInline(MarkdownText.InlineLabel(caption)) + "**\n\n" + transcription;
-
-        blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, markdown));
     }
 
     private void HandleGraphicFrame(
@@ -401,7 +315,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         long y,
         long x,
         List<SlideReadingOrder.SlideBlock> blocks,
-        ExtractionState state)
+        PptxExtractionState state)
     {
         var graphicData = graphicFrame.Graphic?.GraphicData;
         if (graphicData is null)
@@ -459,7 +373,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         long y,
         long x,
         List<SlideReadingOrder.SlideBlock> blocks,
-        ExtractionState state)
+        PptxExtractionState state)
     {
         // Skip auto-generated slide-number / date fields so they do not pollute the text payload — the
         // same exclusion ReadSpeakerNotes applies to the notes slide (a slide-number placeholder's cached
@@ -624,7 +538,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     /// consumer can override to supply hints (e.g. from per-tenant config).
     /// </summary>
     protected virtual IList<string> ResolveLanguageHints(TextExtractionContext context)
-        => context.LanguageHints ?? new List<string>();
+        => OpenXmlExtractionState.ResolveLanguageHints(context);
 
     /// <summary>
     /// Builds the #268 incompleteness reason from the loss counters, or returns <c>null</c> when nothing
@@ -633,58 +547,17 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     /// </summary>
     internal static string? BuildIncompleteReason(
         int failedSlides, int droppedByCap, int undecodable, int oversizedImages, int truncatedOcr, int failedFigureOcr, int chartFailures)
+        => OpenXmlIncompleteReason.Build(
+            "slide", failedSlides, droppedByCap, undecodable, oversizedImages, truncatedOcr, failedFigureOcr, chartFailures);
+
+    /// <summary>
+    /// PPTX reading-order extends the shared <see cref="OpenXmlExtractionState"/> with a monotonic
+    /// document-encounter counter: PPTX is fixed-layout, so blocks are sorted by shape offset and
+    /// <see cref="Sequence"/> breaks ties in document order (DOCX emits in flow order and needs no such
+    /// field). All the image-budget / #268 loss counters are inherited (#317).
+    /// </summary>
+    private sealed class PptxExtractionState : OpenXmlExtractionState
     {
-        var parts = new List<string>();
-        if (failedSlides > 0)
-        {
-            parts.Add($"{failedSlides} slide(s) could not be parsed and were skipped");
-        }
-
-        if (undecodable > 0)
-        {
-            parts.Add($"{undecodable} embedded image(s) could not be decoded to a supported raster format (e.g. EMF/WMF vector)");
-        }
-
-        if (oversizedImages > 0)
-        {
-            parts.Add($"{oversizedImages} embedded image(s) exceeded the per-image size cap and were skipped");
-        }
-
-        if (failedFigureOcr > 0)
-        {
-            parts.Add($"{failedFigureOcr} embedded image(s) failed OCR (provider error)");
-        }
-
-        if (truncatedOcr > 0)
-        {
-            parts.Add($"{truncatedOcr} image transcription(s) were truncated or discarded by the OCR provider");
-        }
-
-        if (chartFailures > 0)
-        {
-            parts.Add($"{chartFailures} chart(s) could not be rendered as a table");
-        }
-
-        if (droppedByCap > 0)
-        {
-            parts.Add($"{droppedByCap} image(s) were skipped after reaching the per-file image cap");
-        }
-
-        return parts.Count == 0 ? null : string.Join("; ", parts) + ".";
-    }
-
-    /// <summary>Mutable per-extraction accumulator: image budget, block sequence, and #268 loss counters.</summary>
-    private sealed class ExtractionState
-    {
-        public int ImageBudget;
         public int Sequence;
-        public int FailedSlides;
-        public int DroppedByCap;
-        public int Undecodable;
-        public int OversizedImages;
-        public int TruncatedOcr;
-        public int FailedFigureOcr;
-        public int ChartFailures;
-        public IList<string> LanguageHints = new List<string>();
     }
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -91,7 +91,10 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         PresentationDocument document;
         try
         {
-            document = PresentationDocument.Open(new MemoryStream(bytes, writable: false), isEditable: false);
+            // Collapse OOXML markup-compatibility (mc:AlternateContent) to its selected branch before parsing,
+            // so a shape/picture PowerPoint wraps in an AlternateContent fork — which the typed WalkShapesAsync
+            // switch matches none of — is not silently skipped with no #268 signal (#319, shared with DOCX).
+            document = PresentationDocument.Open(new MemoryStream(bytes, writable: false), isEditable: false, OpenXmlPackageSettings.McCollapsing);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -114,8 +114,29 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
 
         using (document)
         {
-            var presentation = document.PresentationPart?.Presentation;
-            var slideIds = presentation?.SlideIdList?.Elements<P.SlideId>().ToList() ?? new List<P.SlideId>();
+            List<P.SlideId> slideIds;
+            try
+            {
+                // presentation.xml parses lazily, so markup-compatibility processing (mc:AlternateContent
+                // collapsing, #319) runs on this access — a fault (e.g. an AlternateContent with no valid
+                // Choice/Fallback for the target FileFormatVersions) surfaces HERE, outside the per-slide
+                // try/catch below. Report empty + incomplete (the honest #268 escape hatch) rather than
+                // letting it escape ExtractAsync, mirroring the Open failure path above.
+                var presentation = document.PresentationPart?.Presentation;
+                slideIds = presentation?.SlideIdList?.Elements<P.SlideId>().ToList() ?? new List<P.SlideId>();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(ex, "Could not read the presentation part; reporting empty + incomplete.");
+                return new TextExtractionResult
+                {
+                    Markdown = string.Empty,
+                    ProviderName = ProviderIdentifier,
+                    UsedOcr = false,
+                    IsComplete = false,
+                    IncompleteReason = "The presentation could not be opened (corrupt or unsupported file)."
+                };
+            }
 
             var state = new PptxExtractionState
             {
@@ -550,9 +571,10 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
                 continue;
             }
 
-            // idx is the primary placeholder key; when the slide placeholder carries one, require the same
-            // idx. Otherwise fall back to a type match (title / body placeholders often omit idx).
-            var indexMatches = index is null ? ph.Index?.Value is null : ph.Index?.Value == index;
+            // idx is the primary placeholder key. Per ECMA-376 an absent idx defaults to 0, so a slide's
+            // <p:ph type="title"/> and a layout's <p:ph type="title" idx="0"/> are the same placeholder — treat
+            // absent and explicit 0 as equal (some producers write the explicit 0). Type must still match.
+            var indexMatches = (index ?? 0) == (ph.Index?.Value ?? 0);
             if (indexMatches
                 && PlaceholderTypesMatch(ph.Type?.Value, type)
                 && candidate.ShapeProperties?.Transform2D?.Offset is { } offset)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordListNumbering.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordListNumbering.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using W = DocumentFormat.OpenXml.Wordprocessing;
@@ -22,7 +23,12 @@ internal static class WordListNumbering
     public readonly record struct ListInfo(int Level, bool Ordered);
 
     /// <returns>The list placement, or <c>null</c> when the paragraph is not a list item.</returns>
-    public static ListInfo? Resolve(W.Paragraph paragraph, NumberingDefinitionsPart? numberingPart)
+    /// <param name="formatCache">Optional per-document <c>(numId, level) → format</c> memo (#318): when
+    /// supplied, the numbering part is scanned once per distinct key rather than once per list item.</param>
+    public static ListInfo? Resolve(
+        W.Paragraph paragraph,
+        NumberingDefinitionsPart? numberingPart,
+        IDictionary<(int NumId, int Level), W.NumberFormatValues?>? formatCache = null)
     {
         var numberingProperties = paragraph.ParagraphProperties?.NumberingProperties;
         var numId = numberingProperties?.NumberingId?.Val?.Value;
@@ -34,7 +40,7 @@ internal static class WordListNumbering
         }
 
         var level = numberingProperties!.NumberingLevelReference?.Val?.Value ?? 0;
-        var format = ResolveFormat(numId.Value, level, numberingPart);
+        var format = ResolveFormat(numId.Value, level, numberingPart, formatCache);
 
         // An explicit "none" format means numbering is turned off for this level — treat as a normal paragraph.
         if (format == W.NumberFormatValues.None)
@@ -48,7 +54,29 @@ internal static class WordListNumbering
         return new ListInfo(level, ordered);
     }
 
-    private static W.NumberFormatValues? ResolveFormat(int numId, int level, NumberingDefinitionsPart? numberingPart)
+    private static W.NumberFormatValues? ResolveFormat(
+        int numId,
+        int level,
+        NumberingDefinitionsPart? numberingPart,
+        IDictionary<(int NumId, int Level), W.NumberFormatValues?>? formatCache)
+    {
+        // Cache the (numId, level) -> format resolution once per document (#318) — otherwise every list item
+        // re-scans the numbering part's instances + abstract definitions.
+        if (formatCache is not null && formatCache.TryGetValue((numId, level), out var cached))
+        {
+            return cached;
+        }
+
+        var format = ComputeFormat(numId, level, numberingPart);
+        if (formatCache is not null)
+        {
+            formatCache[(numId, level)] = format;
+        }
+
+        return format;
+    }
+
+    private static W.NumberFormatValues? ComputeFormat(int numId, int level, NumberingDefinitionsPart? numberingPart)
     {
         var numbering = numberingPart?.Numbering;
         if (numbering is null)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordParagraphRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordParagraphRenderer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DocumentFormat.OpenXml.Packaging;
@@ -25,9 +26,12 @@ namespace Dignite.Vault.Extract.Parse.OpenXml;
 /// </summary>
 internal static class WordParagraphRenderer
 {
-    public static string Render(W.Paragraph paragraph, MainDocumentPart mainPart)
+    public static string Render(
+        W.Paragraph paragraph,
+        MainDocumentPart mainPart,
+        ICollection<NoteReference>? noteReferences = null)
     {
-        var builder = new InlineBuilder(mainPart);
+        var builder = new InlineBuilder(mainPart, noteReferences);
         builder.Walk(paragraph);
         return builder.ToMarkdown();
     }
@@ -39,12 +43,17 @@ internal static class WordParagraphRenderer
     private sealed class InlineBuilder
     {
         private readonly MainDocumentPart _mainPart;
+        private readonly ICollection<NoteReference>? _noteReferences;
         private readonly StringBuilder _sb = new();
         private string? _pendingText;
         private bool _pendingBold;
         private bool _pendingItalic;
 
-        public InlineBuilder(MainDocumentPart mainPart) => _mainPart = mainPart;
+        public InlineBuilder(MainDocumentPart mainPart, ICollection<NoteReference>? noteReferences)
+        {
+            _mainPart = mainPart;
+            _noteReferences = noteReferences;
+        }
 
         public void Walk(DocumentFormat.OpenXml.OpenXmlElement container)
         {
@@ -54,6 +63,7 @@ internal static class WordParagraphRenderer
                 {
                     case W.Run run:
                         AppendRun(run);
+                        AppendNoteMarkers(run);
                         break;
 
                     case W.Hyperlink link:
@@ -132,6 +142,36 @@ internal static class WordParagraphRenderer
             _pendingText = null;
             _pendingBold = false;
             _pendingItalic = false;
+        }
+
+        /// <summary>
+        /// Emits a stable inline footnote/endnote marker (<c>[^fn{id}]</c> / <c>[^en{id}]</c>) for each
+        /// <c>w:footnoteReference</c> / <c>w:endnoteReference</c> in the run, at its reading position, and
+        /// records the reference so the caller can resolve + append the note bodies (#315). The marker is
+        /// generated structure, so it is appended directly (past run-text inline-escaping), like a hyperlink.
+        /// </summary>
+        private void AppendNoteMarkers(W.Run run)
+        {
+            foreach (var child in run.ChildElements)
+            {
+                var reference = child switch
+                {
+                    W.FootnoteReference fn when fn.Id?.Value is { } fnId => new NoteReference(NoteKind.Footnote, fnId),
+                    W.EndnoteReference en when en.Id?.Value is { } enId => new NoteReference(NoteKind.Endnote, enId),
+                    _ => (NoteReference?)null
+                };
+
+                if (reference is not { } note)
+                {
+                    continue;
+                }
+
+                // The marker is generated structure (not run text), so flush pending run text first and append
+                // the raw marker directly — bypassing the inline-escaping that would turn "[" into "\[".
+                Flush();
+                _sb.Append(note.Marker);
+                _noteReferences?.Add(note);
+            }
         }
 
         private string RenderHyperlink(W.Hyperlink link)

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordParagraphRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordParagraphRenderer.cs
@@ -29,9 +29,10 @@ internal static class WordParagraphRenderer
     public static string Render(
         W.Paragraph paragraph,
         MainDocumentPart mainPart,
-        ICollection<NoteReference>? noteReferences = null)
+        ICollection<NoteReference>? noteReferences = null,
+        IReadOnlyDictionary<string, string?>? hyperlinkUris = null)
     {
-        var builder = new InlineBuilder(mainPart, noteReferences);
+        var builder = new InlineBuilder(mainPart, noteReferences, hyperlinkUris);
         builder.Walk(paragraph);
         return builder.ToMarkdown();
     }
@@ -44,15 +45,20 @@ internal static class WordParagraphRenderer
     {
         private readonly MainDocumentPart _mainPart;
         private readonly ICollection<NoteReference>? _noteReferences;
+        private readonly IReadOnlyDictionary<string, string?>? _hyperlinkUris;
         private readonly StringBuilder _sb = new();
         private string? _pendingText;
         private bool _pendingBold;
         private bool _pendingItalic;
 
-        public InlineBuilder(MainDocumentPart mainPart, ICollection<NoteReference>? noteReferences)
+        public InlineBuilder(
+            MainDocumentPart mainPart,
+            ICollection<NoteReference>? noteReferences,
+            IReadOnlyDictionary<string, string?>? hyperlinkUris)
         {
             _mainPart = mainPart;
             _noteReferences = noteReferences;
+            _hyperlinkUris = hyperlinkUris;
         }
 
         public void Walk(DocumentFormat.OpenXml.OpenXmlElement container)
@@ -197,6 +203,13 @@ internal static class WordParagraphRenderer
             {
                 // An internal anchor (w:anchor, no r:id) has no resolvable URL — render the text only.
                 return null;
+            }
+
+            // Per-document id -> uri cache (#318) avoids an O(relationships) scan per hyperlink; a null cache
+            // (e.g. the note-body render path) falls back to the direct lookup.
+            if (_hyperlinkUris is not null)
+            {
+                return _hyperlinkUris.TryGetValue(id, out var uri) ? uri : null;
             }
 
             var relationship = _mainPart.HyperlinkRelationships.FirstOrDefault(r => r.Id == id);

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordStyleMap.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordStyleMap.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Globalization;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace Dignite.Vault.Extract.Parse.OpenXml;
@@ -11,8 +13,13 @@ namespace Dignite.Vault.Extract.Parse.OpenXml;
 ///   <item>the paragraph <b>style ID</b> — the built-in <c>Heading1</c>..<c>Heading9</c> (and <c>Title</c>).
 ///   Style IDs are stable English identifiers even when the display name is localized (e.g. German
 ///   "Überschrift 1" still has ID <c>Heading1</c>), so matching the ID is more robust than the name;</item>
-///   <item>the explicit outline level (<c>w:outlineLvl</c>, 0-based) as a fallback for paragraphs that
-///   carry an outline level without a heading style (e.g. a custom style linked to an outline level).</item>
+///   <item>the paragraph-direct outline level (<c>w:pPr/w:outlineLvl</c>, 0-based) — direct formatting that
+///   overrides the style;</item>
+///   <item>[#316] the paragraph's <b>custom style</b> resolved against <c>styles.xml</c>: follow the
+///   <c>w:basedOn</c> chain to a built-in <c>HeadingN</c>/<c>Title</c> ancestor, or read a style-level
+///   <c>w:outlineLvl</c>. This recovers a heading authored via a custom style (e.g. a house "Chapter Title"
+///   style based on <c>Heading1</c>) that the paragraph-own checks miss. Requires the style part; falls back
+///   to <c>null</c> when no style part / definition resolves.</item>
 /// </list>
 /// Word supports nine heading levels; Markdown (ATX) supports six, so levels are clamped to 6.
 /// </summary>
@@ -21,8 +28,19 @@ internal static class WordStyleMap
     private const int MaxMarkdownHeadingLevel = 6;
     private const string HeadingStylePrefix = "Heading";
 
-    /// <returns>The Markdown heading level (1-6), or <c>null</c> when the paragraph is not a heading.</returns>
-    public static int? HeadingLevel(W.Paragraph paragraph)
+    /// <summary>
+    /// Bound on the <c>w:basedOn</c> chain walk — style inheritance is shallow in practice, and the bound
+    /// also stops a malformed / cyclic <c>basedOn</c> chain from looping.
+    /// </summary>
+    private const int MaxStyleChainDepth = 16;
+
+    /// <summary>
+    /// The Markdown heading level (1-6) for a paragraph, or <c>null</c> when it is not a heading.
+    /// <paramref name="mainPart"/> is optional: when supplied, a paragraph carrying a <b>custom</b> style is
+    /// resolved against <c>styles.xml</c> (the <c>basedOn</c> chain + style-level outline); when <c>null</c>,
+    /// only the paragraph's own properties are considered (the pre-#316 behavior).
+    /// </summary>
+    public static int? HeadingLevel(W.Paragraph paragraph, MainDocumentPart? mainPart = null)
     {
         var properties = paragraph.ParagraphProperties;
         if (properties is null)
@@ -31,37 +49,111 @@ internal static class WordStyleMap
         }
 
         var styleId = properties.ParagraphStyleId?.Val?.Value;
-        if (!string.IsNullOrEmpty(styleId))
-        {
-            // "Title" maps to the top heading level.
-            if (string.Equals(styleId, "Title", StringComparison.OrdinalIgnoreCase))
-            {
-                return 1;
-            }
 
-            // Built-in "Heading{n}" style IDs (no space; the localized display name may differ). A trailing
-            // non-numeric suffix (e.g. the linked character style "Heading1Char") fails the parse and is
-            // correctly NOT treated as a paragraph heading.
-            if (styleId.StartsWith(HeadingStylePrefix, StringComparison.OrdinalIgnoreCase)
-                && int.TryParse(
-                    styleId.AsSpan(HeadingStylePrefix.Length),
-                    NumberStyles.None,
-                    CultureInfo.InvariantCulture,
-                    out var n)
-                && n >= 1)
-            {
-                return Math.Min(n, MaxMarkdownHeadingLevel);
-            }
+        // 1. Built-in "Heading{n}" / "Title" style ID on the paragraph's own style.
+        var builtIn = BuiltInHeadingLevel(styleId);
+        if (builtIn is not null)
+        {
+            return builtIn;
         }
 
-        // Explicit outline level (0-based: 0 => H1). Word uses level 9 to mean "body text" (no outline),
-        // so only 0-8 denote a heading.
+        // 2. Paragraph-direct outline level (0-based: 0 => H1). Word uses level 9 to mean "body text" (no
+        //    outline), so only 0-8 denote a heading. Direct formatting overrides the style.
         var outline = properties.OutlineLevel?.Val?.Value;
         if (outline is >= 0 and < 9)
         {
             return Math.Min(outline.Value + 1, MaxMarkdownHeadingLevel);
         }
 
+        // 3. [#316] A custom style whose heading semantics live in styles.xml (based on a built-in HeadingN,
+        //    or a style-level outlineLvl). Requires the style part; otherwise the paragraph is not a heading.
+        if (!string.IsNullOrEmpty(styleId) && mainPart is not null)
+        {
+            return ResolveStyleHeadingLevel(styleId!, mainPart);
+        }
+
         return null;
     }
+
+    /// <summary>
+    /// The heading level for a <b>built-in</b> style ID — <c>Title</c> (=&gt; 1) or <c>Heading{n}</c>
+    /// (=&gt; n, clamped to 6) — or <c>null</c>. A trailing non-numeric suffix (the auto-generated linked
+    /// character style <c>Heading1Char</c>) fails the parse and is correctly NOT treated as a heading.
+    /// </summary>
+    private static int? BuiltInHeadingLevel(string? styleId)
+    {
+        if (string.IsNullOrEmpty(styleId))
+        {
+            return null;
+        }
+
+        // "Title" maps to the top heading level.
+        if (string.Equals(styleId, "Title", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        // Built-in "Heading{n}" style IDs (no space; the localized display name may differ).
+        if (styleId.StartsWith(HeadingStylePrefix, StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(
+                styleId.AsSpan(HeadingStylePrefix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var n)
+            && n >= 1)
+        {
+            return Math.Min(n, MaxMarkdownHeadingLevel);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a custom paragraph style against <c>styles.xml</c> by walking the <c>w:basedOn</c> chain: a
+    /// built-in <c>HeadingN</c> / <c>Title</c> id reached along the chain (even a latent style with no
+    /// explicit definition) supplies the level, as does the first style-level <c>w:outlineLvl</c> encountered
+    /// (the closest override wins). Returns <c>null</c> when the chain resolves to no heading.
+    /// </summary>
+    private static int? ResolveStyleHeadingLevel(string styleId, MainDocumentPart mainPart)
+    {
+        var styles = mainPart.StyleDefinitionsPart?.Styles;
+        if (styles is null)
+        {
+            return null;
+        }
+
+        var currentId = styleId;
+        for (var depth = 0; depth < MaxStyleChainDepth && !string.IsNullOrEmpty(currentId); depth++)
+        {
+            // A built-in Heading / Title id in the chain carries the level even if that style has no explicit
+            // definition (a latent built-in style) — so check the id before requiring a definition.
+            var builtIn = BuiltInHeadingLevel(currentId);
+            if (builtIn is not null)
+            {
+                return builtIn;
+            }
+
+            var style = FindParagraphStyle(styles, currentId!);
+            if (style is null)
+            {
+                return null;
+            }
+
+            // A style-level outline level (w:style/w:pPr/w:outlineLvl).
+            var outline = style.StyleParagraphProperties?.OutlineLevel?.Val?.Value;
+            if (outline is >= 0 and < 9)
+            {
+                return Math.Min(outline.Value + 1, MaxMarkdownHeadingLevel);
+            }
+
+            currentId = style.BasedOn?.Val?.Value;
+        }
+
+        return null;
+    }
+
+    /// <summary>The <c>w:style</c> whose <c>w:styleId</c> matches, or <c>null</c>.</summary>
+    private static W.Style? FindParagraphStyle(W.Styles styles, string styleId)
+        => styles.Elements<W.Style>().FirstOrDefault(s =>
+            string.Equals(s.StyleId?.Value, styleId, StringComparison.Ordinal));
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordStyleMap.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordStyleMap.cs
@@ -65,6 +65,15 @@ internal static class WordStyleMap
             return Math.Min(outline.Value + 1, MaxMarkdownHeadingLevel);
         }
 
+        // An EXPLICIT body-text outline level (9) is direct formatting too, so it must cancel a heading the
+        // paragraph's custom style would otherwise imply (step 3) — a paragraph based on a Heading style but
+        // set back to "Body Text" in the paragraph dialog is body text. Short-circuit rather than fall through.
+        // (An out-of-range value is malformed; leave it to the style chain as before.)
+        if (outline == 9)
+        {
+            return null;
+        }
+
         // 3. [#316] A custom style whose heading semantics live in styles.xml (based on a built-in HeadingN,
         //    or a style-level outlineLvl). Requires the style part; otherwise the paragraph is not a heading.
         if (!string.IsNullOrEmpty(styleId) && mainPart is not null)
@@ -144,6 +153,13 @@ internal static class WordStyleMap
             if (outline is >= 0 and < 9)
             {
                 return Math.Min(outline.Value + 1, MaxMarkdownHeadingLevel);
+            }
+
+            // An explicit body-text outline (9) on this style overrides whatever it is based on (the closest
+            // override wins), so it stops the chain and is not a heading — mirrors the paragraph-direct rule.
+            if (outline == 9)
+            {
+                return null;
             }
 
             currentId = style.BasedOn?.Val?.Value;

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordTableRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordTableRenderer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using DocumentFormat.OpenXml;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace Dignite.Vault.Extract.Parse.OpenXml;
@@ -19,11 +20,14 @@ namespace Dignite.Vault.Extract.Parse.OpenXml;
 /// </summary>
 internal static class WordTableRenderer
 {
-    public static string? Render(W.Table table)
+    /// <param name="noteReferences">Optional sink for footnote/endnote references found in cells (#315): a
+    /// reference is collected (so its body is defined at the document end) and its marker appended to the cell
+    /// text. When null, references are ignored (the pre-#315 behavior).</param>
+    public static string? Render(W.Table table, ICollection<NoteReference>? noteReferences = null)
     {
         var rows = table
             .Elements<W.TableRow>()
-            .Select(row => row.Elements<W.TableCell>().Select(CellText).ToList())
+            .Select(row => row.Elements<W.TableCell>().Select(cell => CellText(cell, noteReferences)).ToList())
             .Where(cells => cells.Count > 0)
             .ToList();
         if (rows.Count == 0)
@@ -46,7 +50,7 @@ internal static class WordTableRenderer
         return MarkdownText.RenderTable(rows);
     }
 
-    private static string CellText(W.TableCell cell)
+    private static string CellText(W.TableCell cell, ICollection<NoteReference>? noteReferences)
     {
         // Join the cell's paragraphs' text with a space — a Markdown table cell can't contain a newline — and
         // escape inline metacharacters + table breakers once (#329, matching the PDF table path so a literal
@@ -54,12 +58,19 @@ internal static class WordTableRenderer
         // Descendants (not Elements) so paragraphs wrapped in a content control (w:sdt) or custom-XML inside
         // the cell are still picked up; but skip paragraphs that belong to a NESTED table (a nested w:tbl's
         // text is an accepted blind spot and must not bleed into this cell's own text).
+        var noteMarkers = noteReferences is null ? null : new StringBuilder();
         var paragraphs = cell
             .Descendants<W.Paragraph>()
             .Where(p => !IsInNestedTable(p, cell))
-            .Select(ParagraphPlainText)
+            .Select(p => ParagraphPlainText(p, noteReferences, noteMarkers))
             .Where(text => text.Length > 0);
-        return MarkdownText.EscapeInlineCell(string.Join(" ", paragraphs));
+        var text = MarkdownText.EscapeInlineCell(string.Join(" ", paragraphs));
+
+        // Note markers ([^fn2]) are generated structure, so append them PAST the cell escaping, at the cell's
+        // end — a Markdown table cell can't host a multi-line note, so the marker links to the definition
+        // appended at the document end (#315). Position within the cell is not preserved (acceptable for a
+        // cell), but the reference is captured rather than silently dropped.
+        return noteMarkers is { Length: > 0 } ? text + noteMarkers : text;
     }
 
     /// <summary>
@@ -84,27 +95,50 @@ internal static class WordTableRenderer
         return false;
     }
 
-    private static string ParagraphPlainText(W.Paragraph paragraph)
+    private static string ParagraphPlainText(
+        W.Paragraph paragraph, ICollection<NoteReference>? noteReferences, StringBuilder? noteMarkers)
     {
         // Cell text is rendered as plain inline text (no bold/italic markup inside a table cell this step):
         // read w:t (delText excluded => accepted view of tracked changes, matching DocxExtractor.ParagraphText),
-        // and turn tabs / line breaks into a space since a cell can't span lines.
+        // and turn tabs / line breaks into a space since a cell can't span lines. A footnote/endnote reference
+        // is collected (its marker accumulated for the cell, its body defined at document end) rather than
+        // silently dropped (#315).
         var sb = new StringBuilder();
-        foreach (var element in paragraph.Descendants<DocumentFormat.OpenXml.OpenXmlElement>())
+        foreach (var element in paragraph.Descendants<OpenXmlElement>())
         {
-            switch (element.LocalName)
+            switch (element)
             {
-                case "t":
-                    sb.Append(element.InnerText);
+                case W.FootnoteReference fn when noteReferences is not null && fn.Id?.Value is { } fnId:
+                    CollectNote(new NoteReference(NoteKind.Footnote, fnId), noteReferences, noteMarkers);
                     break;
-                case "tab":
-                case "br":
-                case "cr":
-                    sb.Append(' ');
+
+                case W.EndnoteReference en when noteReferences is not null && en.Id?.Value is { } enId:
+                    CollectNote(new NoteReference(NoteKind.Endnote, enId), noteReferences, noteMarkers);
+                    break;
+
+                default:
+                    switch (element.LocalName)
+                    {
+                        case "t":
+                            sb.Append(element.InnerText);
+                            break;
+                        case "tab":
+                        case "br":
+                        case "cr":
+                            sb.Append(' ');
+                            break;
+                    }
+
                     break;
             }
         }
 
         return sb.ToString().Trim();
+    }
+
+    private static void CollectNote(NoteReference note, ICollection<NoteReference> sink, StringBuilder? markers)
+    {
+        markers?.Append(note.Marker);
+        sink.Add(note);
     }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -831,6 +831,87 @@ public class DocxExtractor_Tests
         result.IsComplete.ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task Surfaces_footnote_and_endnote_markers_and_bodies()
+    {
+        // #315: an in-text marker at the reference position, and the resolved note body appended at the end.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Footnote("Body with a footnote", 2, "The footnote text.")
+            .Endnote("Body with an endnote", 3, "The endnote text."));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        // Markers sit at the reference's reading position (right after the run text).
+        result.Markdown.ShouldContain("Body with a footnote[^fn2]");
+        result.Markdown.ShouldContain("Body with an endnote[^en3]");
+        // The resolved bodies are appended as Markdown-footnote definitions.
+        result.Markdown.ShouldContain("[^fn2]: The footnote text.");
+        result.Markdown.ShouldContain("[^en3]: The endnote text.");
+        // The definitions come AFTER the body text they annotate.
+        result.Markdown.IndexOf("[^fn2]:", StringComparison.Ordinal)
+            .ShouldBeGreaterThan(result.Markdown.IndexOf("Body with a footnote", StringComparison.Ordinal));
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task A_document_without_notes_emits_no_note_markers()
+    {
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec().Paragraph("Plain body, no notes."));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("Plain body, no notes.");
+        result.Markdown.ShouldNotContain("[^");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Excludes_separator_notes_from_output()
+    {
+        // The FootnotesPart carries the auto-inserted separator / continuationSeparator notes (sentinel text);
+        // only the referenced author note is emitted, never the separators.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Footnote("See note", 2, "Author footnote."));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("[^fn2]: Author footnote.");
+        result.Markdown.ShouldNotContain("SEP_SENTINEL");
+        result.Markdown.ShouldNotContain("CONT_SENTINEL");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Marks_incomplete_for_a_dangling_note_reference()
+    {
+        // A footnote ref to id 99 with a FootnotesPart present (real note 2 + separators) but no id 99 —
+        // dangling, so the completeness signal trips rather than silently dropping the note.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Footnote("Real", 2, "Real note.")
+            .DanglingFootnote("Dangling", 99));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("[^fn2]: Real note.");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("footnote/endnote reference");
+    }
+
+    [Fact]
+    public async Task Marks_incomplete_when_the_notes_part_is_missing()
+    {
+        // A footnote reference with NO FootnotesPart at all (missing part) — dangling, tripping #268. The
+        // in-text marker is still emitted at its reading position.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .DanglingFootnote("Orphan ref", 2));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("Orphan ref[^fn2]");
+        result.IsComplete.ShouldBeFalse();
+        result.IncompleteReason!.ShouldContain("footnote/endnote reference");
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         var count = 0;

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -980,6 +980,25 @@ public class DocxExtractor_Tests
     }
 
     [Fact]
+    public async Task Transcribes_a_shape_picture_fill_image()
+    {
+        StubOcr("FILL_FIG");
+
+        // #322 regression: a shape whose fill is a picture (wps:wsp/a:blipFill/a:blip) has no pic:pic, so the
+        // pic:pic walk missed it and it was dropped silently. It carries real image content, so it must be
+        // transcribed via the shape's own extent + alt-text.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .ShapeFillImage(Png(alt: null), altText: "FILL_ALT"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        await _ocr.Received(1).RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+        result.Markdown.ShouldContain("FILL_FIG");
+        result.Markdown.ShouldContain("**FILL_ALT**");
+    }
+
+    [Fact]
     public async Task Uses_the_images_own_caption_for_a_text_box_image()
     {
         StubOcr("BOX_FIG");

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -854,6 +854,24 @@ public class DocxExtractor_Tests
     }
 
     [Fact]
+    public async Task Indents_the_continuation_of_a_multi_paragraph_footnote_body()
+    {
+        // #315: a footnote body with two paragraphs. The definition's continuation paragraph must be indented
+        // four spaces so it stays part of the [^fn2] definition (Markdown footnote syntax) rather than
+        // escaping flush-left as an ordinary document paragraph (which could also wedge between definitions).
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Paragraph("Intro")
+            .Footnote("Body with a footnote", 2, "First note paragraph.\n\nSecond note paragraph."));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("[^fn2]: First note paragraph.");
+        // The continuation paragraph is indented four spaces (attached to the definition), never flush-left.
+        result.Markdown.ShouldContain("\n    Second note paragraph.");
+        result.Markdown.ShouldNotContain("\nSecond note paragraph.");
+    }
+
+    [Fact]
     public async Task A_document_without_notes_emits_no_note_markers()
     {
         var docx = DocxFixtures.Build(new DocxFixtures.DocSpec().Paragraph("Plain body, no notes."));

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -912,6 +912,41 @@ public class DocxExtractor_Tests
         result.IncompleteReason!.ShouldContain("footnote/endnote reference");
     }
 
+    [Fact]
+    public async Task Transcribes_every_image_in_a_grouped_drawing()
+    {
+        StubOcr("GROUPED_FIG");
+
+        // #322: a grouped drawing (wpg:wgp) with two pictures. The old Descendants<Blip>().FirstOrDefault()
+        // walk transcribed only the first; iterating pic:pic transcribes each.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .GroupedImages(Png(alt: null), Png(alt: null)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        await _ocr.Received(2).RecognizeAsync(
+            Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
+        CountOccurrences(result.Markdown, "GROUPED_FIG").ShouldBe(2);
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Uses_the_images_own_caption_for_a_text_box_image()
+    {
+        StubOcr("BOX_FIG");
+
+        // #322: a text-box image's caption must come from the image's OWN wp:inline/docPr (descr "IMAGE_ALT"),
+        // not the outer text box's docPr (which carries no descr). Before the pic:pic refactor the outer
+        // drawing's docPr was read, so the image's alt-text was lost.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .TextBoxWithImage("box text", Png(alt: "IMAGE_ALT")));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("**IMAGE_ALT**");
+        CountOccurrences(result.Markdown, "BOX_FIG").ShouldBe(1);
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         var count = 0;

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -872,6 +872,37 @@ public class DocxExtractor_Tests
     }
 
     [Fact]
+    public async Task Captures_a_footnote_anchored_in_a_heading()
+    {
+        // #315: a footnote reference inside a HeadingN. The plain-text heading path used to drop both the
+        // marker and the note body silently, bypassing #268. Now the heading carries the marker and the body
+        // is defined at the document end.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .HeadingFootnote("Chapter One", 2, "Heading note body.", level: 1));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("# Chapter One[^fn2]");
+        result.Markdown.ShouldContain("[^fn2]: Heading note body.");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Captures_a_footnote_anchored_in_a_table_cell()
+    {
+        // #315: a footnote reference inside a table cell. The cell path used to drop both the marker and the
+        // body silently, bypassing #268. Now the marker is appended to the cell text and the body is defined.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .FootnoteInTableCell("Cell value", 2, "Cell note body."));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("Cell value[^fn2]");
+        result.Markdown.ShouldContain("[^fn2]: Cell note body.");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task A_document_without_notes_emits_no_note_markers()
     {
         var docx = DocxFixtures.Build(new DocxFixtures.DocSpec().Paragraph("Plain body, no notes."));

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
@@ -123,6 +123,9 @@ internal static class DocxFixtures
     /// <summary>A paragraph carrying a single grouped drawing (wpg:wgp) with several pictures (#322).</summary>
     public sealed record GroupedImagesSpec(IReadOnlyList<ImageSpec> Images) : BlockSpec;
 
+    /// <summary>A shape whose fill is a picture (wps:wsp/a:blipFill/a:blip, no pic:pic) — a #322 fill image.</summary>
+    public sealed record ShapeFillImageSpec(ImageSpec Image, string? AltText) : BlockSpec;
+
     public sealed class DocSpec
     {
         public List<BlockSpec> Blocks { get; } = new();
@@ -303,6 +306,13 @@ internal static class DocxFixtures
             Blocks.Add(new GroupedImagesSpec(images));
             return this;
         }
+
+        /// <summary>A shape (wps:wsp) whose fill is a picture — real image content with no pic:pic (#322 fill regression).</summary>
+        public DocSpec ShapeFillImage(ImageSpec image, string? altText = null)
+        {
+            Blocks.Add(new ShapeFillImageSpec(image, altText));
+            return this;
+        }
     }
 
     public static byte[] Build(DocSpec spec)
@@ -419,6 +429,10 @@ internal static class DocxFixtures
                         body.Append(GroupedImagesXml(
                             grouped.Images,
                             grouped.Images.Select(img => AddImage(mainPart, img, ref imageRel)).ToList()));
+                        break;
+
+                    case ShapeFillImageSpec shapeFill:
+                        body.Append(ShapeFillImageXml(AddImage(mainPart, shapeFill.Image, ref imageRel), shapeFill.AltText));
                         break;
                 }
             }
@@ -671,6 +685,31 @@ internal static class DocxFixtures
            </wp:inline>
          </w:drawing></w:r></w:p>
          """;
+
+    // A shape (wps:wsp) whose fill is a picture (a:blipFill/a:blip) with NO pic:pic. The wp:extent is large
+    // enough not to be decorative-filtered; an optional descr becomes the caption (#322 fill regression).
+    private static string ShapeFillImageXml(string relId, string? altText)
+    {
+        var descr = string.IsNullOrEmpty(altText) ? string.Empty : $" descr=\"{Escape(altText)}\"";
+        return $"""
+                <w:p><w:r><w:drawing>
+                  <wp:inline>
+                    <wp:extent cx="2000000" cy="2000000"/>
+                    <wp:docPr id="70" name="ShapeFill 70"{descr}/>
+                    <a:graphic>
+                      <a:graphicData uri="{WpsUri}">
+                        <wps:wsp>
+                          <wps:spPr>
+                            <a:blipFill><a:blip r:embed="{relId}"/><a:stretch><a:fillRect/></a:stretch></a:blipFill>
+                          </wps:spPr>
+                          <wps:bodyPr/>
+                        </wps:wsp>
+                      </a:graphicData>
+                    </a:graphic>
+                  </wp:inline>
+                </w:drawing></w:r></w:p>
+                """;
+    }
 
     private static string DeeplyNestedSdtXml(int depth, string text)
     {

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
@@ -476,12 +476,18 @@ internal static class DocxFixtures
         return $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(note.ParagraphText)}</w:t></w:r><w:r>{reference}</w:r></w:p>";
     }
 
+    // A note body: one <w:p> per paragraph, splitting NoteText on a blank line so a multi-paragraph note body
+    // (#315 continuation-indent) can be authored as "para1\n\npara2".
+    private static string NoteBodyParagraphs(string noteText)
+        => string.Concat(noteText.Split("\n\n").Select(p =>
+            $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(p)}</w:t></w:r></w:p>"));
+
     private static string FootnotesXml(IEnumerable<NoteSpec> notes)
     {
         // Real Word documents carry auto-inserted separator / continuationSeparator notes; include them (with
         // sentinel text) so the extractor's separator exclusion is exercised. Author notes follow.
         var bodies = string.Concat(notes.Select(n =>
-            $"<w:footnote w:id=\"{n.Id}\"><w:p><w:r><w:t xml:space=\"preserve\">{Escape(n.NoteText!)}</w:t></w:r></w:p></w:footnote>"));
+            $"<w:footnote w:id=\"{n.Id}\">{NoteBodyParagraphs(n.NoteText!)}</w:footnote>"));
         return $"""
                 <w:footnotes xmlns:w="{NsW}">
                   <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:t xml:space="preserve">SEP_SENTINEL</w:t></w:r></w:p></w:footnote>
@@ -494,7 +500,7 @@ internal static class DocxFixtures
     private static string EndnotesXml(IEnumerable<NoteSpec> notes)
     {
         var bodies = string.Concat(notes.Select(n =>
-            $"<w:endnote w:id=\"{n.Id}\"><w:p><w:r><w:t xml:space=\"preserve\">{Escape(n.NoteText!)}</w:t></w:r></w:p></w:endnote>"));
+            $"<w:endnote w:id=\"{n.Id}\">{NoteBodyParagraphs(n.NoteText!)}</w:endnote>"));
         return $"""
                 <w:endnotes xmlns:w="{NsW}">
                   <w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:t xml:space="preserve">SEP_SENTINEL</w:t></w:r></w:p></w:endnote>

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
@@ -29,6 +29,7 @@ internal static class DocxFixtures
     private const string NsC = "http://schemas.openxmlformats.org/drawingml/2006/chart";
     private const string PictureUri = "http://schemas.openxmlformats.org/drawingml/2006/picture";
     private const string WpsUri = "http://schemas.microsoft.com/office/word/2010/wordprocessingShape";
+    private const string WpgUri = "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup";
     private const string ChartUri = "http://schemas.openxmlformats.org/drawingml/2006/chart";
 
     /// <summary>An image to embed: raster bytes, MIME type, optional alt-text, EMU display extent.</summary>
@@ -116,6 +117,9 @@ internal static class DocxFixtures
     /// separator / continuationSeparator notes so the extractor's separator exclusion is exercised.
     /// </summary>
     public sealed record NoteSpec(string ParagraphText, int Id, bool IsEndnote, string? NoteText) : BlockSpec;
+
+    /// <summary>A paragraph carrying a single grouped drawing (wpg:wgp) with several pictures (#322).</summary>
+    public sealed record GroupedImagesSpec(IReadOnlyList<ImageSpec> Images) : BlockSpec;
 
     public sealed class DocSpec
     {
@@ -276,6 +280,13 @@ internal static class DocxFixtures
             Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: false, NoteText: null));
             return this;
         }
+
+        /// <summary>A single grouped drawing (wpg:wgp) containing several pictures, to exercise the pic:pic walk (#322).</summary>
+        public DocSpec GroupedImages(params ImageSpec[] images)
+        {
+            Blocks.Add(new GroupedImagesSpec(images));
+            return this;
+        }
     }
 
     public static byte[] Build(DocSpec spec)
@@ -387,6 +398,12 @@ internal static class DocxFixtures
                     case NoteSpec note:
                         body.Append(NoteReferenceParagraphXml(note));
                         break;
+
+                    case GroupedImagesSpec grouped:
+                        body.Append(GroupedImagesXml(
+                            grouped.Images,
+                            grouped.Images.Select(img => AddImage(mainPart, img, ref imageRel)).ToList()));
+                        break;
                 }
             }
 
@@ -489,6 +506,41 @@ internal static class DocxFixtures
 
     private static string ImageParagraphXml(ImageSpec image, string relId) =>
         $"<w:p><w:r>{InlineDrawingXml(image, relId)}</w:r></w:p>";
+
+    /// <summary>
+    /// One inline drawing whose graphic is a wpg:wgp GROUP of several pic:pic pictures (each with its own
+    /// blip + a:ext). The old FirstOrDefault-blip walk transcribed only the first picture; the pic:pic walk
+    /// (#322) transcribes each. The group's wp:inline carries a large extent so the pictures are not
+    /// decorative-filtered.
+    /// </summary>
+    private static string GroupedImagesXml(IReadOnlyList<ImageSpec> images, IReadOnlyList<string> relIds)
+    {
+        var pics = string.Concat(images.Select((image, i) =>
+        {
+            var descr = image.AltText is { Length: > 0 } ? $" descr=\"{Escape(image.AltText)}\"" : string.Empty;
+            return $"<pic:pic><pic:nvPicPr><pic:cNvPr id=\"{i + 1}\" name=\"GroupImg{i}\"{descr}/><pic:cNvPicPr/></pic:nvPicPr>"
+                 + $"<pic:blipFill><a:blip r:embed=\"{relIds[i]}\"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>"
+                 + $"<pic:spPr><a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"{image.ExtentCx}\" cy=\"{image.ExtentCy}\"/></a:xfrm><a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>";
+        }));
+
+        return $"""
+                <w:p><w:r><w:drawing>
+                  <wp:inline>
+                    <wp:extent cx="4000000" cy="2000000"/>
+                    <wp:docPr id="500" name="Group 1"/>
+                    <a:graphic>
+                      <a:graphicData uri="{WpgUri}">
+                        <wpg:wgp xmlns:wpg="{WpgUri}">
+                          <wpg:cNvGrpSpPr/>
+                          <wpg:grpSpPr/>
+                          {pics}
+                        </wpg:wgp>
+                      </a:graphicData>
+                    </a:graphic>
+                  </wp:inline>
+                </w:drawing></w:r></w:p>
+                """;
+    }
 
     /// <summary>A single inline <c>w:drawing</c> carrying a picture blip — the shared building block.</summary>
     private static string InlineDrawingXml(ImageSpec image, string relId) =>

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
@@ -109,6 +109,14 @@ internal static class DocxFixtures
     /// <summary>A modern DrawingML text box (wps:txbx) containing a paragraph of text AND an embedded image.</summary>
     public sealed record TextBoxImageSpec(string Text, ImageSpec Image) : BlockSpec;
 
+    /// <summary>
+    /// A paragraph carrying a footnote / endnote reference after its text (#315). <c>NoteText</c> null = a
+    /// DANGLING reference (no matching note body); when it is the only note of its kind the notes part is not
+    /// created either (the missing-part case). The notes part, when created, also carries the auto-inserted
+    /// separator / continuationSeparator notes so the extractor's separator exclusion is exercised.
+    /// </summary>
+    public sealed record NoteSpec(string ParagraphText, int Id, bool IsEndnote, string? NoteText) : BlockSpec;
+
     public sealed class DocSpec
     {
         public List<BlockSpec> Blocks { get; } = new();
@@ -247,6 +255,27 @@ internal static class DocxFixtures
             Blocks.Add(new TextBoxImageSpec(text, image));
             return this;
         }
+
+        /// <summary>A paragraph whose text is followed by a footnote reference; the note body is registered in the FootnotesPart.</summary>
+        public DocSpec Footnote(string paragraphText, int id, string noteText)
+        {
+            Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: false, noteText));
+            return this;
+        }
+
+        /// <summary>A paragraph whose text is followed by an endnote reference; the note body is registered in the EndnotesPart.</summary>
+        public DocSpec Endnote(string paragraphText, int id, string noteText)
+        {
+            Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: true, noteText));
+            return this;
+        }
+
+        /// <summary>A footnote reference whose id has no matching note body — dangling if a FootnotesPart exists, missing-part if not.</summary>
+        public DocSpec DanglingFootnote(string paragraphText, int id)
+        {
+            Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: false, NoteText: null));
+            return this;
+        }
     }
 
     public static byte[] Build(DocSpec spec)
@@ -354,7 +383,27 @@ internal static class DocxFixtures
                     case TextBoxImageSpec textBoxImage:
                         body.Append(TextBoxImageXml(textBoxImage.Text, textBoxImage.Image, AddImage(mainPart, textBoxImage.Image, ref imageRel)));
                         break;
+
+                    case NoteSpec note:
+                        body.Append(NoteReferenceParagraphXml(note));
+                        break;
                 }
+            }
+
+            var footnoteBodies = spec.Blocks.OfType<NoteSpec>().Where(n => !n.IsEndnote && n.NoteText is not null).ToList();
+            if (footnoteBodies.Count > 0)
+            {
+                var footnotesPart = mainPart.AddNewPart<FootnotesPart>();
+                footnotesPart.Footnotes = new Footnotes(FootnotesXml(footnoteBodies));
+                footnotesPart.Footnotes.Save();
+            }
+
+            var endnoteBodies = spec.Blocks.OfType<NoteSpec>().Where(n => n.IsEndnote && n.NoteText is not null).ToList();
+            if (endnoteBodies.Count > 0)
+            {
+                var endnotesPart = mainPart.AddNewPart<EndnotesPart>();
+                endnotesPart.Endnotes = new Endnotes(EndnotesXml(endnoteBodies));
+                endnotesPart.Endnotes.Save();
             }
 
             mainPart.Document = new Document(DocumentXml(body.ToString()));
@@ -400,6 +449,43 @@ internal static class DocxFixtures
 
     private static string SoftBreakXml(SoftBreakSpec softBreak) =>
         $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(softBreak.Line1)}</w:t><w:br/><w:t xml:space=\"preserve\">{Escape(softBreak.Line2)}</w:t></w:r></w:p>";
+
+    private static string NoteReferenceParagraphXml(NoteSpec note)
+    {
+        var reference = note.IsEndnote
+            ? $"<w:endnoteReference w:id=\"{note.Id}\"/>"
+            : $"<w:footnoteReference w:id=\"{note.Id}\"/>";
+        // Text run, then a separate run carrying only the reference (as Word authors it).
+        return $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(note.ParagraphText)}</w:t></w:r><w:r>{reference}</w:r></w:p>";
+    }
+
+    private static string FootnotesXml(IEnumerable<NoteSpec> notes)
+    {
+        // Real Word documents carry auto-inserted separator / continuationSeparator notes; include them (with
+        // sentinel text) so the extractor's separator exclusion is exercised. Author notes follow.
+        var bodies = string.Concat(notes.Select(n =>
+            $"<w:footnote w:id=\"{n.Id}\"><w:p><w:r><w:t xml:space=\"preserve\">{Escape(n.NoteText!)}</w:t></w:r></w:p></w:footnote>"));
+        return $"""
+                <w:footnotes xmlns:w="{NsW}">
+                  <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:t xml:space="preserve">SEP_SENTINEL</w:t></w:r></w:p></w:footnote>
+                  <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:t xml:space="preserve">CONT_SENTINEL</w:t></w:r></w:p></w:footnote>
+                  {bodies}
+                </w:footnotes>
+                """;
+    }
+
+    private static string EndnotesXml(IEnumerable<NoteSpec> notes)
+    {
+        var bodies = string.Concat(notes.Select(n =>
+            $"<w:endnote w:id=\"{n.Id}\"><w:p><w:r><w:t xml:space=\"preserve\">{Escape(n.NoteText!)}</w:t></w:r></w:p></w:endnote>"));
+        return $"""
+                <w:endnotes xmlns:w="{NsW}">
+                  <w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:t xml:space="preserve">SEP_SENTINEL</w:t></w:r></w:p></w:endnote>
+                  <w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:t xml:space="preserve">CONT_SENTINEL</w:t></w:r></w:p></w:endnote>
+                  {bodies}
+                </w:endnotes>
+                """;
+    }
 
     private static string ImageParagraphXml(ImageSpec image, string relId) =>
         $"<w:p><w:r>{InlineDrawingXml(image, relId)}</w:r></w:p>";

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
@@ -116,7 +116,9 @@ internal static class DocxFixtures
     /// created either (the missing-part case). The notes part, when created, also carries the auto-inserted
     /// separator / continuationSeparator notes so the extractor's separator exclusion is exercised.
     /// </summary>
-    public sealed record NoteSpec(string ParagraphText, int Id, bool IsEndnote, string? NoteText) : BlockSpec;
+    public sealed record NoteSpec(
+        string ParagraphText, int Id, bool IsEndnote, string? NoteText,
+        int? HeadingLevel = null, bool InTableCell = false) : BlockSpec;
 
     /// <summary>A paragraph carrying a single grouped drawing (wpg:wgp) with several pictures (#322).</summary>
     public sealed record GroupedImagesSpec(IReadOnlyList<ImageSpec> Images) : BlockSpec;
@@ -271,6 +273,20 @@ internal static class DocxFixtures
         public DocSpec Endnote(string paragraphText, int id, string noteText)
         {
             Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: true, noteText));
+            return this;
+        }
+
+        /// <summary>A HeadingN paragraph carrying a footnote reference (#315): a note anchored in a heading.</summary>
+        public DocSpec HeadingFootnote(string headingText, int id, string noteText, int level = 1)
+        {
+            Blocks.Add(new NoteSpec(headingText, id, IsEndnote: false, noteText, HeadingLevel: level));
+            return this;
+        }
+
+        /// <summary>A single-cell table whose cell paragraph carries a footnote reference (#315): a note anchored in a table cell.</summary>
+        public DocSpec FootnoteInTableCell(string cellText, int id, string noteText)
+        {
+            Blocks.Add(new NoteSpec(cellText, id, IsEndnote: false, noteText, InTableCell: true));
             return this;
         }
 
@@ -472,8 +488,15 @@ internal static class DocxFixtures
         var reference = note.IsEndnote
             ? $"<w:endnoteReference w:id=\"{note.Id}\"/>"
             : $"<w:footnoteReference w:id=\"{note.Id}\"/>";
+        var pPr = note.HeadingLevel is { } level
+            ? $"<w:pPr><w:pStyle w:val=\"Heading{level}\"/></w:pPr>"
+            : string.Empty;
         // Text run, then a separate run carrying only the reference (as Word authors it).
-        return $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(note.ParagraphText)}</w:t></w:r><w:r>{reference}</w:r></w:p>";
+        var paragraph = $"<w:p>{pPr}<w:r><w:t xml:space=\"preserve\">{Escape(note.ParagraphText)}</w:t></w:r><w:r>{reference}</w:r></w:p>";
+        // A cell-scoped reference lives inside a single-cell table so it is reached via the table path (#315).
+        return note.InTableCell
+            ? $"<w:tbl><w:tblPr/><w:tr><w:tc>{paragraph}</w:tc></w:tr></w:tbl>"
+            : paragraph;
     }
 
     // A note body: one <w:p> per paragraph, splitting NoteText on a blank line so a multi-paragraph note body

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -748,4 +748,44 @@ public class PptxExtractor_Tests
         result.Markdown.ShouldContain("| 2024 / Q2 | 40 |");
         result.IsComplete.ShouldBeTrue();
     }
+
+    [Fact]
+    public async Task Orders_grouped_shapes_by_their_own_position_not_xml_order()
+    {
+        StubOcr("GROUP_IMAGE");
+
+        // #313: inside a group, a caption authored BEFORE the image but positioned BELOW it (higher Y) must
+        // render image-then-caption by position. The old walk collapsed both to the group anchor and kept XML
+        // order (caption first). The group carries its own a:off, so each child is translated then ordered by
+        // its own position.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .GroupedCaptionAndImage(caption: "GROUP_CAPTION", captionY: 3_000_000, image: Png(alt: null, x: 100, y: 100)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        var image = result.Markdown.IndexOf("GROUP_IMAGE", StringComparison.Ordinal);
+        var caption = result.Markdown.IndexOf("GROUP_CAPTION", StringComparison.Ordinal);
+        image.ShouldBeGreaterThanOrEqualTo(0);
+        caption.ShouldBeGreaterThanOrEqualTo(0);
+        image.ShouldBeLessThan(caption, "the image (positioned above) must render before the caption (positioned below)");
+    }
+
+    [Fact]
+    public async Task Orders_a_layout_inherited_placeholder_by_its_inherited_position()
+    {
+        // #313: a body placeholder that omits its own a:xfrm inherits its position from the slide layout. A
+        // manually positioned shape higher up must render before the (visually lower) inherited body
+        // placeholder — the old walk sorted the no-xfrm placeholder to (0,0) (the top), inverting the order.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("MANUAL_SHAPE", x: 100, y: 1_000_000)
+            .WithLayoutInheritedBody("INHERITED_BODY", layoutBodyY: 5_000_000));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        var manual = result.Markdown.IndexOf("MANUAL_SHAPE", StringComparison.Ordinal);
+        var body = result.Markdown.IndexOf("INHERITED_BODY", StringComparison.Ordinal);
+        manual.ShouldBeGreaterThanOrEqualTo(0);
+        body.ShouldBeGreaterThanOrEqualTo(0);
+        manual.ShouldBeLessThan(body, "the manually-positioned shape (higher) must render before the layout-inherited body placeholder (lower)");
+    }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -811,4 +811,23 @@ public class PptxExtractor_Tests
         body.ShouldBeGreaterThanOrEqualTo(0);
         manual.ShouldBeLessThan(body, "the manually-positioned shape (higher) must render before the layout-inherited body placeholder (lower)");
     }
+
+    [Fact]
+    public async Task Composes_group_scale_into_the_reading_order_position()
+    {
+        // #456: a group scaled to one-third (ext cy = chExt cy / 3) at off y=500,000 contains a text at
+        // child-frame y=5,000,000, so its true slide y = 500,000 + 5,000,000/3 ≈ 2.17M. An ungrouped text sits
+        // at y=3M, so the group child must render FIRST. Translation-only (the pre-#456 math) placed the child
+        // at 500,000 + 5,000,000 = 5.5M and wrongly ordered it after the ungrouped text.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .ScaledGroupOrdering(inside: "INSIDE_GROUP", insideLocalY: 5_000_000, outside: "OUTSIDE_SHAPE", outsideY: 3_000_000));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        var inside = result.Markdown.IndexOf("INSIDE_GROUP", StringComparison.Ordinal);
+        var outside = result.Markdown.IndexOf("OUTSIDE_SHAPE", StringComparison.Ordinal);
+        inside.ShouldBeGreaterThanOrEqualTo(0);
+        outside.ShouldBeGreaterThanOrEqualTo(0);
+        inside.ShouldBeLessThan(outside, "the scaled group's child (true y ≈ 2.17M) must render before the ungrouped shape at y=3M");
+    }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -705,4 +705,23 @@ public class PptxExtractor_Tests
             Arg.Is<OcrOptions>(o => o.LanguageHints.Count == 0),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Surfaces_a_shape_wrapped_in_mc_alternate_content()
+    {
+        // #319: a shape PowerPoint wraps in <mc:AlternateContent> is a direct spTree child of type
+        // AlternateContent — none of the typed WalkShapesAsync cases — so without collapsing the
+        // markup-compatibility fork on open its text is silently dropped with no #268 signal. Opening with the
+        // MC-collapsing settings resolves the fork to its selected branch (a real p:sp) before the walk runs.
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Ordinary slide text")
+            .McAlternateContentText("MC_WRAPPED_CONTENT"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("Ordinary slide text");
+        result.Markdown.ShouldContain("MC_WRAPPED_CONTENT");
+        // Exactly one branch survives collapsing — the content must not be doubled from both Choice and Fallback.
+        (result.Markdown.Split("MC_WRAPPED_CONTENT").Length - 1).ShouldBe(1);
+    }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -724,4 +724,28 @@ public class PptxExtractor_Tests
         // Exactly one branch survives collapsing — the content must not be doubled from both Choice and Fallback.
         (result.Markdown.Split("MC_WRAPPED_CONTENT").Length - 1).ShouldBe(1);
     }
+
+    [Fact]
+    public async Task Renders_a_multi_level_category_axis_as_compound_row_labels()
+    {
+        // #321: a multi-level category axis (c:multiLvlStrRef with an inner "quarter" level and an outer
+        // "year" level) repeats idx values per level. Flattening every level into one idx→label map collided
+        // the indices and mislabeled rows (idx 0 became the outer "2023" instead of "2023 / Q1"). The renderer
+        // must compose one compound label per position, outer → inner.
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: System.Array.Empty<string>(),
+            Series: new[] { ("Revenue", (IReadOnlyList<string>)new[] { "10", "20", "30", "40" }) },
+            TwoLevelCategories: new[] { ("2023", "Q1"), ("2023", "Q2"), ("2024", "Q1"), ("2024", "Q2") });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("| 2023 / Q1 | 10 |");
+        result.Markdown.ShouldContain("| 2023 / Q2 | 20 |");
+        result.Markdown.ShouldContain("| 2024 / Q1 | 30 |");
+        result.Markdown.ShouldContain("| 2024 / Q2 | 40 |");
+        result.IsComplete.ShouldBeTrue();
+    }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -750,6 +750,29 @@ public class PptxExtractor_Tests
     }
 
     [Fact]
+    public async Task A_blank_leaf_category_cell_is_not_filled_from_the_previous_leaf()
+    {
+        // #321 follow-up: forward-fill is a span semantic for OUTER grouping levels only. A blank INNER (leaf)
+        // cell — Excel omits its c:pt — must stay blank, not inherit the previous leaf's label. Here idx 2
+        // opens a new outer group "2024" with an empty inner, so its label must be "2024", NOT "2024 / Q2"
+        // (carrying Q2 across the group boundary).
+        var chart = new PptxFixtures.ChartSpec(
+            Title: null,
+            Categories: System.Array.Empty<string>(),
+            Series: new[] { ("Revenue", (IReadOnlyList<string>)new[] { "10", "20", "30" }) },
+            TwoLevelCategories: new[] { ("2023", "Q1"), ("2023", "Q2"), ("2024", "") });
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec().Chart(chart));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("| 2023 / Q1 | 10 |");
+        result.Markdown.ShouldContain("| 2023 / Q2 | 20 |");
+        result.Markdown.ShouldContain("| 2024 | 30 |");
+        result.Markdown.ShouldNotContain("2024 / Q2");
+    }
+
+    [Fact]
     public async Task Orders_grouped_shapes_by_their_own_position_not_xml_order()
     {
         StubOcr("GROUP_IMAGE");

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
@@ -494,7 +494,10 @@ internal static class PptxFixtures
 
         string MultiLevelCategoryCache(IReadOnlyList<(string Outer, string Inner)> cats)
         {
-            var inner = string.Concat(cats.Select((c, i) => $"<c:pt idx=\"{i}\"><c:v>{Escape(c.Inner)}</c:v></c:pt>"));
+            // An empty inner value omits its c:pt entirely — exactly how Excel writes a blank leaf cell (a
+            // position that carries only an outer-group label). The extractor must NOT forward-fill the leaf.
+            var inner = string.Concat(cats.Select((c, i) =>
+                string.IsNullOrEmpty(c.Inner) ? string.Empty : $"<c:pt idx=\"{i}\"><c:v>{Escape(c.Inner)}</c:v></c:pt>"));
             // Outer level: cache a point only where the outer label changes (the group's first index), exactly
             // as Excel writes a multi-level axis — the extractor must forward-fill the label across the group.
             var outer = new StringBuilder();

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
@@ -56,7 +56,11 @@ internal static class PptxFixtures
         IReadOnlyList<string>? SecondSeriesCategories = null,
         // When true, the FIRST series omits its c:cat cache entirely (categories must seed from a later
         // series instead of the first).
-        bool FirstSeriesOmitsCategories = false);
+        bool FirstSeriesOmitsCategories = false,
+        // When set, the category axis is a two-level (c:multiLvlStrRef) axis: each tuple is (outer, inner) for
+        // that position. Verifies multi-level axes compose compound labels ("2024 / Q1") rather than colliding
+        // idx values across levels (#321). Takes precedence over the single-level Categories.
+        IReadOnlyList<(string Outer, string Inner)>? TwoLevelCategories = null);
 
     /// <summary>A native table: rows of cells (first row is the header), at an EMU offset.</summary>
     public sealed record TableSpec(IReadOnlyList<IReadOnlyList<string>> Rows, long OffsetX = 100, long OffsetY = 6_000_000);
@@ -388,13 +392,39 @@ internal static class PptxFixtures
             return $"<c:cat><c:strRef><c:f>cats</c:f><c:strCache><c:ptCount val=\"{cats.Count}\"/>{points}</c:strCache></c:strRef></c:cat>";
         }
 
+        string MultiLevelCategoryCache(IReadOnlyList<(string Outer, string Inner)> cats)
+        {
+            var inner = string.Concat(cats.Select((c, i) => $"<c:pt idx=\"{i}\"><c:v>{Escape(c.Inner)}</c:v></c:pt>"));
+            // Outer level: cache a point only where the outer label changes (the group's first index), exactly
+            // as Excel writes a multi-level axis — the extractor must forward-fill the label across the group.
+            var outer = new StringBuilder();
+            string? prev = null;
+            for (var i = 0; i < cats.Count; i++)
+            {
+                if (cats[i].Outer != prev)
+                {
+                    outer.Append($"<c:pt idx=\"{i}\"><c:v>{Escape(cats[i].Outer)}</c:v></c:pt>");
+                    prev = cats[i].Outer;
+                }
+            }
+
+            // Innermost c:lvl first (per ECMA-376), then the outer level.
+            return $"<c:cat><c:multiLvlStrRef><c:f>cats</c:f><c:multiLvlStrCache><c:ptCount val=\"{cats.Count}\"/>"
+                 + $"<c:lvl>{inner}</c:lvl><c:lvl>{outer}</c:lvl>"
+                 + "</c:multiLvlStrCache></c:multiLvlStrRef></c:cat>";
+        }
+
         var seriesXml = string.Concat(chart.Series.Select((ser, si) =>
         {
             var valuePoints = string.Concat(ser.Values.Select((v, i) =>
                 $"<c:pt{Idx(i)}><c:v>{Escape(v)}</c:v></c:pt>"));
             var cats = si == 1 && chart.SecondSeriesCategories is not null ? chart.SecondSeriesCategories : chart.Categories;
             // The first series can be made to omit its category cache so seeding falls to a later series.
-            var catXml = si == 0 && chart.FirstSeriesOmitsCategories ? string.Empty : CategoryCache(cats);
+            var catXml = si == 0 && chart.FirstSeriesOmitsCategories
+                ? string.Empty
+                : chart.TwoLevelCategories is not null
+                    ? MultiLevelCategoryCache(chart.TwoLevelCategories)
+                    : CategoryCache(cats);
             return $"""
                     <c:ser>
                       <c:idx val="{si}"/><c:order val="{si}"/>

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
@@ -143,6 +143,35 @@ internal static class PptxFixtures
             McTexts.Add(text);
             return this;
         }
+
+        /// <summary>Caption + image pairs inside one grouped shape (#313), added via <see cref="GroupedCaptionAndImage"/>.</summary>
+        public List<(string Caption, long CaptionY, ImageSpec Image)> CaptionImageGroups { get; } = new();
+
+        /// <summary>
+        /// Adds a grouped shape containing a caption text (authored FIRST) at <paramref name="captionY"/> and an
+        /// image (authored SECOND) at the image's own offset, to verify group-transform reading order (#313):
+        /// the two must sort by their own positions within the group, not by XML/encounter order.
+        /// </summary>
+        public SlideSpec GroupedCaptionAndImage(string caption, long captionY, ImageSpec image)
+        {
+            CaptionImageGroups.Add((caption, captionY, image));
+            return this;
+        }
+
+        /// <summary>A slide body placeholder that omits its own xfrm (position inherited from the layout, #313).</summary>
+        public string? InheritedBodyText { get; private set; }
+
+        /// <summary>The Y offset (EMU) the layout's body placeholder carries — the position the slide's no-xfrm body placeholder should inherit (#313).</summary>
+        public long LayoutBodyOffsetY { get; private set; }
+
+        /// <summary>Adds a slide body placeholder with no xfrm, and a slide layout whose matching body
+        /// placeholder sits at <paramref name="layoutBodyY"/>, to verify layout-inherited position (#313).</summary>
+        public SlideSpec WithLayoutInheritedBody(string text, long layoutBodyY)
+        {
+            InheritedBodyText = text;
+            LayoutBodyOffsetY = layoutBodyY;
+            return this;
+        }
     }
 
     public static byte[] Build(params SlideSpec[] slides)
@@ -242,6 +271,29 @@ internal static class PptxFixtures
             shapes.Append(GroupXml(shapeId++, groupShapes.ToString()));
         }
 
+        foreach (var (caption, captionY, image) in slide.CaptionImageGroups)
+        {
+            var relId = $"rIdCapImg{slideIndex}_{imageRel++}";
+            var imagePart = slidePart.AddNewPart<ImagePart>(image.ContentType, relId);
+            using (var s = imagePart.GetStream(FileMode.Create, FileAccess.Write))
+            {
+                s.Write(image.Bytes, 0, image.Bytes.Length);
+            }
+
+            var groupId = shapeId++;
+            var captionId = shapeId++;
+            var picId = shapeId++;
+            shapes.Append(CaptionImageGroupXml(groupId, captionId, caption, captionY, picId, image, relId));
+        }
+
+        if (slide.InheritedBodyText is { Length: > 0 } inheritedBody)
+        {
+            shapes.Append(InheritedBodyPlaceholderXml(shapeId++, inheritedBody));
+            var layoutPart = slidePart.AddNewPart<SlideLayoutPart>();
+            layoutPart.SlideLayout = new SlideLayout(SlideLayoutXml(slide.LayoutBodyOffsetY));
+            layoutPart.SlideLayout.Save();
+        }
+
         slidePart.Slide = new Slide(SlideXml(shapes.ToString()));
 
         if (slide.Notes is { Length: > 0 })
@@ -272,6 +324,54 @@ internal static class PptxFixtures
            </a:xfrm></p:grpSpPr>
            {childShapes}
          </p:grpSp>
+         """;
+
+    /// <summary>
+    /// A grouped shape with a caption text (authored first) at <paramref name="captionY"/> and a picture
+    /// (authored second) at the image's own offset. The group carries its own <c>a:off</c>/<c>a:chOff</c>, so
+    /// the extractor must translate each child by the group offset and order them by their own positions (#313).
+    /// </summary>
+    private static string CaptionImageGroupXml(uint groupId, uint captionId, string caption, long captionY, uint picId, ImageSpec image, string relId) =>
+        $"""
+         <p:grpSp>
+           <p:nvGrpSpPr><p:cNvPr id="{groupId}" name="Group{groupId}"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+           <p:grpSpPr><a:xfrm>
+             <a:off x="500000" y="500000"/><a:ext cx="6000000" cy="6000000"/>
+             <a:chOff x="0" y="0"/><a:chExt cx="6000000" cy="6000000"/>
+           </a:xfrm></p:grpSpPr>
+           <p:sp>
+             <p:nvSpPr><p:cNvPr id="{captionId}" name="Caption{captionId}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+             <p:spPr><a:xfrm><a:off x="100" y="{captionY}"/><a:ext cx="3000000" cy="500000"/></a:xfrm></p:spPr>
+             <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(caption)}</a:t></a:r></a:p></p:txBody>
+           </p:sp>
+           {PictureXml(picId, image, relId)}
+         </p:grpSp>
+         """;
+
+    /// <summary>A slide body placeholder (type=body, idx=1) with NO xfrm — its position is layout-inherited (#313).</summary>
+    private static string InheritedBodyPlaceholderXml(uint id, string text) =>
+        $"""
+         <p:sp>
+           <p:nvSpPr><p:cNvPr id="{id}" name="Body {id}"/><p:cNvSpPr/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>
+           <p:spPr/>
+           <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(text)}</a:t></a:r></a:p></p:txBody>
+         </p:sp>
+         """;
+
+    /// <summary>A minimal slide layout whose body placeholder (type=body, idx=1) carries an xfrm at the given Y.</summary>
+    private static string SlideLayoutXml(long bodyY) =>
+        $"""
+         <p:sldLayout xmlns:p="{NsP}" xmlns:a="{NsA}" xmlns:r="{NsR}" type="obj">
+           <p:cSld><p:spTree>
+             <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+             <p:grpSpPr/>
+             <p:sp>
+               <p:nvSpPr><p:cNvPr id="2" name="Body Placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>
+               <p:spPr><a:xfrm><a:off x="838200" y="{bodyY}"/><a:ext cx="7772400" cy="4351338"/></a:xfrm></p:spPr>
+               <p:txBody><a:bodyPr/><a:lstStyle/><a:p/></p:txBody>
+             </p:sp>
+           </p:spTree></p:cSld>
+         </p:sldLayout>
          """;
 
     private static string TextShapeXml(uint id, TextSpec text)

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
@@ -172,6 +172,16 @@ internal static class PptxFixtures
             LayoutBodyOffsetY = layoutBodyY;
             return this;
         }
+
+        /// <summary>A group scaled ext ≪ chExt containing one text at InsideLocalY, plus an ungrouped text at
+        /// OutsideY — to verify the group's ext/chExt scale is composed into the reading-order position (#456).</summary>
+        public (string Inside, long InsideLocalY, string Outside, long OutsideY)? ScaledGroup { get; private set; }
+
+        public SlideSpec ScaledGroupOrdering(string inside, long insideLocalY, string outside, long outsideY)
+        {
+            ScaledGroup = (inside, insideLocalY, outside, outsideY);
+            return this;
+        }
     }
 
     public static byte[] Build(params SlideSpec[] slides)
@@ -294,6 +304,14 @@ internal static class PptxFixtures
             layoutPart.SlideLayout.Save();
         }
 
+        if (slide.ScaledGroup is { } scaled)
+        {
+            var groupId = shapeId++;
+            var innerId = shapeId++;
+            shapes.Append(ScaledGroupTextXml(groupId, innerId, scaled.Inside, scaled.InsideLocalY));
+            shapes.Append(PlainTextShapeXml(shapeId++, scaled.Outside, scaled.OutsideY));
+        }
+
         slidePart.Slide = new Slide(SlideXml(shapes.ToString()));
 
         if (slide.Notes is { Length: > 0 })
@@ -346,6 +364,38 @@ internal static class PptxFixtures
            </p:sp>
            {PictureXml(picId, image, relId)}
          </p:grpSp>
+         """;
+
+    /// <summary>
+    /// A group scaled to one-third (ext cy = chExt cy / 3) at off y=500000, containing one text shape at
+    /// child-frame <paramref name="localY"/>. Its true slide Y is <c>500000 + localY/3</c>, well ABOVE the
+    /// translation-only <c>500000 + localY</c> — so composing the ext/chExt scale changes its reading-order
+    /// rank against an ungrouped shape (#456).
+    /// </summary>
+    private static string ScaledGroupTextXml(uint groupId, uint textId, string text, long localY) =>
+        $"""
+         <p:grpSp>
+           <p:nvGrpSpPr><p:cNvPr id="{groupId}" name="Group{groupId}"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+           <p:grpSpPr><a:xfrm>
+             <a:off x="500000" y="500000"/><a:ext cx="2000000" cy="2000000"/>
+             <a:chOff x="0" y="0"/><a:chExt cx="6000000" cy="6000000"/>
+           </a:xfrm></p:grpSpPr>
+           <p:sp>
+             <p:nvSpPr><p:cNvPr id="{textId}" name="Inner{textId}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+             <p:spPr><a:xfrm><a:off x="0" y="{localY}"/><a:ext cx="1000000" cy="500000"/></a:xfrm></p:spPr>
+             <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(text)}</a:t></a:r></a:p></p:txBody>
+           </p:sp>
+         </p:grpSp>
+         """;
+
+    /// <summary>An ungrouped text shape at an explicit slide offset (#456 reading-order comparison target).</summary>
+    private static string PlainTextShapeXml(uint id, string text, long y) =>
+        $"""
+         <p:sp>
+           <p:nvSpPr><p:cNvPr id="{id}" name="Text{id}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+           <p:spPr><a:xfrm><a:off x="0" y="{y}"/><a:ext cx="3000000" cy="500000"/></a:xfrm></p:spPr>
+           <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(text)}</a:t></a:r></a:p></p:txBody>
+         </p:sp>
          """;
 
     /// <summary>A slide body placeholder (type=body, idx=1) with NO xfrm — its position is layout-inherited (#313).</summary>

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxFixtures.cs
@@ -125,6 +125,20 @@ internal static class PptxFixtures
             Notes = notes;
             return this;
         }
+
+        /// <summary>Text shapes wrapped in an mc:AlternateContent fork (#319), added via <see cref="McAlternateContentText"/>.</summary>
+        public List<string> McTexts { get; } = new();
+
+        /// <summary>
+        /// Adds a text shape wrapped in an <c>mc:AlternateContent</c> fork (a Choice + a Fallback carrying the
+        /// same text), to verify the extractor collapses the markup-compatibility fork on open (#319) instead of
+        /// skipping the AlternateContent node in the typed shape walk.
+        /// </summary>
+        public SlideSpec McAlternateContentText(string text)
+        {
+            McTexts.Add(text);
+            return this;
+        }
     }
 
     public static byte[] Build(params SlideSpec[] slides)
@@ -162,6 +176,11 @@ internal static class PptxFixtures
         foreach (var text in slide.Texts)
         {
             shapes.Append(TextShapeXml(shapeId++, text));
+        }
+
+        foreach (var mcText in slide.McTexts)
+        {
+            shapes.Append(McAlternateContentShapeXml(shapeId++, mcText));
         }
 
         foreach (var (line1, line2, x, y) in slide.SoftBreakTexts)
@@ -286,6 +305,29 @@ internal static class PptxFixtures
            </p:txBody>
          </p:sp>
          """;
+
+    private static string McAlternateContentShapeXml(uint id, string text)
+    {
+        // A shape PowerPoint wraps in a markup-compatibility fork: the Choice requires a modern namespace, the
+        // Fallback is the legacy equivalent. Both branches carry the same text so the assertion holds whichever
+        // branch the SDK selects when it collapses the markup on open. As a direct spTree child this is an
+        // <mc:AlternateContent> element — none of the typed shape cases — so without collapsing it is skipped.
+        string Sp(uint spId) =>
+            $"<p:sp><p:nvSpPr><p:cNvPr id=\"{spId}\" name=\"Mc{spId}\"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>" +
+            $"<p:spPr><a:xfrm><a:off x=\"100\" y=\"2000000\"/><a:ext cx=\"3000000\" cy=\"500000\"/></a:xfrm></p:spPr>" +
+            $"<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>{Escape(text)}</a:t></a:r></a:p></p:txBody></p:sp>";
+
+        return $"""
+                <mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+                  <mc:Choice xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" Requires="a14">
+                    {Sp(id)}
+                  </mc:Choice>
+                  <mc:Fallback>
+                    {Sp(id + 1000)}
+                  </mc:Fallback>
+                </mc:AlternateContent>
+                """;
+    }
 
     private static string PictureXml(uint id, ImageSpec image, string relId)
     {

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/WordStyleMap_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/WordStyleMap_Tests.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using Shouldly;
 using Xunit;
 using W = DocumentFormat.OpenXml.Wordprocessing;
@@ -66,5 +69,84 @@ public class WordStyleMap_Tests
     {
         WordStyleMap.HeadingLevel(new W.Paragraph()).ShouldBeNull();
         WordStyleMap.HeadingLevel(WithStyle("Normal")).ShouldBeNull();
+    }
+
+    // Builds an in-memory DOCX carrying the given styles (the inner XML of <w:styles>) plus a standalone
+    // paragraph using paragraphStyleId, so HeadingLevel can resolve a custom style against the
+    // StyleDefinitionsPart (#316). Dispose the returned document in the caller's using-scope.
+    private static (WordprocessingDocument Document, MainDocumentPart MainPart, W.Paragraph Paragraph) BuildWithStyles(
+        string paragraphStyleId, string stylesInnerXml)
+    {
+        var document = WordprocessingDocument.Create(new MemoryStream(), WordprocessingDocumentType.Document);
+        var mainPart = document.AddMainDocumentPart();
+        mainPart.Document = new W.Document(new W.Body());
+        mainPart.AddNewPart<StyleDefinitionsPart>().Styles = new W.Styles(
+            $"<w:styles xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">{stylesInnerXml}</w:styles>");
+        var paragraph = new W.Paragraph(new W.ParagraphProperties(new W.ParagraphStyleId { Val = paragraphStyleId }));
+        return (document, mainPart, paragraph);
+    }
+
+    [Fact]
+    public void Resolves_a_custom_style_based_on_a_builtin_heading()
+    {
+        // #316: the paragraph uses a custom style whose w:basedOn points at Heading1. The paragraph itself
+        // carries no built-in style id and no direct outline, so it is a heading only if HeadingLevel follows
+        // the basedOn chain in styles.xml. (Heading1 need not be defined — the id itself carries the level.)
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "ChapterTitle",
+            "<w:style w:type=\"paragraph\" w:styleId=\"ChapterTitle\"><w:basedOn w:val=\"Heading1\"/></w:style>");
+        using (document)
+        {
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public void Resolves_a_custom_style_with_a_style_level_outline()
+    {
+        // #316: the custom style's definition carries w:outlineLvl (not on the paragraph). outlineLvl=1
+        // (0-based) => H2, proving the level is read from the style, not hardcoded to 1.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "Section",
+            "<w:style w:type=\"paragraph\" w:styleId=\"Section\"><w:pPr><w:outlineLvl w:val=\"1\"/></w:pPr></w:style>");
+        using (document)
+        {
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBe(2);
+        }
+    }
+
+    [Fact]
+    public void Resolves_a_custom_style_through_a_multi_hop_basedOn_chain()
+    {
+        // #316: A -> B -> Heading2. The walk must follow more than one basedOn hop.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "A",
+            "<w:style w:type=\"paragraph\" w:styleId=\"A\"><w:basedOn w:val=\"B\"/></w:style>"
+            + "<w:style w:type=\"paragraph\" w:styleId=\"B\"><w:basedOn w:val=\"Heading2\"/></w:style>");
+        using (document)
+        {
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBe(2);
+        }
+    }
+
+    [Fact]
+    public void A_custom_style_that_is_not_a_heading_returns_null()
+    {
+        // A custom style based on Normal with no outline level is body text, not a heading.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "BodyCustom",
+            "<w:style w:type=\"paragraph\" w:styleId=\"BodyCustom\"><w:basedOn w:val=\"Normal\"/></w:style>");
+        using (document)
+        {
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void A_custom_heading_style_without_a_styles_part_is_not_resolved()
+    {
+        // Backward-compatible fallback: with no MainDocumentPart, a custom style id cannot be resolved against
+        // styles.xml, so it is not treated as a heading (the pre-#316 single-arg behavior is unchanged).
+        WordStyleMap.HeadingLevel(WithStyle("ChapterTitle")).ShouldBeNull();
     }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/WordStyleMap_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/WordStyleMap_Tests.cs
@@ -149,4 +149,54 @@ public class WordStyleMap_Tests
         // styles.xml, so it is not treated as a heading (the pre-#316 single-arg behavior is unchanged).
         WordStyleMap.HeadingLevel(WithStyle("ChapterTitle")).ShouldBeNull();
     }
+
+    [Fact]
+    public void An_explicit_paragraph_outline_of_nine_cancels_a_heading_style()
+    {
+        // #316: the paragraph's custom style is based on Heading1, but the paragraph carries a direct
+        // outlineLvl=9 ("Body Text" chosen in the paragraph dialog). Direct formatting overrides the style, so
+        // it is body text — not H1. Without the explicit-9 short-circuit this fell through to the style chain
+        // and wrongly rendered a heading.
+        var (document, mainPart, _) = BuildWithStyles(
+            "ChapterTitle",
+            "<w:style w:type=\"paragraph\" w:styleId=\"ChapterTitle\"><w:basedOn w:val=\"Heading1\"/></w:style>");
+        using (document)
+        {
+            var paragraph = new W.Paragraph(new W.ParagraphProperties(
+                new W.ParagraphStyleId { Val = "ChapterTitle" },
+                new W.OutlineLevel { Val = 9 }));
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void A_style_level_outline_of_nine_overrides_a_based_on_heading()
+    {
+        // #316: the custom style is based on Heading1 but explicitly sets outlineLvl=9 (body text) in its own
+        // definition — the closest override wins, so it is not a heading. Without the explicit-9 stop the walk
+        // continued up to Heading1 and returned H1.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "QuietHeading",
+            "<w:style w:type=\"paragraph\" w:styleId=\"QuietHeading\"><w:basedOn w:val=\"Heading1\"/>"
+            + "<w:pPr><w:outlineLvl w:val=\"9\"/></w:pPr></w:style>");
+        using (document)
+        {
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void A_cyclic_basedOn_chain_terminates_and_is_not_a_heading()
+    {
+        // Defense: a malformed A -> B -> A cycle must not loop forever (MaxStyleChainDepth bounds the walk)
+        // and, resolving to no built-in heading / outline, is body text.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "A",
+            "<w:style w:type=\"paragraph\" w:styleId=\"A\"><w:basedOn w:val=\"B\"/></w:style>"
+            + "<w:style w:type=\"paragraph\" w:styleId=\"B\"><w:basedOn w:val=\"A\"/></w:style>");
+        using (document)
+        {
+            WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBeNull();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

OpenXML text-extraction fast-follows from the #299 figure-extraction epic review, all in `Dignite.Vault.Extract.Parse.OpenXml`. Pure text-extraction; no egress contract / field-architecture change; every change is inline-into-Markdown only with `TextExtractionResult` unchanged.

### `refactor` — shared OpenXML figure/OCR/completeness pipeline (#317)
Consolidated the copy-pasted Docx/Pptx figure-OCR orchestration into `OpenXmlIncompleteReason.Build`, `OpenXmlExtractionState`, and `OpenXmlFigureTranscriber.TranscribeAsync`. Behavior-preserving; net −263 lines across the two extractors.

### `feat` — collapse markup-compatibility on PPTX open (#319)
`PptxExtractor` now opens with the same MC-collapsing `OpenSettings` DOCX used (shared `OpenXmlPackageSettings.McCollapsing`), so an `mc:AlternateContent`-wrapped shape is no longer silently skipped by the typed walk.

### `fix` — compose multi-level chart category axes (#321)
`ChartRenderer` composes a compound label per position for a multi-level `c:cat` (`c:multiLvlStrRef`) instead of colliding levels; shared renderer, so fixes both DOCX and PPTX.

### `feat` — resolve DOCX heading level from custom styles (#316)
`WordStyleMap.HeadingLevel` resolves a custom paragraph style against `styles.xml` (walk `w:basedOn` to a built-in `HeadingN`/`Title`, or read the style-level `w:outlineLvl`). Built-in / direct-outline / plain paragraphs unchanged.

### `feat` — surface DOCX footnotes/endnotes in Markdown (#315)
Emits a Markdown-footnote marker (`[^fn{id}]` / `[^en{id}]`) at each reference position and appends the resolved bodies as definitions (de-duped, reusing the body renderer; note images via the shared OCR path). Separator/continuation notes excluded; a dangling reference / missing part trips #268.

### `feat` — walk DOCX figures by picture instance (#322)
Iterates `pic:pic` (not `w:drawing` + first-blip), so a grouped drawing's several images are each transcribed once and a text-box image uses its OWN extent/caption (read from the picture's nearest `wp:inline`/`wp:anchor`); removes the grouped-multi-image loss and the double-OCR special-case.

### `perf` — collapse DOCX figure traversal + cache lookups (#318)
Single-pass figure traversal (was three), a per-document hyperlink id→URI cache, and a `(numId, level)→format` numbering memo. Byte-for-byte-identical output.

### `feat` — PPTX group-transform & layout-inherited reading order (#313)
Grouped shapes now order by their own positions (translation composed through nested groups) instead of collapsing to the group anchor; a layout-inherited placeholder (no `a:xfrm`) resolves its position from the matching layout/master placeholder instead of sorting to (0,0).

## Testing
- Full solution build clean (no new warnings).
- All **125** OpenXml tests pass (14 new across #319/#321/#316/#315/#322/#313).
- Every new bug/feature test was confirmed **red without its fix**, then green with it; #318 (perf) is verified by the unchanged 125-test suite.

Closes #317
Closes #319
Closes #321
Closes #316
Closes #315
Closes #322
Closes #318
Closes #313