### PR TITLE
feat(mcp): API-key channel hardening — integration test, rate limit, least-privilege seed, hash-at-rest (#432 #433 #434 #435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **MCP API-key channel hardening** (follow-ups to #428 / #430): the `/mcp` endpoint is now **rate-limited** per client IP — covering both the API-key channel and the OAuth discovery `401` path — and a present-but-invalid key raises a rate-limited security `Warning` (source IP + header name, never the value) (#433). API keys can be configured as a **SHA-256 `KeyHash`** (hash-at-rest) instead of plaintext, so a config/secret-store leak no longer exposes usable keys (#435). An opt-in host seed (`Mcp:ApiKey:SeedServiceAccounts`) **enforces least privilege** on each configured service account — applying exactly the `VaultExtract.Documents` grant and failing startup if the account is missing, over-privileged, or holds any role (#434).
+
+### Added
+
+- A full ABP integration test for the MCP API-key channel: a key-authenticated service-account principal resolves permissions through the real ABP permission checker (granted → search returns rows; ungranted → fail-closed `AbpAuthorizationException`) (#432).
+
 ## [0.2.0] - 2026-07-01
 
 First stable release of the 0.2.0 line. Headlined by the rebrand to **Dignite Vault Extract**, the container / sub-document model, and a major expansion of structure-aware text extraction (PDF / DOCX / PPTX). The granular per-preview history is retained in the `0.2.0-preview.*` sections below.

--- a/Dignite.Vault.Extract.slnx
+++ b/Dignite.Vault.Extract.slnx
@@ -27,6 +27,7 @@
         <Project Path="core/test/Dignite.Vault.Extract.Domain.Tests/Dignite.Vault.Extract.Domain.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/Dignite.Vault.Extract.EntityFrameworkCore.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Application.Tests/Dignite.Vault.Extract.Application.Tests.csproj" />
+        <Project Path="core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Mcp.Tests/Dignite.Vault.Extract.Mcp.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Ocr.VisionLlm.Tests/Dignite.Vault.Extract.Ocr.VisionLlm.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Ocr.PaddleOcr.Tests/Dignite.Vault.Extract.Ocr.PaddleOcr.Tests.csproj" />

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyAuthenticationMiddleware.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyAuthenticationMiddleware.cs
@@ -1,13 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Claims;
 using System.Security.Cryptography;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Volo.Abp.Security.Claims;
 
 namespace Dignite.Vault.Extract.Mcp.Authentication;
 
@@ -46,7 +45,12 @@ public sealed class McpApiKeyAuthenticationMiddleware
     private readonly ILogger<McpApiKeyAuthenticationMiddleware> _logger;
     private readonly string _headerName;
     private readonly bool _requireHttps;
+    private readonly long _invalidKeyWarningWindowMs;
     private readonly IReadOnlyList<CompiledKey> _keys;
+
+    // Monotonic (boot-relative, not wall-clock) throttle gate for the invalid-key Warning (#433). One shared
+    // instance backs all requests (convention middleware is instantiated once), so this is a global gate.
+    private long _lastInvalidKeyWarningTicks;
 
     public McpApiKeyAuthenticationMiddleware(
         RequestDelegate next,
@@ -59,11 +63,16 @@ public sealed class McpApiKeyAuthenticationMiddleware
         var value = options.Value;
         _headerName = value.HeaderName;
         _requireHttps = value.RequireHttps;
+        _invalidKeyWarningWindowMs = Math.Max(0, value.InvalidKeyWarningWindowSeconds) * 1000L;
+        // Seed the gate so the first present-but-invalid key logs a Warning immediately.
+        _lastInvalidKeyWarningTicks = Environment.TickCount64 - _invalidKeyWarningWindowMs - 1;
 
-        // Precompute SHA-256 digests once. Comparing fixed-length digests (not the raw keys) removes the
-        // length side-channel and lets FixedTimeEquals run over a constant-size buffer.
+        // Precompute the 32-byte SHA-256 digest of every configured key once — from the plaintext Key or the
+        // pre-computed KeyHash (#435), whichever was configured. Comparing fixed-length digests (not the raw
+        // keys) removes the length side-channel and lets FixedTimeEquals run over a constant-size buffer.
+        // Options.Validate() already fail-fast-checked the hash shape at startup, so EffectiveDigest won't throw.
         _keys = value.Keys
-            .Select(k => new CompiledKey(SHA256.HashData(Encoding.UTF8.GetBytes(k.Key)), k))
+            .Select(k => new CompiledKey(McpApiKeyHasher.EffectiveDigest(k), k))
             .ToList();
     }
 
@@ -82,19 +91,14 @@ public sealed class McpApiKeyAuthenticationMiddleware
                 var matched = Match(presented);
                 if (matched != null)
                 {
-                    context.User = BuildPrincipal(matched);
+                    context.User = McpApiKeyPrincipalFactory.Create(matched);
                     _logger.LogDebug(
                         "MCP request authenticated via API key (label: {Label}).",
                         string.IsNullOrWhiteSpace(matched.Label) ? "<unlabeled>" : matched.Label);
                 }
                 else
                 {
-                    // Present-but-invalid key. Logged at Debug (not Warning) so an unauthenticated caller
-                    // cannot flood Warning-level logs / alerts; a rate-limited security event is the proper
-                    // signal (deferred, see #428). Never log the value.
-                    _logger.LogDebug(
-                        "An invalid MCP API key was presented in header '{Header}'; falling through to Bearer authentication.",
-                        _headerName);
+                    LogInvalidKey(context);
                 }
             }
         }
@@ -119,7 +123,7 @@ public sealed class McpApiKeyAuthenticationMiddleware
 
     private McpApiKeyEntry? Match(string presented)
     {
-        var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
+        var presentedHash = McpApiKeyHasher.ComputeDigest(presented);
 
         // Compare against every configured key with no early-exit, so neither the match position nor the
         // key count is timing-observable; SHA-256 digests are a fixed 32 bytes for FixedTimeEquals.
@@ -135,23 +139,40 @@ public sealed class McpApiKeyAuthenticationMiddleware
         return matched;
     }
 
-    private static ClaimsPrincipal BuildPrincipal(McpApiKeyEntry entry)
+    // Present-but-invalid key: an attack signal (unlike a simply-absent key). Emit a Warning with the source IP
+    // + header name (NEVER the value) so it surfaces at default log levels, throttled by ShouldWarnInvalidKey so
+    // an unauthenticated caller cannot flood Warning-level logs/alerts; between windows it stays Debug. The /mcp
+    // rate limiter (#433) caps how many such requests can reach here at all.
+    private void LogInvalidKey(HttpContext context)
     {
-        var claims = new List<Claim>
+        if (ShouldWarnInvalidKey())
         {
-            new(AbpClaimTypes.UserId, entry.ServiceAccountUserId)
-        };
+            _logger.LogWarning(
+                "An invalid MCP API key was presented in header '{Header}' from {RemoteIp}; falling through to Bearer authentication.",
+                _headerName,
+                context.Connection.RemoteIpAddress?.ToString() ?? "unknown");
+        }
+        else
+        {
+            _logger.LogDebug(
+                "An invalid MCP API key was presented in header '{Header}'; falling through to Bearer authentication.",
+                _headerName);
+        }
+    }
 
-        if (!string.IsNullOrWhiteSpace(entry.TenantId))
+    // True at most once per configured window: the window elapsed AND this thread won the compare-exchange.
+    // Concurrent losers fall back to Debug. Environment.TickCount64 is monotonic (not wall-clock), so it is
+    // unaffected by clock changes and needs no IClock.
+    private bool ShouldWarnInvalidKey()
+    {
+        var now = Environment.TickCount64;
+        var last = Interlocked.Read(ref _lastInvalidKeyWarningTicks);
+        if (now - last < _invalidKeyWarningWindowMs)
         {
-            claims.Add(new Claim(AbpClaimTypes.TenantId, entry.TenantId));
+            return false;
         }
 
-        // Non-empty authenticationType => IsAuthenticated == true (load-bearing; see class remarks). The
-        // key's Label is used only for log attribution, NOT stamped as AbpClaimTypes.UserName: faking a
-        // user name would mislead audit correlation against the real Identity service-account user.
-        var identity = new ClaimsIdentity(claims, McpApiKeyDefaults.AuthenticationType);
-        return new ClaimsPrincipal(identity);
+        return Interlocked.CompareExchange(ref _lastInvalidKeyWarningTicks, now, last) == last;
     }
 
     private sealed record CompiledKey(byte[] Hash, McpApiKeyEntry Entry);

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyEntry.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyEntry.cs
@@ -10,10 +10,22 @@ namespace Dignite.Vault.Extract.Mcp.Authentication;
 public class McpApiKeyEntry
 {
     /// <summary>
-    /// The shared secret. Supplied via environment variables / user-secrets, <b>never committed</b>;
-    /// at least <see cref="McpApiKeyDefaults.MinKeyLength"/> characters, CSPRNG-generated.
+    /// The shared secret in plaintext. Supplied via environment variables / user-secrets, <b>never committed</b>;
+    /// at least <see cref="McpApiKeyDefaults.MinKeyLength"/> characters, CSPRNG-generated. Configure <b>either</b>
+    /// this <b>or</b> <see cref="KeyHash"/> for a given entry, not both — the runtime compares SHA-256 digests, so
+    /// the two forms are interchangeable and setting both is ambiguous (rejected fail-fast).
     /// </summary>
     public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Hash-at-rest alternative to <see cref="Key"/> (#435): the lowercase hex SHA-256 digest
+    /// (<see cref="McpApiKeyHasher.Sha256HexLength"/> hex chars) of the shared secret. Prefer this so a leak of
+    /// host config / the secret store does not hand over usable keys — the digest is not reversible to the key.
+    /// Compute it with <see cref="McpApiKeyHasher.ComputeSha256Hex"/> or the documented shell one-liner. The
+    /// runtime compares <c>SHA256(presented)</c> against this digest via <c>FixedTimeEquals</c>, identical to the
+    /// plaintext path. Mutually exclusive with <see cref="Key"/>.
+    /// </summary>
+    public string? KeyHash { get; set; }
 
     /// <summary>
     /// The <c>Guid</c> of a real, provisioned ABP <c>IdentityUser</c> this key authenticates as; stamped as

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyHasher.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyHasher.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// SHA-256 helpers shared by the API-key channel (#435). The runtime compares fixed-length SHA-256 digests
+/// (not raw keys) so a key may be configured either as plaintext (<see cref="McpApiKeyEntry.Key"/>) or as its
+/// pre-computed digest (<see cref="McpApiKeyEntry.KeyHash"/>, hash-at-rest). Both collapse to the same 32-byte
+/// digest here, so the match loop is identical regardless of how the key was configured.
+/// </summary>
+public static class McpApiKeyHasher
+{
+    /// <summary>Length in characters of a hex-encoded SHA-256 digest (32 bytes * 2).</summary>
+    public const int Sha256HexLength = 64;
+
+    /// <summary>SHA-256 of the UTF-8 bytes of <paramref name="value"/> as a 32-byte digest.</summary>
+    public static byte[] ComputeDigest(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return SHA256.HashData(Encoding.UTF8.GetBytes(value));
+    }
+
+    /// <summary>
+    /// Lowercase hex SHA-256 of <paramref name="value"/> — the exact form an operator configures as
+    /// <see cref="McpApiKeyEntry.KeyHash"/>. Equivalent to <c>printf '%s' "&lt;key&gt;" | sha256sum</c> (bash) or
+    /// <c>[BitConverter]::ToString([Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($k)))</c>
+    /// (PowerShell, minus the dashes, lowercased).
+    /// </summary>
+    public static string ComputeSha256Hex(string value)
+    {
+        return Convert.ToHexStringLower(ComputeDigest(value));
+    }
+
+    /// <summary>
+    /// Decode a 64-char hex SHA-256 digest to its 32 raw bytes. Callers must validate the length/charset first
+    /// (<see cref="McpApiKeyOptions.Validate"/> does, fail-fast at startup); <see cref="Convert.FromHexString(string)"/>
+    /// throws on a malformed value.
+    /// </summary>
+    public static byte[] DecodeHexDigest(string hex)
+    {
+        ArgumentNullException.ThrowIfNull(hex);
+        return Convert.FromHexString(hex);
+    }
+
+    /// <summary>
+    /// The effective lowercase-hex digest of an entry, whichever form it was configured in. Used for
+    /// duplicate detection so a plaintext key and the hash of the same key collide.
+    /// </summary>
+    public static string EffectiveDigestHex(McpApiKeyEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return string.IsNullOrWhiteSpace(entry.KeyHash)
+            ? ComputeSha256Hex(entry.Key)
+            : entry.KeyHash.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The effective 32-byte digest of an entry — from the pre-computed hash when present, else hashed from the
+    /// plaintext key. Feeds the constant-time compare loop.
+    /// </summary>
+    public static byte[] EffectiveDigest(McpApiKeyEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return string.IsNullOrWhiteSpace(entry.KeyHash)
+            ? ComputeDigest(entry.Key)
+            : DecodeHexDigest(entry.KeyHash);
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyOptions.cs
@@ -31,6 +31,24 @@ public class McpApiKeyOptions
     /// </summary>
     public bool RequireHttps { get; set; } = true;
 
+    /// <summary>
+    /// Minimum seconds between <c>Warning</c>-level "present-but-invalid key" security events (#433). A
+    /// present-but-invalid key is an attack signal (unlike a simply-absent one), so it is logged at Warning with
+    /// the source IP + header name (never the value); this gate throttles it so an unauthenticated caller cannot
+    /// flood Warning-level logs/alerts, dropping to Debug between windows. The <c>/mcp</c> rate limiter caps the
+    /// request volume that can reach the middleware in the first place. Default 60s; <c>0</c> = warn every time.
+    /// </summary>
+    public int InvalidKeyWarningWindowSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// When <c>true</c> (default <c>false</c>), the host's optional service-account seed (#434) enforces
+    /// least-privilege on every configured key's <see cref="McpApiKeyEntry.ServiceAccountUserId"/>: it applies the
+    /// minimal <c>VaultExtract.Documents</c> grant and fails startup if the account is missing, holds any other
+    /// VaultExtract permission, or has any role. Opt-in so OAuth-only deployments and hosts that manage the
+    /// accounts by hand are untouched. Seeding never creates users.
+    /// </summary>
+    public bool SeedServiceAccounts { get; set; } = false;
+
     /// <summary>Configured keys. Empty = feature disabled.</summary>
     public List<McpApiKeyEntry> Keys { get; set; } = new();
 
@@ -65,15 +83,7 @@ public class McpApiKeyOptions
             var entry = Keys[i];
             var where = $"Mcp:ApiKey:Keys[{i}]";
 
-            if (string.IsNullOrWhiteSpace(entry.Key)
-                || entry.Key == McpApiKeyDefaults.PlaceholderKey
-                || entry.Key.Length < McpApiKeyDefaults.MinKeyLength)
-            {
-                throw new AbpException(
-                    $"{where}.Key is missing, the placeholder, or shorter than {McpApiKeyDefaults.MinKeyLength} characters. " +
-                    "Supply a CSPRNG-generated secret (>= 32 chars) via environment variables or user-secrets — never commit it. " +
-                    "Leave Mcp:ApiKey:Keys empty to disable the API-key channel (OAuth-only).");
-            }
+            ValidateSecret(entry, where);
 
             if (!Guid.TryParse(entry.ServiceAccountUserId, out var userId) || userId == Guid.Empty)
             {
@@ -88,12 +98,72 @@ public class McpApiKeyOptions
             }
         }
 
-        var duplicate = Keys.GroupBy(k => k.Key).FirstOrDefault(g => g.Count() > 1);
+        // Dedup on the effective digest (#435), not the raw Key, so a plaintext key and the pre-computed hash of
+        // the same key are recognised as the same credential; each key must stay distinct so audit attribution
+        // and independent revocation remain meaningful.
+        var duplicate = Keys.GroupBy(McpApiKeyHasher.EffectiveDigestHex).FirstOrDefault(g => g.Count() > 1);
         if (duplicate != null)
         {
             throw new AbpException(
-                "Mcp:ApiKey:Keys contains duplicate Key values; each key must be distinct so audit " +
-                "attribution and independent revocation stay meaningful.");
+                "Mcp:ApiKey:Keys contains duplicate keys (same secret configured twice, possibly one as Key and " +
+                "one as KeyHash); each key must be distinct so audit attribution and independent revocation stay meaningful.");
         }
+    }
+
+    // A key is configured EITHER as plaintext Key OR as its SHA-256 KeyHash (#435), never both and never neither.
+    // Plaintext mirrors ConfigureAI's placeholder/length fail-fast; the hash form only needs to be a well-formed
+    // 64-char hex digest (its entropy was fixed when it was generated from the >=32-char key).
+    private static void ValidateSecret(McpApiKeyEntry entry, string where)
+    {
+        var hasKey = !string.IsNullOrWhiteSpace(entry.Key);
+        var hasHash = !string.IsNullOrWhiteSpace(entry.KeyHash);
+
+        if (hasKey && hasHash)
+        {
+            throw new AbpException(
+                $"{where} sets both Key and KeyHash; configure exactly one (they are interchangeable — the runtime " +
+                "compares SHA-256 digests). Prefer KeyHash so a config/secret-store leak does not expose usable keys.");
+        }
+
+        if (!hasKey && !hasHash)
+        {
+            throw new AbpException(
+                $"{where} has neither Key nor KeyHash. Supply a CSPRNG-generated secret (>= {McpApiKeyDefaults.MinKeyLength} chars) " +
+                "as Key, or its lowercase hex SHA-256 as KeyHash, via environment variables or user-secrets — never commit it. " +
+                "Leave Mcp:ApiKey:Keys empty to disable the API-key channel (OAuth-only).");
+        }
+
+        if (hasKey)
+        {
+            if (entry.Key == McpApiKeyDefaults.PlaceholderKey
+                || entry.Key.Length < McpApiKeyDefaults.MinKeyLength)
+            {
+                throw new AbpException(
+                    $"{where}.Key is the placeholder or shorter than {McpApiKeyDefaults.MinKeyLength} characters. " +
+                    "Supply a CSPRNG-generated secret (>= 32 chars) via environment variables or user-secrets — never commit it.");
+            }
+
+            return;
+        }
+
+        if (entry.KeyHash!.Length != McpApiKeyHasher.Sha256HexLength || !IsHex(entry.KeyHash))
+        {
+            throw new AbpException(
+                $"{where}.KeyHash must be a {McpApiKeyHasher.Sha256HexLength}-character hex SHA-256 digest of the key " +
+                "(compute it with the documented one-liner). Leave it empty and set Key to configure the plaintext key instead.");
+        }
+    }
+
+    private static bool IsHex(string value)
+    {
+        foreach (var c in value)
+        {
+            if (!Uri.IsHexDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyPrincipalFactory.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpApiKeyPrincipalFactory.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using Volo.Abp.Security.Claims;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Builds the synthetic authenticated principal a matched API key authenticates as (#428). Kept as a single
+/// shared factory so the request middleware and the integration test (#432) construct byte-identical principals —
+/// the test's fidelity depends on exercising the <b>same</b> claim shape the runtime produces, not a hand-rolled
+/// copy that could drift. A future <c>AuthenticationHandler</c>/scheme upgrade (#431) would reuse this too.
+/// </summary>
+public static class McpApiKeyPrincipalFactory
+{
+    /// <summary>
+    /// The principal carries only <c>AbpClaimTypes.UserId</c> (+ tenant when configured) and a non-empty
+    /// authentication type. Permissions are NOT stamped as claims — ABP resolves them from the permission store
+    /// by user id at the tools' <c>CheckPolicyAsync</c>. The non-empty <see cref="McpApiKeyDefaults.AuthenticationType"/>
+    /// makes the identity <c>IsAuthenticated == true</c>, which is load-bearing: otherwise <c>RequireAuthorization</c>
+    /// 401s and ABP's <c>!IsAuthenticated</c> guard would re-run OpenIddict over it. The key's <c>Label</c> is used
+    /// only for log attribution, never stamped as <c>AbpClaimTypes.UserName</c> (that would mislead audit
+    /// correlation against the real Identity service-account user).
+    /// </summary>
+    public static ClaimsPrincipal Create(McpApiKeyEntry entry)
+    {
+        var claims = new List<Claim>
+        {
+            new(AbpClaimTypes.UserId, entry.ServiceAccountUserId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(entry.TenantId))
+        {
+            claims.Add(new Claim(AbpClaimTypes.TenantId, entry.TenantId));
+        }
+
+        var identity = new ClaimsIdentity(claims, McpApiKeyDefaults.AuthenticationType);
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpRateLimiterDefaults.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpRateLimiterDefaults.cs
@@ -1,0 +1,22 @@
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Constants for the <c>/mcp</c> rate limiter (#433). The limiter is a brute-force / log-flood / DoS backstop on
+/// the egress endpoint — it caps request volume per client so an unauthenticated caller cannot probe API keys
+/// indefinitely or drown the discovery <c>401</c> path, while staying generous enough not to disturb legitimate
+/// MCP session traffic (configurable per deployment).
+/// </summary>
+public static class McpRateLimiterDefaults
+{
+    /// <summary>
+    /// Name of the rate-limiting policy applied to the <c>/mcp</c> endpoint via <c>RequireRateLimiting</c>.
+    /// A stable identifier — the host references it when mapping the endpoint.
+    /// </summary>
+    public const string PolicyName = "VaultExtractMcp";
+
+    /// <summary>Default requests permitted per window, per client partition. Generous; a DoS/brute-force cap, not a quota.</summary>
+    public const int DefaultPermitLimit = 300;
+
+    /// <summary>Default fixed-window length in seconds.</summary>
+    public const int DefaultWindowSeconds = 60;
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpRateLimiterOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpRateLimiterOptions.cs
@@ -1,0 +1,53 @@
+using Volo.Abp;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Options for the <c>/mcp</c> rate limiter (#433). Bound from <c>Mcp:RateLimit</c> in the host. Enabled by
+/// default with generous limits so it is a security backstop rather than a throughput quota; a deployment with
+/// unusual traffic can widen the window / limit or disable it entirely.
+/// </summary>
+public class McpRateLimiterOptions
+{
+    /// <summary>
+    /// When <c>false</c>, the policy is still registered (so the endpoint's <c>RequireRateLimiting</c> resolves)
+    /// but applies no limit. Default <c>true</c>.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Requests permitted per <see cref="WindowSeconds"/> window, per client partition (source IP).</summary>
+    public int PermitLimit { get; set; } = McpRateLimiterDefaults.DefaultPermitLimit;
+
+    /// <summary>Fixed-window length in seconds.</summary>
+    public int WindowSeconds { get; set; } = McpRateLimiterDefaults.DefaultWindowSeconds;
+
+    /// <summary>
+    /// Requests queued when the window is exhausted (they wait for the next window rather than being rejected).
+    /// Default <c>0</c> — reject immediately with <c>429</c>, the right shape for a brute-force backstop.
+    /// </summary>
+    public int QueueLimit { get; set; } = 0;
+
+    /// <summary>Fail-fast shape validation at startup, mirroring the API-key options. A no-op when disabled.</summary>
+    public void Validate()
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        if (PermitLimit <= 0)
+        {
+            throw new AbpException("Mcp:RateLimit:PermitLimit must be greater than 0 (or set Mcp:RateLimit:Enabled=false to disable).");
+        }
+
+        if (WindowSeconds <= 0)
+        {
+            throw new AbpException("Mcp:RateLimit:WindowSeconds must be greater than 0.");
+        }
+
+        if (QueueLimit < 0)
+        {
+            throw new AbpException("Mcp:RateLimit:QueueLimit must be greater than or equal to 0.");
+        }
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpRateLimiterServiceCollectionExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpRateLimiterServiceCollectionExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Reusable registration for the <c>/mcp</c> rate limiter (#433), exported by the Mcp egress module so any host
+/// enables it with one <c>Add</c> call + <c>app.UseRateLimiter()</c> + <c>RequireRateLimiting</c> on the endpoint.
+/// Mirrors the #428 <c>AddVaultExtractMcpApiKey</c> split: the deployment-agnostic MECHANISM (the policy, the
+/// per-IP partition, the <c>429</c> rejection) lives here; the HOST owns the config and the pipeline wiring.
+/// The policy is <b>always</b> registered under <see cref="McpRateLimiterDefaults.PolicyName"/> so the endpoint's
+/// <c>RequireRateLimiting</c> resolves even when the limiter is disabled (it then applies no limit).
+/// </summary>
+public static class McpRateLimiterServiceCollectionExtensions
+{
+    public static IServiceCollection AddVaultExtractMcpRateLimiter(
+        this IServiceCollection services,
+        Action<McpRateLimiterOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var options = new McpRateLimiterOptions();
+        configure(options);
+        options.Validate();
+
+        services.AddRateLimiter(limiter =>
+        {
+            // 429 (not the framework-default 503): "too many requests" is the honest signal to a probing client
+            // and does not read as a server fault. It never fires for legitimate, in-limit traffic.
+            limiter.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            limiter.AddPolicy(McpRateLimiterDefaults.PolicyName, httpContext =>
+            {
+                if (!options.Enabled)
+                {
+                    // Policy present but inert: the endpoint stays mapped with RequireRateLimiting, no throttling.
+                    return RateLimitPartition.GetNoLimiter(McpRateLimiterDefaults.PolicyName);
+                }
+
+                // Partition per source IP so one abusive client cannot exhaust another's budget, and so a flood
+                // from a single origin is contained. Unknown IPs share one partition. Behind a reverse proxy this
+                // is only as accurate as the host's forwarded-headers handling (document proxy setup).
+                var partitionKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+                return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ =>
+                    new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = options.PermitLimit,
+                        Window = TimeSpan.FromSeconds(options.WindowSeconds),
+                        QueueLimit = options.QueueLimit,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                    });
+            });
+        });
+
+        return services;
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpServiceAccountLeastPrivilege.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpServiceAccountLeastPrivilege.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using Dignite.Vault.Extract.Permissions;
+using Volo.Abp;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// The least-privilege contract for an API-key service account (#434), as a pure guard so it is unit-testable
+/// without an ABP/Identity host. An API-key caller authenticates as a real ABP user and its authority is whatever
+/// that user is granted, so the account MUST be pinned to exactly the read surface every MCP path needs and
+/// nothing more: it must exist, hold <see cref="VaultExtractPermissions.Documents.Default"/> at the user level,
+/// hold <b>no other</b> VaultExtract permission, and have <b>no roles</b> (a shared role could later widen it
+/// silently, letting the key exceed an OAuth user). The host seed gathers the account's real state from ABP and
+/// calls <see cref="Guard"/>; a violation fails startup fail-closed rather than silently over-permitting.
+/// </summary>
+public static class McpServiceAccountLeastPrivilege
+{
+    /// <summary>The one permission an API-key service account may hold — the minimal grant covering every MCP path.</summary>
+    public const string AllowedPermission = VaultExtractPermissions.Documents.Default;
+
+    /// <summary>
+    /// Throws <see cref="AbpException"/> unless the account is exactly least-privilege. Inputs are the account's
+    /// real state as read from ABP: whether the user exists, the VaultExtract permission names granted to it at
+    /// the user level, and its role names.
+    /// </summary>
+    public static void Guard(
+        string serviceAccountUserId,
+        string? label,
+        bool userExists,
+        IReadOnlyCollection<string> grantedVaultExtractPermissions,
+        IReadOnlyCollection<string> roleNames)
+    {
+        var who = Describe(serviceAccountUserId, label);
+
+        if (!userExists)
+        {
+            throw new AbpException(
+                $"MCP API-key service account {who} does not exist. Least-privilege seeding does not create users: " +
+                "create the service-account user first (e.g. the admin UI), copy its Guid into Mcp:ApiKey:Keys, then re-run seeding.");
+        }
+
+        if (roleNames.Count > 0)
+        {
+            throw new AbpException(
+                $"MCP API-key service account {who} holds role(s) [{string.Join(", ", roleNames.OrderBy(r => r))}]. " +
+                "An API-key service account MUST have NO roles — a shared role could later widen its permissions beyond an " +
+                "OAuth user. Remove the role assignment(s), granting only " + AllowedPermission + " directly at the user level.");
+        }
+
+        var extras = grantedVaultExtractPermissions.Where(p => p != AllowedPermission).OrderBy(p => p).ToList();
+        if (extras.Count > 0)
+        {
+            throw new AbpException(
+                $"MCP API-key service account {who} holds VaultExtract permission(s) beyond the read allowlist: " +
+                $"[{string.Join(", ", extras)}]. It may hold ONLY {AllowedPermission}. Revoke the extra permission(s) so an " +
+                "API-key caller can never exceed an OAuth user.");
+        }
+
+        if (!grantedVaultExtractPermissions.Contains(AllowedPermission))
+        {
+            throw new AbpException(
+                $"MCP API-key service account {who} is missing the required {AllowedPermission} grant (the minimal permission " +
+                "covering every MCP path). Grant it directly at the user level, with no roles.");
+        }
+    }
+
+    private static string Describe(string serviceAccountUserId, string? label)
+    {
+        return string.IsNullOrWhiteSpace(label)
+            ? $"'{serviceAccountUserId}'"
+            : $"'{serviceAccountUserId}' (label '{label}')";
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Dignite.Vault.Extract</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- DocumentSearchTool + the synthetic principal compile through Microsoft.AspNetCore.Authorization. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.extensibility.execution" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Volo.Abp.Autofac" />
+    <PackageReference Include="Volo.Abp.Authorization" />
+    <PackageReference Include="Volo.Abp.TestBase" />
+    <!-- The point of this project: a REAL permission checker + store (no AddAlwaysAllowAuthorization), so the
+         key-authenticated service-account principal resolves grants through ABP's genuine permission pipeline (#432). -->
+    <PackageReference Include="Volo.Abp.PermissionManagement.EntityFrameworkCore" />
+    <PackageReference Include="Volo.Abp.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dignite.Vault.Extract.Mcp\Dignite.Vault.Extract.Mcp.csproj" />
+    <ProjectReference Include="..\..\src\Dignite.Vault.Extract.Application\Dignite.Vault.Extract.Application.csproj" />
+    <ProjectReference Include="..\..\src\Dignite.Vault.Extract.EntityFrameworkCore\Dignite.Vault.Extract.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Documents/McpApiKeyPermissionResolution_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Documents/McpApiKeyPermissionResolution_Tests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Mcp.Authentication;
+using Dignite.Vault.Extract.Mcp.Documents;
+using Dignite.Vault.Extract.Permissions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Volo.Abp.Authorization;
+using Volo.Abp.Guids;
+using Volo.Abp.PermissionManagement;
+using Volo.Abp.Security.Claims;
+using Volo.Abp.Users;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Mcp.Documents;
+
+/// <summary>
+/// #432: the single riskiest claim of the API-key channel, verified end-to-end against a REAL ABP permission
+/// pipeline (no <c>AddAlwaysAllowAuthorization</c>; real <c>PermissionChecker</c> + EF <c>PermissionStore</c>).
+///
+/// The #430 TestServer tests proved the middleware builds the right principal and the HTTP fall-through shape, but
+/// used a stub auth scheme — they could not prove that a hand-crafted service-account principal (carrying ONLY
+/// <c>AbpClaimTypes.UserId</c> + the <c>McpApiKey</c> authentication type, and <b>no</b> permission claims) actually
+/// resolves grants through ABP's permission checker. These tests drive the real <c>search_documents</c> tool as
+/// that exact principal (built by the shared <see cref="McpApiKeyPrincipalFactory"/>, so the test cannot drift from
+/// the runtime) and assert:
+///   (a) granted the minimal <c>Documents.Default</c> -> <c>CheckPolicyAsync</c> passes and a search returns rows;
+///   (b) NOT granted -> fail-closed <see cref="AbpAuthorizationException"/> (the LLM path is not a privilege-escalation channel);
+///   (c) <c>CurrentUser.Id</c> == the mapped service account.
+/// </summary>
+public class McpApiKeyPermissionResolution_Tests : McpApiKeyIntegrationTestBase<McpApiKeyIntegrationTestModule>
+{
+    private const string TypeCode = "contract.integration";
+
+    // The service account the key maps to (granted) and a second, ungranted account for the fail-closed case.
+    private static readonly Guid GrantedServiceAccountId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid UngrantedServiceAccountId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private readonly IDocumentAppService _documentAppService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IPermissionGrantRepository _permissionGrantRepository;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly ICurrentPrincipalAccessor _principalAccessor;
+    private readonly ICurrentUser _currentUser;
+
+    public McpApiKeyPermissionResolution_Tests()
+    {
+        _documentAppService = GetRequiredService<IDocumentAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _permissionGrantRepository = GetRequiredService<IPermissionGrantRepository>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _principalAccessor = GetRequiredService<ICurrentPrincipalAccessor>();
+        _currentUser = GetRequiredService<ICurrentUser>();
+    }
+
+    [Fact]
+    public async Task Granted_key_principal_resolves_permissions_and_search_returns_rows()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAndDocumentAsync();
+            await GrantDocumentsDefaultAsync(GrantedServiceAccountId);
+        });
+
+        using (_principalAccessor.Change(ApiKeyPrincipal(GrantedServiceAccountId)))
+        {
+            await WithUnitOfWorkAsync(async () =>
+            {
+                // (c) the ambient principal really is the mapped service account.
+                _currentUser.Id.ShouldBe(GrantedServiceAccountId);
+
+                // (a) drive the real MCP tool: CheckPolicyAsync(Documents.Default) inside GetListAsync passes and
+                // the search returns the seeded document — proving the store grant resolves from the user-id claim.
+                var result = await DocumentSearchTool.SearchAsync(_documentAppService, documentTypeCode: TypeCode);
+
+                result.Items.ShouldNotBeEmpty();
+                result.Items.ShouldContain(i => i.DocumentTypeCode == TypeCode);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task Ungranted_key_principal_is_fail_closed_denied()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAndDocumentAsync();
+            // Grant the OTHER account only, so the store has grants but not for this principal — proving the check
+            // is keyed on the principal's user id, not merely "some grant exists".
+            await GrantDocumentsDefaultAsync(GrantedServiceAccountId);
+        });
+
+        using (_principalAccessor.Change(ApiKeyPrincipal(UngrantedServiceAccountId)))
+        {
+            await Should.ThrowAsync<AbpAuthorizationException>(() =>
+                WithUnitOfWorkAsync(() => DocumentSearchTool.SearchAsync(_documentAppService, documentTypeCode: TypeCode)));
+        }
+    }
+
+    // Seeds the searched document type plus one document classified to it (DocumentTypeId has a Domain private
+    // setter; mirror the EF search tests and set it via reflection to simulate the classified state).
+    private async Task SeedTypeAndDocumentAsync()
+    {
+        var typeId = Guid.NewGuid();
+        await _documentTypeRepository.InsertAsync(
+            new DocumentType(typeId, tenantId: null, TypeCode, "Integration Contract"), autoSave: true);
+
+        var document = new Document(
+            Guid.NewGuid(),
+            tenantId: null,
+            fileOrigin: new FileOrigin(
+                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
+                uploadedByUserName: "svc",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "integration.pdf"));
+
+        typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(document, typeId);
+
+        await _documentRepository.InsertAsync(document, autoSave: true);
+    }
+
+    // ABP's user-scoped permission value provider name (UserPermissionValueProvider.ProviderName == "U"). We
+    // write the grant row straight to the store rather than through IPermissionManager.SetAsync, because the "U"
+    // *management* provider (the SetAsync dispatch target) lives in the Identity-integration package; the *check*
+    // still runs through the real UserPermissionValueProvider + PermissionStore, which is the seam #432 verifies.
+    private const string UserProviderName = "U";
+
+    private async Task GrantDocumentsDefaultAsync(Guid userId)
+    {
+        // Direct user-level grant (provider "U", no roles) — exactly the least-privilege model the channel requires.
+        await _permissionGrantRepository.InsertAsync(
+            new PermissionGrant(
+                _guidGenerator.Create(),
+                VaultExtractPermissions.Documents.Default,
+                UserProviderName,
+                userId.ToString(),
+                tenantId: null),
+            autoSave: true);
+    }
+
+    // The exact principal the request middleware builds for a matched key — via the shared factory so this test
+    // exercises the real claim shape (UserId + McpApiKey auth type, no permission claims), not a copy.
+    private static ClaimsPrincipal ApiKeyPrincipal(Guid serviceAccountUserId)
+    {
+        return McpApiKeyPrincipalFactory.Create(new McpApiKeyEntry
+        {
+            Key = "integration-test-key-not-used-for-matching-0000",
+            ServiceAccountUserId = serviceAccountUserId.ToString()
+        });
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpApiKeyIntegrationTestBase.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpApiKeyIntegrationTestBase.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
+using Volo.Abp.Modularity;
+using Volo.Abp.Testing;
+using Volo.Abp.Uow;
+
+namespace Dignite.Vault.Extract.Mcp;
+
+/// <summary>Base for the #432 integration tests: an Autofac ABP host with a real permission pipeline.</summary>
+public abstract class McpApiKeyIntegrationTestBase<TStartupModule> : AbpIntegratedTest<TStartupModule>
+    where TStartupModule : IAbpModule
+{
+    protected override void SetAbpApplicationCreationOptions(AbpApplicationCreationOptions options)
+    {
+        options.UseAutofac();
+    }
+
+    protected virtual async Task WithUnitOfWorkAsync(Func<Task> action)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var uowManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+        using var uow = uowManager.Begin(new AbpUnitOfWorkOptions());
+        await action();
+        await uow.CompleteAsync();
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpApiKeyIntegrationTestModule.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpApiKeyIntegrationTestModule.cs
@@ -1,0 +1,91 @@
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Volo.Abp;
+using Volo.Abp.Autofac;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore.Sqlite;
+using Volo.Abp.Modularity;
+using Volo.Abp.PermissionManagement;
+using Volo.Abp.PermissionManagement.EntityFrameworkCore;
+using Volo.Abp.Testing;
+using Volo.Abp.Uow;
+
+namespace Dignite.Vault.Extract.Mcp;
+
+/// <summary>
+/// Integration-test host for the MCP API-key channel (#432). Unlike the shared <c>VaultExtractTestBase</c>, this
+/// module <b>does not</b> call <c>AddAlwaysAllowAuthorization</c>: it boots the real Application + EF stack plus
+/// real ABP PermissionManagement (Domain + EF), so the permission checker resolves grants from the store by the
+/// principal's user id — exactly the seam the API-key channel depends on and the #430 TestServer tests (with a
+/// stub scheme) could not cover. Two DbContexts (Extract + PermissionManagement) share one in-memory SQLite
+/// connection so a granted service-account user id and the searched documents live in the same database.
+/// </summary>
+[DependsOn(
+    typeof(AbpAutofacModule),
+    typeof(AbpTestBaseModule),
+    typeof(VaultExtractApplicationModule),
+    typeof(VaultExtractEntityFrameworkCoreModule),
+    typeof(AbpEntityFrameworkCoreSqliteModule),
+    typeof(AbpPermissionManagementDomainModule),
+    typeof(AbpPermissionManagementEntityFrameworkCoreModule)
+)]
+public class McpApiKeyIntegrationTestModule : AbpModule
+{
+    public override void PreConfigureServices(ServiceConfigurationContext context)
+    {
+        PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
+    }
+
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Keep permissions purely code-based (static providers): no DB-persisted permission definitions and no
+        // dynamic store, so the test needs no definition seeding / distributed lock — only grant rows matter.
+        Configure<PermissionManagementOptions>(options =>
+        {
+            options.SaveStaticPermissionsToDatabase = false;
+            options.IsDynamicPermissionStoreEnabled = false;
+        });
+
+        // DocumentAppService depends on the document BLOB container; this test never touches blob storage
+        // (it only searches), so substitute it rather than wiring a real provider — same pattern as the
+        // Application/EF tests. The real repositories + real DB stay in place for the search path.
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+
+        context.Services.AddAlwaysDisableUnitOfWorkTransaction();
+
+        var sqliteConnection = CreateDatabaseAndGetConnection();
+
+        Configure<AbpDbContextOptions>(options =>
+        {
+            options.Configure(configurationContext =>
+            {
+                configurationContext.UseSqlite(sqliteConnection);
+            });
+        });
+    }
+
+    private static SqliteConnection CreateDatabaseAndGetConnection()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        // Create both schemas on the SAME open in-memory connection: Extract tables (documents / types) and the
+        // ABP permission-grant tables. The connection stays open for the app lifetime so the schema persists.
+        new VaultExtractDbContext(
+            new DbContextOptionsBuilder<VaultExtractDbContext>().UseSqlite(connection).Options
+        ).GetService<IRelationalDatabaseCreator>().CreateTables();
+
+        new PermissionManagementDbContext(
+            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
+        ).GetService<IRelationalDatabaseCreator>().CreateTables();
+
+        return connection;
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpApiKeyAuthentication_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpApiKeyAuthentication_Tests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
@@ -45,9 +47,12 @@ public class McpApiKeyAuthentication_Tests
     // >= McpApiKeyDefaults.MinKeyLength (32). Test-only values, not real secrets.
     private const string ValidKey = "test-mcp-api-key-0123456789abcdefghijklmnop";
     private const string SecondKey = "second-mcp-api-key-zyxwvutsrqponmlkjihgfedcba";
+    // #435: presented in plaintext but configured only as its SHA-256 digest (KeyHash).
+    private const string HashOnlyKey = "hash-only-mcp-api-key-abcdefghijklmnopqrstuvwx";
 
     private static readonly Guid ServiceAccountId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private static readonly Guid SecondAccountId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid HashAccountId = Guid.Parse("33333333-3333-3333-3333-333333333333");
 
     [Fact]
     public async Task Valid_api_key_authenticates_as_the_mapped_service_account()
@@ -198,7 +203,135 @@ public class McpApiKeyAuthentication_Tests
         Should.NotThrow(() => options.Validate());
     }
 
-    private static async Task<TestServer> BuildServerAsync(bool requireHttps = false)
+    // ---- #435: hash-at-rest (KeyHash) ----
+
+    [Fact]
+    public async Task A_keyhash_configured_key_authenticates_when_the_plaintext_is_presented()
+    {
+        // The entry carries only the SHA-256 digest; the client still sends the plaintext key. The runtime
+        // hashes the presented value and constant-time-compares digests, so the hash-at-rest form is transparent.
+        using var server = await BuildServerAsync(customize: options => options.Keys.Add(new McpApiKeyEntry
+        {
+            KeyHash = McpApiKeyHasher.ComputeSha256Hex(HashOnlyKey),
+            ServiceAccountUserId = HashAccountId.ToString(),
+            Label = "hash-test"
+        }));
+        using var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add(HeaderName, HashOnlyKey);
+
+        var response = await client.GetAsync("/mcp");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).ShouldBe(HashAccountId.ToString());
+    }
+
+    [Fact]
+    public void Configuration_setting_both_key_and_keyhash_fails_fast()
+    {
+        var options = new McpApiKeyOptions
+        {
+            Keys = new List<McpApiKeyEntry>
+            {
+                new()
+                {
+                    Key = ValidKey,
+                    KeyHash = McpApiKeyHasher.ComputeSha256Hex(ValidKey),
+                    ServiceAccountUserId = ServiceAccountId.ToString()
+                }
+            }
+        };
+
+        Should.Throw<AbpException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void Configuration_with_neither_key_nor_keyhash_fails_fast()
+    {
+        var options = new McpApiKeyOptions
+        {
+            Keys = new List<McpApiKeyEntry>
+            {
+                new() { ServiceAccountUserId = ServiceAccountId.ToString() }
+            }
+        };
+
+        Should.Throw<AbpException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void Configuration_with_a_malformed_keyhash_fails_fast()
+    {
+        var options = new McpApiKeyOptions
+        {
+            Keys = new List<McpApiKeyEntry>
+            {
+                // Not 64 hex chars.
+                new() { KeyHash = "not-a-valid-sha256-digest", ServiceAccountUserId = ServiceAccountId.ToString() }
+            }
+        };
+
+        Should.Throw<AbpException>(() => options.Validate());
+    }
+
+    [Fact]
+    public void Configuration_with_a_plaintext_key_duplicating_a_keyhash_fails_fast()
+    {
+        // Same secret configured twice — once as plaintext, once as its digest — must be rejected as a duplicate
+        // so audit attribution / independent revocation stay meaningful.
+        var options = new McpApiKeyOptions
+        {
+            Keys = new List<McpApiKeyEntry>
+            {
+                new() { Key = ValidKey, ServiceAccountUserId = ServiceAccountId.ToString() },
+                new() { KeyHash = McpApiKeyHasher.ComputeSha256Hex(ValidKey), ServiceAccountUserId = SecondAccountId.ToString() }
+            }
+        };
+
+        Should.Throw<AbpException>(() => options.Validate());
+    }
+
+    // ---- #433: rate-limited invalid-key Warning, no value leak ----
+
+    [Fact]
+    public async Task Invalid_key_logs_a_throttled_warning_that_never_contains_the_value()
+    {
+        const string firstBadKey = "invalid-key-one-aaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const string secondBadKey = "invalid-key-two-bbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        var provider = new CapturingLoggerProvider();
+        using var server = await BuildServerAsync(loggerProvider: provider);
+
+        // Two DIFFERENT invalid keys back-to-back. The default 60s throttle window means only the first emits a
+        // Warning; the second stays at Debug — an unauthenticated caller cannot flood Warning-level alerts.
+        using (var client = server.CreateClient())
+        {
+            client.DefaultRequestHeaders.Add(HeaderName, firstBadKey);
+            (await client.GetAsync("/mcp")).StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        using (var client = server.CreateClient())
+        {
+            client.DefaultRequestHeaders.Add(HeaderName, secondBadKey);
+            (await client.GetAsync("/mcp")).StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        var warnings = provider.Entries
+            .Where(e => e.Level == LogLevel.Warning && e.Message.Contains("invalid MCP API key"))
+            .ToList();
+
+        // Rate-limited to one Warning across the window despite two invalid attempts.
+        warnings.Count.ShouldBe(1);
+        warnings[0].Message.ShouldContain(HeaderName);
+
+        // The secret value must never appear in any captured log entry, at any level.
+        provider.Entries.ShouldNotContain(e => e.Message.Contains(firstBadKey));
+        provider.Entries.ShouldNotContain(e => e.Message.Contains(secondBadKey));
+    }
+
+    private static async Task<TestServer> BuildServerAsync(
+        bool requireHttps = false,
+        Action<McpApiKeyOptions>? customize = null,
+        ILoggerProvider? loggerProvider = null)
     {
         var host = await new HostBuilder()
             .ConfigureWebHost(web =>
@@ -236,8 +369,20 @@ public class McpApiKeyAuthentication_Tests
                                 Label = "abp-ai-test"
                             }
                         };
+
+                        // Let a test append a KeyHash entry / tweak the throttle window without rebuilding all of this.
+                        customize?.Invoke(options);
                     });
                 });
+                if (loggerProvider != null)
+                {
+                    // Capture the middleware's ILogger output (invalid-key Warning + no-value-leak assertions).
+                    web.ConfigureLogging(logging =>
+                    {
+                        logging.SetMinimumLevel(LogLevel.Trace);
+                        logging.AddProvider(loggerProvider);
+                    });
+                }
                 web.Configure(app =>
                 {
                     app.UseRouting();
@@ -293,6 +438,39 @@ public class McpApiKeyAuthentication_Tests
             identity.AddClaim(new Claim("stage", RawClaim));
             return Task.FromResult(AuthenticateResult.Success(
                 new AuthenticationTicket(new ClaimsPrincipal(identity), TokenScheme)));
+        }
+    }
+
+    // Captures every log entry (level + rendered message) so a test can assert what was / was not logged.
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentBag<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Entries);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly ConcurrentBag<(LogLevel, string)> _entries;
+
+            public CapturingLogger(ConcurrentBag<(LogLevel, string)> entries) => _entries = entries;
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                _entries.Add((logLevel, formatter(state, exception)));
+            }
         }
     }
 }

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpRateLimiter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpRateLimiter_Tests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// #433 guard for the /mcp rate limiter. A minimal TestServer mirrors the host wiring
+/// (<c>UseRateLimiter</c> after routing + <c>RequireRateLimiting</c> on the /mcp endpoint) and locks:
+///  - over-limit requests get 429 while in-limit ones pass (the brute-force / DoS backstop actually fires);
+///  - a non-/mcp endpoint without the policy is never limited (scoping);
+///  - a disabled limiter applies no limit (policy still registered so RequireRateLimiting resolves).
+/// </summary>
+public class McpRateLimiter_Tests
+{
+    [Fact]
+    public async Task Requests_over_the_limit_get_429_while_in_limit_requests_pass()
+    {
+        using var server = await BuildServerAsync(permitLimit: 2);
+        using var client = server.CreateClient();
+
+        (await client.GetAsync("/mcp")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await client.GetAsync("/mcp")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        // Third request in the same window exceeds PermitLimit=2 -> rejected with 429 (QueueLimit=0).
+        (await client.GetAsync("/mcp")).StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task A_non_mcp_endpoint_without_the_policy_is_not_limited()
+    {
+        using var server = await BuildServerAsync(permitLimit: 2);
+        using var client = server.CreateClient();
+
+        // Far more than PermitLimit, none rejected: the limiter is scoped to endpoints that opt in.
+        for (var i = 0; i < 5; i++)
+        {
+            (await client.GetAsync("/other")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+    }
+
+    [Fact]
+    public async Task A_disabled_limiter_applies_no_limit()
+    {
+        using var server = await BuildServerAsync(permitLimit: 2, enabled: false);
+        using var client = server.CreateClient();
+
+        // RequireRateLimiting still resolves (policy registered as a no-limiter), but nothing is throttled.
+        for (var i = 0; i < 5; i++)
+        {
+            (await client.GetAsync("/mcp")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+    }
+
+    private static async Task<TestServer> BuildServerAsync(int permitLimit, bool enabled = true)
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddVaultExtractMcpRateLimiter(options =>
+                    {
+                        options.Enabled = enabled;
+                        options.PermitLimit = permitLimit;
+                        options.WindowSeconds = 60;
+                        options.QueueLimit = 0;
+                    });
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseRateLimiter();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints
+                            .MapGet("/mcp", (HttpContext _) => "ok")
+                            .RequireRateLimiting(McpRateLimiterDefaults.PolicyName);
+
+                        endpoints.MapGet("/other", (HttpContext _) => "ok");
+                    });
+                });
+            })
+            .StartAsync();
+
+        return host.GetTestServer();
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpServiceAccountLeastPrivilege_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpServiceAccountLeastPrivilege_Tests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using Dignite.Vault.Extract.Permissions;
+using Shouldly;
+using Volo.Abp;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// #434: the least-privilege contract for an API-key service account, verified as a pure guard (no host needed).
+/// The seed contributor gathers the account's real ABP state and delegates the decision here; these lock the
+/// decision: exactly <c>VaultExtract.Documents</c> at the user level, no other VaultExtract permission, no roles,
+/// and the user must exist.
+/// </summary>
+public class McpServiceAccountLeastPrivilege_Tests
+{
+    private static readonly string Account = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").ToString();
+
+    [Fact]
+    public void Exactly_documents_default_with_no_roles_passes()
+    {
+        Should.NotThrow(() => McpServiceAccountLeastPrivilege.Guard(
+            Account,
+            label: "codex-prod",
+            userExists: true,
+            grantedVaultExtractPermissions: new[] { VaultExtractPermissions.Documents.Default },
+            roleNames: Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void A_missing_user_fails_closed()
+    {
+        var ex = Should.Throw<AbpException>(() => McpServiceAccountLeastPrivilege.Guard(
+            Account,
+            label: null,
+            userExists: false,
+            grantedVaultExtractPermissions: Array.Empty<string>(),
+            roleNames: Array.Empty<string>()));
+
+        ex.Message.ShouldContain("does not exist");
+    }
+
+    [Fact]
+    public void Any_role_fails_closed()
+    {
+        var ex = Should.Throw<AbpException>(() => McpServiceAccountLeastPrivilege.Guard(
+            Account,
+            label: null,
+            userExists: true,
+            grantedVaultExtractPermissions: new[] { VaultExtractPermissions.Documents.Default },
+            roleNames: new[] { "DocumentManager" }));
+
+        ex.Message.ShouldContain("NO roles");
+    }
+
+    [Fact]
+    public void A_permission_beyond_the_allowlist_fails_closed()
+    {
+        // The account also holds Documents.Delete — a write permission an API-key caller must never have.
+        var ex = Should.Throw<AbpException>(() => McpServiceAccountLeastPrivilege.Guard(
+            Account,
+            label: "over-privileged",
+            userExists: true,
+            grantedVaultExtractPermissions: new[]
+            {
+                VaultExtractPermissions.Documents.Default,
+                VaultExtractPermissions.Documents.Delete
+            },
+            roleNames: Array.Empty<string>()));
+
+        ex.Message.ShouldContain(VaultExtractPermissions.Documents.Delete);
+    }
+
+    [Fact]
+    public void A_schema_admin_permission_fails_closed()
+    {
+        // FieldDefinitions.* / DocumentTypes.* / Cabinets.* are all outside the read allowlist.
+        var ex = Should.Throw<AbpException>(() => McpServiceAccountLeastPrivilege.Guard(
+            Account,
+            label: null,
+            userExists: true,
+            grantedVaultExtractPermissions: new[]
+            {
+                VaultExtractPermissions.Documents.Default,
+                VaultExtractPermissions.FieldDefinitions.Default
+            },
+            roleNames: Array.Empty<string>()));
+
+        ex.Message.ShouldContain(VaultExtractPermissions.FieldDefinitions.Default);
+    }
+
+    [Fact]
+    public void Missing_the_required_documents_default_fails_closed()
+    {
+        // An existing user with no VaultExtract grant at all is not usable and must fail loudly, not silently.
+        var ex = Should.Throw<AbpException>(() => McpServiceAccountLeastPrivilege.Guard(
+            Account,
+            label: null,
+            userExists: true,
+            grantedVaultExtractPermissions: new List<string>(),
+            roleNames: Array.Empty<string>()));
+
+        ex.Message.ShouldContain(VaultExtractPermissions.Documents.Default);
+    }
+}

--- a/docs/en/egress/mcp-server.md
+++ b/docs/en/egress/mcp-server.md
@@ -124,14 +124,22 @@ Some MCP clients cannot run the OAuth flow above but can send a **static custom 
   "ApiKey": {
     "HeaderName": "X-Api-Key",                       // configurable; match it to the client's header
     "RequireHttps": true,                            // ignore a key presented over plain HTTP (default true)
+    "SeedServiceAccounts": false,                    // opt-in least-privilege seed/guard (#434), see below
     "Keys": [
       {
-        "Key": "<a CSPRNG secret, >= 32 chars>",     // env / user-secrets only
+        // Configure EITHER the plaintext Key OR its KeyHash (hash-at-rest, #435) — not both.
+        "KeyHash": "<lowercase hex sha256 of the key>",  // preferred: a config leak does not expose usable keys
+        // "Key": "<a CSPRNG secret, >= 32 chars>",      // alternative: plaintext, env / user-secrets only
         "ServiceAccountUserId": "<guid of a provisioned service-account user>",
         "TenantId": null,                            // host space; set a tenant Guid once multi-tenant
         "Label": "codex-prod"                        // audit attribution; never the key value
       }
     ]
+  },
+  "RateLimit": {                                     // #433: /mcp rate limiter (per client IP); on by default
+    "Enabled": true,
+    "PermitLimit": 300,                              // requests per window per IP — generous; a DoS/brute-force cap
+    "WindowSeconds": 60
   }
 }
 ```
@@ -141,11 +149,17 @@ Some MCP clients cannot run the OAuth flow above but can send a **static custom 
 1. **Provision a dedicated service-account user** (ABP admin UI or your own seed), then
 2. **Grant it only `VaultExtract.Documents`** (`ExtractPermissions.Documents.Default`) — directly at the user level, **no roles**. That single permission covers every MCP path (`search_documents`, `get_document`, `list_document_types`, the document and document-type resources). Granting anything more — or via a shared role — would let an API-key caller exceed an OAuth user; don't.
 
+Set `Mcp:ApiKey:SeedServiceAccounts: true` to have the host **enforce** that least-privilege at startup (opt-in, #434): for every configured `ServiceAccountUserId` it applies the `VaultExtract.Documents` grant and **fails startup** if the account is missing, holds any other VaultExtract permission, or has any role. It never creates users — provision the account first, then copy its Guid into config. Leave it `false` (default) to manage the accounts by hand.
+
 **Operational notes.**
 
 - **TLS only.** The key is a long-lived, bearer-equivalent secret. `Mcp:ApiKey:RequireHttps` (default `true`) makes the server **ignore a key presented over a non-HTTPS request** (it falls through to Bearer), so a key never travels in clear text; behind a TLS-terminating proxy this relies on the host's forwarded-headers handling. Also configure the proxy to strip any inbound copy of the header before forwarding. Set `RequireHttps: false` only for a deliberate plain-HTTP deployment (e.g. local testing).
+- **Hash-at-rest (preferred, #435).** Configure a key's **`KeyHash`** (lowercase hex SHA-256 of the key) instead of the plaintext `Key`, so a leak of host config / the secret store does not hand over usable keys — the runtime compares digests, so the two forms are interchangeable. Set exactly one of `Key` / `KeyHash` per entry. Compute the digest without echoing the secret to history:
+  - bash: `printf %s "$MCP_KEY" | sha256sum` (take the hex, lowercase)
+  - PowerShell: `[BitConverter]::ToString([Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($env:MCP_KEY))).Replace('-','').ToLower()`
 - **Rotation / revocation.** Multiple keys are supported, each with its own `Label` for audit attribution. Rotate with an overlap window (add the new key → migrate clients → remove the old). Revoke by removing the key from config (or removing the service account's grant). The API-key principal does **not** pass through ABP dynamic claims, so *disabling the underlying user is not an instant revocation path* — remove the key.
-- **Generation / fail-fast.** Generate keys from a CSPRNG (≥ 256 bits, e.g. 32 random bytes base64url); the host refuses to start on a placeholder value or a key shorter than 32 characters when keys are configured.
+- **Generation / fail-fast.** Generate keys from a CSPRNG (≥ 256 bits, e.g. 32 random bytes base64url); the host refuses to start on a placeholder value or a plaintext key shorter than 32 characters, a malformed `KeyHash`, both/neither of `Key`/`KeyHash`, or duplicate keys when keys are configured.
+- **Rate limiting (#433).** The `/mcp` endpoint is rate-limited per client IP (`Mcp:RateLimit`, on by default, `300`/`60s`), covering both the API-key channel and the discovery `401` path; over-limit requests get `429`. Limits are generous so legitimate MCP session traffic is unaffected — widen `PermitLimit` / `WindowSeconds` or set `Enabled: false` for unusual deployments. Behind a reverse proxy the per-IP partition is only as accurate as the host's forwarded-headers handling. A **present-but-invalid** key is logged as a rate-limited `Warning` (source IP + header name, **never** the value) — an attack signal a simply-absent key does not raise.
 
 #### Connect OpenAI Codex
 

--- a/host/src/Data/McpServiceAccountSeedContributor.cs
+++ b/host/src/Data/McpServiceAccountSeedContributor.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Mcp.Authentication;
+using Dignite.Vault.Extract.Permissions;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Identity;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.PermissionManagement;
+
+namespace Dignite.Vault.Extract.Host.Data;
+
+/// <summary>
+/// #434: optional, opt-in provisioning guard for the MCP API-key service accounts. When
+/// <c>Mcp:ApiKey:SeedServiceAccounts</c> is <c>true</c>, each configured key's service-account user is pinned to
+/// least privilege: the minimal <c>VaultExtract.Documents</c> grant is applied at the user level, and startup
+/// fails fail-closed if the account is missing, holds any other VaultExtract permission, or has any role
+/// (a shared role could later widen it silently beyond an OAuth user). It never creates users — the operator
+/// provisions the account (admin UI) and copies its Guid into config. Disabled by default so OAuth-only
+/// deployments and hand-managed accounts are untouched. The least-privilege decision is the pure, unit-tested
+/// <see cref="McpServiceAccountLeastPrivilege"/> guard in the Mcp module; this contributor only gathers the
+/// account's real ABP state and applies the grant.
+/// </summary>
+public class McpServiceAccountSeedContributor : IDataSeedContributor, ITransientDependency
+{
+    private readonly McpApiKeyOptions _options;
+    private readonly IIdentityUserRepository _userRepository;
+    private readonly IdentityUserManager _userManager;
+    private readonly IPermissionManager _permissionManager;
+    private readonly ICurrentTenant _currentTenant;
+
+    public McpServiceAccountSeedContributor(
+        IOptions<McpApiKeyOptions> options,
+        IIdentityUserRepository userRepository,
+        IdentityUserManager userManager,
+        IPermissionManager permissionManager,
+        ICurrentTenant currentTenant)
+    {
+        _options = options.Value;
+        _userRepository = userRepository;
+        _userManager = userManager;
+        _permissionManager = permissionManager;
+        _currentTenant = currentTenant;
+    }
+
+    public virtual async Task SeedAsync(DataSeedContext context)
+    {
+        if (!_options.SeedServiceAccounts || _options.Keys.Count == 0)
+        {
+            return;
+        }
+
+        // Dedup: several keys (e.g. during rotation) may map to the same account; process each once.
+        var accounts = _options.Keys
+            .GroupBy(k => (k.ServiceAccountUserId, k.TenantId))
+            .Select(g => new {
+                UserId = Guid.Parse(g.Key.ServiceAccountUserId),
+                TenantId = string.IsNullOrWhiteSpace(g.Key.TenantId) ? (Guid?)null : Guid.Parse(g.Key.TenantId!),
+                Label = g.Select(k => k.Label).FirstOrDefault(l => !string.IsNullOrWhiteSpace(l)),
+                RawUserId = g.Key.ServiceAccountUserId
+            });
+
+        foreach (var account in accounts)
+        {
+            using (_currentTenant.Change(account.TenantId))
+            {
+                await EnforceLeastPrivilegeAsync(account.UserId, account.RawUserId, account.Label);
+            }
+        }
+    }
+
+    protected virtual async Task EnforceLeastPrivilegeAsync(Guid userId, string rawUserId, string? label)
+    {
+        var user = await _userRepository.FindAsync(userId);
+        var userExists = user != null;
+
+        IReadOnlyCollection<string> roleNames = userExists
+            ? (await _userManager.GetRolesAsync(user!)).ToList()
+            : Array.Empty<string>();
+
+        // Apply the minimal grant (idempotent) before the guard reads it back, so a freshly-provisioned account
+        // converges to least privilege. If the user is missing, skip granting — the guard fails on non-existence.
+        if (userExists)
+        {
+            await _permissionManager.SetForUserAsync(userId, McpServiceAccountLeastPrivilege.AllowedPermission, isGranted: true);
+        }
+
+        var grantedVaultExtractPermissions = userExists
+            ? await GetGrantedVaultExtractPermissionsAsync(userId)
+            : Array.Empty<string>();
+
+        McpServiceAccountLeastPrivilege.Guard(rawUserId, label, userExists, grantedVaultExtractPermissions, roleNames);
+    }
+
+    // ABP's user-scoped permission value provider name (UserPermissionValueProvider.ProviderName == "U").
+    private const string UserProviderName = "U";
+
+    // The VaultExtract permission names granted to this user directly at the user level (provider "U").
+    protected virtual async Task<IReadOnlyCollection<string>> GetGrantedVaultExtractPermissionsAsync(Guid userId)
+    {
+        var granted = new List<string>();
+        foreach (var permission in VaultExtractPermissions.GetAll())
+        {
+            var result = await _permissionManager.GetAsync(permission, UserProviderName, userId.ToString());
+            if (result.IsGranted)
+            {
+                granted.Add(permission);
+            }
+        }
+
+        return granted;
+    }
+}

--- a/host/src/VaultExtractHostModule.cs
+++ b/host/src/VaultExtractHostModule.cs
@@ -136,8 +136,8 @@ namespace Dignite.Vault.Extract.Host;
     typeof(VaultExtractParseOpenXmlModule),         // OpenXML: PPTX (slide text/notes, #307) + DOCX (headings/tables/lists/inline formatting/hyperlinks/text boxes, #308), each with charts/tables + embedded-image transcription. Claims .pptx and .docx. REQUIRED for .pptx (ElBruno has no PresentationML converter -> empty Markdown, no OCR fallback since .pptx != .pdf); .docx degrades gracefully to ElBruno if this module is omitted.
     typeof(VaultExtractParseElBrunoMarkItDownModule),
     typeof(VaultExtractVisionLlmOcrModule)                  // Vision-LLM OCR for photos, receipts, and image PDFs; current default OCR provider (#259). IOcrProvider implementations are mutually exclusive: when switching providers, update the .csproj ProjectReference and ConfigureAI keyed vision IChatClient together. See docs/en/text-extraction/ocr-vision-llm.md.
-    // typeof(VaultExtractPaddleOcrModule),                 // Local PaddleOCR sidecar (free CPU, PP-StructureV3); to switch back, uncomment this, comment VisionLlm, and restore its .csproj ProjectReference
-    // typeof(VaultExtractAzureDocumentIntelligenceModule), // Cloud option (higher accuracy); when switching, also comment / enable the matching ProjectReference in .csproj
+                                                            // typeof(VaultExtractPaddleOcrModule),                 // Local PaddleOCR sidecar (free CPU, PP-StructureV3); to switch back, uncomment this, comment VisionLlm, and restore its .csproj ProjectReference
+                                                            // typeof(VaultExtractAzureDocumentIntelligenceModule), // Cloud option (higher accuracy); when switching, also comment / enable the matching ProjectReference in .csproj
 )]
 public class VaultExtractHostModule : AbpModule
 {
@@ -265,6 +265,22 @@ public class VaultExtractHostModule : AbpModule
         ConfigureAI(context, configuration);
         ConfigureOpenTelemetry(context, configuration);
         ConfigureRequestLimits(context);
+        ConfigureMcpRateLimiter(context);
+    }
+
+    // #433: rate-limit the /mcp egress endpoint (API-key brute-force + invalid-key log-flood + DoS backstop).
+    // The mechanism (per-IP fixed-window policy, 429 rejection) lives in the Mcp egress module
+    // (AddVaultExtractMcpRateLimiter, mirroring #428's AddVaultExtractMcpApiKey); the host owns the config and the
+    // pipeline wiring. Enabled by default with generous limits (Mcp:RateLimit), applied to /mcp via
+    // RequireRateLimiting in OnApplicationInitialization so it covers BOTH the API-key channel and the #278
+    // discovery-401 path. The limiter never fires for legitimate, in-limit MCP session traffic.
+    private void ConfigureMcpRateLimiter(ServiceConfigurationContext context)
+    {
+        var configuration = context.Services.GetConfiguration();
+        context.Services.AddVaultExtractMcpRateLimiter(options =>
+        {
+            configuration.GetSection("Mcp:RateLimit").Bind(options);
+        });
     }
 
     // #221: upload request body limits as Kestrel / Form-layer backstop. The real fail-closed friendly error lives in
@@ -749,6 +765,9 @@ public class VaultExtractHostModule : AbpModule
 
         app.UseCorrelationId();
         app.UseRouting();
+        // #433: rate limiter, after UseRouting so it can read the endpoint's RequireRateLimiting metadata.
+        // Only the /mcp endpoint opts in (below); every other endpoint is unaffected.
+        app.UseRateLimiter();
         app.UseStaticFiles();
         app.UseAbpStudioLink();
         app.UseAbpSecurityHeaders();
@@ -787,8 +806,11 @@ public class VaultExtractHostModule : AbpModule
             // Tool / resource method bodies still perform explicit permission assertions as fail-closed double insurance.
             // #278: McpDiscoveryChallengeMarker lets 401 responses without token be routed by McpDiscoveryAuthorizationResultHandler
             // to McpAuth challenge, injecting the `WWW-Authenticate: Bearer resource_metadata="..."` discovery pointer.
+            // #433: RequireRateLimiting scopes the /mcp rate limiter to this endpoint, covering the API-key
+            // channel and the #278 discovery-401 path in one place.
             endpoints.MapMcp("/mcp")
                 .RequireAuthorization()
+                .RequireRateLimiting(McpRateLimiterDefaults.PolicyName)
                 .WithMetadata(McpDiscoveryChallengeMarker.Instance);
         });
     }

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -63,7 +63,13 @@
     "ApiKey": {
       "HeaderName": "X-Api-Key",
       "RequireHttps": true,
+      "SeedServiceAccounts": false,
       "Keys": []
+    },
+    "RateLimit": {
+      "Enabled": true,
+      "PermitLimit": 300,
+      "WindowSeconds": 60
     }
   },
   "VisionLlmOcr": {


### PR DESCRIPTION
MCP API-key channel hardening — the v0.3.0 workstream **B** follow-ups to #428 / #430. Built **on the existing path-scoped middleware**, not the #431 `AuthenticationHandler` upgrade (still deferred, out of scope here).

Closes #432
Closes #433
Closes #434
Closes #435

## What's in it

| # | Change |
|---|--------|
| **#435** hash-at-rest | `McpApiKeyEntry.KeyHash` (lowercase hex SHA-256) as an *either/or* alternative to plaintext `Key`, so a config/secret-store leak does not expose usable keys. New shared `McpApiKeyHasher`; `Validate()` enforces exactly-one-of `Key`/`KeyHash`, a 64-char hex digest, and **dedup on the effective digest** (a plaintext key and the hash of the same key collide). Constant-time `FixedTimeEquals` over fixed 32-byte digests preserved for both forms. |
| **#433** rate limit | Per-client-IP fixed-window limiter on `/mcp` (`Mcp:RateLimit`, on by default, `300`/`60s`, `429`), covering both the API-key channel and the #278 discovery-`401` path via `RequireRateLimiting` on `MapMcp`. The policy is always registered (`GetNoLimiter` when disabled) so the endpoint stays mapped. Restored the present-but-invalid-key **`Warning`** (source IP + header name, **never the value**), throttled in-middleware by a monotonic `TickCount64` gate so it can't flood. |
| **#432** integration test | New `Dignite.Vault.Extract.Mcp.Integration.Tests` project boots a **real** ABP host (Application + EF + PermissionManagement, **no `AddAlwaysAllowAuthorization`**) so a key-authenticated service-account principal resolves grants through the genuine `PermissionChecker`/`PermissionStore` — the seam the #430 TestServer tests (stub scheme) could not cover. Asserts granted → search returns rows; ungranted → fail-closed `AbpAuthorizationException`; `CurrentUser.Id` == the account. |
| **#434** least-privilege seed | Opt-in `Mcp:ApiKey:SeedServiceAccounts` (default `false`) **enforces** least privilege on every configured service account: applies exactly `VaultExtract.Documents` and **fails startup** if the account is missing, holds any role, or holds any other VaultExtract permission. Pure `McpServiceAccountLeastPrivilege` guard in the Mcp module (unit-tested), seed plumbing in the host. Never creates users. |

## Design notes

- The synthetic-principal construction was refactored out of the middleware into a shared `McpApiKeyPrincipalFactory`, so the #432 test exercises the **exact** runtime claim shape (`AbpClaimTypes.UserId` + `McpApiKey` auth type, no permission claims) and cannot drift.
- Fail-**open** in the middleware (never `401`/`403`) is unchanged, so the #278 discovery challenge still fires for OAuth clients.
- The #432 test host writes the user grant directly via `IPermissionGrantRepository` (provider `"U"`) and omits ABP Identity — the base `PermissionManagement` module still registers the `"U"` *value* provider used at check time, keeping the test lean.

## Testing

- `Dignite.Vault.Extract.Mcp.Tests` → **60/60** (added: `KeyHash` auth + all `Validate()` forks; invalid-key Warning throttle + no-value-leak log capture; 3 rate-limiter cases; 6 least-privilege guard cases; existing #278 / #430 regression suite unbroken).
- `Dignite.Vault.Extract.Mcp.Integration.Tests` → **2/2** (granted / fail-closed).
- Full solution builds clean (0 errors).
- Docs: `docs/en/egress/mcp-server.md` §3 updated (`KeyHash` + one-liner, rate limit, seed). `CHANGELOG.md` updated.

## Review

Reviewed by the `abp-architecture-reviewer` and `maf-workflow-reviewer` agents — **both clean, no blockers**. Confirmed: dependency direction intact (the Mcp module `.csproj` is unchanged, still `Application.Contracts`-only, #222 holds); middleware wiring host-only; constant-time compare + zero secret leakage; fail-open preserved; the guard truly fails closed. The two non-blocking 🟡 notes (global vs. per-IP Warning throttle; forwarded-headers dependency for the IP partition) are deliberate trade-offs, the latter already documented.
