### PR TITLE
feat(segmentation): figure sub-documents get their FileOrigin from the shared #477 retained blob (#478, revisits #393)

### DIFF
--- a/.claude/rules/sub-document-segmentation.md
+++ b/.claude/rules/sub-document-segmentation.md
@@ -59,6 +59,7 @@ default — the #364-class missed-branch bug, hardened in #379), not a license t
 | `RoutedDocumentId` | **keep explicit** | reconstructable from `(OriginDocumentId, OriginConstituentKey)`, but the explicit pointer is the ledger's purpose (idempotency + retraction clarity); reconstructing the join is more complex, not less |
 | `SliceText` | **transient one-way seed** | duplicated by `Document.Markdown` after parse; bounded duplication is accepted; **do not add a parse→segment writeback to clear it** (couples parse job to the ledger for a low-value saving) |
 | `PageNumber` | **retained provenance** | deliberate out-of-band anchor (Markdown-first "named, strongly-typed, nullable extension field" rule); write-only by design, not dead weight |
+| `FigureContentHash` | **spawn-input (resumable)** | #477/#478: SHA-256 of the retained figure's **image bytes** (≠ `SegmentKey`, the transcription-**text** hash), parsed at detection from the in-span `figures/{hash}` reference; read once at spawn to resolve the source's `FigureManifest` and point the child `FileOrigin` at the **shared** blob. Null = Text slice / retention off → child `FileOrigin` stays null |
 
 Watch for accreted residue: a fast-iterated subsystem leaves write-only fields / never-assigned enum values / dead
 projections. #390 removed three (`DocumentSegmentStatus.NotADocument`, `DetectionContext.UploadedByUserName`,

--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/FigureReference.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/FigureReference.cs
@@ -22,8 +22,9 @@ public static class FigureReference
         => "figures/" + contentHash + "." + Extension(contentType);
 
     /// <summary>Maps an image MIME type to a file extension. Any <c>image/*</c> subtype passes through
-    /// (<c>jpeg</c> → <c>jpg</c>); a missing / non-image type falls back to <c>img</c>.</summary>
-    private static string Extension(string? contentType)
+    /// (<c>jpeg</c> → <c>jpg</c>); a missing / non-image type falls back to <c>img</c>. Public because the
+    /// spawn path (#478) reuses it to synthesize a figure sub-document's <c>OriginalFileName</c>.</summary>
+    public static string Extension(string? contentType)
     {
         if (string.IsNullOrEmpty(contentType) ||
             !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))

--- a/core/src/Dignite.Vault.Extract.Abstractions/Parse/ImageOcrMarkup.cs
+++ b/core/src/Dignite.Vault.Extract.Abstractions/Parse/ImageOcrMarkup.cs
@@ -216,6 +216,31 @@ public static class ImageOcrMarkup
     }
 
     /// <summary>
+    /// Parses the retained-figure <b>content hash</b> out of a <c>![…](figures/{hash}.{ext})</c> reference line
+    /// (#478): the segmentation pass correlates a figure span to its retained blob with it (the reference is the
+    /// span's first body line, so the figure's own slice carries it). Returns <c>null</c> for any non-reference
+    /// line, or when the target carries no hash. The hash is everything between <c>](figures/</c> and the
+    /// extension dot (the <see cref="FigureReference"/> format: a lowercase hex hash contains no dots).
+    /// </summary>
+    public static string? TryParseImageReferenceHash(string? line)
+    {
+        if (!IsImageReferenceLine(line))
+        {
+            return null;
+        }
+
+        var trimmed = line!.Trim();
+        var start = trimmed.IndexOf(ImageReferenceTarget, StringComparison.Ordinal) + ImageReferenceTarget.Length;
+        var end = start;
+        while (end < trimmed.Length && trimmed[end] != '.' && trimmed[end] != ')')
+        {
+            end++;
+        }
+
+        return end > start ? trimmed[start..end] : null;
+    }
+
+    /// <summary>
     /// Parses the 1-based page from a page-anchored open marker line (<c>*[Image OCR p:3]*</c>), or <c>null</c>
     /// for a bare open line / any non-open line.
     /// </summary>

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -398,7 +398,10 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
 
         await _documentRepository.HardDeleteAsync(id);
 
-        if (document.FileOrigin is not null)
+        // #478: the FileOrigin reclaim is reference-aware — a figure sub-document's FileOrigin SHARES its source's
+        // extraction-figures blob (never copied), so a borrowed blob is deleted only by whichever referencing side
+        // is permanently deleted last. A per-document upload blob (GUID key) is unshared and reclaims as always.
+        if (document.FileOrigin is not null && await ShouldReclaimFileOriginBlobAsync(document))
         {
             try
             {
@@ -432,11 +435,22 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         // #477: reclaim retained figure blobs by their manifest keys. ABP's IBlobContainer has no list-by-prefix, so
         // (like the native-payload reclaim above) delete by stable key from ExtractionMetadata.Figures — never a
         // prefix sweep. Best-effort: a failure is logged but does not block the permanent-delete flow.
+        // #478: skip entries a figure sub-document's FileOrigin still references (the blob is SHARED, never copied) —
+        // the sub-document outlives its source, and its own permanent delete reclaims the blob once this owner row is
+        // gone (ShouldReclaimFileOriginBlobAsync's borrowed branch). Soft-deleted sub-documents count (restorable).
         var figureManifest = document.ExtractionMetadata?.Figures;
         if (figureManifest is { Count: > 0 })
         {
             foreach (var figure in figureManifest)
             {
+                if (await _documentRepository.AnyWithFileOriginBlobNameAsync(figure.BlobName, excludeDocumentId: id))
+                {
+                    Logger.LogDebug(
+                        "Skipping retained figure blob {BlobName} of document {DocumentId}: still referenced by a sub-document's FileOrigin.",
+                        figure.BlobName, id);
+                    continue;
+                }
+
                 try
                 {
                     await _blobContainer.DeleteAsync(figure.BlobName);
@@ -458,6 +472,58 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
                 TenantId = document.TenantId,
                 EventTime = Clock.Now
             });
+    }
+
+    /// <summary>
+    /// Whether this document's <c>FileOrigin</c> blob may be reclaimed on permanent delete (#478). A per-document
+    /// upload blob (GUID key) is unshared — always reclaim. A blob under another document's
+    /// <c>extraction-figures/{ownerId}/…</c> prefix is a <b>borrowed</b> shared figure image (never copied): while
+    /// the owner row exists (including soft-deleted — restorable), the owner's own manifest reclaim governs it, so
+    /// skip; once the owner is hard-deleted (its reclaim skipped this blob because this document still referenced
+    /// it), the last borrower to be permanently deleted reclaims it — unless a sibling still references it.
+    /// Net: deleted exactly once, by whichever referencing side dies last; no leak in either order.
+    /// </summary>
+    protected virtual async Task<bool> ShouldReclaimFileOriginBlobAsync(Document document)
+    {
+        var blobName = document.FileOrigin!.BlobName;
+        var ownerId = TryParseFigureBlobOwner(blobName);
+        if (ownerId is null || ownerId == document.Id)
+        {
+            return true;
+        }
+
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            if (await _documentRepository.FindAsync(ownerId.Value, includeDetails: false) is not null)
+            {
+                Logger.LogDebug(
+                    "Skipping borrowed figure blob {BlobName}: its owner document {OwnerId} still exists and governs it.",
+                    blobName, ownerId);
+                return false;
+            }
+        }
+
+        // Owner gone — reclaim unless a sibling sub-document still references the same shared blob.
+        return !await _documentRepository.AnyWithFileOriginBlobNameAsync(blobName, excludeDocumentId: document.Id);
+    }
+
+    /// <summary>Parses the owning document id out of a retained-figure blob key
+    /// (<c>extraction-figures/{documentId}/{hash}</c>, #477), or <c>null</c> for any other key shape.</summary>
+    private static Guid? TryParseFigureBlobOwner(string blobName)
+    {
+        if (!blobName.StartsWith(DocumentConsts.FigureBlobNamePrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var rest = blobName.AsSpan(DocumentConsts.FigureBlobNamePrefix.Length);
+        var slash = rest.IndexOf('/');
+        if (slash <= 0)
+        {
+            return null;
+        }
+
+        return Guid.TryParse(rest[..slash], out var ownerId) ? ownerId : null;
     }
 
     [Authorize(VaultExtractPermissions.Documents.Restore)]

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
@@ -301,7 +301,7 @@ public class DocumentParseBackgroundJob
                 continue;
             }
 
-            var blobName = $"extraction-figures/{documentId}/{figure.ContentHash}";
+            var blobName = $"{DocumentConsts.FigureBlobNamePrefix}{documentId}/{figure.ContentHash}";
             try
             {
                 using var stream = new MemoryStream(content, writable: false);

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -192,7 +192,11 @@ public class DocumentSegmentationJob
             markdown,
             source.IsContainer,
             alreadySegmented,
-            detection);
+            detection,
+            // #478: the source's retained-figure manifest (#477) + uploader snapshot, carried so the spawn phase can
+            // point a figure sub-document's FileOrigin at the SHARED retained blob without re-loading the source.
+            source.ExtractionMetadata?.Figures,
+            source.FileOrigin?.UploadedByUserName);
     }
 
     /// <summary>
@@ -281,7 +285,11 @@ public class DocumentSegmentationJob
                 ContentHasher.Sha256Hex(Encoding.UTF8.GetBytes(cleanText)),
                 cleanText,
                 isFigure ? DocumentSegmentKind.Figure : DocumentSegmentKind.Text,
-                isFigure ? ExtractFirstPage(slice.Text) : null));
+                isFigure ? ExtractFirstPage(slice.Text) : null,
+                // #478: the retained image's content hash from the in-span figures/{hash} reference (#477); parsed
+                // from the RAW slice (the clean seed above deliberately drops the reference line). Null when
+                // retention was off — the spawn then leaves FileOrigin null, exactly the pre-#478 behavior.
+                isFigure ? ExtractFigureContentHash(slice.Text) : null));
         }
 
         // Byte-identical detection among the spawnable slices: same content -> same key -> the unique
@@ -382,7 +390,8 @@ public class DocumentSegmentationJob
                     ordinal++,
                     p.Kind,
                     DocumentSegmentStatus.Pending,
-                    p.PageNumber));
+                    p.PageNumber,
+                    p.FigureContentHash));
             }
 
             // #377: mark the document segmented in the SAME transaction as the rows — the precise resume gate, so a
@@ -421,7 +430,7 @@ public class DocumentSegmentationJob
 
         var snapshot = pending
             .OrderBy(s => s.Ordinal)
-            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Ordinal))
+            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Ordinal, s.FigureContentHash, s.PageNumber))
             .ToList();
 
         await uow.CompleteAsync();
@@ -448,15 +457,20 @@ public class DocumentSegmentationJob
     private async Task SpawnDerivedDocumentAsync(
         PendingSegment segment, DetectionContext context, CancellationToken cancellationToken)
     {
+        // #478 (revisits #393): a Figure-kind segment whose retained image survives in the source's #477 manifest
+        // spawns with a FileOrigin pointing at the SHARED extraction-figures blob (no copy — the image is never
+        // stored twice); reclaim is reference-aware on both sides (DocumentAppService.PermanentDeleteAsync). A Text
+        // segment / retention-off figure keeps FileOrigin null. Markdown is still seeded from segment.SliceText by
+        // DocumentParseBackgroundJob (seed precedence) — the blob is provenance, never re-extracted (no drift).
+        var fileOrigin = BuildFigureFileOrigin(segment, context);
+
         // Shared complete-phase UoW (#358): insert the derived document, mark this segment Spawned, publish
         // DocumentUploadedEto, and queue text extraction — atomically. The reload guard is kind-aware (#371).
-        // FileOrigin is null: sub-documents carry no source blob; their Markdown is seeded from segment.SliceText
-        // by DocumentParseBackgroundJob instead of re-extracting a blob.
         await _derivedDocumentSpawner.SpawnAsync<DocumentSegment>(
             context.SourceDocumentId,
             context.TenantId,
             segment.SegmentKey,
-            fileOrigin: null,
+            fileOrigin,
             reloadClaimable: async () =>
             {
                 var entity = await _segmentRepository.FindAsync(segment.SegmentId);
@@ -615,25 +629,98 @@ public class DocumentSegmentationJob
         return null;
     }
 
+    /// <summary>The retained image's content hash from the slice's first in-span <c>![figure](figures/{hash}.{ext})</c>
+    /// reference line (#477/#478), or <c>null</c> when the slice carries none (retention off / pre-#477 content).</summary>
+    private static string? ExtractFigureContentHash(string markedSliceText)
+    {
+        foreach (var line in markedSliceText.Split('\n'))
+        {
+            var hash = ImageOcrMarkup.TryParseImageReferenceHash(line);
+            if (hash is not null)
+            {
+                return hash;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the figure sub-document's <see cref="FileOrigin"/> (#478) by resolving the segment's
+    /// <see cref="DocumentSegment.FigureContentHash"/> against the source's retained-figure manifest (#477) — the
+    /// manifest is authoritative (its own stored blob key / content type / size; the key is never rebuilt from
+    /// parsed input), and the blob is <b>shared</b> with the source (never copied). Returns <c>null</c> — leaving
+    /// today's no-FileOrigin behavior — for a Text segment, a retention-off figure, a manifest miss, or a source
+    /// missing its uploader snapshot.
+    /// </summary>
+    private FileOrigin? BuildFigureFileOrigin(PendingSegment segment, DetectionContext context)
+    {
+        if (segment.FigureContentHash is null)
+        {
+            return null;
+        }
+
+        var entry = context.FigureManifest?.FirstOrDefault(
+            f => string.Equals(f.ContentHash, segment.FigureContentHash, StringComparison.Ordinal));
+        if (entry is null)
+        {
+            Logger.LogInformation(
+                "Figure segment {SegmentId} of source {SourceId} references image {Hash}, but the source has no "
+                + "matching retained-figure manifest entry (retention off or archive failed); spawning without FileOrigin.",
+                segment.SegmentId, context.SourceDocumentId, segment.FigureContentHash);
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(context.SourceUploadedByUserName))
+        {
+            Logger.LogWarning(
+                "Source {SourceId} has no uploader snapshot; spawning figure segment {SegmentId} without FileOrigin.",
+                context.SourceDocumentId, segment.SegmentId);
+            return null;
+        }
+
+        var extension = FigureReference.Extension(entry.ContentType);
+        var originalFileName = segment.PageNumber is { } page && page > 0
+            ? $"figure-p{page}.{extension}"
+            : $"figure.{extension}";
+
+        return new FileOrigin(
+            entry.BlobName,
+            context.SourceUploadedByUserName!,
+            entry.ContentType,
+            entry.ContentHash,
+            entry.SizeBytes,
+            originalFileName);
+    }
+
     private static bool IsSchemaDeserializationError(Exception ex)
         => ex is JsonException || ex.GetBaseException() is JsonException;
 
-    /// <summary>Per-source detection context loaded once up front: the source id + tenant, the Document.Markdown to detect over (with inline figure markers, #381), the container flag, whether a prior split exists, and the parent context for the LLM.</summary>
+    /// <summary>Per-source detection context loaded once up front: the source id + tenant, the Document.Markdown to
+    /// detect over (with inline figure markers, #381), the container flag, whether a prior split exists, the parent
+    /// context for the LLM, and — for the #478 figure FileOrigin — the source's retained-figure manifest (#477) plus
+    /// its uploader snapshot.</summary>
     protected sealed record DetectionContext(
         Guid SourceDocumentId,
         Guid? TenantId,
         string Markdown,
         bool IsContainer,
         bool AlreadySegmented,
-        SubDocumentDetectionContext Detection);
+        SubDocumentDetectionContext Detection,
+        IReadOnlyList<FigureManifestEntry>? FigureManifest = null,
+        string? SourceUploadedByUserName = null);
 
-    /// <summary>A standalone span prepared for persistence: its content key, clean slice text, kind, and figure page anchor.</summary>
-    private sealed record PreparedSegment(string Key, string CleanText, DocumentSegmentKind Kind, int? PageNumber);
+    /// <summary>A standalone span prepared for persistence: its content key, clean slice text, kind, figure page
+    /// anchor, and the retained image's content hash (#478; null for Text / retention off).</summary>
+    private sealed record PreparedSegment(
+        string Key, string CleanText, DocumentSegmentKind Kind, int? PageNumber, string? FigureContentHash);
 
     /// <summary>Detached snapshot of one still-Pending segment, carried across the per-segment external + UoW phases.
     /// Carries no slice text: the spawn path keys off <see cref="SegmentKey"/>, and the derived document's Markdown
-    /// is seeded by <c>DocumentParseBackgroundJob</c> reading the segment's <c>SliceText</c> column fresh from the DB.</summary>
-    protected sealed record PendingSegment(Guid SegmentId, string SegmentKey, int Ordinal);
+    /// is seeded by <c>DocumentParseBackgroundJob</c> reading the segment's <c>SliceText</c> column fresh from the DB.
+    /// <see cref="FigureContentHash"/> + <see cref="PageNumber"/> feed the #478 figure FileOrigin resolution.</summary>
+    protected sealed record PendingSegment(
+        Guid SegmentId, string SegmentKey, int Ordinal, string? FigureContentHash = null, int? PageNumber = null);
 }
 
 public class DocumentSegmentationJobArgs

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentConsts.cs
@@ -91,6 +91,16 @@ public static class DocumentConsts
     public static long MaxNativePayloadArchiveBytes { get; set; } = 16L * 1024 * 1024;
 
     /// <summary>
+    /// Blob key prefix of retained embedded-figure images (#477): a figure blob lives at
+    /// <c>extraction-figures/{documentId}/{contentHash}</c>, so the key itself names its <b>owning</b> document.
+    /// The #478 reclaim rules key on this structure: a <c>FileOrigin</c> pointing under another document's prefix
+    /// is a <b>borrowed</b> shared blob (a figure sub-document sharing its source's image — never copied), deleted
+    /// only by whichever referencing side is permanently deleted last. A <c>const</c> (not host-mutable): it is a
+    /// persisted storage-key format, changing it would orphan existing blobs.
+    /// </summary>
+    public const string FigureBlobNamePrefix = "extraction-figures/";
+
+    /// <summary>
     /// Hard per-call result limit for programmatic / LLM-triggered retrieval, such as MCP search tools.
     /// Fail-closed safety gate: prevents prompt injection from inducing broad queries that explode LLM context or create cost attacks.
     /// Compile-time <c>const</c>: the safety boundary cannot be enlarged by runtime configuration.

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentSegmentConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentSegmentConsts.cs
@@ -10,7 +10,14 @@ public static class DocumentSegmentConsts
 {
     /// <summary>
     /// Length of <see cref="DocumentSegment.SegmentKey"/>: the SHA-256 (lowercase hex) of the slice text,
-    /// which equals the spawned derived document's <c>FileOrigin.ContentHash</c> / <c>OriginConstituentKey</c>.
+    /// which equals the spawned derived document's <c>OriginConstituentKey</c>.
     /// </summary>
     public static int MaxSegmentKeyLength { get; set; } = 64;
+
+    /// <summary>
+    /// Length of <see cref="DocumentSegment.FigureContentHash"/> (#478): the SHA-256 (lowercase hex) of the
+    /// retained figure's <b>image bytes</b> — distinct from <see cref="DocumentSegment.SegmentKey"/> (the hash of
+    /// the transcription <b>text</b>).
+    /// </summary>
+    public static int MaxFigureContentHashLength { get; set; } = 64;
 }

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
@@ -17,6 +17,23 @@ public interface IDocumentRepository : IRepository<Document, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Whether any document other than <paramref name="excludeDocumentId"/> has a <c>FileOrigin.BlobName</c> equal to
+    /// <paramref name="blobName"/> — the #478 shared-blob reference check used by
+    /// <c>DocumentAppService.PermanentDeleteAsync</c> before reclaiming a blob a figure sub-document may share with
+    /// its source. Existence-only (SQL <c>EXISTS</c>, no row materialization).
+    /// <para>
+    /// The implementation disables the <c>ISoftDelete</c> filter itself (like <see cref="FindByContentHashAsync"/>):
+    /// a recycle-bin document is restorable, so it still counts as a live reference; a hard-deleted row no longer
+    /// exists and correctly does not. <c>IMultiTenant</c> still applies by ambient state (source and sub-documents
+    /// share a tenant).
+    /// </para>
+    /// </summary>
+    Task<bool> AnyWithFileOriginBlobNameAsync(
+        string blobName,
+        Guid? excludeDocumentId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Duplicate-detection candidate query (#411): <b>other</b> documents in the current layer with the same
     /// <see cref="Document.DocumentTypeId"/> and the same <see cref="Document.FieldFingerprint"/> as the document
     /// being extracted. Two documents sharing a (type, fingerprint) are likely the same business entity re-uploaded.

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/Segments/DocumentSegment.cs
@@ -75,6 +75,17 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
     public virtual int? PageNumber { get; private set; }
 
     /// <summary>
+    /// SHA-256 (lowercase hex) of the retained figure's <b>image bytes</b> (#477/#478), parsed from the in-span
+    /// <c>![figure](figures/{hash}.{ext})</c> reference of a <see cref="DocumentSegmentKind.Figure"/> slice at
+    /// detection time; <c>null</c> for a <see cref="DocumentSegmentKind.Text"/> slice or when retention was off.
+    /// Persisted so the spawn phase is resumable: at spawn it resolves the source document's retained-figure
+    /// manifest by this hash and points the derived document's <c>FileOrigin</c> at the <b>shared</b> blob
+    /// (<c>extraction-figures/{sourceId}/{hash}</c> — the image is never stored twice). Distinct from
+    /// <see cref="SegmentKey"/> (the hash of the transcription <b>text</b>, the idempotency identity).
+    /// </summary>
+    public virtual string? FigureContentHash { get; private set; }
+
+    /// <summary>
     /// The derived <see cref="Document"/> spawned from this slice, or <c>null</c> when not (yet) spawned /
     /// classified as a non-document segment.
     /// </summary>
@@ -103,7 +114,8 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         int ordinal,
         DocumentSegmentKind kind,
         DocumentSegmentStatus status = DocumentSegmentStatus.Pending,
-        int? pageNumber = null)
+        int? pageNumber = null,
+        string? figureContentHash = null)
         : base(id)
     {
         TenantId = tenantId;
@@ -114,6 +126,8 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         Kind = kind;
         Status = status;
         PageNumber = pageNumber;
+        FigureContentHash = Check.Length(
+            figureContentHash, nameof(figureContentHash), DocumentSegmentConsts.MaxFigureContentHashLength);
     }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -51,6 +51,26 @@ public class EfCoreDocumentRepository
         }
     }
 
+    public virtual async Task<bool> AnyWithFileOriginBlobNameAsync(
+        string blobName,
+        Guid? excludeDocumentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        // #478 shared-blob reference check: soft-deleted documents are restorable, so they still count as live
+        // references (the same ISoftDelete-disable stance as FindByContentHashAsync above). excludeDocumentId keeps
+        // the document being permanently deleted from counting as its own reference — its hard delete may not be
+        // flushed yet within the ambient UoW.
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            var dbSet = await GetDbSetAsync();
+            return await dbSet.AnyAsync(
+                d => d.FileOrigin != null
+                    && d.FileOrigin.BlobName == blobName
+                    && (excludeDocumentId == null || d.Id != excludeDocumentId),
+                GetCancellationToken(cancellationToken));
+        }
+    }
+
     public virtual async Task<List<DuplicateCandidateModel>> FindDuplicateCandidatesAsync(
         Guid documentId,
         Guid documentTypeId,
@@ -239,8 +259,7 @@ public class EfCoreDocumentRepository
         // grouped projection; keep the two in sync.
         var byStatus = await dbSet
             .GroupBy(d => d.LifecycleStatus)
-            .Select(g => new
-            {
+            .Select(g => new {
                 Status = g.Key,
                 // #346: a container is an infrastructure wrapper, not a business document — its sub-documents are the
                 // real records. Exclude containers from the document counts / storage so a container + its N
@@ -367,31 +386,31 @@ public class EfCoreDocumentRepository
                     .Any(f => f.FieldDefinitionId == fieldDefinitionId && f.BooleanValue == boolValue));
 
             case FieldDataType.Number:
-            {
-                var (min, max) = ParseRange(fieldQuery, ParseDecimal);
-                return query.Where(d => d.ExtractedFieldValues.Any(f =>
-                    f.FieldDefinitionId == fieldDefinitionId
-                    && (min == null || f.NumberValue >= min)
-                    && (max == null || f.NumberValue <= max)));
-            }
+                {
+                    var (min, max) = ParseRange(fieldQuery, ParseDecimal);
+                    return query.Where(d => d.ExtractedFieldValues.Any(f =>
+                        f.FieldDefinitionId == fieldDefinitionId
+                        && (min == null || f.NumberValue >= min)
+                        && (max == null || f.NumberValue <= max)));
+                }
 
             case FieldDataType.Date:
-            {
-                var (min, max) = ParseRange(fieldQuery, ParseDate);
-                return query.Where(d => d.ExtractedFieldValues.Any(f =>
-                    f.FieldDefinitionId == fieldDefinitionId
-                    && (min == null || f.DateValue >= min)
-                    && (max == null || f.DateValue <= max)));
-            }
+                {
+                    var (min, max) = ParseRange(fieldQuery, ParseDate);
+                    return query.Where(d => d.ExtractedFieldValues.Any(f =>
+                        f.FieldDefinitionId == fieldDefinitionId
+                        && (min == null || f.DateValue >= min)
+                        && (max == null || f.DateValue <= max)));
+                }
 
             case FieldDataType.DateTime:
-            {
-                var (min, max) = ParseRange(fieldQuery, ParseDateTime);
-                return query.Where(d => d.ExtractedFieldValues.Any(f =>
-                    f.FieldDefinitionId == fieldDefinitionId
-                    && (min == null || f.DateTimeValue >= min)
-                    && (max == null || f.DateTimeValue <= max)));
-            }
+                {
+                    var (min, max) = ParseRange(fieldQuery, ParseDateTime);
+                    return query.Where(d => d.ExtractedFieldValues.Any(f =>
+                        f.FieldDefinitionId == fieldDefinitionId
+                        && (min == null || f.DateTimeValue >= min)
+                        && (max == null || f.DateTimeValue <= max)));
+                }
 
             default:
                 throw InvalidValue(name, fieldQuery.FieldDataType);

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/EntityFrameworkCore/VaultExtractDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/EntityFrameworkCore/VaultExtractDbContextModelCreatingExtensions.cs
@@ -252,6 +252,11 @@ public static class VaultExtractDbContextModelCreatingExtensions
             b.Property(x => x.Kind).IsRequired();
             b.Property(x => x.Status).IsRequired();
 
+            // #478: SHA-256 (hex) of a Figure-kind slice's retained image bytes (#477), parsed from the in-span
+            // figures/{hash} reference; null for Text slices / retention off. Read back at spawn to resolve the
+            // source's retained-figure manifest; looked up per row, never scanned — not indexed.
+            b.Property(x => x.FigureContentHash).HasMaxLength(DocumentSegmentConsts.MaxFigureContentHashLength);
+
             // #346: born-digital slice -> container Document, FK + CASCADE so hard-deleting the container removes
             // its segment rows (mirrors the #306 DocumentFigure child-side declaration). RoutedDocumentId is a
             // soft pointer to the spawned derived Document with NO FK constraint: the derived document is a peer

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Ai/ImageOcrMarkup_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Ai/ImageOcrMarkup_Tests.cs
@@ -122,6 +122,19 @@ public class ImageOcrMarkup_Tests
     }
 
     [Fact]
+    public void TryParseImageReferenceHash_Extracts_The_Content_Hash_From_A_Reference_Line()
+    {
+        // #478: the segmentation pass correlates a figure span to its retained blob by this hash.
+        ImageOcrMarkup.TryParseImageReferenceHash("![figure](figures/abc123.png)").ShouldBe("abc123");
+        ImageOcrMarkup.TryParseImageReferenceHash("  ![diagram](figures/def456.jpg)  ").ShouldBe("def456"); // alt-agnostic + trimmed
+        ImageOcrMarkup.TryParseImageReferenceHash("![figure](figures/noext)").ShouldBe("noext");            // extension-less target
+        ImageOcrMarkup.TryParseImageReferenceHash("![logo](https://example.com/a.png)").ShouldBeNull();     // not a figures/ reference
+        ImageOcrMarkup.TryParseImageReferenceHash("![figure](figures/.png)").ShouldBeNull();                // empty hash
+        ImageOcrMarkup.TryParseImageReferenceHash("just prose").ShouldBeNull();
+        ImageOcrMarkup.TryParseImageReferenceHash(null).ShouldBeNull();
+    }
+
+    [Fact]
     public void Strip_And_ExtractBodies_Drop_The_Retained_Figure_Reference_Line()
     {
         // #477: the spawned child sub-document's seed is the transcription only (#373) — the retained image belongs to

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -418,6 +418,94 @@ public class DocumentAppService_Delete_Tests
         await _blobContainer.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task PermanentDeleteAsync_Skips_A_Manifest_Figure_Blob_Still_Referenced_By_A_SubDocument()
+    {
+        // #478 owner side: the source's manifest reclaim must NOT delete a figure blob a sub-document's FileOrigin
+        // still shares — the sub-document outlives its source; its own permanent delete reclaims the blob later.
+        var doc = CreateDocument();
+        var sharedBlob = $"extraction-figures/{doc.Id}/imghash";
+        SetExtractionMetadata(doc, new DocumentParseMetadata(
+            "PdfPig", null, figures: new[] { new FigureManifestEntry(sharedBlob, "imghash", "image/png", 10) }));
+
+        _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(doc);
+        _documentRepository
+            .AnyWithFileOriginBlobNameAsync(sharedBlob, doc.Id, Arg.Any<CancellationToken>())
+            .Returns(true); // a live (or restorable) sub-document still references it
+
+        await _appService.PermanentDeleteAsync(doc.Id);
+
+        await _blobContainer.DidNotReceive().DeleteAsync(sharedBlob, Arg.Any<CancellationToken>());
+        // The document's own (unshared, GUID-keyed) upload blob is still reclaimed as always.
+        await _blobContainer.Received(1).DeleteAsync(doc.FileOrigin!.BlobName, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Reclaims_A_Manifest_Figure_Blob_Nothing_References()
+    {
+        var doc = CreateDocument();
+        var figureBlob = $"extraction-figures/{doc.Id}/imghash";
+        SetExtractionMetadata(doc, new DocumentParseMetadata(
+            "PdfPig", null, figures: new[] { new FigureManifestEntry(figureBlob, "imghash", "image/png", 10) }));
+
+        _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(doc);
+        // AnyWithFileOriginBlobNameAsync substitute default = false: no reference remains.
+
+        await _appService.PermanentDeleteAsync(doc.Id);
+
+        await _blobContainer.Received(1).DeleteAsync(figureBlob, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Keeps_A_Borrowed_Figure_Blob_While_Its_Owner_Exists()
+    {
+        // #478 borrower side: a figure sub-document's FileOrigin SHARES its source's extraction-figures blob.
+        // While the owner row exists (even soft-deleted — restorable), the owner's manifest reclaim governs the
+        // blob, so the sub-document's own permanent delete must not touch it.
+        var ownerId = Guid.NewGuid();
+        var borrowedBlob = $"extraction-figures/{ownerId}/imghash";
+        var subDoc = CreateDocumentWithFileOrigin(borrowedBlob);
+
+        _documentRepository.GetAsync(subDoc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(subDoc);
+        _documentRepository.FindAsync(ownerId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CreateDocument()); // the owner still exists
+
+        await _appService.PermanentDeleteAsync(subDoc.Id);
+
+        await _blobContainer.DidNotReceive().DeleteAsync(borrowedBlob, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Reclaims_A_Borrowed_Figure_Blob_Once_The_Owner_Is_Gone()
+    {
+        // The last referencing side reclaims: owner hard-deleted (its manifest reclaim skipped the blob because
+        // this sub-document still referenced it), no sibling references it → this delete reclaims the blob.
+        var ownerId = Guid.NewGuid();
+        var borrowedBlob = $"extraction-figures/{ownerId}/imghash";
+        var subDoc = CreateDocumentWithFileOrigin(borrowedBlob);
+
+        _documentRepository.GetAsync(subDoc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(subDoc);
+        // FindAsync default = null (owner gone); AnyWithFileOriginBlobNameAsync default = false (no sibling).
+
+        await _appService.PermanentDeleteAsync(subDoc.Id);
+
+        await _blobContainer.Received(1).DeleteAsync(borrowedBlob, Arg.Any<CancellationToken>());
+    }
+
+    private static Document CreateDocumentWithFileOrigin(string blobName)
+    {
+        return new Document(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            new FileOrigin(
+                blobName: blobName,
+                uploadedByUserName: "test-user",
+                contentType: "image/png",
+                contentHash: "imghash",
+                fileSize: 10,
+                originalFileName: "figure-p1.png"));
+    }
+
     // Document.SetExtractionMetadata is internal and InternalsVisibleTo covers only EntityFrameworkCore.Tests, so
     // set it via reflection here rather than broaden internal visibility for a test convenience.
     private static void SetExtractionMetadata(Document document, DocumentParseMetadata metadata)

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -155,6 +155,80 @@ public class DocumentSegmentationJob_Tests : VaultExtractTestBase<DocumentSegmen
     }
 
     [Fact]
+    public async Task Figure_Sub_Document_Gets_Its_FileOrigin_From_The_Shared_Retained_Blob()
+    {
+        // #478 (revisits #393): the figure span carries the #477 in-span figures/{hash} reference, and the source's
+        // retained-figure manifest has a matching entry. The spawned sub-document's FileOrigin must point at the
+        // SHARED blob (the manifest's own key — never a copy), with metadata from the manifest + the source's
+        // uploader snapshot, while the child seed (SliceText) stays pure transcription (reference line dropped).
+        var invoiceText = "INVOICE No 42 Total 100";
+        var imageHash = "abc123"; // short fake hash: parse + manifest match are length-agnostic (cap-friendly)
+        var sharedBlob = $"{DocumentConsts.FigureBlobNamePrefix}{Guid.NewGuid():D}/{imageHash}";
+        var marked = $"Contract body\n{ImageOcrMarkup.Wrap(invoiceText, 1, $"figures/{imageHash}.png")}";
+
+        var docId = await ArrangeContainerAsync(
+            markdown: "Contract body", asContainer: false, markedMarkdown: marked,
+            extractionMetadata: new DocumentParseMetadata(
+                "PdfPig", null,
+                figures: new[] { new FigureManifestEntry(sharedBlob, imageHash, "image/png", 2048) }));
+
+        StubSplit(("Contract body", false), (ImageOcrMarkup.OpenPagePrefix + "1]*", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = docId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == docId);
+            segments.Count.ShouldBe(1);
+            segments[0].Kind.ShouldBe(DocumentSegmentKind.Figure);
+            // The ledger carries the image hash (resumable spawn input); the seed stays transcription-only.
+            segments[0].FigureContentHash.ShouldBe(imageHash);
+            segments[0].SliceText.ShouldBe(invoiceText);
+
+            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == docId);
+            derived.Count.ShouldBe(1);
+            var fileOrigin = derived[0].FileOrigin;
+            fileOrigin.ShouldNotBeNull();
+            fileOrigin!.BlobName.ShouldBe(sharedBlob);          // the SHARED blob — no copy was written
+            fileOrigin.ContentType.ShouldBe("image/png");
+            fileOrigin.ContentHash.ShouldBe(imageHash);
+            fileOrigin.FileSize.ShouldBe(2048);
+            fileOrigin.OriginalFileName.ShouldBe("figure-p1.png");
+            fileOrigin.UploadedByUserName.ShouldBe("test-user"); // the source's uploader snapshot
+        });
+    }
+
+    [Fact]
+    public async Task Figure_Spawn_Without_A_Manifest_Match_Leaves_FileOrigin_Null()
+    {
+        // #478 gating: the reference is present in the span, but the source has no retained-figure manifest
+        // (#477 retention was off / archive failed). The hash is still persisted on the ledger (resumability),
+        // and the sub-document spawns with FileOrigin null — exactly the pre-#478 behavior.
+        var invoiceText = "INVOICE No 42 Total 100";
+        var imageHash = "abc123";
+        var marked = $"Contract body\n{ImageOcrMarkup.Wrap(invoiceText, 1, $"figures/{imageHash}.png")}";
+
+        var docId = await ArrangeContainerAsync(
+            markdown: "Contract body", asContainer: false, markedMarkdown: marked);
+
+        StubSplit(("Contract body", false), (ImageOcrMarkup.OpenPagePrefix + "1]*", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = docId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var segments = await _segmentRepository.GetListAsync(s => s.SourceDocumentId == docId);
+            segments.Count.ShouldBe(1);
+            segments[0].FigureContentHash.ShouldBe(imageHash);
+            segments[0].Status.ShouldBe(DocumentSegmentStatus.Spawned);
+
+            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == docId);
+            derived.Count.ShouldBe(1);
+            derived[0].FileOrigin.ShouldBeNull();
+        });
+    }
+
+    [Fact]
     public async Task Inlined_Figure_Span_In_A_Container_Spawns_Exactly_One_Invoice_Sub_Document()
     {
         // #356/#359 REGRESSION: a born-digital container whose Document.Markdown carries an inlined, marker-bracketed
@@ -701,7 +775,8 @@ public class DocumentSegmentationJob_Tests : VaultExtractTestBase<DocumentSegmen
     }
 
     private async Task<Guid> ArrangeContainerAsync(
-        string markdown, bool asContainer = true, string? markedMarkdown = null)
+        string markdown, bool asContainer = true, string? markedMarkdown = null,
+        DocumentParseMetadata? extractionMetadata = null)
     {
         var containerId = _guidGenerator.Create();
         await WithUnitOfWorkAsync(async () =>
@@ -716,6 +791,13 @@ public class DocumentSegmentationJob_Tests : VaultExtractTestBase<DocumentSegmen
                     contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
                     fileSize: 2048,
                     originalFileName: "bundle.pdf"));
+
+            // #478: a figure test supplies the source's retained-figure manifest (#477) so the spawn can resolve a
+            // figure segment's FigureContentHash against it. Internal setter, visible via InternalsVisibleTo.
+            if (extractionMetadata is not null)
+            {
+                doc.SetExtractionMetadata(extractionMetadata);
+            }
 
             // #381: the unified pass reads Document.Markdown, which now carries the inline *[Image OCR]*…*[End OCR]*
             // figure markers (no separate marked artifact). A figure test supplies that marked content via

--- a/host/src/Migrations/20260708070557_Add_DocumentSegment_FigureContentHash.Designer.cs
+++ b/host/src/Migrations/20260708070557_Add_DocumentSegment_FigureContentHash.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.Vault.Extract.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.Vault.Extract.Host.Migrations
 {
     [DbContext(typeof(VaultExtractHostDbContext))]
-    partial class VaultExtractHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708070557_Add_DocumentSegment_FigureContentHash")]
+    partial class Add_DocumentSegment_FigureContentHash
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260708070557_Add_DocumentSegment_FigureContentHash.cs
+++ b/host/src/Migrations/20260708070557_Add_DocumentSegment_FigureContentHash.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.Vault.Extract.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_DocumentSegment_FigureContentHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FigureContentHash",
+                table: "VaultDocumentSegments",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FigureContentHash",
+                table: "VaultDocumentSegments");
+        }
+    }
+}


### PR DESCRIPTION
Closes #478 — a **figure-derived sub-document** gets a real `FileOrigin` pointing at the **shared** #477 retained image blob (the explicit revisit of #393; **no copy** — the image is never stored twice, per the decided share design).

## What this does

1. **Correlation (ledger, one nullable column + safe migration).** At detection, `DocumentSegmentationJob` parses the content hash out of the #477 in-span `![figure](figures/{hash}.{ext})` reference (new `ImageOcrMarkup.TryParseImageReferenceHash`) and persists it as `DocumentSegment.FigureContentHash` — Figure-kind only, null for Text / retention-off; the child seed (`SliceText`) stays pure transcription (the reference line is dropped, #373). Migration `Add_DocumentSegment_FigureContentHash` adds the single nullable `nvarchar(64)` column (metadata-only on SQL Server, no lock risk, no data change; `Down()` drops only itself).

2. **Spawn (no blob IO).** At spawn, the hash resolves against the **source's retained-figure manifest** (authoritative — the blob key is never rebuilt from parsed input): found → `FileOrigin { BlobName = the SHARED extraction-figures/{sourceId}/{hash} blob, ContentType/FileSize from the manifest, ContentHash = the image hash, OriginalFileName = "figure-p{N}.{ext}", UploadedByUserName = the source's snapshot }` → passed through the existing `DerivedDocumentSpawner` seam (the `fileOrigin: null` #393 flip is literally one argument — the spawner and `DocumentUploadedEto` were already wired). Manifest miss → `FileOrigin` stays null, byte-identical to before; **the feature rides #477's toggle with no new knob**.

3. **Reference-aware reclaim (both sides; no refcount table, no JSON-column queries).** Ownership is derived from the key structure (`extraction-figures/{ownerId}/…` names its owner — now a shared `DocumentConsts.FigureBlobNamePrefix` const):
   - **Owner side** (`PermanentDeleteAsync` manifest reclaim): skips a figure blob any other document's `FileOrigin` still references (new `IDocumentRepository.AnyWithFileOriginBlobNameAsync`, existence-only; **soft-deleted rows count** — they are restorable).
   - **Borrower side** (`FileOrigin` reclaim): a `FileOrigin` under another document's figure prefix is borrowed — kept while the owner row exists (its manifest reclaim governs it), reclaimed only once the owner is hard-deleted **and** no sibling references it.
   - Net: the blob is deleted exactly once, by whichever referencing side dies **last** — no leak in either delete order. Normally-uploaded documents (GUID blob keys) are untouched by the checks.

4. **No re-OCR / no drift** — the parse job's seed precedence is untouched: the sub-document's Markdown is still seeded from `SliceText`; the blob is downloadable provenance (via the **existing** `documents/{subDocId}/blob` endpoint) and is never re-extracted.

## Boundary honored (#393)

Parse/OCR still mints no Application provenance — the provider only surfaced bytes (#477); the manifest resolution and `FileOrigin` minting happen in the Application layer (segmentation job). What flips is #393's conclusion, not its boundary. `OriginConstituentKey` (slice-**text** hash) ≠ `FileOrigin.ContentHash` (image-**bytes** hash) — intentional, different purposes.

## #390 contract

`DocumentSegment` gains one field; the field-lifecycle table in `.claude/rules/sub-document-segmentation.md` is updated in this PR and the addition is recorded on #390.

## Scope notes

- **Text-kind sub-documents keep `FileOrigin = null`** — universalizing FileOrigin is #481 (design discussion).
- OpenXML figures don't become Figure-kind segments yet (no `*[Image OCR]*` markers) — #480 extends the same path to DOCX/PPTX with zero further #478 work.

## Tests (7 new, all green; full solution builds clean)

- **EF (segmentation, real SQLite)**: figure spawn resolves the manifest → `FileOrigin` = the shared blob key + manifest metadata + uploader snapshot + `figure-p1.png`, seed stays transcription-only; manifest miss → hash persisted, `FileOrigin` null. Existing container-split test still asserts Text children carry null `FileOrigin`.
- **Application (reclaim)**: owner skips a still-referenced manifest blob (own upload blob still reclaimed) / reclaims an unreferenced one; borrower keeps a borrowed blob while the owner exists / reclaims it once the owner is gone with no sibling.
- **ImageOcrMarkup**: `TryParseImageReferenceHash` (alt-agnostic, extension-less, non-reference, empty-hash cases).

Suites: EF 118, Application 339, solution 0 errors.
