### PR TITLE
fix(text-extraction): resolve DOCX note-body hyperlinks against the owning FootnotesPart/EndnotesPart (#457)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -497,6 +497,13 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         var footnotes = BuildNoteBodyMap(mainPart.FootnotesPart?.Footnotes?.Elements<W.Footnote>());
         var endnotes = BuildNoteBodyMap(mainPart.EndnotesPart?.Endnotes?.Elements<W.Endnote>());
 
+        // #457: a hyperlink inside a note body is a relationship of the FootnotesPart / EndnotesPart, not the
+        // main part, so it must be resolved against the owning part's own id -> uri map. Built once per part,
+        // mirroring the body-path cache (#318). A missing part yields no map here, but that pairs with a null
+        // body map above (the note is then unresolvable), so a resolved note always has its part's map in hand.
+        var footnoteHyperlinkUris = mainPart.FootnotesPart is { } footnotesPart ? BuildHyperlinkUris(footnotesPart) : null;
+        var endnoteHyperlinkUris = mainPart.EndnotesPart is { } endnotesPart ? BuildHyperlinkUris(endnotesPart) : null;
+
         var seen = new HashSet<NoteReference>();
         foreach (var reference in state.NoteReferences)
         {
@@ -508,7 +515,8 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 continue;
             }
 
-            var map = reference.Kind == NoteKind.Footnote ? footnotes : endnotes;
+            var isFootnote = reference.Kind == NoteKind.Footnote;
+            var map = isFootnote ? footnotes : endnotes;
             if (map is null || !map.TryGetValue(reference.Id, out var note))
             {
                 // Dangling reference, or the notes part is missing entirely — surface the loss (#268).
@@ -518,7 +526,8 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 continue;
             }
 
-            var body = await RenderNoteBodyAsync(note, mainPart, state, cancellationToken);
+            var hyperlinkUris = isFootnote ? footnoteHyperlinkUris : endnoteHyperlinkUris;
+            var body = await RenderNoteBodyAsync(note, mainPart, hyperlinkUris, state, cancellationToken);
             blocks.Add(FormatNoteDefinition(reference.Marker, body));
         }
     }
@@ -597,6 +606,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
     private async Task<string> RenderNoteBodyAsync(
         W.FootnoteEndnoteType note,
         MainDocumentPart mainPart,
+        IReadOnlyDictionary<string, string?>? hyperlinkUris,
         DocxExtractionState state,
         CancellationToken cancellationToken)
     {
@@ -605,7 +615,9 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var text = WordParagraphRenderer.Render(paragraph, mainPart);
+            // #457: resolve note-body hyperlinks against the owning notes part's relationships (threaded in),
+            // not the main document's — the two parts have independent r:id spaces.
+            var text = WordParagraphRenderer.Render(paragraph, mainPart, hyperlinkUris: hyperlinkUris);
             if (!string.IsNullOrWhiteSpace(text))
             {
                 parts.Add(text);
@@ -975,13 +987,15 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         => NearestDrawingWrapper(picture)?.GetFirstChild<DW.DocProperties>();
 
     /// <summary>
-    /// Builds the per-document hyperlink relationship-id → URI map once (#318). Relationship ids are unique,
-    /// so a plain dictionary suffices; a relationship with no target maps to <c>null</c> (an internal anchor).
+    /// Builds a part's hyperlink relationship-id → URI map once (#318 for the main part; #457 for a
+    /// FootnotesPart / EndnotesPart, whose note-body links live in a separate relationship space). Relationship
+    /// ids are unique within a part, so a plain dictionary suffices; a relationship with no target maps to
+    /// <c>null</c> (an internal anchor).
     /// </summary>
-    private static IReadOnlyDictionary<string, string?> BuildHyperlinkUris(MainDocumentPart mainPart)
+    private static IReadOnlyDictionary<string, string?> BuildHyperlinkUris(OpenXmlPart part)
     {
         var map = new Dictionary<string, string?>();
-        foreach (var relationship in mainPart.HyperlinkRelationships)
+        foreach (var relationship in part.HyperlinkRelationships)
         {
             map[relationship.Id] = relationship.Uri?.ToString();
         }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordParagraphRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordParagraphRenderer.cs
@@ -205,8 +205,10 @@ internal static class WordParagraphRenderer
                 return null;
             }
 
-            // Per-document id -> uri cache (#318) avoids an O(relationships) scan per hyperlink; a null cache
-            // (e.g. the note-body render path) falls back to the direct lookup.
+            // Both render paths pass a prebuilt id -> uri cache — the main part's (#318) for the body, the
+            // owning notes part's (#457) for a note body — so a link resolves in O(1) against the part that
+            // actually owns the relationship. A null cache is only a defensive fallback to the direct
+            // O(relationships) scan against the main part.
             if (_hyperlinkUris is not null)
             {
                 return _hyperlinkUris.TryGetValue(id, out var uri) ? uri : null;

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -962,6 +962,42 @@ public class DocxExtractor_Tests
     }
 
     [Fact]
+    public async Task Resolves_a_footnote_body_hyperlink_against_the_footnotes_part()
+    {
+        // #457: a hyperlink inside a footnote body is a relationship of the FootnotesPart, not the main part.
+        // Here the r:id exists ONLY in the FootnotesPart, so resolving against the main part (the old bug)
+        // finds nothing and drops the URL, degrading the link to plain text.
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Paragraph("Intro")
+            .FootnoteWithBodyLink("See note", 2, "Reference: ", "the source", "https://notes.example/fn-source"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("[^fn2]: Reference: [the source](https://notes.example/fn-source)");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Resolves_an_endnote_body_hyperlink_against_its_own_part_when_the_id_collides_with_the_main_part()
+    {
+        // #457: the endnote body's r:id ALSO exists in the main part (a legitimate collision — the two parts
+        // have independent relationship spaces) pointing at a DIFFERENT target. The note link must resolve to
+        // the EndnotesPart's target, never the main document's decoy (the old bug resolved to the decoy).
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Paragraph("Intro")
+            .EndnoteWithBodyLink(
+                "See endnote", 3, "Cited at ", "the archive",
+                linkUrl: "https://notes.example/en-archive",
+                mainDecoyUrl: "https://main.example/decoy"));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("[^en3]: Cited at [the archive](https://notes.example/en-archive)");
+        result.Markdown.ShouldNotContain("https://main.example/decoy");
+        result.IsComplete.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task Transcribes_every_image_in_a_grouped_drawing()
     {
         StubOcr("GROUPED_FIG");

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxFixtures.cs
@@ -115,10 +115,17 @@ internal static class DocxFixtures
     /// DANGLING reference (no matching note body); when it is the only note of its kind the notes part is not
     /// created either (the missing-part case). The notes part, when created, also carries the auto-inserted
     /// separator / continuationSeparator notes so the extractor's separator exclusion is exercised.
+    /// <para>
+    /// <c>BodyLinkText</c> / <c>BodyLinkUrl</c> author a hyperlink inside the note BODY whose relationship is
+    /// registered on the owning notes part (#457). <c>BodyLinkMainDecoyUrl</c>, when set, registers the SAME
+    /// relationship id on the main part with a different target, so a resolver that consults the main part
+    /// instead of the notes part yields the wrong URL.
+    /// </para>
     /// </summary>
     public sealed record NoteSpec(
         string ParagraphText, int Id, bool IsEndnote, string? NoteText,
-        int? HeadingLevel = null, bool InTableCell = false) : BlockSpec;
+        int? HeadingLevel = null, bool InTableCell = false,
+        string? BodyLinkText = null, string? BodyLinkUrl = null, string? BodyLinkMainDecoyUrl = null) : BlockSpec;
 
     /// <summary>A paragraph carrying a single grouped drawing (wpg:wgp) with several pictures (#322).</summary>
     public sealed record GroupedImagesSpec(IReadOnlyList<ImageSpec> Images) : BlockSpec;
@@ -276,6 +283,29 @@ internal static class DocxFixtures
         public DocSpec Endnote(string paragraphText, int id, string noteText)
         {
             Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: true, noteText));
+            return this;
+        }
+
+        /// <summary>
+        /// A paragraph with a footnote whose BODY carries a hyperlink (#457). The hyperlink relationship is
+        /// registered on the FootnotesPart. When <paramref name="mainDecoyUrl"/> is non-null the SAME
+        /// relationship id is also registered on the main part with a DIFFERENT target, so a correct resolver
+        /// must pick the note's own part rather than the main document's.
+        /// </summary>
+        public DocSpec FootnoteWithBodyLink(
+            string paragraphText, int id, string noteText, string linkText, string linkUrl, string? mainDecoyUrl = null)
+        {
+            Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: false, noteText,
+                BodyLinkText: linkText, BodyLinkUrl: linkUrl, BodyLinkMainDecoyUrl: mainDecoyUrl));
+            return this;
+        }
+
+        /// <summary>An endnote counterpart of <see cref="FootnoteWithBodyLink"/> — the link relationship lives on the EndnotesPart (#457).</summary>
+        public DocSpec EndnoteWithBodyLink(
+            string paragraphText, int id, string noteText, string linkText, string linkUrl, string? mainDecoyUrl = null)
+        {
+            Blocks.Add(new NoteSpec(paragraphText, id, IsEndnote: true, noteText,
+                BodyLinkText: linkText, BodyLinkUrl: linkUrl, BodyLinkMainDecoyUrl: mainDecoyUrl));
             return this;
         }
 
@@ -441,6 +471,7 @@ internal static class DocxFixtures
             if (footnoteBodies.Count > 0)
             {
                 var footnotesPart = mainPart.AddNewPart<FootnotesPart>();
+                RegisterNoteBodyHyperlinks(mainPart, footnotesPart, footnoteBodies);
                 footnotesPart.Footnotes = new Footnotes(FootnotesXml(footnoteBodies));
                 footnotesPart.Footnotes.Save();
             }
@@ -449,6 +480,7 @@ internal static class DocxFixtures
             if (endnoteBodies.Count > 0)
             {
                 var endnotesPart = mainPart.AddNewPart<EndnotesPart>();
+                RegisterNoteBodyHyperlinks(mainPart, endnotesPart, endnoteBodies);
                 endnotesPart.Endnotes = new Endnotes(EndnotesXml(endnoteBodies));
                 endnotesPart.Endnotes.Save();
             }
@@ -514,19 +546,47 @@ internal static class DocxFixtures
     }
 
     // A note body: one <w:p> per paragraph, splitting NoteText on a blank line so a multi-paragraph note body
-    // (#315 continuation-indent) can be authored as "para1\n\npara2".
-    private static string NoteBodyParagraphs(string noteText)
-        => string.Concat(noteText.Split("\n\n").Select(p =>
-            $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(p)}</w:t></w:r></w:p>"));
+    // (#315 continuation-indent) can be authored as "para1\n\npara2". A body hyperlink (#457), when present, is
+    // appended to the LAST paragraph so the note reads "text <link>" at its reading position.
+    private static string NoteBodyParagraphs(NoteSpec note)
+    {
+        var paragraphs = note.NoteText!.Split("\n\n");
+        var linkXml = note is { BodyLinkText: { } linkText, BodyLinkUrl: not null }
+            ? $"<w:hyperlink r:id=\"{NoteBodyLinkRelId(note)}\"><w:r><w:t xml:space=\"preserve\">{Escape(linkText)}</w:t></w:r></w:hyperlink>"
+            : string.Empty;
+        return string.Concat(paragraphs.Select((p, i) =>
+            $"<w:p><w:r><w:t xml:space=\"preserve\">{Escape(p)}</w:t></w:r>{(i == paragraphs.Length - 1 ? linkXml : string.Empty)}</w:p>"));
+    }
+
+    // The stable relationship id for a note body's hyperlink (#457). Footnote / endnote ids can overlap, so the
+    // prefix keeps them distinct within a part; the SAME id is intentionally reused on the main part as a decoy
+    // in the collision test.
+    private static string NoteBodyLinkRelId(NoteSpec note) => $"rIdNoteLink{(note.IsEndnote ? "En" : "Fn")}{note.Id}";
+
+    // Registers each note body's hyperlink relationship on its OWN part (FootnotesPart / EndnotesPart). When a
+    // decoy is requested, the same relationship id is registered on the main part pointing elsewhere, so a note
+    // resolved against the main part would surface the wrong URL (#457).
+    private static void RegisterNoteBodyHyperlinks(MainDocumentPart mainPart, OpenXmlPart notesPart, IEnumerable<NoteSpec> notes)
+    {
+        foreach (var note in notes.Where(n => n.BodyLinkUrl is not null))
+        {
+            var relId = NoteBodyLinkRelId(note);
+            notesPart.AddHyperlinkRelationship(new System.Uri(note.BodyLinkUrl!), isExternal: true, relId);
+            if (note.BodyLinkMainDecoyUrl is not null)
+            {
+                mainPart.AddHyperlinkRelationship(new System.Uri(note.BodyLinkMainDecoyUrl), isExternal: true, relId);
+            }
+        }
+    }
 
     private static string FootnotesXml(IEnumerable<NoteSpec> notes)
     {
         // Real Word documents carry auto-inserted separator / continuationSeparator notes; include them (with
         // sentinel text) so the extractor's separator exclusion is exercised. Author notes follow.
         var bodies = string.Concat(notes.Select(n =>
-            $"<w:footnote w:id=\"{n.Id}\">{NoteBodyParagraphs(n.NoteText!)}</w:footnote>"));
+            $"<w:footnote w:id=\"{n.Id}\">{NoteBodyParagraphs(n)}</w:footnote>"));
         return $"""
-                <w:footnotes xmlns:w="{NsW}">
+                <w:footnotes xmlns:w="{NsW}" xmlns:r="{NsR}">
                   <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:t xml:space="preserve">SEP_SENTINEL</w:t></w:r></w:p></w:footnote>
                   <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:t xml:space="preserve">CONT_SENTINEL</w:t></w:r></w:p></w:footnote>
                   {bodies}
@@ -537,9 +597,9 @@ internal static class DocxFixtures
     private static string EndnotesXml(IEnumerable<NoteSpec> notes)
     {
         var bodies = string.Concat(notes.Select(n =>
-            $"<w:endnote w:id=\"{n.Id}\">{NoteBodyParagraphs(n.NoteText!)}</w:endnote>"));
+            $"<w:endnote w:id=\"{n.Id}\">{NoteBodyParagraphs(n)}</w:endnote>"));
         return $"""
-                <w:endnotes xmlns:w="{NsW}">
+                <w:endnotes xmlns:w="{NsW}" xmlns:r="{NsR}">
                   <w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:t xml:space="preserve">SEP_SENTINEL</w:t></w:r></w:p></w:endnote>
                   <w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:t xml:space="preserve">CONT_SENTINEL</w:t></w:r></w:p></w:endnote>
                   {bodies}


### PR DESCRIPTION
Closes #457.

## Problem

A footnote/endnote **body** is rendered by `RenderNoteBodyAsync` → `WordParagraphRenderer.Render(paragraph, mainPart)` with no hyperlink map, so a note-body hyperlink `r:id` fell through to `mainPart.HyperlinkRelationships`. But note-body `r:id`s belong to the **`FootnotesPart` / `EndnotesPart`**, whose relationship space is independent of the main document's.

Consequences (pre-existing; surfaced during PR #453 review, not introduced by #315/#318):
- An `r:id` present **only** in the notes part → URL lost, link degraded to plain text.
- An `r:id` present in **both** parts with different targets → note link resolved to the **main document's** URL (wrong destination).

## Fix

- Build a per-notes-part `id → uri` map (reusing the #318 body-path cache mechanism) and thread the owning part's map into the note-body render path, instead of always resolving against `mainPart`.
- Generalize `BuildHyperlinkUris` from `MainDocumentPart` to `OpenXmlPart` so the main / footnotes / endnotes parts share one builder.

No contract change: `TextExtractionResult` shape is unchanged and Markdown-first is preserved (the fix only improves note-link fidelity).

## Tests

- `DocxFixtures` can now author a note-body hyperlink whose relationship lives on the notes part, with an optional colliding main-part decoy target.
- Two new tests cover both consequences (footnote id only in the notes part; endnote id colliding with the main part).
- Verified **red before the fix, green after**; full OpenXml suite green (136 tests).