### PR TITLE
fix(angular): document-list field-value filter silently sends no filters (#415 follow-up)

### DIFF
--- a/angular/packages/vault-extract/documents/src/lib/documents/document-list/document-list.component.ts
+++ b/angular/packages/vault-extract/documents/src/lib/documents/document-list/document-list.component.ts
@@ -36,6 +36,7 @@ import {
   DocumentFieldFilter,
   DocumentLifecycleStatus,
   DocumentListItemDto,
+  DocumentListQueryService,
   DocumentReviewReasons,
   DocumentService,
   DocumentStatisticsService,
@@ -78,6 +79,10 @@ interface TableActivateEvent {
 })
 export class DocumentListComponent implements OnInit {
   private readonly documentService = inject(DocumentService);
+  // #415 fix: the list GET goes through the hand-written wrapper, which serializes the fieldFilters
+  // collection into the indexed query notation ASP.NET Core binds (the generated getList sends
+  // "[object Object]"). All other document operations still use the generated DocumentService.
+  private readonly documentListQueryService = inject(DocumentListQueryService);
   private readonly statisticsService = inject(DocumentStatisticsService);
   private readonly documentTypeService = inject(DocumentTypeService);
   private readonly fieldDefinitionService = inject(FieldDefinitionService);
@@ -341,7 +346,8 @@ export class DocumentListComponent implements OnInit {
 
     this.list
       .hookToQuery(query =>
-        this.documentService.getList({
+        // #415 fix: via the wrapper so fieldFilters serializes to bindable indexed query params.
+        this.documentListQueryService.getList({
           ...this.buildFilter(),
           maxResultCount: query.maxResultCount,
           skipCount: query.skipCount,

--- a/angular/packages/vault-extract/src/lib/services/document-list-query.params.spec.ts
+++ b/angular/packages/vault-extract/src/lib/services/document-list-query.params.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { GetDocumentListInput } from '../proxy/documents/models';
+import { toDocumentListParams } from './document-list-query.params';
+
+// #415 fix: the document list GET must serialize fieldFilters (an array of objects) into the indexed query
+// notation ASP.NET Core binds (fieldFilters[i].name / value / min / max). The generated proxy passed the raw
+// array, which HttpParams stringifies to "[object Object]", so the backend bound NO filters and the feature
+// silently did nothing. These lock the serialization; any regression reintroduces the silent no-op.
+
+describe('toDocumentListParams', () => {
+  it('expands an equality filter into indexed name + value keys, no bounds', () => {
+    const params = toDocumentListParams({
+      fieldFilters: [{ name: 'amount', value: '100' }],
+    } as GetDocumentListInput);
+
+    expect(params['fieldFilters[0].name']).toBe('amount');
+    expect(params['fieldFilters[0].value']).toBe('100');
+    expect(params['fieldFilters[0].min']).toBeUndefined();
+    expect(params['fieldFilters[0].max']).toBeUndefined();
+    // The raw array key that broke serialization must be gone.
+    expect(params['fieldFilters']).toBeUndefined();
+  });
+
+  it('expands a two-sided range filter into indexed min + max keys, no value', () => {
+    const params = toDocumentListParams({
+      fieldFilters: [{ name: 'signedOn', min: '2024-01-01', max: '2024-12-31' }],
+    } as GetDocumentListInput);
+
+    expect(params['fieldFilters[0].name']).toBe('signedOn');
+    expect(params['fieldFilters[0].min']).toBe('2024-01-01');
+    expect(params['fieldFilters[0].max']).toBe('2024-12-31');
+    expect(params['fieldFilters[0].value']).toBeUndefined();
+  });
+
+  it('emits only the present bound for a one-sided range', () => {
+    const params = toDocumentListParams({
+      fieldFilters: [{ name: 'amount', min: '50', max: null }],
+    } as GetDocumentListInput);
+
+    expect(params['fieldFilters[0].min']).toBe('50');
+    expect(params['fieldFilters[0].max']).toBeUndefined();
+  });
+
+  it('indexes multiple filters independently', () => {
+    const params = toDocumentListParams({
+      fieldFilters: [
+        { name: 'amount', value: '100' },
+        { name: 'party', value: 'Acme' },
+      ],
+    } as GetDocumentListInput);
+
+    expect(params['fieldFilters[0].name']).toBe('amount');
+    expect(params['fieldFilters[1].name']).toBe('party');
+    expect(params['fieldFilters[1].value']).toBe('Acme');
+  });
+
+  it('keeps a literal "0" value (a real value, not empty)', () => {
+    const params = toDocumentListParams({
+      fieldFilters: [{ name: 'balance', value: '0' }],
+    } as GetDocumentListInput);
+
+    expect(params['fieldFilters[0].value']).toBe('0');
+  });
+
+  it('passes scalar filters through and adds no fieldFilters keys when there are none', () => {
+    const params = toDocumentListParams({
+      documentTypeCode: 'contract.general',
+      skipCount: 20,
+      maxResultCount: 10,
+    } as GetDocumentListInput);
+
+    expect(params['documentTypeCode']).toBe('contract.general');
+    expect(params['skipCount']).toBe(20);
+    expect(params['maxResultCount']).toBe(10);
+    expect(Object.keys(params).some(k => k.startsWith('fieldFilters'))).toBe(false);
+  });
+});

--- a/angular/packages/vault-extract/src/lib/services/document-list-query.params.ts
+++ b/angular/packages/vault-extract/src/lib/services/document-list-query.params.ts
@@ -1,0 +1,38 @@
+import type { GetDocumentListInput } from '../proxy/documents/models';
+
+// Flattens a GetDocumentListInput into a query-param map for the document list GET.
+//
+// The bug this fixes (#415): the generated DocumentService.getList passes `fieldFilters` — a
+// DocumentFieldFilter[] (an array of OBJECTS) — straight into ABP's RestService params, which builds Angular
+// HttpParams via `fromObject`. HttpParams serializes each array element with String(obj) => "[object Object]",
+// so the GET sends `fieldFilters=%5Bobject%20Object%5D&...` and ASP.NET Core binds an EMPTY
+// List<DocumentFieldFilter> — the field-value filter silently does nothing. (The backend unit tests call the
+// app service directly, bypassing this HTTP serialization, so they never caught it.)
+//
+// The fix: expand `fieldFilters` into the indexed query notation ASP.NET Core's model binder reads —
+// `fieldFilters[0].name=amount&fieldFilters[0].value=100&fieldFilters[1].min=A&...`. Scalar fields pass
+// through unchanged (RestService then drops the undefined/empty/null ones as usual). Pure + exported so the
+// serialization — the whole point of the fix — is unit-testable without the Angular runtime.
+export function toDocumentListParams(input: GetDocumentListInput): Record<string, unknown> {
+  const { fieldFilters, ...scalars } = input;
+  const params: Record<string, unknown> = { ...scalars };
+
+  (fieldFilters ?? []).forEach((filter, index) => {
+    // Emit only the bounds actually present: a filter carries either `value` (equality) or one/both of
+    // `min`/`max` (range), never a stray empty bound. `name` keys the filter to its FieldDefinition server-side.
+    setIfPresent(params, `fieldFilters[${index}].name`, filter.name);
+    setIfPresent(params, `fieldFilters[${index}].value`, filter.value);
+    setIfPresent(params, `fieldFilters[${index}].min`, filter.min);
+    setIfPresent(params, `fieldFilters[${index}].max`, filter.max);
+  });
+
+  return params;
+}
+
+// Set a key only when the value is meaningful. A literal "0" / "false" is a real value and MUST be kept
+// (mirrors the composer's "0 is a real value" rule); only null / undefined / "" are dropped.
+function setIfPresent(params: Record<string, unknown>, key: string, value: string | null | undefined): void {
+  if (value !== null && value !== undefined && value !== '') {
+    params[key] = value;
+  }
+}

--- a/angular/packages/vault-extract/src/lib/services/document-list-query.service.ts
+++ b/angular/packages/vault-extract/src/lib/services/document-list-query.service.ts
@@ -1,0 +1,27 @@
+import { PagedResultDto, Rest, RestService } from '@abp/ng.core';
+import { Injectable, inject } from '@angular/core';
+import type { DocumentListItemDto, GetDocumentListInput } from '../proxy/documents/models';
+import { toDocumentListParams } from './document-list-query.params';
+
+// #415 fix: hand-written, regeneration-safe wrapper for the document list GET.
+//
+// The generated DocumentService.getList mis-serializes the `fieldFilters` collection query param (it reaches
+// the wire as "[object Object]", so the backend binds no filters — see document-list-query.params.ts). This
+// wrapper hits the same endpoint but flattens fieldFilters into the indexed notation ASP.NET Core binds. It
+// lives OUTSIDE proxy/ so `npm run generate-proxy` never overwrites it; the document list calls this instead
+// of the generated getList. Drop it once/if the generator learns to serialize a complex collection query param.
+@Injectable({ providedIn: 'root' })
+export class DocumentListQueryService {
+  private readonly restService = inject(RestService);
+  apiName = 'Default';
+
+  getList = (input: GetDocumentListInput, config?: Partial<Rest.Config>) =>
+    this.restService.request<unknown, PagedResultDto<DocumentListItemDto>>(
+      {
+        method: 'GET',
+        url: '/api/vault-extract/documents',
+        params: toDocumentListParams(input),
+      },
+      { apiName: this.apiName, ...config },
+    );
+}

--- a/angular/packages/vault-extract/src/public-api.ts
+++ b/angular/packages/vault-extract/src/public-api.ts
@@ -10,6 +10,7 @@ export * from './lib/shared';
 
 // Hand-written, proxy-external services (survive proxy regeneration).
 export * from './lib/services/document-upload.service';
+export * from './lib/services/document-list-query.service';
 // #447: named export (not `export *`) so the DTO interface names don't collide with the generated
 // proxy models when the AI-polish endpoint is picked up by a future `npm run generate-proxy`.
 export { FieldPromptPolishService } from './lib/services/field-prompt-polish.service';


### PR DESCRIPTION
## The bug (on `main`, shipped via #459 / #415)

The document-list extracted-field-value filter is **silently a no-op at runtime**. The generated `DocumentService.getList` puts `fieldFilters` — a `DocumentFieldFilter[]` (array of objects) — straight into ABP `RestService` params, which builds Angular `HttpParams` via `fromObject`. `HttpParams` serializes each array element with `String(obj)` → `"[object Object]"`, so the GET sends:

```
fieldFilters=%5Bobject%20Object%5D&fieldFilters=%5Bobject%20Object%5D
```

ASP.NET Core then binds an **empty** `List<DocumentFieldFilter>` — the operator's field filters never reach the query.

### Why nothing caught it
- Backend unit tests (`DocumentAppService_FieldFilter_Tests`) call the app service **directly**, bypassing HTTP query serialization — they prove the *logic*, not the *wire*.
- CI only **compiles** the TS (types are fine).
- The #459 review was code-level ("GO"), not a browser end-to-end.

This was flagged as "the one runtime-only unknown" in the #415 notes; this PR resolves it — confirmed broken by inspecting the exact serialization path (`RestService.getParams` → `new HttpParams({ fromObject })`).

## The fix (frontend only, no contract change)
A hand-written, regeneration-safe wrapper `DocumentListQueryService` (outside `proxy/`, same pattern as `document-upload.service`) that hits the same GET but expands `fieldFilters` into the indexed notation the ASP.NET Core model binder reads:

```
fieldFilters[0].name=amount&fieldFilters[0].value=100&fieldFilters[1].min=A&fieldFilters[1].max=Z
```

- The serialization is a **pure exported function** `toDocumentListParams` with unit tests that lock it and go **red against the raw-array form**. Scalars pass through unchanged; a literal `"0"` is kept; only present range bounds are emitted.
- The document list calls the wrapper for its list GET; **all other document operations still use the generated `DocumentService`**.
- Not affected: `#414`'s Data Download export sends `fieldFilters` in a **POST body** (JSON), which serializes correctly — only the list **GET** was broken.

## Verification
- `vitest` 34/34, `nx build vault-extract` + `nx lint vault-extract` green.
- ⚠️ **Still needs a browser end-to-end check** against seeded typed documents — the wire binding can only be exercised with the live stack (SQL + host + SPA). Please verify the filter actually narrows results before relying on it.

Follow-up to #415 (that issue is already closed/merged).