### PR TITLE
fix(text-extraction): trip #268 completeness when the PDF lattice path drops an out-of-grid fragment (#450 follow-up)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
@@ -128,6 +128,8 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
             var truncatedOcr = 0;
             var failedFigureOcr = 0;
             var figureOcrCount = 0;
+            // #268 (#450 lattice): meaningful table fragments dropped as outside-the-drawn-grid, across all pages.
+            var latticeDroppedFragments = 0;
             // Distinct from failedPages (GetWords fault → whole page dropped): here GetImages faulted but
             // the page's text was already extracted and is retained — only its images are skipped.
             var pagesWithSkippedImages = 0;
@@ -292,7 +294,9 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                 }
 
                 var pageMarkdown = PdfReadingOrder.RenderPage(
-                    renderWords, figures, _options.ReconstructTables, headingScale, rulingBounds);
+                    renderWords, figures, _options.ReconstructTables, headingScale, rulingBounds,
+                    out var pageLatticeDropped);
+                latticeDroppedFragments += pageLatticeDropped;
                 if (!string.IsNullOrWhiteSpace(pageMarkdown))
                 {
                     pageMarkdowns.Add(pageMarkdown);
@@ -303,7 +307,8 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
             // is null iff nothing was lost; completeness derives from it (no parallel hand-synced predicate
             // that could drift when a new counter is added).
             var incompleteReason = BuildIncompleteReason(
-                failedPages, pagesWithSkippedImages, droppedByCap, undecodable, truncatedOcr, failedFigureOcr);
+                failedPages, pagesWithSkippedImages, droppedByCap, undecodable, truncatedOcr, failedFigureOcr,
+                latticeDroppedFragments);
             var complete = incompleteReason is null;
             if (!complete)
             {
@@ -510,7 +515,8 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
     /// boolean predicate.
     /// </summary>
     internal static string? BuildIncompleteReason(
-        int failedPages, int pagesWithSkippedImages, int droppedByCap, int undecodable, int truncatedOcr, int failedFigureOcr)
+        int failedPages, int pagesWithSkippedImages, int droppedByCap, int undecodable, int truncatedOcr, int failedFigureOcr,
+        int latticeDroppedFragments)
     {
         var parts = new List<string>();
         if (failedPages > 0)
@@ -541,6 +547,11 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
         if (droppedByCap > 0)
         {
             parts.Add($"{droppedByCap} image(s) were skipped after reaching the per-document image cap");
+        }
+
+        if (latticeDroppedFragments > 0)
+        {
+            parts.Add($"{latticeDroppedFragments} table fragment(s) fell outside a drawn table grid and were dropped");
         }
 
         return parts.Count == 0 ? null : string.Join("; ", parts) + ".";

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -635,10 +635,12 @@ internal static class PdfReadingOrder
     /// </para>
     /// </summary>
     public static string RenderPage(
-        IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables = true,
-        PdfHeadingScale? headingScale = null, IReadOnlyList<PdfRectangle>? rulingBounds = null)
+        IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables,
+        PdfHeadingScale? headingScale, IReadOnlyList<PdfRectangle>? rulingBounds,
+        out int latticeDroppedFragments)
     {
-        var markdown = RenderPageCore(words, figures, reconstructTables, headingScale, rulingBounds);
+        var markdown = RenderPageCore(
+            words, figures, reconstructTables, headingScale, rulingBounds, out latticeDroppedFragments);
         // #403: a heading that wrapped across lines / bands renders as adjacent same-level "# …" blocks; stitch
         // them back into one heading (e.g. the title and its trailing 「書」). A no-op when no headings exist.
         return headingScale is { HasHeadings: true } ? MergeAdjacentHeadings(markdown) : markdown;
@@ -646,8 +648,12 @@ internal static class PdfReadingOrder
 
     private static string RenderPageCore(
         IReadOnlyList<Word> words, IReadOnlyList<Figure> figures, bool reconstructTables,
-        PdfHeadingScale? headingScale, IReadOnlyList<PdfRectangle>? rulingBounds)
+        PdfHeadingScale? headingScale, IReadOnlyList<PdfRectangle>? rulingBounds,
+        out int latticeDroppedFragments)
     {
+        // No lattice table built on the early flat-render fall-throughs below -> no dropped fragment.
+        latticeDroppedFragments = 0;
+
         // #407: build the page's justification-aware paragraph model once (right margin + measured wrap pitch)
         // and feed it to every Render call below, so a paragraph the segmenter cut into per-line blocks re-folds.
         var pageLines = GroupWordsIntoLines(words);
@@ -706,6 +712,7 @@ internal static class PdfReadingOrder
         // loop below is exactly the Phase A per-block path; the host switch off -> empty maps -> identical to
         // Phase A.
         var tables = reconstructTables ? DetectTableClusters(orderedBlocks, grids) : TableClusters.Empty;
+        latticeDroppedFragments = tables.LatticeDroppedFragments;
 
         var rendered = new List<string>(orderedBlocks.Count);
         var emittedTables = new HashSet<int>();
@@ -807,6 +814,14 @@ internal static class PdfReadingOrder
 
         /// <summary>Lead block index -> all block indices in the cluster (ascending).</summary>
         public Dictionary<int, List<int>> BlocksByLead { get; } = new();
+
+        /// <summary>
+        /// #268: count of meaningful fragments the lattice path dropped as outside-the-drawn-grid, summed across
+        /// every EMITTED lattice table on the page. Only emitted tables count — a lattice that returned null
+        /// un-claims its blocks so the stream/paragraph path re-renders them (non-lossy), and those drops are not
+        /// losses. <see cref="PdfExtractor"/> surfaces this into the #268 completeness signal.
+        /// </summary>
+        public int LatticeDroppedFragments { get; set; }
     }
 
     /// <summary>
@@ -852,11 +867,14 @@ internal static class PdfReadingOrder
 
             // TryRenderLattice returns null unless the claimed blocks fill a >= 2x2 grid, so a lone caption
             // block that happens to sit inside a grid extent does not become a spurious table.
-            var lattice = PdfTableReconstruction.TryRenderLattice(latticeCells, g);
+            var lattice = PdfTableReconstruction.TryRenderLattice(latticeCells, g, out var droppedFragments);
             if (lattice is null)
             {
                 continue;
             }
+
+            // Only an EMITTED table's drops are losses (a null return un-claimed the blocks for the stream path).
+            result.LatticeDroppedFragments += droppedFragments;
 
             var latticeLead = insideBlocks.Min();
             result.MarkdownByLead[latticeLead] = lattice;

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfTableReconstruction.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfTableReconstruction.cs
@@ -204,8 +204,14 @@ internal static class PdfTableReconstruction
     /// the grid is smaller than 2×2 or no drawn row carries text, so the caller falls back to
     /// <see cref="TryRender"/>.
     /// </summary>
-    public static string? TryRenderLattice(IReadOnlyList<Cell> cells, PdfRulingLines.Grid grid)
+    /// <param name="droppedFragments">Count of meaningful fragments whose centre fell outside the drawn grid and
+    /// were dropped. Only a real loss when this method returns a table (non-null): on a <c>null</c> return the
+    /// caller un-claims the blocks and the stream/paragraph path re-renders them, so the caller reads this only
+    /// past the null check.</param>
+    public static string? TryRenderLattice(IReadOnlyList<Cell> cells, PdfRulingLines.Grid grid, out int droppedFragments)
     {
+        droppedFragments = 0;
+
         var meaningful = cells.Where(c => !string.IsNullOrWhiteSpace(c.Text)).ToList();
         if (meaningful.Count == 0 || grid.ColumnCount < MinColumns || grid.RowCount < MinRows)
         {
@@ -223,12 +229,15 @@ internal static class PdfTableReconstruction
             var bandFromBottom = BandIndex(rows, (cell.Bounds.Top + cell.Bounds.Bottom) / 2.0);
             if (column < 0 || bandFromBottom < 0)
             {
-                // A fragment whose centre is outside the drawn boundaries is deliberately dropped as non-table
-                // content. NOTE (#450 review): the caller claims a block by its CENTROID being inside the grid,
+                // A fragment whose centre is outside the drawn boundaries is dropped as non-table content, and
+                // COUNTED (#450 review / #268): the caller claims a block by its CENTROID being inside the grid,
                 // so a block straddling the outer rule could contribute a fragment that lands here and is not
                 // re-rendered by the stream path — a narrow lossy edge, unlike the strict non-lossy guarantee
                 // RenderPageCore enforces around segmentation. It is bounded by real ruled tables enclosing their
                 // text, and by this method returning null (un-claiming the blocks) whenever the grid degrades.
+                // Reporting the count lets the caller trip the #268 completeness signal instead of silently
+                // losing the fragment.
+                droppedFragments++;
                 continue;
             }
 

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfIncompleteReason_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfIncompleteReason_Tests.cs
@@ -10,20 +10,21 @@ namespace Dignite.Vault.Extract.Parse.Pdf;
 /// </summary>
 public class PdfIncompleteReason_Tests
 {
-    // (failedPages, pagesWithSkippedImages, droppedByCap, undecodable, truncatedOcr, failedFigureOcr)
+    // (failedPages, pagesWithSkippedImages, droppedByCap, undecodable, truncatedOcr, failedFigureOcr, latticeDroppedFragments)
 
     [Fact]
     public void Returns_null_when_nothing_was_lost()
     {
         // null reason ⇒ IsComplete = true. This is what makes the boolean derive from one source.
-        PdfExtractor.BuildIncompleteReason(0, 0, 0, 0, 0, 0).ShouldBeNull();
+        PdfExtractor.BuildIncompleteReason(0, 0, 0, 0, 0, 0, 0).ShouldBeNull();
     }
 
     [Fact]
     public void Reports_a_dropped_page_as_unparsed()
     {
         var reason = PdfExtractor.BuildIncompleteReason(
-            failedPages: 1, pagesWithSkippedImages: 0, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 0);
+            failedPages: 1, pagesWithSkippedImages: 0, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 0,
+            latticeDroppedFragments: 0);
 
         reason.ShouldNotBeNull();
         reason!.ShouldContain("could not be parsed");
@@ -34,7 +35,8 @@ public class PdfIncompleteReason_Tests
     {
         // GetImages faulted but the page's text was retained — must NOT say the page was skipped/unparsed.
         var reason = PdfExtractor.BuildIncompleteReason(
-            failedPages: 0, pagesWithSkippedImages: 1, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 0);
+            failedPages: 0, pagesWithSkippedImages: 1, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 0,
+            latticeDroppedFragments: 0);
 
         reason.ShouldNotBeNull();
         reason!.ShouldContain("page text retained");
@@ -45,9 +47,25 @@ public class PdfIncompleteReason_Tests
     public void Reports_a_failed_figure_ocr()
     {
         var reason = PdfExtractor.BuildIncompleteReason(
-            failedPages: 0, pagesWithSkippedImages: 0, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 2);
+            failedPages: 0, pagesWithSkippedImages: 0, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 2,
+            latticeDroppedFragments: 0);
 
         reason.ShouldNotBeNull();
         reason!.ShouldContain("failed OCR");
+    }
+
+    [Fact]
+    public void Reports_lattice_dropped_table_fragments()
+    {
+        // #450 lattice / #268: a table fragment that fell outside a drawn grid was dropped — the page is
+        // incomplete and the reason must say so (not conflated with an image or page-parse failure).
+        var reason = PdfExtractor.BuildIncompleteReason(
+            failedPages: 0, pagesWithSkippedImages: 0, droppedByCap: 0, undecodable: 0, truncatedOcr: 0, failedFigureOcr: 0,
+            latticeDroppedFragments: 3);
+
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("outside a drawn table grid");
+        reason.ShouldNotContain("could not be parsed");
+        reason.ShouldNotContain("image");
     }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfLatticeIntegration_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfLatticeIntegration_Tests.cs
@@ -26,7 +26,7 @@ public class PdfLatticeIntegration_Tests
             .ToList();
 
         return PdfReadingOrder.RenderPage(
-            words, Array.Empty<PdfReadingOrder.Figure>(), true, PdfHeadingScale.Build(words), rulingBounds);
+            words, Array.Empty<PdfReadingOrder.Figure>(), true, PdfHeadingScale.Build(words), rulingBounds, out _);
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRulingLines_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfRulingLines_Tests.cs
@@ -134,15 +134,18 @@ public class PdfRulingLines_Tests
             Cell("Apple", 60, 110, 150), Cell("10", 160, 185, 150)    // bottom row
         };
 
-        PdfTableReconstruction.TryRenderLattice(cells, grid).ShouldBe(
-            "| Name | Price |\n| --- | --- |\n| Apple | 10 |");
+        var markdown = PdfTableReconstruction.TryRenderLattice(cells, grid, out var dropped);
+
+        markdown.ShouldBe("| Name | Price |\n| --- | --- |\n| Apple | 10 |");
+        dropped.ShouldBe(0); // every cell is inside the drawn grid
     }
 
     [Fact]
-    public void Keeps_an_empty_drawn_column_and_ignores_fragments_outside_the_grid()
+    public void Keeps_an_empty_drawn_column_and_reports_fragments_outside_the_grid()
     {
         // 3 columns; the middle column has no content (a drawn-but-empty column, like メモ). A fragment whose
-        // centre is outside the grid extent is not table content and is dropped.
+        // centre is outside the grid extent is not table content, so it is dropped — AND counted (#268), so the
+        // caller trips the completeness signal instead of losing it silently.
         var grid = new PdfRulingLines.Grid(
             new[] { 50.0, 150, 250, 350 }, new[] { 100.0, 200, 300 });
 
@@ -150,11 +153,13 @@ public class PdfRulingLines_Tests
         {
             Cell("A", 60, 100, 250), Cell("C", 260, 300, 250),
             Cell("x", 60, 100, 150), Cell("z", 260, 300, 150),
-            Cell("outside", 400, 480, 150) // right of the last boundary (350) -> ignored
+            Cell("outside", 400, 480, 150) // right of the last boundary (350) -> dropped + counted
         };
 
-        PdfTableReconstruction.TryRenderLattice(cells, grid).ShouldBe(
-            "| A |  | C |\n| --- | --- | --- |\n| x |  | z |");
+        var markdown = PdfTableReconstruction.TryRenderLattice(cells, grid, out var dropped);
+
+        markdown.ShouldBe("| A |  | C |\n| --- | --- | --- |\n| x |  | z |");
+        dropped.ShouldBe(1);
     }
 
     [Fact]
@@ -176,7 +181,9 @@ public class PdfRulingLines_Tests
             Cell("v", 310, 350, 150)
         };
 
-        PdfTableReconstruction.TryRenderLattice(cells, grid).ShouldBe(
-            "| H | H2 |\n| --- | --- |\n| wire alpha beta cont | v |");
+        var markdown = PdfTableReconstruction.TryRenderLattice(cells, grid, out var dropped);
+
+        markdown.ShouldBe("| H | H2 |\n| --- | --- |\n| wire alpha beta cont | v |");
+        dropped.ShouldBe(0);
     }
 }


### PR DESCRIPTION
## What

Wires the #450 PDF **lattice** table path into the #268 extraction-completeness signal. When the lattice renderer drops a meaningful text fragment because its centre falls outside the drawn table grid, the page is now reported as incomplete (`IsComplete=false` + an `IncompleteReason` clause) instead of silently reporting complete.

## Why

`PdfTableReconstruction.TryRenderLattice` places each fragment in the cell whose drawn boundaries contain its centre and **drops** any fragment outside the grid. The caller (`DetectTableClusters`) claims a block for the lattice table by the block's **centroid** being inside the grid, so a block straddling the outer rule can contribute a fragment that lands outside and is dropped. That drop was documented at the drop site (per the #450 review) but **silent** — the egress reported `ExtractionIsComplete=true`, so a downstream consumer could not tell a fragment had been lost.

#268 exists precisely to surface dropped content (an unparsed page, a truncated/failed image OCR). The lattice drop is the same class of loss and should feed the same signal — the same lesson as the #315 review fix, where DOCX footnotes were being dropped past #268.

## How

- `TryRenderLattice(cells, grid, out int droppedFragments)` — reports the count of meaningful fragments dropped as outside-the-grid.
- `DetectTableClusters` accumulates the count into `TableClusters.LatticeDroppedFragments`, but **only for an EMITTED table**. A `null` render un-claims its blocks, so the stream/paragraph path re-renders them non-lossily — those drops are not losses and are not counted.
- `PdfReadingOrder.RenderPage(..., out int latticeDroppedFragments)` surfaces the per-page count.
- `PdfExtractor` adds it to the existing single-source-of-truth loss-counter set feeding `BuildIncompleteReason`, so `IsComplete` / `IncompleteReason` still derive from **one** place (no parallel hand-synced predicate).

**Not** changed: the egress contract shape (still the #268 `IsComplete` + `IncompleteReason` fields — no new field, no `Dictionary<string,object>` bag), and the rendering of any lattice table. This PR only **adds** the honest loss signal for a fragment that was already being dropped; every existing lattice table renders byte-identically.

## Tests

- `PdfRulingLines_Tests` — the outside-grid fragment case now asserts `dropped == 1` while all-inside cases assert `0`.
- `PdfIncompleteReason_Tests` — a new case covers the lattice reason clause and asserts it is not conflated with a page-parse or image failure.
- **Red-verified**: removing the `droppedFragments++` increment makes the count assertion fail; restored to green.
- Pdf test suite **101 green**; full solution builds clean (0 errors).

## Process note

Per `CLAUDE.md` working-rule 3 this is a **bug fix** (an existing lossy code path was not populating an existing egress signal), recorded in the commit message — no contract-shape change, so no new Issue. Found in the post-v0.3.0 audit alongside #468 (prompt-cap round-trip) and #469 (/mcp rate-limiter proxy partition), which are filed as Issues because they need a direction decision.

Refs #450, #268.
