### PR TITLE
feat(document-types): config pack import/export (#444)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackDto.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackDto.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Volo.Abp.Validation;
+
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>
+/// A portable, declarative snapshot of one <c>DocumentType</c> plus its <c>FieldDefinition</c>s — the unit
+/// of config import/export (#444). It carries NO identity or layer: <see cref="TypeCode"/> is the match key
+/// and the target layer is the caller's current layer, so the same pack applies cleanly to any deployment
+/// or tenant. Business-neutral by design — the channel ships no bundled packs (packs are consumer/community
+/// content authored against this mechanism).
+/// </summary>
+public class DocumentTypePackDto
+{
+    /// <summary>Pack schema version. Only <see cref="DocumentTypePackConsts.CurrentVersion"/> is accepted on
+    /// import; a newer/unknown version loud-fails rather than silently mis-mapping.</summary>
+    public int Version { get; set; } = DocumentTypePackConsts.CurrentVersion;
+
+    [Required]
+    [RegularExpression(DocumentTypeConsts.TypeCodePattern)]
+    [DynamicStringLength(typeof(DocumentTypeConsts), nameof(DocumentTypeConsts.MaxTypeCodeLength))]
+    public string TypeCode { get; set; } = default!;
+
+    [Required]
+    [DynamicStringLength(typeof(DocumentTypeConsts), nameof(DocumentTypeConsts.MaxDisplayNameLength))]
+    public string DisplayName { get; set; } = default!;
+
+    [DynamicStringLength(typeof(DocumentTypeConsts), nameof(DocumentTypeConsts.MaxDescriptionLength))]
+    public string? Description { get; set; }
+
+    [Range(0d, 1d)]
+    public double ConfidenceThreshold { get; set; } = 0.7;
+
+    public int Priority { get; set; }
+
+    public List<DocumentTypePackFieldDto> Fields { get; set; } = new();
+}

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackFieldDto.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackFieldDto.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using Dignite.Vault.Extract.Documents.Fields;
+using Volo.Abp.Validation;
+
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>
+/// One field definition inside a <see cref="DocumentTypePackDto"/>. Mirrors the mutable shape of a
+/// <c>FieldDefinition</c> minus identity/layer (resolved on import from the caller's layer + owning type).
+/// Matched on import by (owning type, <see cref="Name"/>).
+/// </summary>
+public class DocumentTypePackFieldDto
+{
+    [Required]
+    [RegularExpression(FieldDefinitionConsts.NamePattern)]
+    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxNameLength))]
+    public string Name { get; set; } = default!;
+
+    [Required]
+    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxDisplayNameLength))]
+    public string DisplayName { get; set; } = default!;
+
+    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxPromptLength))]
+    public string? Prompt { get; set; }
+
+    public FieldDataType DataType { get; set; } = FieldDataType.Text;
+
+    public int DisplayOrder { get; set; }
+
+    public bool IsRequired { get; set; }
+
+    public bool AllowMultiple { get; set; }
+
+    public bool IsUniqueKey { get; set; }
+}

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackImportResultDto.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackImportResultDto.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>Summary of an import: per-pack outcomes plus rolled-up totals so a caller can report exactly
+/// what was created / updated / skipped without re-diffing.</summary>
+public class DocumentTypePackImportResultDto
+{
+    public List<DocumentTypePackItemResultDto> Items { get; set; } = new();
+
+    public int TypesCreated { get; set; }
+    public int TypesUpdated { get; set; }
+    public int TypesSkipped { get; set; }
+    public int FieldsCreated { get; set; }
+    public int FieldsUpdated { get; set; }
+    public int FieldsSkipped { get; set; }
+}
+
+/// <summary>Per-pack outcome: what happened to the type, and how its fields were reconciled.</summary>
+public class DocumentTypePackItemResultDto
+{
+    public string TypeCode { get; set; } = default!;
+    public PackItemAction TypeAction { get; set; }
+    public int FieldsCreated { get; set; }
+    public int FieldsUpdated { get; set; }
+    public int FieldsSkipped { get; set; }
+}

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/IDocumentTypePackAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/IDocumentTypePackAppService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Services;
+
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>
+/// Config import/export ("pack") mechanism for document types + their field definitions (#444). Export
+/// serializes the caller's-layer config to portable, declarative packs; import applies packs back
+/// idempotently (match type by TypeCode, field by Name; re-import produces no duplicates). Layer-aware:
+/// reads and writes only the caller's current layer, never crossing the Host/tenant boundary.
+/// </summary>
+public interface IDocumentTypePackAppService : IApplicationService
+{
+    /// <summary>Export a single document type (in the caller's layer) and its fields as a pack.</summary>
+    Task<DocumentTypePackDto> ExportAsync(Guid id);
+
+    /// <summary>Export every document type in the caller's layer as a list of packs.</summary>
+    Task<List<DocumentTypePackDto>> ExportAllAsync();
+
+    /// <summary>Idempotently apply one or more packs to the caller's layer, per the chosen mode.</summary>
+    Task<DocumentTypePackImportResultDto> ImportAsync(ImportDocumentTypePacksInput input);
+}

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/ImportDocumentTypePacksInput.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/ImportDocumentTypePacksInput.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>Input for <see cref="IDocumentTypePackAppService.ImportAsync"/>: one or more packs plus the
+/// reconciliation <see cref="Mode"/>. All packs apply to the caller's current layer.</summary>
+public class ImportDocumentTypePacksInput
+{
+    [Required]
+    [MinLength(1)]
+    [MaxLength(DocumentTypePackConsts.MaxPacksPerImport)]
+    public List<DocumentTypePackDto> Packs { get; set; } = new();
+
+    public PackImportMode Mode { get; set; } = PackImportMode.CreateOrUpdate;
+}

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/PackImportMode.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/PackImportMode.cs
@@ -1,0 +1,17 @@
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>
+/// How <see cref="IDocumentTypePackAppService.ImportAsync"/> reconciles a pack against the current layer.
+/// Neither mode ever deletes a locally-present type or field the pack omits — import is additive by design;
+/// removal stays a deliberate CRUD action.
+/// </summary>
+public enum PackImportMode
+{
+    /// <summary>Create what is missing and overwrite existing types/fields (matched by TypeCode / Name) to
+    /// match the pack. The default: the pack is the source of truth.</summary>
+    CreateOrUpdate = 0,
+
+    /// <summary>Create only what is missing; leave every existing type/field untouched (preserving local
+    /// customizations). Existing rows are reported as skipped.</summary>
+    CreateOnly = 1
+}

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/PackItemAction.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/PackItemAction.cs
@@ -1,0 +1,9 @@
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>What an import did to a single type (or is reported per-field in the result counts).</summary>
+public enum PackItemAction
+{
+    Created = 0,
+    Updated = 1,
+    Skipped = 2
+}

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/Packs/DocumentTypePackAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/Packs/DocumentTypePackAppService.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents.Fields;
+using Dignite.Vault.Extract.Permissions;
+using Microsoft.AspNetCore.Authorization;
+using Volo.Abp;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Entities;
+
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>
+/// Config import/export "pack" engine (#444). Serializes a <see cref="DocumentType"/> + its
+/// <see cref="FieldDefinition"/>s to a portable declarative pack and applies a pack back idempotently.
+/// <para>
+/// Everything goes through the domain entities + managers (never a raw DbContext), so every invariant holds:
+/// code/name layer-uniqueness (<see cref="DocumentTypeManager"/> / <see cref="FieldDefinitionManager"/>),
+/// entity validation (name pattern, lengths, multi-value-only-for-text), and the data-safety guard that
+/// forbids changing a field's data type or narrowing multi→single once extracted values exist.
+/// </para>
+/// <para>
+/// Layer-aware: reads and writes only the caller's current layer (Host = <c>TenantId</c> null, tenant = its
+/// GUID) via the ambient <c>IMultiTenant</c> filter + <c>CurrentTenant.Id</c>; there is no cross-layer
+/// mixing. Identity is <c>TypeCode</c> / field <c>Name</c> (#207: a rename = a new type/field). Import is
+/// atomic: it runs in the ambient application-service unit of work, and all pack versions are validated
+/// before any write, so an unsupported version leaves nothing partially applied.
+/// </para>
+/// </summary>
+public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypePackAppService
+{
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentTypeManager _documentTypeManager;
+    private readonly FieldDefinitionManager _fieldDefinitionManager;
+
+    public DocumentTypePackAppService(
+        IDocumentTypeRepository documentTypeRepository,
+        IFieldDefinitionRepository fieldDefinitionRepository,
+        IDocumentRepository documentRepository,
+        DocumentTypeManager documentTypeManager,
+        FieldDefinitionManager fieldDefinitionManager)
+    {
+        _documentTypeRepository = documentTypeRepository;
+        _fieldDefinitionRepository = fieldDefinitionRepository;
+        _documentRepository = documentRepository;
+        _documentTypeManager = documentTypeManager;
+        _fieldDefinitionManager = fieldDefinitionManager;
+    }
+
+    [Authorize(VaultExtractPermissions.DocumentTypes.Default)]
+    public virtual async Task<DocumentTypePackDto> ExportAsync(Guid id)
+    {
+        var type = await _documentTypeRepository.GetAsync(id);
+        // Defense in depth on top of the IMultiTenant filter: never export another layer's type.
+        if (type.TenantId != CurrentTenant.Id)
+        {
+            throw new EntityNotFoundException(typeof(DocumentType), id);
+        }
+
+        var fields = await _fieldDefinitionRepository.GetListAsync(type.Id);
+        return MapToPack(type, fields);
+    }
+
+    [Authorize(VaultExtractPermissions.DocumentTypes.Default)]
+    public virtual async Task<List<DocumentTypePackDto>> ExportAllAsync()
+    {
+        // The ambient IMultiTenant filter narrows this to the caller's layer.
+        var types = await _documentTypeRepository.GetListAsync();
+        var packs = new List<DocumentTypePackDto>(types.Count);
+        foreach (var type in types.OrderBy(t => t.Priority).ThenBy(t => t.TypeCode))
+        {
+            var fields = await _fieldDefinitionRepository.GetListAsync(type.Id);
+            packs.Add(MapToPack(type, fields));
+        }
+
+        return packs;
+    }
+
+    // Import both creates and updates types + fields, so it requires the full config-management permission
+    // set (all four must be granted). This is not an LLM-influenced path, so [Authorize] fires normally.
+    [Authorize(VaultExtractPermissions.DocumentTypes.Create)]
+    [Authorize(VaultExtractPermissions.DocumentTypes.Update)]
+    [Authorize(VaultExtractPermissions.FieldDefinitions.Create)]
+    [Authorize(VaultExtractPermissions.FieldDefinitions.Update)]
+    public virtual async Task<DocumentTypePackImportResultDto> ImportAsync(ImportDocumentTypePacksInput input)
+    {
+        // Validate every pack version up front, before touching the store, so an unsupported version can
+        // never leave earlier packs partially applied (the production UoW would roll back anyway, but the
+        // test harness disables the transaction — pre-validation makes the guarantee unconditional).
+        foreach (var pack in input.Packs)
+        {
+            if (pack.Version != DocumentTypePackConsts.CurrentVersion)
+            {
+                throw new BusinessException(VaultExtractErrorCodes.DocumentTypePack.UnsupportedVersion)
+                    .WithData("TypeCode", pack.TypeCode)
+                    .WithData("Version", pack.Version)
+                    .WithData("Supported", DocumentTypePackConsts.CurrentVersion);
+            }
+        }
+
+        var result = new DocumentTypePackImportResultDto();
+        foreach (var pack in input.Packs)
+        {
+            var item = await ImportPackAsync(pack, input.Mode);
+            result.Items.Add(item);
+
+            switch (item.TypeAction)
+            {
+                case PackItemAction.Created: result.TypesCreated++; break;
+                case PackItemAction.Updated: result.TypesUpdated++; break;
+                default: result.TypesSkipped++; break;
+            }
+
+            result.FieldsCreated += item.FieldsCreated;
+            result.FieldsUpdated += item.FieldsUpdated;
+            result.FieldsSkipped += item.FieldsSkipped;
+        }
+
+        return result;
+    }
+
+    protected virtual async Task<DocumentTypePackItemResultDto> ImportPackAsync(
+        DocumentTypePackDto pack, PackImportMode mode)
+    {
+        var item = new DocumentTypePackItemResultDto { TypeCode = pack.TypeCode };
+
+        // Match the type by code within the caller's layer (active rows only). Rename = new type (#207).
+        var type = await _documentTypeRepository.FindByTypeCodeAsync(pack.TypeCode);
+
+        if (type == null)
+        {
+            // Both modes create what is missing. CheckCodeAvailableAsync is soft-delete-aware: if a deleted
+            // row occupies the code it loud-fails rather than colliding on restore.
+            await _documentTypeManager.CheckCodeAvailableAsync(pack.TypeCode);
+            type = new DocumentType(
+                GuidGenerator.Create(),
+                CurrentTenant.Id,
+                pack.TypeCode,
+                pack.DisplayName,
+                pack.Description,
+                pack.ConfidenceThreshold,
+                pack.Priority);
+            StampProvenance(type, pack.Version);
+            await _documentTypeRepository.InsertAsync(type, autoSave: true);
+            item.TypeAction = PackItemAction.Created;
+        }
+        else if (mode == PackImportMode.CreateOrUpdate)
+        {
+            type.Update(pack.TypeCode, pack.DisplayName, pack.Description, pack.ConfidenceThreshold, pack.Priority);
+            StampProvenance(type, pack.Version);
+            await _documentTypeRepository.UpdateAsync(type, autoSave: true);
+            item.TypeAction = PackItemAction.Updated;
+        }
+        else
+        {
+            // CreateOnly: leave the existing type's own properties untouched (but still add missing fields).
+            item.TypeAction = PackItemAction.Skipped;
+        }
+
+        await ImportFieldsAsync(type.Id, pack.Fields, mode, pack.Version, item);
+        return item;
+    }
+
+    protected virtual async Task ImportFieldsAsync(
+        Guid documentTypeId,
+        List<DocumentTypePackFieldDto> fields,
+        PackImportMode mode,
+        int version,
+        DocumentTypePackItemResultDto item)
+    {
+        foreach (var f in fields)
+        {
+            var existing = await _fieldDefinitionRepository.FindByNameAsync(documentTypeId, f.Name);
+
+            if (existing == null)
+            {
+                await _fieldDefinitionManager.CheckNameAvailableAsync(documentTypeId, f.Name);
+                var field = new FieldDefinition(
+                    GuidGenerator.Create(),
+                    CurrentTenant.Id,
+                    documentTypeId,
+                    f.Name,
+                    f.DisplayName,
+                    f.Prompt,
+                    f.DataType,
+                    f.DisplayOrder,
+                    f.IsRequired,
+                    f.AllowMultiple,
+                    f.IsUniqueKey);
+                StampProvenance(field, version);
+                await _fieldDefinitionRepository.InsertAsync(field, autoSave: true);
+                item.FieldsCreated++;
+            }
+            else if (mode == PackImportMode.CreateOrUpdate)
+            {
+                await GuardFieldMutationAsync(existing, f);
+                existing.Update(
+                    f.Name,
+                    f.DisplayName,
+                    f.Prompt,
+                    f.DataType,
+                    f.DisplayOrder,
+                    f.IsRequired,
+                    f.AllowMultiple,
+                    f.IsUniqueKey);
+                StampProvenance(existing, version);
+                await _fieldDefinitionRepository.UpdateAsync(existing, autoSave: true);
+                item.FieldsUpdated++;
+            }
+            else
+            {
+                item.FieldsSkipped++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Mirror of the <see cref="FieldDefinitionAppService"/> data-safety guard: never break already-extracted
+    /// values by changing a field's data type or narrowing it from multi- to single-valued. A pack that
+    /// would do so loud-fails (the whole import rolls back in the ambient UoW) instead of silently
+    /// corrupting stored values.
+    /// </summary>
+    protected virtual async Task GuardFieldMutationAsync(FieldDefinition existing, DocumentTypePackFieldDto pack)
+    {
+        var dataTypeChanged = pack.DataType != existing.DataType;
+        var multiValueNarrowed = existing.AllowMultiple && !pack.AllowMultiple;
+        if (!dataTypeChanged && !multiValueNarrowed)
+        {
+            return;
+        }
+
+        var hasValues = await _documentRepository.AnyExtractedFieldValueAsync(existing.Id);
+        if (dataTypeChanged && hasValues)
+        {
+            throw new BusinessException(VaultExtractErrorCodes.FieldDefinition.DataTypeChangeNotAllowed)
+                .WithData("Name", existing.Name);
+        }
+
+        if (multiValueNarrowed && hasValues)
+        {
+            throw new BusinessException(VaultExtractErrorCodes.FieldDefinition.MultiValueChangeNotAllowed)
+                .WithData("Name", existing.Name);
+        }
+    }
+
+    // Provenance: mark pack-sourced config in ExtraProperties (config metadata on the type/field aggregate,
+    // not the Document truth source). A stable value keeps re-import idempotent (no phantom diffs).
+    protected virtual void StampProvenance(IHasExtraProperties entity, int version)
+    {
+        entity.SetProperty(DocumentTypePackConsts.ProvenanceSourceKey, DocumentTypePackConsts.ProvenanceSourceValue);
+        entity.SetProperty(DocumentTypePackConsts.ProvenanceVersionKey, version);
+    }
+
+    protected virtual DocumentTypePackDto MapToPack(DocumentType type, List<FieldDefinition> fields)
+    {
+        return new DocumentTypePackDto
+        {
+            Version = DocumentTypePackConsts.CurrentVersion,
+            TypeCode = type.TypeCode,
+            DisplayName = type.DisplayName,
+            Description = type.Description,
+            ConfidenceThreshold = type.ConfidenceThreshold,
+            Priority = type.Priority,
+            Fields = fields
+                .OrderBy(f => f.DisplayOrder)
+                .ThenBy(f => f.Name)
+                .Select(f => new DocumentTypePackFieldDto
+                {
+                    Name = f.Name,
+                    DisplayName = f.DisplayName,
+                    Prompt = f.Prompt,
+                    DataType = f.DataType,
+                    DisplayOrder = f.DisplayOrder,
+                    IsRequired = f.IsRequired,
+                    AllowMultiple = f.AllowMultiple,
+                    IsUniqueKey = f.IsUniqueKey
+                })
+                .ToList()
+        };
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/Packs/DocumentTypePackAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/Packs/DocumentTypePackAppService.cs
@@ -79,12 +79,12 @@ public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypeP
         return packs;
     }
 
-    // Import both creates and updates types + fields, so it requires the full config-management permission
-    // set (all four must be granted). This is not an LLM-influenced path, so [Authorize] fires normally.
+    // Import always may create types + fields, so both Create permissions gate entry. The Update permissions
+    // are asserted lazily, only on the branches that actually update an existing type / field (ImportPackAsync
+    // / ImportFieldsAsync), so a CreateOnly import — or a first-time import of all-new types/fields — never
+    // demands Update. This is not an LLM-influenced path, so [Authorize] fires normally.
     [Authorize(VaultExtractPermissions.DocumentTypes.Create)]
-    [Authorize(VaultExtractPermissions.DocumentTypes.Update)]
     [Authorize(VaultExtractPermissions.FieldDefinitions.Create)]
-    [Authorize(VaultExtractPermissions.FieldDefinitions.Update)]
     public virtual async Task<DocumentTypePackImportResultDto> ImportAsync(ImportDocumentTypePacksInput input)
     {
         // Validate every pack version up front, before touching the store, so an unsupported version can
@@ -149,6 +149,9 @@ public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypeP
         }
         else if (mode == PackImportMode.CreateOrUpdate)
         {
+            // Updating an existing type needs the Update permission — asserted here rather than as a blanket
+            // method attribute, so a CreateOnly / all-new import never requires it.
+            await CheckPolicyAsync(VaultExtractPermissions.DocumentTypes.Update);
             type.Update(pack.TypeCode, pack.DisplayName, pack.Description, pack.ConfidenceThreshold, pack.Priority);
             StampProvenance(type, pack.Version);
             await _documentTypeRepository.UpdateAsync(type, autoSave: true);
@@ -196,6 +199,9 @@ public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypeP
             }
             else if (mode == PackImportMode.CreateOrUpdate)
             {
+                // Updating an existing field needs the Update permission — asserted lazily; a CreateOnly or
+                // all-new import never reaches here.
+                await CheckPolicyAsync(VaultExtractPermissions.FieldDefinitions.Update);
                 await GuardFieldMutationAsync(existing, f);
                 existing.Update(
                     f.Name,

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentTypes/Packs/DocumentTypePackConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentTypes/Packs/DocumentTypePackConsts.cs
@@ -1,0 +1,26 @@
+namespace Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+
+/// <summary>
+/// Constants for the document-type config "pack" mechanism (#444). The <see cref="ProvenanceSourceKey"/> /
+/// <see cref="ProvenanceVersionKey"/> live in the type's / field's <c>ExtraProperties</c> (config metadata
+/// on the DocumentType / FieldDefinition aggregates — NOT the Document truth source, so the Markdown-first
+/// single-payload rules do not apply here).
+/// </summary>
+public static class DocumentTypePackConsts
+{
+    /// <summary>Current pack schema version emitted by export and required by import. A pack with any other
+    /// version loud-fails on import (<c>DocumentTypePackUnsupportedVersion</c>) rather than being mis-mapped.</summary>
+    public const int CurrentVersion = 1;
+
+    /// <summary>Fail-closed cap on how many packs one import call may carry.</summary>
+    public const int MaxPacksPerImport = 100;
+
+    /// <summary><c>ExtraProperties</c> key marking a type/field as pack-sourced.</summary>
+    public const string ProvenanceSourceKey = "__packSource";
+
+    /// <summary>Value stored under <see cref="ProvenanceSourceKey"/>.</summary>
+    public const string ProvenanceSourceValue = "pack";
+
+    /// <summary><c>ExtraProperties</c> key recording the pack schema version last applied.</summary>
+    public const string ProvenanceVersionKey = "__packVersion";
+}

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -325,6 +325,7 @@
 
     "Extract:InvalidDocumentTypeCodeFormat": "Document type code '{typeCode}' is not allowed. Must match pattern '{pattern}' (letters, digits, underscore, hyphen segments, optionally separated by '.'; no leading/trailing/consecutive '.').",
     "Extract:DocumentTypeCodeAlreadyExists": "Document type code '{TypeCode}' is already in use (including soft-deleted records). Use a different code, or restore the existing one.",
+    "Extract:DocumentTypePackUnsupportedVersion": "Configuration pack for '{TypeCode}' uses an unsupported version ({Version}). This deployment supports pack version {Supported}.",
     "Extract:DocumentTypeInUse": "Document type '{TypeCode}' is still referenced by one or more documents. Reclassify those documents before deleting this type.",
     "Extract:DocumentTypeRestoreConflict": "Cannot restore document type '{TypeCode}': another active document type with the same code already exists.",
     "Extract:FieldDefinitionAlreadyExists": "Field '{Name}' is already defined on document type '{DocumentTypeCode}' (including soft-deleted records).",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -325,6 +325,7 @@
 
     "Extract:InvalidDocumentTypeCodeFormat": "ドキュメントタイプコード '{typeCode}' は使用できません。パターン '{pattern}' に一致する必要があります（英字・数字・アンダースコア・ハイフンのセグメント。任意で '.' 区切り。先頭・末尾・連続する '.' は不可）。",
     "Extract:DocumentTypeCodeAlreadyExists": "ドキュメントタイプコード '{TypeCode}' は既に使用されています（論理削除済みのレコードを含む）。別のコードを使用するか、既存のものを復元してください。",
+    "Extract:DocumentTypePackUnsupportedVersion": "構成パック「{TypeCode}」のバージョン（{Version}）はサポートされていません。この配置がサポートするパックバージョンは {Supported} です。",
     "Extract:DocumentTypeInUse": "ドキュメントタイプ '{TypeCode}' は 1 件以上のドキュメントから参照されています。このタイプを削除する前に、それらのドキュメントを再分類してください。",
     "Extract:DocumentTypeRestoreConflict": "ドキュメントタイプ '{TypeCode}' を復元できません：同じコードの別のアクティブなドキュメントタイプが既に存在します。",
     "Extract:FieldDefinitionAlreadyExists": "フィールド '{Name}' はドキュメントタイプ '{DocumentTypeCode}' に既に定義されています（論理削除済みのレコードを含む）。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -325,6 +325,7 @@
 
     "Extract:InvalidDocumentTypeCodeFormat": "文档类型代码 '{typeCode}' 不符合格式 '{pattern}'：仅允许字母 / 数字 / 下划线 / 短横线段，可选用 '.' 分隔多段；不允许首尾或连续 '.'。",
     "Extract:DocumentTypeCodeAlreadyExists": "文档类型代码 '{TypeCode}' 已被占用（包括已软删除的记录）。请使用其他代码，或先恢复已存在的同名类型。",
+    "Extract:DocumentTypePackUnsupportedVersion": "配置包「{TypeCode}」的版本（{Version}）不受支持；本部署支持的包版本为 {Supported}。",
     "Extract:DocumentTypeInUse": "文档类型 '{TypeCode}' 仍被一个或多个文档引用，请先重新分类这些文档再删除该类型。",
     "Extract:DocumentTypeRestoreConflict": "无法恢复文档类型 '{TypeCode}'：已存在另一个未删除的同代码类型。",
     "Extract:FieldDefinitionAlreadyExists": "文档类型 '{DocumentTypeCode}' 下已定义字段 '{Name}'（包括已软删除的记录）。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -325,6 +325,7 @@
 
     "Extract:InvalidDocumentTypeCodeFormat": "文件類型代碼 '{typeCode}' 不符合格式 '{pattern}'：僅允許字母 / 數字 / 底線 / 連字號區段，可選用 '.' 分隔多段；不允許開頭、結尾或連續 '.'。",
     "Extract:DocumentTypeCodeAlreadyExists": "文件類型代碼 '{TypeCode}' 已被佔用（包括已軟刪除的記錄）。請使用其他代碼，或先還原已存在的同名類型。",
+    "Extract:DocumentTypePackUnsupportedVersion": "設定包「{TypeCode}」的版本（{Version}）不受支援；本部署支援的包版本為 {Supported}。",
     "Extract:DocumentTypeInUse": "文件類型 '{TypeCode}' 仍被一份或多份文件參照，請先重新分類這些文件再刪除此類型。",
     "Extract:DocumentTypeRestoreConflict": "無法還原文件類型 '{TypeCode}'：已存在另一個未刪除的同代碼類型。",
     "Extract:FieldDefinitionAlreadyExists": "文件類型 '{DocumentTypeCode}' 下已定義欄位 '{Name}'（包括已軟刪除的記錄）。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -43,6 +43,12 @@ public static class VaultExtractErrorCodes
         public const string NoneConfigured = "Extract:NoDocumentTypesConfigured";
     }
 
+    // #444: config import/export ("pack") mechanism for a document type + its field definitions.
+    public static class DocumentTypePack
+    {
+        public const string UnsupportedVersion = "Extract:DocumentTypePackUnsupportedVersion";
+    }
+
     public static class FieldDefinition
     {
         public const string AlreadyExists = "Extract:FieldDefinitionAlreadyExists";

--- a/core/src/Dignite.Vault.Extract.HttpApi/Documents/DocumentTypes/Packs/DocumentTypePackController.cs
+++ b/core/src/Dignite.Vault.Extract.HttpApi/Documents/DocumentTypes/Packs/DocumentTypePackController.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dignite.Vault.Extract.HttpApi.Documents.DocumentTypes.Packs;
+
+[Area("vault-extract")]
+[Route("api/vault-extract/document-type-packs")]
+public class DocumentTypePackController : VaultExtractController, IDocumentTypePackAppService
+{
+    private readonly IDocumentTypePackAppService _appService;
+
+    public DocumentTypePackController(IDocumentTypePackAppService appService)
+    {
+        _appService = appService;
+    }
+
+    [HttpGet("{id}")]
+    public virtual Task<DocumentTypePackDto> ExportAsync(Guid id)
+    {
+        return _appService.ExportAsync(id);
+    }
+
+    [HttpGet]
+    public virtual Task<List<DocumentTypePackDto>> ExportAllAsync()
+    {
+        return _appService.ExportAllAsync();
+    }
+
+    [HttpPost("import")]
+    public virtual Task<DocumentTypePackImportResultDto> ImportAsync([FromBody] ImportDocumentTypePacksInput input)
+    {
+        return _appService.ImportAsync(input);
+    }
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTypes/DocumentTypePackAppService_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTypes/DocumentTypePackAppService_Tests.cs
@@ -1,0 +1,189 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
+using Dignite.Vault.Extract.Documents.Fields;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.Data;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents.DocumentTypes;
+
+/// <summary>
+/// #444 config pack round-trip: exercises <see cref="IDocumentTypePackAppService"/> against the real SQLite
+/// DB + real repositories/managers. Covers create-from-pack, export↔import round-trip, idempotent re-import
+/// (no duplicates), CreateOnly additive semantics, and up-front version rejection with no partial writes.
+/// </summary>
+public class DocumentTypePackAppService_Tests : VaultExtractEntityFrameworkCoreTestBase
+{
+    private readonly IDocumentTypePackAppService _packAppService;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+
+    public DocumentTypePackAppService_Tests()
+    {
+        _packAppService = GetRequiredService<IDocumentTypePackAppService>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _fieldDefinitionRepository = GetRequiredService<IFieldDefinitionRepository>();
+    }
+
+    private static DocumentTypePackDto SamplePack(string typeCode = "host.invoice") => new()
+    {
+        Version = DocumentTypePackConsts.CurrentVersion,
+        TypeCode = typeCode,
+        DisplayName = "Invoice",
+        Description = "Invoice documents",
+        ConfidenceThreshold = 0.8,
+        Priority = 5,
+        Fields = new List<DocumentTypePackFieldDto>
+        {
+            new() { Name = "amount", DisplayName = "Amount", Prompt = "the total", DataType = FieldDataType.Number, DisplayOrder = 1 },
+            new() { Name = "issuer", DisplayName = "Issuer", DataType = FieldDataType.Text, DisplayOrder = 2 }
+        }
+    };
+
+    [Fact]
+    public async Task Import_Creates_Type_And_Fields_When_Absent_And_Stamps_Provenance()
+    {
+        var result = await _packAppService.ImportAsync(new ImportDocumentTypePacksInput
+        {
+            Packs = new List<DocumentTypePackDto> { SamplePack() }
+        });
+
+        result.TypesCreated.ShouldBe(1);
+        result.FieldsCreated.ShouldBe(2);
+        result.Items.Single().TypeAction.ShouldBe(PackItemAction.Created);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var type = await _documentTypeRepository.FindByTypeCodeAsync("host.invoice");
+            type.ShouldNotBeNull();
+            type!.DisplayName.ShouldBe("Invoice");
+            type.ConfidenceThreshold.ShouldBe(0.8);
+            type.Priority.ShouldBe(5);
+            // Provenance stamped in ExtraProperties (config metadata, not the Document truth source).
+            type.GetProperty<string>(DocumentTypePackConsts.ProvenanceSourceKey)
+                .ShouldBe(DocumentTypePackConsts.ProvenanceSourceValue);
+
+            var fields = await _fieldDefinitionRepository.GetListAsync(type.Id);
+            fields.Select(f => f.Name).OrderBy(n => n).ShouldBe(new[] { "amount", "issuer" });
+            fields.Single(f => f.Name == "amount").DataType.ShouldBe(FieldDataType.Number);
+        });
+    }
+
+    [Fact]
+    public async Task Export_Round_Trips_An_Imported_Pack()
+    {
+        await _packAppService.ImportAsync(new ImportDocumentTypePacksInput
+        {
+            Packs = new List<DocumentTypePackDto> { SamplePack() }
+        });
+
+        DocumentTypePackDto exported = null!;
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var type = await _documentTypeRepository.FindByTypeCodeAsync("host.invoice");
+            exported = await _packAppService.ExportAsync(type!.Id);
+        });
+
+        exported.Version.ShouldBe(DocumentTypePackConsts.CurrentVersion);
+        exported.TypeCode.ShouldBe("host.invoice");
+        exported.DisplayName.ShouldBe("Invoice");
+        exported.Description.ShouldBe("Invoice documents");
+        exported.ConfidenceThreshold.ShouldBe(0.8);
+        exported.Priority.ShouldBe(5);
+        exported.Fields.Count.ShouldBe(2);
+        // Export orders by DisplayOrder, so amount (1) precedes issuer (2).
+        exported.Fields[0].Name.ShouldBe("amount");
+        exported.Fields[0].Prompt.ShouldBe("the total");
+        exported.Fields[0].DataType.ShouldBe(FieldDataType.Number);
+        exported.Fields[1].Name.ShouldBe("issuer");
+    }
+
+    [Fact]
+    public async Task Reimport_Is_Idempotent_And_Produces_No_Duplicates()
+    {
+        var input = new ImportDocumentTypePacksInput { Packs = new List<DocumentTypePackDto> { SamplePack() } };
+
+        await _packAppService.ImportAsync(input);
+        var second = await _packAppService.ImportAsync(input);
+
+        // Second run updates in place — no new rows.
+        second.TypesCreated.ShouldBe(0);
+        second.TypesUpdated.ShouldBe(1);
+        second.FieldsCreated.ShouldBe(0);
+        second.FieldsUpdated.ShouldBe(2);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var type = await _documentTypeRepository.FindByTypeCodeAsync("host.invoice");
+            type.ShouldNotBeNull();
+            var fields = await _fieldDefinitionRepository.GetListAsync(type!.Id);
+            fields.Count.ShouldBe(2); // no duplicate field rows
+        });
+    }
+
+    [Fact]
+    public async Task CreateOnly_Skips_Existing_Type_But_Adds_Missing_Fields()
+    {
+        await _packAppService.ImportAsync(new ImportDocumentTypePacksInput
+        {
+            Packs = new List<DocumentTypePackDto> { SamplePack() }
+        });
+
+        // Same type code, changed displayName + changed existing-field prompt + one new field, in CreateOnly.
+        var additivePack = SamplePack();
+        additivePack.DisplayName = "CHANGED";
+        additivePack.Fields.Single(f => f.Name == "amount").Prompt = "CHANGED";
+        additivePack.Fields.Add(new DocumentTypePackFieldDto
+        {
+            Name = "duedate",
+            DisplayName = "Due date",
+            DataType = FieldDataType.Date,
+            DisplayOrder = 3
+        });
+
+        var result = await _packAppService.ImportAsync(new ImportDocumentTypePacksInput
+        {
+            Packs = new List<DocumentTypePackDto> { additivePack },
+            Mode = PackImportMode.CreateOnly
+        });
+
+        result.Items.Single().TypeAction.ShouldBe(PackItemAction.Skipped);
+        result.FieldsCreated.ShouldBe(1);
+        result.FieldsSkipped.ShouldBe(2);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var type = await _documentTypeRepository.FindByTypeCodeAsync("host.invoice");
+            type!.DisplayName.ShouldBe("Invoice"); // existing type left untouched
+
+            var fields = await _fieldDefinitionRepository.GetListAsync(type.Id);
+            fields.Count.ShouldBe(3); // the new field was added
+            fields.Single(f => f.Name == "amount").Prompt.ShouldBe("the total"); // existing field untouched
+        });
+    }
+
+    [Fact]
+    public async Task Unsupported_Version_Is_Rejected_Before_Any_Write()
+    {
+        var goodPack = SamplePack("host.alpha");
+        var badPack = SamplePack("host.beta");
+        badPack.Version = 999;
+
+        var ex = await Should.ThrowAsync<BusinessException>(() => _packAppService.ImportAsync(
+            new ImportDocumentTypePacksInput
+            {
+                Packs = new List<DocumentTypePackDto> { goodPack, badPack }
+            }));
+
+        ex.Code.ShouldBe(VaultExtractErrorCodes.DocumentTypePack.UnsupportedVersion);
+
+        // Version is validated for the whole batch before any write, so the valid pack ahead of the bad one
+        // is not partially applied.
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentTypeRepository.FindByTypeCodeAsync("host.alpha")).ShouldBeNull());
+    }
+}


### PR DESCRIPTION
## What
Business-neutral config "pack" engine: export a `DocumentType` + its `FieldDefinition`s to a portable declarative artifact and re-apply it idempotently (match type by `TypeCode`, field by `(type, Name)`; `CreateOrUpdate` vs `CreateOnly`; **never deletes**). All writes go through domain entities/managers (no raw DbContext); provenance stamped in `ExtraProperties` (config metadata, not on `Document`). No DB migration (the `ExtraProperties` column already exists).

## Review
Strict review: **GO** — no blockers/majors. Verified: idempotency, atomic version pre-validation (before any write), `GuardFieldMutationAsync` is a faithful mirror of `FieldDefinitionAppService` (no dataType change / multi→single narrowing once values exist), layer isolation via the ambient `IMultiTenant` filter.

Review fix included in this branch: `c89a9615` — import previously AND-stacked four `[Authorize]` (Create+Update × types/fields), so a `CreateOnly` / all-new import over-required `Update`. Now both `Create` gates stay as method attributes and the two `Update` checks are asserted lazily via `CheckPolicyAsync` only on the branches that actually update. **Application builds clean; pack integration tests 5/5 green.**

Closes #444