### PR TITLE
feat(text-extraction): retain embedded figure source images, reference + serve them (#477 Phases 1-3)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/ExtractedFigure.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/ExtractedFigure.cs
@@ -1,0 +1,44 @@
+namespace Dignite.Vault.Extract.Abstractions.Parse;
+
+/// <summary>
+/// An embedded figure's <b>source image</b>, surfaced out-of-band (#477) so the Application layer can persist it
+/// as a blob and the Markdown can reference it (<c>figures/{ContentHash}</c>). A provider only surfaces bytes it
+/// <b>already decoded for OCR</b> — it persists nothing itself (respecting the Parse/OCR ↔ Application boundary,
+/// #393). <see cref="TextExtractionResult.Figures"/> is <c>null</c> unless figure retention is requested
+/// (<see cref="TextExtractionContext.RetainFigureImages"/>); providers with no spatial model leave it <c>null</c>.
+/// <para>
+/// This is a named, strongly-typed, nullable out-of-band signal (the #210 <c>PageBlocks</c>/<c>NativePayload</c>
+/// precedent — <b>not</b> a <c>Dictionary&lt;string,object&gt;</c> bag, #206). The image bytes never enter
+/// <c>Document.Markdown</c>; only the <c>figures/{hash}</c> reference does.
+/// </para>
+/// </summary>
+public sealed class ExtractedFigure
+{
+    /// <summary>
+    /// SHA-256 (lowercase hex) of <see cref="Content"/> — the stable identity + dedup key. It matches the
+    /// <c>figures/{hash}</c> reference the provider inlined into the Markdown, and becomes the blob key suffix
+    /// (<c>extraction-figures/{documentId}/{hash}</c>) the Application layer writes.
+    /// </summary>
+    public string ContentHash { get; }
+
+    /// <summary>The image bytes — the exact OCR input the provider decoded.</summary>
+    public byte[] Content { get; }
+
+    /// <summary>Image MIME type, e.g. <c>image/png</c> / <c>image/jpeg</c>.</summary>
+    public string ContentType { get; }
+
+    /// <summary>1-based source page anchor (provenance, never identity, #210); <c>null</c> for a page-less source.</summary>
+    public int? PageNumber { get; }
+
+    /// <summary>Native alt-text / caption when the format provides it (e.g. DOCX <c>docPr.Description</c>); <c>null</c> otherwise.</summary>
+    public string? AltText { get; }
+
+    public ExtractedFigure(string contentHash, byte[] content, string contentType, int? pageNumber = null, string? altText = null)
+    {
+        ContentHash = contentHash;
+        Content = content;
+        ContentType = contentType;
+        PageNumber = pageNumber;
+        AltText = altText;
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/FigureReference.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/FigureReference.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Dignite.Vault.Extract.Abstractions.Parse;
+
+/// <summary>
+/// Shared format for the #477 retained-figure Markdown reference (<c>figures/{hash}.{ext}</c>) and its content
+/// hash — used by every image-bearing text-extraction provider (PDF, DOCX, PPTX) so the reference the provider
+/// inlines into the Markdown, the <see cref="ExtractedFigure.ContentHash"/> it surfaces, and the blob key the
+/// Application layer writes (<c>extraction-figures/{documentId}/{hash}</c>) all agree. Centralized here (a sibling
+/// of <see cref="ImageOcrMarkup"/>) so a provider cannot drift the format.
+/// </summary>
+public static class FigureReference
+{
+    /// <summary>SHA-256 (lowercase hex) of the image bytes — the retained figure's content hash / dedup key.</summary>
+    public static string Sha256Hex(byte[] content)
+        => Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+
+    /// <summary>The document-relative Markdown reference for a retained figure (<c>figures/{hash}.{ext}</c>). The
+    /// egress resolves the blob by hash, so the extension is cosmetic (renderer-friendly).</summary>
+    public static string Build(string contentHash, string contentType)
+        => "figures/" + contentHash + "." + Extension(contentType);
+
+    /// <summary>Maps an image MIME type to a file extension. Any <c>image/*</c> subtype passes through
+    /// (<c>jpeg</c> → <c>jpg</c>); a missing / non-image type falls back to <c>img</c>.</summary>
+    private static string Extension(string? contentType)
+    {
+        if (string.IsNullOrEmpty(contentType) ||
+            !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+        {
+            return "img";
+        }
+
+        var subtype = contentType["image/".Length..].Trim().ToLowerInvariant();
+        return subtype switch
+        {
+            "" => "img",
+            "jpeg" => "jpg",
+            _ => subtype
+        };
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/ImageOcrMarkup.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/ImageOcrMarkup.cs
@@ -46,16 +46,38 @@ public static class ImageOcrMarkup
     public const string CloseMarker = "*[End OCR]*";
 
     /// <summary>
+    /// Opens a #477 retained-figure image-reference line, inlined as the figure span's <b>first body line</b>
+    /// (right after the open marker) when the source image is retained; the full line is
+    /// <c>![figure](figures/{hash}.{ext})</c>. The bare marker format is unchanged (MarkItDown parity, #381).
+    /// </summary>
+    private const string ImageReferenceOpen = "![figure](";
+
+    /// <summary>The document-relative target that identifies a #477 figure image-reference line
+    /// (<c>](figures/…)</c>) — matched inside the line so it stays stable across the alt text.</summary>
+    private const string ImageReferenceTarget = "](figures/";
+
+    /// <summary>
     /// Wraps a figure's OCR <paramref name="transcription"/> in the open/close markers, each on its own line,
     /// with an optional 1-based <paramref name="pageNumber"/> anchor on the open line. A non-positive / null page
     /// produces the bare open marker.
+    /// <para>
+    /// When <paramref name="imageReference"/> is supplied (#477 figure retention on), a
+    /// <c>![figure]({imageReference})</c> line is inlined as the <b>first body line</b> (immediately after the
+    /// open marker) so the retained image travels <b>inside</b> the figure span — the sub-document segmentation
+    /// pass (#478) correlates a figure to its blob from there, and segmentation cuts <i>at</i> the marker line so
+    /// a reference placed above it would fall into the previous slice. Null / empty leaves the bare span
+    /// (byte-identical to before #477).
+    /// </para>
     /// </summary>
-    public static string Wrap(string? transcription, int? pageNumber)
+    public static string Wrap(string? transcription, int? pageNumber, string? imageReference = null)
     {
         var open = pageNumber is { } p && p > 0
             ? OpenPagePrefix + p.ToString(CultureInfo.InvariantCulture) + PageSuffix
             : OpenMarker;
-        return open + "\n" + (transcription ?? string.Empty) + "\n" + CloseMarker;
+        var body = string.IsNullOrEmpty(imageReference)
+            ? (transcription ?? string.Empty)
+            : ImageReferenceOpen + imageReference + ")\n" + (transcription ?? string.Empty);
+        return open + "\n" + body + "\n" + CloseMarker;
     }
 
     /// <summary>
@@ -101,7 +123,7 @@ public static class ImageOcrMarkup
             return markdown ?? string.Empty;
         }
 
-        return string.Join("\n", markdown.Split('\n').Where(line => !IsSentinelLine(line)));
+        return string.Join("\n", markdown.Split('\n').Where(line => !IsSentinelLine(line) && !IsImageReferenceLine(line)));
     }
 
     /// <summary>
@@ -137,6 +159,14 @@ public static class ImageOcrMarkup
 
             if (inside)
             {
+                // #477: a retained-figure image reference is provenance, not transcription — the spawned figure
+                // sub-document's seed is the transcription (nothing more, #373), so drop the reference line here.
+                // It survives in the container's Document.Markdown egress; only the child seed excludes it.
+                if (IsImageReferenceLine(line))
+                {
+                    continue;
+                }
+
                 if (sb.Length > 0)
                 {
                     sb.Append('\n');
@@ -164,6 +194,26 @@ public static class ImageOcrMarkup
     /// <summary>Whether the (trimmed) line is the figure close marker.</summary>
     public static bool IsCloseLine(string? line)
         => line is not null && line.Trim() == CloseMarker;
+
+    /// <summary>
+    /// Whether the (trimmed) line is a #477 retained-figure image reference (<c>![…](figures/…)</c>) — the
+    /// provenance image link inlined as the figure span's first body line. Recognized by its <c>](figures/</c>
+    /// document-relative target (stable across the alt text), so <see cref="Strip"/> / <see cref="ExtractBodies"/>
+    /// drop it when deriving a sub-document's clean seed; it stays in the container's <c>Document.Markdown</c>
+    /// egress (only the child-seed utilities exclude it).
+    /// </summary>
+    public static bool IsImageReferenceLine(string? line)
+    {
+        if (line is null)
+        {
+            return false;
+        }
+
+        var trimmed = line.Trim();
+        return trimmed.StartsWith("![", StringComparison.Ordinal)
+            && trimmed.EndsWith(")", StringComparison.Ordinal)
+            && trimmed.IndexOf(ImageReferenceTarget, StringComparison.Ordinal) >= 0;
+    }
 
     /// <summary>
     /// Parses the 1-based page from a page-anchored open marker line (<c>*[Image OCR p:3]*</c>), or <c>null</c>

--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/TextExtractionContext.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/TextExtractionContext.cs
@@ -12,4 +12,13 @@ public class TextExtractionContext
 
     /// <summary>Language hints as a BCP 47 list, such as ["ja", "en"].</summary>
     public IList<string> LanguageHints { get; set; } = new List<string>();
+
+    /// <summary>
+    /// When <c>true</c> (#477), image-bearing providers surface each embedded figure's source bytes on
+    /// <see cref="TextExtractionResult.Figures"/> and inline a <c>figures/{hash}</c> reference into the Markdown,
+    /// so the Application layer can persist the image as a blob. Host-deployment-layer toggle threaded down by the
+    /// parse job; <b>default <c>false</c></b>, in which case a provider behaves exactly as before (no reference,
+    /// no <see cref="TextExtractionResult.Figures"/>). Providers that do not retain images ignore it.
+    /// </summary>
+    public bool RetainFigureImages { get; set; }
 }

--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/TextExtractionResult.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/TextExtractionResult.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Dignite.Vault.Extract.Abstractions.Parse;
 
 public class TextExtractionResult
@@ -45,4 +47,14 @@ public class TextExtractionResult
     /// figure OCR ran.
     /// </summary>
     public int FigureOcrCount { get; set; }
+
+    /// <summary>
+    /// Retained embedded-figure <b>source images</b> (#477), surfaced out-of-band so the Application layer can
+    /// persist each as a blob (<c>extraction-figures/{documentId}/{ContentHash}</c>) while the Markdown carries a
+    /// <c>figures/{hash}</c> reference the provider inlined at the figure's reading position. <c>null</c> unless
+    /// figure retention was requested (<see cref="TextExtractionContext.RetainFigureImages"/>); providers with no
+    /// spatial model (plain text → Markdown) leave it <c>null</c>. The bytes never enter <see cref="Markdown"/> or
+    /// the DB — only the reference does; this is the #210-shaped named/typed/nullable signal, not a text payload.
+    /// </summary>
+    public IReadOnlyList<ExtractedFigure>? Figures { get; set; }
 }

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/IDocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/IDocumentAppService.cs
@@ -16,6 +16,13 @@ public interface IDocumentAppService : IApplicationService
 
     Task<IRemoteStreamContent> GetBlobAsync(Guid id);
 
+    /// <summary>
+    /// Serves a retained embedded-figure image (#477) referenced from the document's Markdown as
+    /// <c>figures/{hash}.{ext}</c>. <paramref name="fileName"/> is that reference's last segment; its content hash
+    /// (the name without the cosmetic extension) is resolved against the document's retained-figure manifest.
+    /// </summary>
+    Task<IRemoteStreamContent> GetFigureAsync(Guid id, string fileName);
+
     Task DeleteAsync(Guid id);
 
     Task PermanentDeleteAsync(Guid id);

--- a/core/src/Dignite.Vault.Extract.Application/Ai/VaultExtractBehaviorOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Ai/VaultExtractBehaviorOptions.cs
@@ -87,4 +87,15 @@ public class VaultExtractBehaviorOptions
     /// windows); hosts may raise it for bigger bundles or lower it to cap spend.
     /// </summary>
     public int MaxSegmentationMarkdownLength { get; set; } = 200_000;
+
+    /// <summary>
+    /// Host-deployment-layer toggle (default <c>false</c>) for retaining embedded-figure <b>source images</b> (#477).
+    /// When on, image-bearing text-extraction providers surface each figure's bytes on
+    /// <c>TextExtractionResult.Figures</c> and inline a <c>figures/{hash}</c> reference into the Markdown; the parse
+    /// job persists each image to blob storage (<c>extraction-figures/{documentId}/{hash}</c>) and records a manifest
+    /// on <c>Document.ExtractionMetadata</c> for reclaim on permanent delete. Off = today's behaviour (image OCR'd to
+    /// text, bytes discarded, no reference). Kept off by default: images are heavy, and some deployments must not
+    /// retain source imagery (e.g. PII in scanned IDs) — retention is an explicit host opt-in, never customer-facing.
+    /// </summary>
+    public bool RetainFigureImages { get; set; }
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -403,6 +403,27 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
             }
         }
 
+        // #477: reclaim retained figure blobs by their manifest keys. ABP's IBlobContainer has no list-by-prefix, so
+        // (like the native-payload reclaim above) delete by stable key from ExtractionMetadata.Figures — never a
+        // prefix sweep. Best-effort: a failure is logged but does not block the permanent-delete flow.
+        var figureManifest = document.ExtractionMetadata?.Figures;
+        if (figureManifest is { Count: > 0 })
+        {
+            foreach (var figure in figureManifest)
+            {
+                try
+                {
+                    await _blobContainer.DeleteAsync(figure.BlobName);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex,
+                        "Failed to delete retained figure blob {BlobName} for document {DocumentId}.",
+                        figure.BlobName, id);
+                }
+            }
+        }
+
         // Notify downstream consumers: the Document is unrecoverable, so derived data should be physically deleted.
         await _distributedEventBus.PublishAsync(
             new DocumentPermanentlyDeletedEto

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -329,6 +329,32 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
             disposeStream: true);
     }
 
+    public virtual async Task<IRemoteStreamContent> GetFigureAsync(Guid id, string fileName)
+    {
+        await CheckPolicyAsync(VaultExtractPermissions.Documents.Default);
+
+        // Scalar fields + the ExtractionMetadata JSON column load with the entity; no child collection is needed.
+        // The load already applied the multi-tenant filter, so a figure of another tenant's document is unreachable.
+        var document = await _documentRepository.GetAsync(id, includeDetails: false);
+
+        // The Markdown reference is figures/{hash}.{ext}; the route's last segment is that file name, so the content
+        // hash is its name without the (cosmetic) extension.
+        var contentHash = Path.GetFileNameWithoutExtension(fileName);
+
+        // Resolve against the retained-figure manifest — NEVER build the blob key from the request hash. Only a
+        // figure this document actually retained (#477) is served, using the manifest's own stored BlobName +
+        // ContentType, so an arbitrary / stale / traversal hash cannot reach blob storage.
+        var figure = document.ExtractionMetadata?.Figures?
+            .FirstOrDefault(f => string.Equals(f.ContentHash, contentHash, StringComparison.Ordinal));
+        if (figure is null)
+            throw new BusinessException(VaultExtractErrorCodes.Document.FigureNotFound)
+                .WithData("FileName", fileName);
+
+        var stream = await _blobContainer.GetAsync(figure.BlobName);
+
+        return new RemoteStreamContent(stream, fileName, figure.ContentType, disposeStream: true);
+    }
+
     [Authorize(VaultExtractPermissions.Documents.Delete)]
     public virtual async Task DeleteAsync(Guid id)
     {

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
@@ -121,9 +121,11 @@ public class DocumentParseBackgroundJob
                 var ctx = new TextExtractionContext
                 {
                     ContentType = workItem.ContentType!,
-                    FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty)
+                    FileExtension = Path.GetExtension(workItem.OriginalFileName ?? string.Empty),
                     // No language hints set: OCR language is provider-specific (#441). VisionLlm / Azure DI
                     // auto-detect; PaddleOcr falls back to its own PaddleOcr:Languages config.
+                    // #477: host-deployment-layer toggle (default off) — surface + persist retained figure images.
+                    RetainFigureImages = _behaviorOptions.RetainFigureImages
                 };
 
                 result = await _textExtractor.ExtractAsync(blobStream, ctx, _cancellationTokenProvider.Token);
@@ -257,8 +259,67 @@ public class DocumentParseBackgroundJob
         TextExtractionResult result)
     {
         var manifest = await TryArchiveNativePayloadAsync(documentId, result.NativePayload);
+        var figures = await TryArchiveFiguresAsync(documentId, result.Figures);
         return new DocumentParseMetadata(
-            result.ProviderName, manifest, result.IsComplete, result.IncompleteReason);
+            result.ProviderName, manifest, result.IsComplete, result.IncompleteReason, figures);
+    }
+
+    /// <summary>
+    /// Persists each retained embedded-figure source image (#477) to blob storage under the stable key
+    /// <c>extraction-figures/{documentId}/{contentHash}</c> (content-hash keyed → <b>idempotent</b>, identical
+    /// images collapse to one blob) and returns a <see cref="FigureManifestEntry"/> per persisted image, or
+    /// <c>null</c> when retention was off / nothing was retained. The manifest is the reclaim source on permanent
+    /// delete (ABP's <c>IBlobContainer</c> has no list-by-prefix). Mirrors the native-payload archive discipline:
+    /// <b>fail open</b> — a blob write failing logs a warning and skips that entry (the <c>figures/{hash}</c>
+    /// reference already inlined into the Markdown is left dangling for that one image), and text extraction still
+    /// completes; an auxiliary artifact must never break the main Markdown pipeline.
+    /// </summary>
+    protected virtual async Task<IReadOnlyList<FigureManifestEntry>?> TryArchiveFiguresAsync(
+        Guid documentId,
+        IReadOnlyList<ExtractedFigure>? figures)
+    {
+        if (figures is null || figures.Count == 0)
+        {
+            return null;
+        }
+
+        var entries = new List<FigureManifestEntry>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var figure in figures)
+        {
+            if (figure.Content is not { Length: > 0 } content
+                || string.IsNullOrWhiteSpace(figure.ContentHash)
+                || string.IsNullOrWhiteSpace(figure.ContentType))
+            {
+                continue;
+            }
+
+            // Dedup by content hash: an identical image on several pages is one blob + one manifest entry (its
+            // figures/{hash} reference may appear multiple times in the Markdown — all resolve to the same blob).
+            if (!seen.Add(figure.ContentHash))
+            {
+                continue;
+            }
+
+            var blobName = $"extraction-figures/{documentId}/{figure.ContentHash}";
+            try
+            {
+                using var stream = new MemoryStream(content, writable: false);
+                await _blobContainer.SaveAsync(blobName, stream, overrideExisting: true);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex,
+                    "Failed to persist retained figure blob {BlobName} for document {DocumentId}; "
+                    + "continuing without it (text extraction still succeeds).",
+                    blobName, documentId);
+                continue;
+            }
+
+            entries.Add(new FigureManifestEntry(blobName, figure.ContentHash, figure.ContentType, content.LongLength));
+        }
+
+        return entries.Count > 0 ? entries : null;
     }
 
     private async Task<NativePayloadManifest?> TryArchiveNativePayloadAsync(Guid documentId, NativePayload? payload)

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -370,6 +370,7 @@
     "Extract:DocumentFileTooLarge": "File '{FileName}' exceeds the maximum allowed size of {MaxBytes} bytes.",
     "Extract:DocumentUnsupportedFileType": "File '{FileName}' has an unsupported type ('{ContentType}'). Please upload a supported image, PDF, CSV/TSV, DOCX, PPTX, TXT, or XLSX file.",
     "Extract:DocumentNoSourceBlob": "This document has no source file available for download.",
+    "Extract:DocumentFigureNotFound": "The requested figure '{FileName}' was not found for this document.",
     "Extract:DocumentHasSubDocuments": "This document still has sub-documents derived from it. Delete or move its sub-documents before deleting this document.",
     "Extract:UnknownPipelineCode": "Pipeline '{PipelineCode}' is not retryable.",
     "Extract:PipelineNeverRan": "Pipeline '{PipelineCode}' has not started yet.",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -370,6 +370,7 @@
     "Extract:DocumentFileTooLarge": "ファイル '{FileName}' は許可されている最大サイズ {MaxBytes} バイトを超えています。",
     "Extract:DocumentUnsupportedFileType": "ファイル '{FileName}' のタイプ（'{ContentType}'）はサポートされていません。対応している画像、PDF、CSV/TSV、DOCX、PPTX、TXT、または XLSX ファイルをアップロードしてください。",
     "Extract:DocumentNoSourceBlob": "このドキュメントにはダウンロードできるソースファイルがありません。",
+    "Extract:DocumentFigureNotFound": "要求された図 '{FileName}' はこのドキュメントに見つかりませんでした。",
     "Extract:DocumentHasSubDocuments": "このドキュメントには、まだそこから派生したサブドキュメントがあります。このドキュメントを削除する前に、サブドキュメントを削除または移動してください。",
     "Extract:UnknownPipelineCode": "パイプライン '{PipelineCode}' は再試行できません。",
     "Extract:PipelineNeverRan": "パイプライン '{PipelineCode}' はまだ開始されていません。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -370,6 +370,7 @@
     "Extract:DocumentFileTooLarge": "文件 '{FileName}' 超过了允许的最大大小 {MaxBytes} 字节。",
     "Extract:DocumentUnsupportedFileType": "文件 '{FileName}' 的类型 ('{ContentType}') 不受支持。请上传支持的图片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 文件。",
     "Extract:DocumentNoSourceBlob": "该文档没有可供下载的源文件。",
+    "Extract:DocumentFigureNotFound": "未在该文档中找到请求的图片 '{FileName}'。",
     "Extract:DocumentHasSubDocuments": "该文档仍包含由其拆分出的子文档。请先删除或移动这些子文档，再删除该文档。",
     "Extract:UnknownPipelineCode": "流水线 '{PipelineCode}' 不支持重试。",
     "Extract:PipelineNeverRan": "流水线 '{PipelineCode}' 尚未运行。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -370,6 +370,7 @@
     "Extract:DocumentFileTooLarge": "檔案 '{FileName}' 超過了允許的大小上限 {MaxBytes} 位元組。",
     "Extract:DocumentUnsupportedFileType": "檔案 '{FileName}' 的類型（'{ContentType}'）不受支援。請上傳支援的圖片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 檔案。",
     "Extract:DocumentNoSourceBlob": "此文件沒有可供下載的來源檔案。",
+    "Extract:DocumentFigureNotFound": "未在此文件中找到請求的圖片 '{FileName}'。",
     "Extract:DocumentHasSubDocuments": "此文件仍包含由其分割出的子文件。請先刪除或移動這些子文件，再刪除此文件。",
     "Extract:UnknownPipelineCode": "管線 '{PipelineCode}' 不支援重試。",
     "Extract:PipelineNeverRan": "管線 '{PipelineCode}' 尚未執行。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -27,6 +27,9 @@ public static class VaultExtractErrorCodes
         public const string UnsupportedFileType = "Extract:DocumentUnsupportedFileType";
         // Derived sub-documents spawned from segment SliceText have no source blob; download is unavailable.
         public const string NoSourceBlob = "Extract:DocumentNoSourceBlob";
+        // #477: a figures/{hash} egress request whose hash is not in the document's retained-figure manifest
+        // (retention was off when it was processed, or a stale / invalid reference).
+        public const string FigureNotFound = "Extract:DocumentFigureNotFound";
         // A document still has live (non-deleted) derived sub-documents (#306 / #346): deleting it would strand them
         // with a dangling OriginDocumentId provenance back-reference, so the soft-delete is blocked until they are removed.
         public const string HasSubDocuments = "Extract:DocumentHasSubDocuments";

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentParseMetadata.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentParseMetadata.cs
@@ -53,16 +53,27 @@ public class DocumentParseMetadata : ValueObject
     /// <summary>Short diagnostic when incomplete; <c>null</c> when complete.</summary>
     public string? IncompleteReason { get; }
 
+    /// <summary>
+    /// Retained-figure blob manifest (#477): one entry per persisted embedded-figure <b>source image</b>, or
+    /// <c>null</c> when figure retention was off / no figures were retained. Its only purpose is manifest-driven
+    /// blob reclaim on permanent delete (ABP's <c>IBlobContainer</c> has no list-by-prefix, so — like
+    /// <see cref="NativePayloadManifest"/> — reclaim deletes by stable key, never by prefix sweep). Raw bytes stay
+    /// in blob storage; this stores only the entries. Historical records / retention-off runs default to <c>null</c>.
+    /// </summary>
+    public IReadOnlyList<FigureManifestEntry>? Figures { get; }
+
     public DocumentParseMetadata(
         string? providerName,
         NativePayloadManifest? nativePayloadManifest,
         bool isComplete = true,
-        string? incompleteReason = null)
+        string? incompleteReason = null,
+        IReadOnlyList<FigureManifestEntry>? figures = null)
     {
         ProviderName = providerName;
         NativePayloadManifest = nativePayloadManifest;
         IsComplete = isComplete;
         IncompleteReason = incompleteReason;
+        Figures = figures;
     }
 
     protected override IEnumerable<object> GetAtomicValues()
@@ -79,6 +90,26 @@ public class DocumentParseMetadata : ValueObject
         // when manifest is null and would not participate in equality.
         yield return IsComplete;
         yield return IncompleteReason ?? string.Empty;
+
+        // #477 figures manifest — flattened BEFORE the native-manifest yield break below, so the atomics
+        // participate in equality even when NativePayloadManifest is null (the common case: the PDF figure path
+        // archives no native payload). A NULL sentinel distinguishes "no figures" from an empty list.
+        if (Figures is null)
+        {
+            yield return "\0null-figures";
+        }
+        else
+        {
+            yield return "\0figures";
+            yield return Figures.Count;
+            foreach (var figure in Figures)
+            {
+                yield return figure.BlobName;
+                yield return figure.ContentHash;
+                yield return figure.ContentType;
+                yield return figure.SizeBytes;
+            }
+        }
 
         if (NativePayloadManifest is null)
         {

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/FigureManifestEntry.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/FigureManifestEntry.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Volo.Abp;
+using Volo.Abp.Domain.Values;
+
+namespace Dignite.Vault.Extract.Documents;
+
+/// <summary>
+/// One retained-figure blob's manifest entry (persisted value object, #477). When figure retention is enabled,
+/// the parse job writes each embedded figure's <b>source image</b> to blob storage and records the metadata
+/// required to retrieve and reclaim it here. Raw bytes <b>do not enter the DB</b>. Serialized as part of
+/// <see cref="DocumentParseMetadata.Figures"/> into the <c>Document.ExtractionMetadata</c> JSON column, so
+/// <see cref="Documents.DocumentAppService"/> can reclaim every figure blob on permanent delete by its
+/// <see cref="BlobName"/> — ABP's <c>IBlobContainer</c> has no list-by-prefix, so reclaim is manifest-driven
+/// exactly like <see cref="NativePayloadManifest"/> (no prefix cleanup).
+/// <para>
+/// Get-only properties plus a single parameterized constructor let System.Text.Json reuse this constructor
+/// during deserialization, with parameter names matching property names — the same pattern as
+/// <see cref="NativePayloadManifest"/> and <c>ExportColumn</c>.
+/// </para>
+/// </summary>
+public class FigureManifestEntry : ValueObject
+{
+    /// <summary>
+    /// Stable blob key (<c>extraction-figures/{documentId}/{contentHash}</c>, overwritten on re-extraction). An
+    /// <b>internal storage key</b> — never exposed in outbound DTOs; permanent delete uses it to delete the blob.
+    /// </summary>
+    public string BlobName { get; }
+
+    /// <summary>SHA-256 of the image bytes in lowercase hex — the dedup key and the <c>figures/{hash}</c> reference
+    /// target inlined into <c>Document.Markdown</c>.</summary>
+    public string ContentHash { get; }
+
+    /// <summary>Image MIME type, for example <c>image/png</c> — the content type the egress serves the blob with.</summary>
+    public string ContentType { get; }
+
+    /// <summary>Retained image size in bytes.</summary>
+    public long SizeBytes { get; }
+
+    public FigureManifestEntry(string blobName, string contentHash, string contentType, long sizeBytes)
+    {
+        BlobName = Check.NotNullOrWhiteSpace(blobName, nameof(blobName));
+        ContentHash = Check.NotNullOrWhiteSpace(contentHash, nameof(contentHash));
+        ContentType = Check.NotNullOrWhiteSpace(contentType, nameof(contentType));
+        SizeBytes = sizeBytes;
+    }
+
+    protected override IEnumerable<object> GetAtomicValues()
+    {
+        yield return BlobName;
+        yield return ContentHash;
+        yield return ContentType;
+        yield return SizeBytes;
+    }
+}

--- a/core/src/Dignite.Vault.Extract.HttpApi/Documents/DocumentController.cs
+++ b/core/src/Dignite.Vault.Extract.HttpApi/Documents/DocumentController.cs
@@ -43,6 +43,12 @@ public class DocumentController : VaultExtractController, IDocumentAppService
         return _documentAppService.GetBlobAsync(id);
     }
 
+    [HttpGet("{id}/figures/{fileName}")]
+    public virtual Task<IRemoteStreamContent> GetFigureAsync(Guid id, string fileName)
+    {
+        return _documentAppService.GetFigureAsync(id, fileName);
+    }
+
     [HttpDelete("{id}")]
     public virtual Task DeleteAsync(Guid id)
     {

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -160,7 +160,9 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
             var state = new DocxExtractionState
             {
                 ImageBudget = _options.MaxImagesPerFile,
-                LanguageHints = ResolveLanguageHints(context)
+                LanguageHints = ResolveLanguageHints(context),
+                // #477: host-deployment-layer toggle (default off) — surface + persist retained figure images.
+                RetainFigureImages = context.RetainFigureImages
             };
 
             // Build the per-document hyperlink id -> uri cache once (#318) so a link resolves in O(1) rather
@@ -217,7 +219,10 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
                 IsComplete = complete,
                 IncompleteReason = incompleteReason,
                 // DOCX text + per-image OCR has no single aggregated spatial payload to archive (#210).
-                NativePayload = null
+                NativePayload = null,
+                // #477: retained figure source images (null when retention is off / none retained), for the
+                // Application layer to blob-store; the figures/{hash} references are already in the Markdown above.
+                Figures = state.RetainedFigures.Count > 0 ? state.RetainedFigures : null
             };
         }
     }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlExtractionState.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlExtractionState.cs
@@ -43,6 +43,19 @@ public class OpenXmlExtractionState
     public IList<string> LanguageHints = new List<string>();
 
     /// <summary>
+    /// #477 figure retention (default false; the host toggle threaded from
+    /// <see cref="TextExtractionContext.RetainFigureImages"/>). When true, <see cref="OpenXmlFigureTranscriber"/>
+    /// surfaces each embedded image's source bytes on <see cref="RetainedFigures"/> and prepends a
+    /// <c>figures/{hash}</c> reference to the figure block, so the Application layer can blob-store the image.
+    /// Off = today's behaviour (image OCR'd to text, bytes discarded, no reference).
+    /// </summary>
+    public bool RetainFigureImages;
+
+    /// <summary>Retained embedded-figure source images (#477), accumulated during the walk when
+    /// <see cref="RetainFigureImages"/> is on; surfaced on the format's <c>TextExtractionResult.Figures</c>.</summary>
+    public readonly List<ExtractedFigure> RetainedFigures = new();
+
+    /// <summary>
     /// Resolves the OCR language hints for embedded-image transcription: the per-document hints from the
     /// context, or empty. There is no central host default (#441 removed it); a provider that needs a
     /// language default reads its own config (e.g. <c>PaddleOcr:Languages</c>). Shared by both OpenXML

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlFigureTranscriber.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlFigureTranscriber.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Dignite.Vault.Extract.Abstractions.Parse;
 using Dignite.Vault.Extract.Ocr;
 using DocumentFormat.OpenXml.Packaging;
 using Microsoft.Extensions.Logging;
@@ -132,8 +133,23 @@ internal static class OpenXmlFigureTranscriber
         // Caption (alt-text) is author-controlled free text (often multi-line), so collapse newlines via
         // MarkdownText.InlineLabel AND inline-escape via MarkdownText.EscapeInline so the bold caption can't
         // break the OCR block (often a table) below it, nor inject a link/emphasis from a literal [..](..)/*.
-        return string.IsNullOrWhiteSpace(caption)
+        var body = string.IsNullOrWhiteSpace(caption)
             ? transcription
             : "**" + MarkdownText.EscapeInline(MarkdownText.InlineLabel(caption)) + "**\n\n" + transcription;
+
+        // #477: when figure retention is on, surface the source image out-of-band on the state (the bytes just
+        // OCR'd — this seam persists nothing) and prepend a standard Markdown figures/{hash} image reference so the
+        // Application layer can blob-store it. OpenXML figures carry no *[Image OCR]* markers (unlike the PDF path),
+        // so the reference is an ordinary image line ahead of the (optionally captioned) transcription; the native
+        // alt-text/caption is kept on the retained figure.
+        if (state.RetainFigureImages)
+        {
+            var hash = FigureReference.Sha256Hex(resolved.Bytes!);
+            state.RetainedFigures.Add(
+                new ExtractedFigure(hash, resolved.Bytes!, resolved.ContentType!, pageNumber: null, altText: caption));
+            body = "![figure](" + FigureReference.Build(hash, resolved.ContentType!) + ")\n\n" + body;
+        }
+
+        return body;
     }
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -141,7 +141,9 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
             var state = new PptxExtractionState
             {
                 ImageBudget = _options.MaxImagesPerFile,
-                LanguageHints = ResolveLanguageHints(context)
+                LanguageHints = ResolveLanguageHints(context),
+                // #477: host-deployment-layer toggle (default off) — surface + persist retained figure images.
+                RetainFigureImages = context.RetainFigureImages
             };
 
             var slideMarkdowns = new List<string>(slideIds.Count);
@@ -211,7 +213,10 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
                 IsComplete = complete,
                 IncompleteReason = incompleteReason,
                 // PPTX text + per-image OCR has no single aggregated spatial payload to archive (#210).
-                NativePayload = null
+                NativePayload = null,
+                // #477: retained figure source images (null when retention is off / none retained), for the
+                // Application layer to blob-store; the figures/{hash} references are already in the Markdown above.
+                Figures = state.RetainedFigures.Count > 0 ? state.RetainedFigures : null
             };
         }
     }

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -136,6 +137,11 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
 
             var languageHints = ResolveLanguageHints(context);
 
+            // #477: when figure retention is on, collect each retained figure's source image (the bytes just sent to
+            // OCR); the Application layer persists them and reclaims them by manifest. Null when off → the provider
+            // behaves exactly as before: no figures/{hash} reference in the Markdown, TextExtractionResult.Figures null.
+            var retainedFigures = context.RetainFigureImages ? new List<ExtractedFigure>() : null;
+
             // #383: detect running headers / footers + page numbers (content that repeats in the top/bottom
             // edge band across pages) once over all pages, so it does not pollute the Markdown body. Position
             // only selects candidates; a line is dropped only when its digit-normalized text repeats across
@@ -258,11 +264,24 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                     {
                         // Inline output (#301): woven into the page Markdown at the reading position, bracketed by
                         // *[Image OCR p:N]*…*[End OCR]* provenance markers (#371/#381) carrying the page anchor. The
-                        // figure span — its transcription + page — travels entirely in Document.Markdown (the markers
-                        // stay in the egress); the unified sub-document detection pass routes it from there, so no
-                        // separate out-of-band figure list / candidate crop is produced (the #306
-                        // TextExtractionResult.Figures channel is retired).
-                        figures.Add(new PdfReadingOrder.Figure(image.BoundingBox, transcription, pageContent.Page.Number));
+                        // figure span — its transcription + page — travels in Document.Markdown (the markers stay in
+                        // the egress); the unified sub-document detection pass routes it from there.
+                        //
+                        // #477: when figure retention is on, also surface the source image out-of-band on
+                        // TextExtractionResult.Figures (the exact bytes just OCR'd — the provider persists nothing
+                        // itself) and inline a figures/{hash} reference as the span's first body line, so the
+                        // Application layer can blob-store the image and reclaim it by manifest.
+                        string? imageReference = null;
+                        if (retainedFigures is not null)
+                        {
+                            var figureHash = Sha256Hex(payload.Value.Bytes);
+                            imageReference = FigureReference(figureHash, payload.Value.ContentType);
+                            retainedFigures.Add(new ExtractedFigure(
+                                figureHash, payload.Value.Bytes, payload.Value.ContentType, pageContent.Page.Number));
+                        }
+
+                        figures.Add(new PdfReadingOrder.Figure(
+                            image.BoundingBox, transcription, pageContent.Page.Number, imageReference));
                     }
                 }
 
@@ -334,9 +353,41 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                 // PdfPig text layer + per-image OCR has no single aggregated spatial payload to archive
                 // this round (#210). Left null deliberately.
                 NativePayload = null,
-                FigureOcrCount = figureOcrCount
+                FigureOcrCount = figureOcrCount,
+                // #477: retained figure source images (null when retention is off), for the Application layer to
+                // blob-store; the figures/{hash} references were already inlined into the Markdown above.
+                Figures = retainedFigures
             };
         }
+    }
+
+    /// <summary>SHA-256 (lowercase hex) of the image bytes — the retained figure's content hash / dedup key (#477),
+    /// matching the <c>figures/{hash}</c> Markdown reference and the Application-layer blob key.</summary>
+    private static string Sha256Hex(byte[] bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    /// <summary>The document-relative Markdown reference for a retained figure (<c>figures/{hash}.{ext}</c>, #477).</summary>
+    private static string FigureReference(string contentHash, string contentType)
+        => "figures/" + contentHash + "." + ExtensionForContentType(contentType);
+
+    /// <summary>Maps an image MIME type to a file extension for the retained-figure reference — cosmetic, since the
+    /// egress resolves the blob by hash. Any <c>image/*</c> subtype passes through (<c>jpeg</c> → <c>jpg</c>);
+    /// a missing / non-image type falls back to <c>img</c>.</summary>
+    private static string ExtensionForContentType(string? contentType)
+    {
+        if (string.IsNullOrEmpty(contentType) ||
+            !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+        {
+            return "img";
+        }
+
+        var subtype = contentType["image/".Length..].Trim().ToLowerInvariant();
+        return subtype switch
+        {
+            "" => "img",
+            "jpeg" => "jpg",
+            _ => subtype
+        };
     }
 
     /// <summary>Whether an embedded image is below the <see cref="PdfExtractorOptions.MinImagePixels"/> threshold (decorative).</summary>

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfExtractor.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -274,8 +273,8 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                         string? imageReference = null;
                         if (retainedFigures is not null)
                         {
-                            var figureHash = Sha256Hex(payload.Value.Bytes);
-                            imageReference = FigureReference(figureHash, payload.Value.ContentType);
+                            var figureHash = FigureReference.Sha256Hex(payload.Value.Bytes);
+                            imageReference = FigureReference.Build(figureHash, payload.Value.ContentType);
                             retainedFigures.Add(new ExtractedFigure(
                                 figureHash, payload.Value.Bytes, payload.Value.ContentType, pageContent.Page.Number));
                         }
@@ -359,35 +358,6 @@ public class PdfExtractor : IMarkdownTextProvider, ITransientDependency
                 Figures = retainedFigures
             };
         }
-    }
-
-    /// <summary>SHA-256 (lowercase hex) of the image bytes — the retained figure's content hash / dedup key (#477),
-    /// matching the <c>figures/{hash}</c> Markdown reference and the Application-layer blob key.</summary>
-    private static string Sha256Hex(byte[] bytes)
-        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
-
-    /// <summary>The document-relative Markdown reference for a retained figure (<c>figures/{hash}.{ext}</c>, #477).</summary>
-    private static string FigureReference(string contentHash, string contentType)
-        => "figures/" + contentHash + "." + ExtensionForContentType(contentType);
-
-    /// <summary>Maps an image MIME type to a file extension for the retained-figure reference — cosmetic, since the
-    /// egress resolves the blob by hash. Any <c>image/*</c> subtype passes through (<c>jpeg</c> → <c>jpg</c>);
-    /// a missing / non-image type falls back to <c>img</c>.</summary>
-    private static string ExtensionForContentType(string? contentType)
-    {
-        if (string.IsNullOrEmpty(contentType) ||
-            !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
-        {
-            return "img";
-        }
-
-        var subtype = contentType["image/".Length..].Trim().ToLowerInvariant();
-        return subtype switch
-        {
-            "" => "img",
-            "jpeg" => "jpg",
-            _ => subtype
-        };
     }
 
     /// <summary>Whether an embedded image is below the <see cref="PdfExtractorOptions.MinImagePixels"/> threshold (decorative).</summary>

--- a/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.Pdf/PdfReadingOrder.cs
@@ -44,8 +44,11 @@ namespace Dignite.Vault.Extract.Parse.Pdf;
 /// </summary>
 internal static class PdfReadingOrder
 {
-    /// <summary>An embedded image with its page placement, source page number, and the OCR transcription of its content.</summary>
-    public readonly record struct Figure(PdfRectangle Bounds, string Transcription, int? PageNumber = null);
+    /// <summary>An embedded image with its page placement, source page number, the OCR transcription of its content,
+    /// and — when figure retention is on (#477) — the <c>figures/{hash}</c> reference to inline inside its span
+    /// (<c>null</c> when retention is off, leaving the span byte-identical to before).</summary>
+    public readonly record struct Figure(
+        PdfRectangle Bounds, string Transcription, int? PageNumber = null, string? ImageReference = null);
 
     /// <summary>
     /// A reconstructed visual line of the text layer. <see cref="MaxFontSize"/> (largest glyph point size) and
@@ -455,7 +458,8 @@ internal static class PdfReadingOrder
         for (var fi = 0; fi < figures.Count; fi++)
         {
             figureCaptions.TryGetValue(fi, out var caption);
-            items.Add(Item.ForFigure(figures[fi].Bounds, figures[fi].Transcription, caption, figures[fi].PageNumber));
+            items.Add(Item.ForFigure(
+                figures[fi].Bounds, figures[fi].Transcription, caption, figures[fi].PageNumber, figures[fi].ImageReference));
         }
 
         if (items.Count == 0)
@@ -509,8 +513,9 @@ internal static class PdfReadingOrder
                 // annotate the bracketed text as OCR for any consumer, and the pipeline reads them to recognize the
                 // figure span (the classification embedded-document signal + the unified sub-document detection pass).
                 // The caption is a digital-text-layer line bound to this figure, so escape it; item.Text is the OCR
-                // transcription (already Markdown) and is emitted verbatim inside the markers.
-                var figureMarkup = ImageOcrMarkup.Wrap(item.Text, item.PageNumber);
+                // transcription (already Markdown) and is emitted verbatim inside the markers. #477: when the source
+                // image was retained, item.ImageReference (figures/{hash}) is inlined as the span's first body line.
+                var figureMarkup = ImageOcrMarkup.Wrap(item.Text, item.PageNumber, item.ImageReference);
                 blocks.Add(item.Caption is { Length: > 0 } caption
                     ? MarkdownText.EscapeBlockText(caption) + "\n\n" + figureMarkup
                     : figureMarkup);
@@ -1592,12 +1597,14 @@ internal static class PdfReadingOrder
 
     private static double Sq(double v) => v * v;
 
-    private readonly record struct Item(PdfRectangle Bounds, string Text, bool IsFigure, string? Caption, int? PageNumber, int HeadingLevel)
+    private readonly record struct Item(
+        PdfRectangle Bounds, string Text, bool IsFigure, string? Caption, int? PageNumber, int HeadingLevel,
+        string? ImageReference = null)
     {
         public static Item ForText(PdfRectangle bounds, string text, int headingLevel = 0)
             => new(bounds, text, false, null, null, headingLevel);
 
-        public static Item ForFigure(PdfRectangle bounds, string text, string? caption, int? pageNumber)
-            => new(bounds, text, true, caption, pageNumber, 0);
+        public static Item ForFigure(PdfRectangle bounds, string text, string? caption, int? pageNumber, string? imageReference)
+            => new(bounds, text, true, caption, pageNumber, 0, imageReference);
     }
 }

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Ai/ImageOcrMarkup_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Ai/ImageOcrMarkup_Tests.cs
@@ -91,4 +91,43 @@ public class ImageOcrMarkup_Tests
         ImageOcrMarkup.Contains(reingested).ShouldBeTrue();
         ImageOcrMarkup.ExtractBodies(reingested).ShouldBe("old transcription");
     }
+
+    [Fact]
+    public void Wrap_With_Image_Reference_Inlines_It_As_The_First_Body_Line_Inside_The_Span()
+    {
+        // #477: the figures/{hash} reference travels INSIDE the span (first body line, right after the open marker),
+        // so the sub-document segmentation pass can correlate a figure to its blob (#478). The bare marker is unchanged.
+        ImageOcrMarkup.Wrap("inv", pageNumber: 3, imageReference: "figures/abc.png")
+            .ShouldBe("*[Image OCR p:3]*\n![figure](figures/abc.png)\ninv\n*[End OCR]*");
+    }
+
+    [Fact]
+    public void Wrap_Without_Image_Reference_Is_Byte_Identical_To_Before()
+    {
+        // Retention off (null / empty reference) leaves the span exactly as before #477 — the regression guard.
+        ImageOcrMarkup.Wrap("inv", 3, imageReference: null).ShouldBe("*[Image OCR p:3]*\ninv\n*[End OCR]*");
+        ImageOcrMarkup.Wrap("inv", 3, imageReference: "").ShouldBe("*[Image OCR p:3]*\ninv\n*[End OCR]*");
+    }
+
+    [Fact]
+    public void IsImageReferenceLine_Recognizes_The_Figure_Reference_By_Its_Target()
+    {
+        ImageOcrMarkup.IsImageReferenceLine("![figure](figures/abc.png)").ShouldBeTrue();
+        ImageOcrMarkup.IsImageReferenceLine("  ![figure](figures/abc.png)  ").ShouldBeTrue(); // trimmed
+        // Recognition keys on the `](figures/` document-relative target, so it survives an alt-text change.
+        ImageOcrMarkup.IsImageReferenceLine("![diagram](figures/xyz.jpg)").ShouldBeTrue();
+        // An ordinary image that is NOT a retained-figure reference is untouched.
+        ImageOcrMarkup.IsImageReferenceLine("![logo](https://example.com/a.png)").ShouldBeFalse();
+        ImageOcrMarkup.IsImageReferenceLine("just prose").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Strip_And_ExtractBodies_Drop_The_Retained_Figure_Reference_Line()
+    {
+        // #477: the spawned child sub-document's seed is the transcription only (#373) — the retained image belongs to
+        // the container. Strip / ExtractBodies drop the figures/{hash} reference; it survives only in the container egress.
+        var marked = ImageOcrMarkup.Wrap("inv total 100", pageNumber: 3, imageReference: "figures/abc.png");
+        ImageOcrMarkup.Strip(marked).ShouldBe("inv total 100");
+        ImageOcrMarkup.ExtractBodies(marked).ShouldBe("inv total 100");
+    }
 }

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -380,6 +380,52 @@ public class DocumentAppService_Delete_Tests
         }
     }
 
+    [Fact]
+    public async Task GetFigureAsync_Serves_The_Retained_Figure_Blob_By_Manifest_Hash()
+    {
+        // #477: the endpoint resolves the request hash against the retained-figure manifest and serves the blob by
+        // the manifest's OWN stored key + content type (never a key built from the request).
+        var doc = CreateDocument();
+        const string hash = "abc123";
+        var blobName = $"extraction-figures/{doc.Id}/{hash}";
+        SetExtractionMetadata(doc, new DocumentParseMetadata(
+            "PdfPig", null, figures: new[] { new FigureManifestEntry(blobName, hash, "image/png", 2048) }));
+
+        _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(doc);
+        _blobContainer.GetAsync(blobName, Arg.Any<CancellationToken>())
+            .Returns(new MemoryStream(new byte[] { 1, 2, 3 }));
+
+        var result = await _appService.GetFigureAsync(doc.Id, $"{hash}.png");
+
+        result.ContentType.ShouldBe("image/png");
+        await _blobContainer.Received(1).GetAsync(blobName, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetFigureAsync_Throws_FigureNotFound_For_An_Unknown_Hash_Without_Touching_Blob_Storage()
+    {
+        // Security: a hash not in the manifest never reaches blob storage (no arbitrary / traversal fetch).
+        var doc = CreateDocument();
+        SetExtractionMetadata(doc, new DocumentParseMetadata(
+            "PdfPig", null,
+            figures: new[] { new FigureManifestEntry($"extraction-figures/{doc.Id}/known", "known", "image/png", 10) }));
+
+        _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(doc);
+
+        var ex = await Should.ThrowAsync<BusinessException>(
+            () => _appService.GetFigureAsync(doc.Id, "unknown.png"));
+        ex.Code.ShouldBe(VaultExtractErrorCodes.Document.FigureNotFound);
+        await _blobContainer.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // Document.SetExtractionMetadata is internal and InternalsVisibleTo covers only EntityFrameworkCore.Tests, so
+    // set it via reflection here rather than broaden internal visibility for a test convenience.
+    private static void SetExtractionMetadata(Document document, DocumentParseMetadata metadata)
+        => typeof(Document)
+            .GetMethod("SetExtractionMetadata",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(document, new object?[] { metadata });
+
     private static Document CreateDocument()
     {
         return new Document(

--- a/core/test/Dignite.Vault.Extract.Domain.Tests/Documents/DocumentParseMetadataTests.cs
+++ b/core/test/Dignite.Vault.Extract.Domain.Tests/Documents/DocumentParseMetadataTests.cs
@@ -93,4 +93,67 @@ public class DocumentParseMetadataTests
         metadata!.IsComplete.ShouldBeTrue();
         metadata.IncompleteReason.ShouldBeNull();
     }
+
+    private static FigureManifestEntry CreateFigure(string hash = "fig-hash-1") =>
+        new($"extraction-figures/doc-1/{hash}", hash, "image/png", 2048);
+
+    [Fact]
+    public void FigureManifestEntry_Has_Structural_Equality()
+    {
+        CreateFigure().ValueEquals(CreateFigure()).ShouldBeTrue();
+        CreateFigure().ValueEquals(CreateFigure("other")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Figures_Participate_In_Value_Equality_Even_When_Native_Manifest_Is_Null()
+    {
+        // #477: the figures atomics are emitted BEFORE the native-manifest yield break, so they must affect
+        // equality even in the common PDF case where NativePayloadManifest is null.
+        var withFigure = new DocumentParseMetadata("PdfPig", nativePayloadManifest: null, figures: new[] { CreateFigure() });
+        var withoutFigure = new DocumentParseMetadata("PdfPig", nativePayloadManifest: null);
+
+        withFigure.ValueEquals(withoutFigure).ShouldBeFalse(); // one figure vs null figures
+        withFigure.ValueEquals(new DocumentParseMetadata("PdfPig", null, figures: new[] { CreateFigure() }))
+            .ShouldBeTrue();
+        // A different figure hash is a different value.
+        withFigure.ValueEquals(new DocumentParseMetadata("PdfPig", null, figures: new[] { CreateFigure("fig-hash-2") }))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Empty_Figures_List_Differs_From_Null_Figures()
+    {
+        var empty = new DocumentParseMetadata("PdfPig", null, figures: System.Array.Empty<FigureManifestEntry>());
+        var missing = new DocumentParseMetadata("PdfPig", null);
+        empty.ValueEquals(missing).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Figures_Survive_Json_Roundtrip()
+    {
+        var original = new DocumentParseMetadata(
+            "PdfPig", CreateManifest(), figures: new[] { CreateFigure("a"), CreateFigure("b") });
+
+        var roundtripped = JsonSerializer.Deserialize<DocumentParseMetadata>(JsonSerializer.Serialize(original));
+
+        roundtripped.ShouldNotBeNull();
+        roundtripped!.Figures.ShouldNotBeNull();
+        roundtripped.Figures!.Count.ShouldBe(2);
+        roundtripped.Figures[0].BlobName.ShouldBe("extraction-figures/doc-1/a");
+        roundtripped.Figures[0].ContentType.ShouldBe("image/png");
+        roundtripped.ValueEquals(original).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Legacy_Json_Without_Figures_Deserializes_As_Null_Figures()
+    {
+        // Zero-migration (#477): rows persisted before figure retention have no Figures member, so the
+        // constructor's optional parameter defaults it to null.
+        var legacyJson = "{\"ProviderName\":\"PdfPig\",\"NativePayloadManifest\":null,\"IsComplete\":true}";
+
+        var metadata = JsonSerializer.Deserialize<DocumentParseMetadata>(legacyJson);
+
+        metadata.ShouldNotBeNull();
+        metadata!.Figures.ShouldBeNull();
+    }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Abstractions.Parse;
@@ -30,8 +31,13 @@ public class DocxExtractor_Tests
                 MaxImageBytesPerImage = maxImageBytes
             }));
 
-    private static TextExtractionContext DocxContext()
-        => new() { ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document", FileExtension = ".docx" };
+    private static TextExtractionContext DocxContext(bool retainFigures = false)
+        => new()
+        {
+            ContentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            FileExtension = ".docx",
+            RetainFigureImages = retainFigures
+        };
 
     private void StubOcr(string markdown, bool isComplete = true, string? reason = null)
         => _ocr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
@@ -239,6 +245,59 @@ public class DocxExtractor_Tests
             Arg.Any<Stream>(),
             Arg.Is<OcrOptions>(o => o.ContentType.StartsWith("image/", StringComparison.Ordinal)),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Retention_off_inlines_no_figure_reference_and_surfaces_no_Figures()
+    {
+        // #477 default (off): the transcription is inlined exactly as before — no figures/ reference, no Figures.
+        StubOcr("FIGURE");
+
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Paragraph("Body text")
+            .Image(Png(alt: null)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("FIGURE");
+        result.Markdown.ShouldNotContain("figures/");
+        result.Figures.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Retention_on_surfaces_the_source_image_and_prepends_the_reference()
+    {
+        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures and a standard
+        // Markdown figures/{hash} reference is prepended ahead of the (captioned) transcription. OpenXML figures
+        // carry no *[Image OCR]* markers, so the reference is an ordinary image line; the native alt-text is kept.
+        StubOcr("FIGURE");
+
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Paragraph("Body text")
+            .Image(Png(alt: "Chart 1")));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext(retainFigures: true));
+
+        // Out-of-band: one retained figure, its content type, its native alt-text, and a hash matching the bytes.
+        // DOCX is a flow document, so there is no page anchor.
+        result.Figures.ShouldNotBeNull();
+        result.Figures!.Count.ShouldBe(1);
+        var figure = result.Figures[0];
+        figure.Content.Length.ShouldBeGreaterThan(0);
+        figure.ContentType.ShouldStartWith("image/");
+        figure.PageNumber.ShouldBeNull();
+        figure.AltText.ShouldBe("Chart 1");
+        figure.ContentHash.ShouldBe(Convert.ToHexString(SHA256.HashData(figure.Content)).ToLowerInvariant());
+
+        // In-band: the reference is prepended before the caption, which is before the transcription.
+        var reference = $"![figure](figures/{figure.ContentHash}.";
+        result.Markdown.ShouldContain(reference);
+        var referenceIndex = result.Markdown.IndexOf(reference, StringComparison.Ordinal);
+        var caption = result.Markdown.IndexOf("Chart 1", StringComparison.Ordinal);
+        var transcription = result.Markdown.IndexOf("FIGURE", StringComparison.Ordinal);
+        referenceIndex.ShouldBeGreaterThanOrEqualTo(0);
+        caption.ShouldBeGreaterThan(referenceIndex);
+        transcription.ShouldBeGreaterThan(caption);
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Abstractions.Parse;
@@ -32,8 +33,13 @@ public class PptxExtractor_Tests
                 IncludeSpeakerNotes = includeNotes
             }));
 
-    private static TextExtractionContext PptxContext()
-        => new() { ContentType = "application/vnd.openxmlformats-officedocument.presentationml.presentation", FileExtension = ".pptx" };
+    private static TextExtractionContext PptxContext(bool retainFigures = false)
+        => new()
+        {
+            ContentType = "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            FileExtension = ".pptx",
+            RetainFigureImages = retainFigures
+        };
 
     private void StubOcr(string markdown, bool isComplete = true, string? reason = null)
         => _ocr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
@@ -117,6 +123,57 @@ public class PptxExtractor_Tests
             Arg.Any<Stream>(),
             Arg.Is<OcrOptions>(o => o.ContentType.StartsWith("image/", StringComparison.Ordinal)),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Retention_off_inlines_no_figure_reference_and_surfaces_no_Figures()
+    {
+        // #477 default (off): the transcription is inlined exactly as before — no figures/ reference, no Figures.
+        StubOcr("FIGURE");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("FIGURE");
+        result.Markdown.ShouldNotContain("figures/");
+        result.Figures.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Retention_on_surfaces_the_source_image_and_prepends_the_reference()
+    {
+        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures and a standard
+        // Markdown figures/{hash} reference is prepended ahead of the (captioned) transcription (OpenXML figures
+        // carry no *[Image OCR]* markers); the native alt-text is kept on the retained figure.
+        StubOcr("FIGURE");
+
+        var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
+            .Text("Body text")
+            .Image(Png(alt: "Chart 1", x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext(retainFigures: true));
+
+        result.Figures.ShouldNotBeNull();
+        result.Figures!.Count.ShouldBe(1);
+        var figure = result.Figures[0];
+        figure.Content.Length.ShouldBeGreaterThan(0);
+        figure.ContentType.ShouldStartWith("image/");
+        figure.PageNumber.ShouldBeNull();
+        figure.AltText.ShouldBe("Chart 1");
+        figure.ContentHash.ShouldBe(Convert.ToHexString(SHA256.HashData(figure.Content)).ToLowerInvariant());
+
+        // In-band: the reference is prepended before the caption, which is before the transcription.
+        var reference = $"![figure](figures/{figure.ContentHash}.";
+        result.Markdown.ShouldContain(reference);
+        var referenceIndex = result.Markdown.IndexOf(reference, StringComparison.Ordinal);
+        var caption = result.Markdown.IndexOf("Chart 1", StringComparison.Ordinal);
+        var transcription = result.Markdown.IndexOf("FIGURE", StringComparison.Ordinal);
+        referenceIndex.ShouldBeGreaterThanOrEqualTo(0);
+        caption.ShouldBeGreaterThan(referenceIndex);
+        transcription.ShouldBeGreaterThan(caption);
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.Pdf.Tests/PdfExtractor_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Abstractions.Parse;
@@ -52,8 +53,8 @@ public class PdfExtractor_Tests
         return lines;
     }
 
-    private static TextExtractionContext PdfContext()
-        => new() { ContentType = "application/pdf", FileExtension = ".pdf" };
+    private static TextExtractionContext PdfContext(bool retainFigures = false)
+        => new() { ContentType = "application/pdf", FileExtension = ".pdf", RetainFigureImages = retainFigures };
 
     private void StubOcr(string markdown, bool isComplete = true, string? reason = null)
         => _ocr.RecognizeAsync(Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>())
@@ -776,5 +777,63 @@ public class PdfExtractor_Tests
         result.Markdown.ShouldContain(
             longLine + " " + longLine + " " + longLine + " and that concludes the recital.");
         result.Markdown.ShouldNotContain("\n\n");
+    }
+
+    [Fact]
+    public async Task Retention_off_inlines_no_figure_reference_and_surfaces_no_Figures()
+    {
+        // #477 default (off): the transcription is inlined exactly as before — no figures/ reference in the
+        // Markdown and no out-of-band Figures. The byte-identical-to-pre-#477 regression guard.
+        StubOcr("INVOICE");
+
+        var png = TinyPng.CreateSolid(48, 48);
+        var pdf = PdfFixtures.Build(
+            texts: new[] { ("Body text", 700.0) },
+            images: new[] { (png, new PdfRectangle(50, 400, 200, 550)) });
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pdf), PdfContext());
+
+        result.Markdown.ShouldContain("INVOICE");
+        result.Markdown.ShouldNotContain("figures/");
+        result.Figures.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Retention_on_surfaces_the_source_image_and_inlines_the_reference_inside_the_span()
+    {
+        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures (the exact
+        // OCR input) and a figures/{hash} reference is inlined INSIDE the figure span as its first body line.
+        StubOcr("INVOICE");
+
+        var png = TinyPng.CreateSolid(48, 48);
+        var pdf = PdfFixtures.Build(
+            texts: new[] { ("Body text", 700.0) },
+            images: new[] { (png, new PdfRectangle(50, 400, 200, 550)) });
+
+        var result = await CreateExtractor().ExtractAsync(
+            new MemoryStream(pdf), PdfContext(retainFigures: true));
+
+        // Out-of-band: exactly one retained figure, its content type, its page anchor, and a hash that matches
+        // its bytes (the invariant the Markdown reference and the persisted blob both key on).
+        result.Figures.ShouldNotBeNull();
+        result.Figures!.Count.ShouldBe(1);
+        var figure = result.Figures[0];
+        figure.Content.Length.ShouldBeGreaterThan(0);
+        figure.ContentType.ShouldStartWith("image/");
+        figure.PageNumber.ShouldBe(1);
+        figure.ContentHash.ShouldBe(Convert.ToHexString(SHA256.HashData(figure.Content)).ToLowerInvariant());
+
+        // In-band: the reference is the figure span's FIRST body line — after the open marker, before the
+        // transcription, all inside the *[Image OCR p:1]* … *[End OCR]* span.
+        var reference = $"![figure](figures/{figure.ContentHash}.";
+        result.Markdown.ShouldContain(reference);
+        var open = result.Markdown.IndexOf(ImageOcrMarkup.OpenPagePrefix + "1]*", StringComparison.Ordinal);
+        var referenceIndex = result.Markdown.IndexOf(reference, StringComparison.Ordinal);
+        var transcription = result.Markdown.IndexOf("INVOICE", StringComparison.Ordinal);
+        var close = result.Markdown.IndexOf(ImageOcrMarkup.CloseMarker, StringComparison.Ordinal);
+        open.ShouldBeGreaterThanOrEqualTo(0);
+        referenceIndex.ShouldBeGreaterThan(open);
+        transcription.ShouldBeGreaterThan(referenceIndex);
+        close.ShouldBeGreaterThan(transcription);
     }
 }


### PR DESCRIPTION
Part of #477 — **Phases 1-3**: figure-image retention across PDF + DOCX/PPTX, plus the REST egress endpoint that resolves the references. Host opt-in, **off by default**.

## What this does

With the new host toggle `VaultExtractBehaviorOptions.RetainFigureImages` (default **off**), each image-bearing text-extraction provider:

- surfaces every embedded figure's **source bytes** out-of-band on the new nullable `TextExtractionResult.Figures` (the exact bytes it already decoded for OCR — the provider persists nothing), and
- inlines a `figures/{hash}.{ext}` reference into the Markdown at the figure's position.

**`DocumentParseBackgroundJob`** persists each image to `extraction-figures/{documentId}/{contentHash}` via ABP Blob Storing (`extract-documents` container, deduped by content hash, **fail-open**) and records a `FigureManifest` on `Document.ExtractionMetadata`; **`DocumentAppService.PermanentDeleteAsync`** reclaims the blobs by manifest key (ABP `IBlobContainer` has no list-by-prefix → delete by stable key, closing the #374 leak class). Format-agnostic — one Application-layer implementation serves all providers.

**Egress read endpoint** (Phase 3): `GET /api/vault-extract/documents/{id}/figures/{fileName}` → `IDocumentAppService.GetFigureAsync` resolves a `figures/{hash}` reference to the retained image bytes. `CheckPolicyAsync(Documents.Default)`, multi-tenant-filtered document load, and — crucially — the request hash is **only ever a manifest lookup**, never concatenated into a blob key: it serves the blob by the manifest's own stored key + content type, so an arbitrary / stale / traversal hash cannot reach storage (an unlisted hash → localized `DocumentFigureNotFound`).

With the toggle **off**, extraction output is **byte-identical** to before, and no figure is persisted or served.

### Per-format reference placement

- **PDF** (`PdfExtractor`) — the reference is the figure span's **first body line**, inside the existing `*[Image OCR]* … *[End OCR]*` markers (the in-span placement #478 needs; the bare markers are unchanged, MarkItDown parity #381).
- **DOCX / PPTX** (`DocxExtractor` / `PptxExtractor`, via the shared `OpenXmlFigureTranscriber`) — OpenXML figures carry no `*[Image OCR]*` markers, so the reference is an ordinary Markdown image line prepended ahead of the (optionally captioned) transcription. The native `docPr` / `cNvPr` alt-text is kept on the retained figure.

The `figures/{hash}.{ext}` format + hash live in one shared `FigureReference` helper (Abstractions) so no provider can drift them.

## Why a per-figure endpoint (not redundant with the sub-document blob route)

Figures split into two scenarios (CLAUDE.md / #299 / #306), and they reach downstream by **different** paths:

- **Illustration** (a chart / diagram / photo in the body) — OCR'd and **inlined** into the parent's Markdown; it never becomes a sub-document. Its **only** access path is `GET .../documents/{id}/figures/{hash}`.
- **The figure IS a standalone document** (e.g. an invoice photo embedded in a contract) — routed to its own **sub-document** (#306/#478), which is a first-class `Document` served by the existing `GET .../documents/{subDocId}/blob`.

Downstream timing (`DocumentReadyEventHandler`): a **container** suppresses its own `DocumentReadyEto`, so downstream consumes its **sub-documents** (scenario-2 figures → blob route); a **normal document** fires its own `DocumentReadyEto` carrying a Markdown with **inline scenario-1 figure references** — reachable only through this endpoint. So the per-figure endpoint is the sole access path for illustration figures (the common case), not a duplicate of the sub-document blob route.

## Design constraints honored

- **#393 boundary** — providers only surface bytes; the Application layer owns all blob writes + reclaim + serving. Parse never mints Application provenance.
- **Markdown-first** — the reference is standard Markdown; `Document.Markdown` stays the sole text field; retained bytes ride a named / strongly-typed / nullable out-of-band signal (the #210 shape), no `Dictionary<string,object>` bag, no parallel text field.
- **Zero migration** — `Figures` is an optional constructor parameter on the JSON-column `DocumentParseMetadata`; rows persisted before this deserialize as `null`.
- **Security** — the endpoint is fail-closed (permission + tenant filter) and serves only manifest-listed figures by their stored key.
- **#478 self-consistency** — `Strip` / `ExtractBodies` drop the reference line so figure **sub-document** seeds stay transcription-only (#373).

## Tests (17 new, all green; full solution builds clean)

- **Phase 1** — `ImageOcrMarkup` wrap/strip/extract (4); `PdfExtractor` off / on (2); `DocumentParseMetadata` figure value-equality + JSON roundtrip + legacy-null (5).
- **Phase 2** — `DocxExtractor` + `PptxExtractor` off / on with native alt-text (4).
- **Phase 3** — `GetFigureAsync` serves-by-manifest-hash (fetch by the stored key) + unknown-hash throws `FigureNotFound` without touching blob storage (2).

## Follow-ups (not in this PR)

- **MCP resource** for figures — the REST endpoint is the first egress; an MCP resource can mirror it.
- **Angular** rendering of the retained figures in the document detail view (needs a proxy regen against a live host).
- **#478** — figure sub-document `FileOrigin` from the retained blob (the revisit of #393); depends on this.
