### PR TITLE
perf(text-extraction): memoize custom-style heading resolution per document (#458)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -302,7 +302,7 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocxExtractionState state,
         CancellationToken cancellationToken)
     {
-        var headingLevel = WordStyleMap.HeadingLevel(paragraph, mainPart);
+        var headingLevel = WordStyleMap.HeadingLevel(paragraph, mainPart, state.StyleHeadingCache);
         if (headingLevel is int level)
         {
             // Headings render as plain collapsed text (no inline emphasis markup inside an ATX heading).
@@ -1041,5 +1041,9 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
 
         /// <summary>Per-document <c>(numId, level) → numbering-format</c> memo, populated lazily (#318).</summary>
         public Dictionary<(int NumId, int Level), W.NumberFormatValues?> NumberingFormatCache { get; } = new();
+
+        /// <summary>Per-document custom-style <c>styleId → heading-level</c> memo, populated lazily (#458). Spares
+        /// every styled body paragraph a fresh <c>w:basedOn</c>-chain walk over styles.xml.</summary>
+        public Dictionary<string, int?> StyleHeadingCache { get; } = new();
     }
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordStyleMap.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/WordStyleMap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
@@ -40,7 +41,15 @@ internal static class WordStyleMap
     /// resolved against <c>styles.xml</c> (the <c>basedOn</c> chain + style-level outline); when <c>null</c>,
     /// only the paragraph's own properties are considered (the pre-#316 behavior).
     /// </summary>
-    public static int? HeadingLevel(W.Paragraph paragraph, MainDocumentPart? mainPart = null)
+    /// <param name="styleHeadingCache">Optional per-document <c>styleId → level</c> memo (#458): when supplied,
+    /// a custom style's <c>basedOn</c>-chain resolution is computed once per distinct style id rather than once
+    /// per styled paragraph. Mirrors <see cref="WordListNumbering.Resolve"/>'s optional <c>formatCache</c>. Only
+    /// the step-3 style-chain walk is memoized; the built-in-id and paragraph-direct-outline checks (steps 1-2)
+    /// are per-paragraph direct formatting and are never keyed by style id.</param>
+    public static int? HeadingLevel(
+        W.Paragraph paragraph,
+        MainDocumentPart? mainPart = null,
+        IDictionary<string, int?>? styleHeadingCache = null)
     {
         var properties = paragraph.ParagraphProperties;
         if (properties is null)
@@ -78,7 +87,7 @@ internal static class WordStyleMap
         //    or a style-level outlineLvl). Requires the style part; otherwise the paragraph is not a heading.
         if (!string.IsNullOrEmpty(styleId) && mainPart is not null)
         {
-            return ResolveStyleHeadingLevel(styleId!, mainPart);
+            return ResolveStyleHeadingLevel(styleId!, mainPart, styleHeadingCache);
         }
 
         return null;
@@ -118,12 +127,39 @@ internal static class WordStyleMap
     }
 
     /// <summary>
-    /// Resolves a custom paragraph style against <c>styles.xml</c> by walking the <c>w:basedOn</c> chain: a
-    /// built-in <c>HeadingN</c> / <c>Title</c> id reached along the chain (even a latent style with no
-    /// explicit definition) supplies the level, as does the first style-level <c>w:outlineLvl</c> encountered
-    /// (the closest override wins). Returns <c>null</c> when the chain resolves to no heading.
+    /// Resolves a custom paragraph style to a heading level, reading a per-document memo first (#458): the
+    /// <c>styleId → level</c> resolution is walked once per distinct style id, so a corporate template whose
+    /// every "Body Text" paragraph shares one custom style scans <c>styles.xml</c> once rather than once per
+    /// paragraph. The walk itself lives in <see cref="ComputeStyleHeadingLevel"/>; this wrapper mirrors
+    /// <see cref="WordListNumbering"/>'s <c>ResolveFormat</c> cache layer (a <c>null</c> level is a legitimate
+    /// cached result — "resolved, not a heading" — so absence-of-key, not null-value, is the miss).
     /// </summary>
-    private static int? ResolveStyleHeadingLevel(string styleId, MainDocumentPart mainPart)
+    private static int? ResolveStyleHeadingLevel(
+        string styleId,
+        MainDocumentPart mainPart,
+        IDictionary<string, int?>? styleHeadingCache)
+    {
+        if (styleHeadingCache is not null && styleHeadingCache.TryGetValue(styleId, out var cached))
+        {
+            return cached;
+        }
+
+        var level = ComputeStyleHeadingLevel(styleId, mainPart);
+        if (styleHeadingCache is not null)
+        {
+            styleHeadingCache[styleId] = level;
+        }
+
+        return level;
+    }
+
+    /// <summary>
+    /// Walks a custom paragraph style's <c>w:basedOn</c> chain against <c>styles.xml</c>: a built-in
+    /// <c>HeadingN</c> / <c>Title</c> id reached along the chain (even a latent style with no explicit
+    /// definition) supplies the level, as does the first style-level <c>w:outlineLvl</c> encountered (the
+    /// closest override wins). Returns <c>null</c> when the chain resolves to no heading.
+    /// </summary>
+    private static int? ComputeStyleHeadingLevel(string styleId, MainDocumentPart mainPart)
     {
         var styles = mainPart.StyleDefinitionsPart?.Styles;
         if (styles is null)

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/WordStyleMap_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/WordStyleMap_Tests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
@@ -197,6 +198,56 @@ public class WordStyleMap_Tests
         using (document)
         {
             WordStyleMap.HeadingLevel(paragraph, mainPart).ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void Caches_a_resolved_custom_style_heading_level()
+    {
+        // #458: the first resolution of a custom style writes styleId -> level into the memo, so subsequent
+        // paragraphs sharing the style skip the basedOn-chain walk over styles.xml.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "ChapterTitle",
+            "<w:style w:type=\"paragraph\" w:styleId=\"ChapterTitle\"><w:basedOn w:val=\"Heading1\"/></w:style>");
+        using (document)
+        {
+            var cache = new Dictionary<string, int?>();
+            WordStyleMap.HeadingLevel(paragraph, mainPart, cache).ShouldBe(1);
+            cache.ShouldContainKeyAndValue("ChapterTitle", 1);
+        }
+    }
+
+    [Fact]
+    public void A_cache_hit_short_circuits_the_style_chain_walk()
+    {
+        // #458: a hit on the memo returns the cached level without touching styles.xml. Pre-seed a sentinel the
+        // chain would never produce (the style is based on Heading1 => H1) and assert the sentinel is returned,
+        // proving the memo — not the walk — supplied the answer.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "ChapterTitle",
+            "<w:style w:type=\"paragraph\" w:styleId=\"ChapterTitle\"><w:basedOn w:val=\"Heading1\"/></w:style>");
+        using (document)
+        {
+            var cache = new Dictionary<string, int?> { ["ChapterTitle"] = 4 };
+            WordStyleMap.HeadingLevel(paragraph, mainPart, cache).ShouldBe(4);
+        }
+    }
+
+    [Fact]
+    public void Caches_a_non_heading_custom_style_as_a_null_level()
+    {
+        // #458: "resolved, not a heading" is a real cached result. The memo stores the key with a null value so
+        // a repeated body-text paragraph is a cache HIT (absence-of-key is the miss, not null-value) and does
+        // not re-walk the chain.
+        var (document, mainPart, paragraph) = BuildWithStyles(
+            "BodyCustom",
+            "<w:style w:type=\"paragraph\" w:styleId=\"BodyCustom\"><w:basedOn w:val=\"Normal\"/></w:style>");
+        using (document)
+        {
+            var cache = new Dictionary<string, int?>();
+            WordStyleMap.HeadingLevel(paragraph, mainPart, cache).ShouldBeNull();
+            cache.ShouldContainKey("BodyCustom");
+            cache["BodyCustom"].ShouldBeNull();
         }
     }
 }


### PR DESCRIPTION
Closes #458.

`WordStyleMap.HeadingLevel` (#316) resolved a custom paragraph style by scanning `styles.xml` (`Elements<w:style>().FirstOrDefault`) once per `w:basedOn` hop, for **every** styled body paragraph — worst case `O(paragraphs × styles × chain-depth)`. A corporate template whose every "Body Text" paragraph shares one custom style re-scans the whole style table per paragraph. Its sibling #318 memoized hyperlink and numbering lookups but skipped this one.

## Fix

Per-document `styleId → int?` memo on `DocxExtractionState`, threaded into `HeadingLevel` as an optional cache — mirroring `WordListNumbering.Resolve`'s optional `formatCache`. `ResolveStyleHeadingLevel` splits into a cache wrapper + the `ComputeStyleHeadingLevel` walk (matching `Resolve → ResolveFormat → ComputeFormat`).

Two correctness points locked by tests:

- **Only the step-3 style-chain walk is memoized.** Steps 1–2 (built-in style id, paragraph-direct `outlineLvl`) are per-paragraph direct formatting and are never keyed by style id.
- **A `null` level is a legitimate cached result** ("resolved, not a heading"), so a miss is *absence-of-key*, not null-value — the common body-text style still hits the cache instead of re-walking.

## Tests

Pure performance, **no output change**. 3 new units: write-on-miss, hit-short-circuits-the-walk (sentinel), null-is-cached. Full `Parse.OpenXml` suite green (88 tests); the `DocxExtractor` integration tests exercise the threaded cache end-to-end and confirm identical Markdown.