### PR TITLE
feat(text-extraction): wrap OpenXML figure transcriptions in ImageOcrMarkup markers — unify the parsed figure format with PDF (#480)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/DocxExtractor.cs
@@ -746,8 +746,9 @@ public class DocxExtractor : IMarkdownTextProvider, ITransientDependency
         DocxExtractionState state,
         CancellationToken cancellationToken)
     {
+        // DOCX is a flow document — no page concept — so the figure marker is the bare page-less form (#480).
         var block = await OpenXmlFigureTranscriber.TranscribeAsync(
-            mainPart, relationshipId, caption, state, _options, _ocrProvider, Logger, cancellationToken);
+            mainPart, relationshipId, caption, pageNumber: null, state, _options, _ocrProvider, Logger, cancellationToken);
         if (block is not null)
         {
             blocks.Add(block);

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlFigureTranscriber.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/OpenXmlFigureTranscriber.cs
@@ -39,6 +39,7 @@ internal static class OpenXmlFigureTranscriber
         OpenXmlPartContainer partContainer,
         string relationshipId,
         string? caption,
+        int? pageNumber,
         OpenXmlExtractionState state,
         OpenXmlExtractorOptions options,
         IOcrProvider ocrProvider,
@@ -130,26 +131,31 @@ internal static class OpenXmlFigureTranscriber
             return null;
         }
 
-        // Caption (alt-text) is author-controlled free text (often multi-line), so collapse newlines via
-        // MarkdownText.InlineLabel AND inline-escape via MarkdownText.EscapeInline so the bold caption can't
-        // break the OCR block (often a table) below it, nor inject a link/emphasis from a literal [..](..)/*.
-        var body = string.IsNullOrWhiteSpace(caption)
-            ? transcription
-            : "**" + MarkdownText.EscapeInline(MarkdownText.InlineLabel(caption)) + "**\n\n" + transcription;
-
         // #477: when figure retention is on, surface the source image out-of-band on the state (the bytes just
-        // OCR'd — this seam persists nothing) and prepend a standard Markdown figures/{hash} image reference so the
-        // Application layer can blob-store it. OpenXML figures carry no *[Image OCR]* markers (unlike the PDF path),
-        // so the reference is an ordinary image line ahead of the (optionally captioned) transcription; the native
-        // alt-text/caption is kept on the retained figure.
+        // OCR'd — this seam persists nothing) and build a figures/{hash} reference for ImageOcrMarkup.Wrap to inline
+        // as the span's FIRST body line (INSIDE the markers), exactly as the PDF path does — segmentation (#478)
+        // correlates a figure to its blob from there. The page anchor is the caller's (DOCX flow document → null;
+        // PPTX → 1-based slide number) and is carried onto the retained figure too, so its ExtractedFigure.PageNumber
+        // matches the marker.
+        string? imageReference = null;
         if (state.RetainFigureImages)
         {
             var hash = FigureReference.Sha256Hex(resolved.Bytes!);
+            imageReference = FigureReference.Build(hash, resolved.ContentType!);
             state.RetainedFigures.Add(
-                new ExtractedFigure(hash, resolved.Bytes!, resolved.ContentType!, pageNumber: null, altText: caption));
-            body = "![figure](" + FigureReference.Build(hash, resolved.ContentType!) + ")\n\n" + body;
+                new ExtractedFigure(hash, resolved.Bytes!, resolved.ContentType!, pageNumber, altText: caption));
         }
 
-        return body;
+        // #480: emit the byte-identical figure block the PDF path emits (PdfReadingOrder) — the transcription wrapped
+        // in the *[Image OCR]*…*[End OCR]* provenance markers (#371/#381), with the native caption escaped as a block
+        // BEFORE the open marker (not bolded, not inside the span) so the span body stays "reference + transcription"
+        // and the #373 child seed (ExtractBodies) stays clean. Before #480 OpenXML figures carried no markers, so
+        // ImageOcrMarkup.Contains was blind to them — no deterministic segmentation routing (#379) and #478's figure
+        // FileOrigin never applied. Caption (alt-text) is author-controlled source text, so EscapeBlockText
+        // neutralizes any leading block marker / inline link it carries (multi-line safe, unlike the old bold label).
+        var figureMarkup = ImageOcrMarkup.Wrap(transcription, pageNumber, imageReference);
+        return string.IsNullOrWhiteSpace(caption)
+            ? figureMarkup
+            : MarkdownText.EscapeBlockText(caption) + "\n\n" + figureMarkup;
     }
 }

--- a/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
+++ b/core/src/Dignite.Vault.Extract.Parse.OpenXml/PptxExtractor.cs
@@ -150,6 +150,10 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
 
             foreach (var slideId in slideIds)
             {
+                // #480: 1-based slide ordinal for the figure marker's page anchor (*[Image OCR p:{slide}]*) and the
+                // retained figure's page number. Every SlideIdList entry occupies its position even if it fails to
+                // resolve below, so advance before any skip to keep later slides correctly numbered.
+                state.CurrentSlideNumber++;
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var relId = slideId.RelationshipId?.Value;
@@ -335,7 +339,7 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
         // truncation → caption, #317) returns the finished block; PPTX sinks it as a positioned SlideBlock so
         // reading-order sorting can place it by shape offset (state.Sequence breaks ties in document order).
         var block = await OpenXmlFigureTranscriber.TranscribeAsync(
-            slidePart, embed, AltTextOf(picture), state, _options, _ocrProvider, Logger, cancellationToken);
+            slidePart, embed, AltTextOf(picture), state.CurrentSlideNumber, state, _options, _ocrProvider, Logger, cancellationToken);
         if (block is not null)
         {
             blocks.Add(new SlideReadingOrder.SlideBlock(y, x, state.Sequence++, block));
@@ -723,5 +727,10 @@ public class PptxExtractor : IMarkdownTextProvider, ITransientDependency
     private sealed class PptxExtractionState : OpenXmlExtractionState
     {
         public int Sequence;
+
+        /// <summary>1-based ordinal of the slide currently being walked — the figure marker's page anchor
+        /// (<c>*[Image OCR p:{slide}]*</c>) and the retained figure's <c>ExtractedFigure.PageNumber</c> (#480).
+        /// Slides are page-like (fixed-layout), so a slide ordinal is a valid provenance anchor.</summary>
+        public int CurrentSlideNumber;
     }
 }

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/DocxExtractor_Tests.cs
@@ -185,15 +185,17 @@ public class DocxExtractor_Tests
     [Fact]
     public async Task Escapes_metacharacters_in_an_image_caption()
     {
-        // #320: alt-text is author-controlled source text; a bracketed link in it must not become a clickable
-        // link inside the bold caption.
+        // #320/#480: alt-text is author-controlled source text; a bracketed link in it must not become a clickable
+        // link. The caption is block-escaped (as on the PDF path) and placed before the *[Image OCR]* marker — no
+        // longer bolded.
         StubOcr("TRANSCRIPT");
         var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
             .Image(Png(alt: "See [details](http://evil.example)")));
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
 
-        result.Markdown.ShouldContain("**See \\[details\\](http://evil.example)**");
+        result.Markdown.ShouldContain("See \\[details\\](http://evil.example)");
+        result.Markdown.ShouldNotContain("**See");
     }
 
     [Fact]
@@ -265,11 +267,12 @@ public class DocxExtractor_Tests
     }
 
     [Fact]
-    public async Task Retention_on_surfaces_the_source_image_and_prepends_the_reference()
+    public async Task Retention_on_surfaces_the_source_image_and_inlines_the_reference_in_span()
     {
-        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures and a standard
-        // Markdown figures/{hash} reference is prepended ahead of the (captioned) transcription. OpenXML figures
-        // carry no *[Image OCR]* markers, so the reference is an ordinary image line; the native alt-text is kept.
+        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures. #480: the
+        // figures/{hash} reference is inlined as the figure span's FIRST body line (INSIDE the *[Image OCR]*
+        // markers), matching the PDF path, so segmentation (#478) correlates it to the blob; the native alt-text
+        // caption is block-escaped BEFORE the open marker.
         StubOcr("FIGURE");
 
         var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
@@ -289,15 +292,18 @@ public class DocxExtractor_Tests
         figure.AltText.ShouldBe("Chart 1");
         figure.ContentHash.ShouldBe(Convert.ToHexString(SHA256.HashData(figure.Content)).ToLowerInvariant());
 
-        // In-band: the reference is prepended before the caption, which is before the transcription.
-        var reference = $"![figure](figures/{figure.ContentHash}.";
-        result.Markdown.ShouldContain(reference);
-        var referenceIndex = result.Markdown.IndexOf(reference, StringComparison.Ordinal);
+        // In-band order: caption (before the open marker) < open marker < reference (first body line) <
+        // transcription < close marker — byte-compatible with the PDF path.
         var caption = result.Markdown.IndexOf("Chart 1", StringComparison.Ordinal);
+        var open = result.Markdown.IndexOf("*[Image OCR]*", StringComparison.Ordinal);
+        var reference = result.Markdown.IndexOf($"![figure](figures/{figure.ContentHash}.", StringComparison.Ordinal);
         var transcription = result.Markdown.IndexOf("FIGURE", StringComparison.Ordinal);
-        referenceIndex.ShouldBeGreaterThanOrEqualTo(0);
-        caption.ShouldBeGreaterThan(referenceIndex);
-        transcription.ShouldBeGreaterThan(caption);
+        var close = result.Markdown.IndexOf("*[End OCR]*", StringComparison.Ordinal);
+        caption.ShouldBeGreaterThanOrEqualTo(0);
+        open.ShouldBeGreaterThan(caption);
+        reference.ShouldBeGreaterThan(open);
+        transcription.ShouldBeGreaterThan(reference);
+        close.ShouldBeGreaterThan(transcription);
     }
 
     [Fact]
@@ -310,10 +316,35 @@ public class DocxExtractor_Tests
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
 
-        result.Markdown.ShouldContain("**Quarterly Revenue Diagram**");
+        result.Markdown.ShouldContain("Quarterly Revenue Diagram");
+        result.Markdown.ShouldNotContain("**Quarterly Revenue Diagram**");
         var caption = result.Markdown.IndexOf("Quarterly Revenue Diagram", StringComparison.Ordinal);
+        var open = result.Markdown.IndexOf("*[Image OCR]*", StringComparison.Ordinal);
         var body = result.Markdown.IndexOf("transcribed chart text", StringComparison.Ordinal);
-        body.ShouldBeGreaterThan(caption, "the alt-text caption labels the figure block above the transcription");
+        caption.ShouldBeGreaterThanOrEqualTo(0);
+        open.ShouldBeGreaterThan(caption, "the caption labels the figure block above the open marker");
+        body.ShouldBeGreaterThan(open, "the transcription sits inside the markers, below the caption");
+    }
+
+    [Fact]
+    public async Task Wraps_the_figure_transcription_in_ImageOcrMarkup_markers()
+    {
+        // #480: the deterministic segmentation trigger keys on ImageOcrMarkup.Contains(Document.Markdown). Before
+        // #480 OpenXML figures carried no markers, so a Word-embedded standalone document (e.g. a pasted invoice
+        // photo) was never deterministically routed — only the classifier's subjective flag could catch it, exactly
+        // the single-leg unreliability #379 fixed for the PDF path. DOCX is a flow document, so the marker is the
+        // bare page-less form, byte-compatible with the PDF path.
+        StubOcr("INVOICE TOTAL 42");
+
+        var docx = DocxFixtures.Build(new DocxFixtures.DocSpec()
+            .Paragraph("Cover letter")
+            .Image(Png(alt: null)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
+
+        result.Markdown.ShouldContain("*[Image OCR]*");
+        result.Markdown.ShouldContain("*[End OCR]*");
+        ImageOcrMarkup.Contains(result.Markdown).ShouldBeTrue();
     }
 
     [Fact]
@@ -1090,7 +1121,8 @@ public class DocxExtractor_Tests
         await _ocr.Received(1).RecognizeAsync(
             Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
         result.Markdown.ShouldContain("FILL_FIG");
-        result.Markdown.ShouldContain("**FILL_ALT**");
+        result.Markdown.ShouldContain("FILL_ALT");          // #480: caption present, no longer bolded
+        result.Markdown.ShouldNotContain("**FILL_ALT**");
     }
 
     [Fact]
@@ -1106,7 +1138,8 @@ public class DocxExtractor_Tests
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(docx), DocxContext());
 
-        result.Markdown.ShouldContain("**IMAGE_ALT**");
+        result.Markdown.ShouldContain("IMAGE_ALT");         // #480: caption present, no longer bolded
+        result.Markdown.ShouldNotContain("**IMAGE_ALT**");
         CountOccurrences(result.Markdown, "BOX_FIG").ShouldBe(1);
     }
 

--- a/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Parse.OpenXml.Tests/PptxExtractor_Tests.cs
@@ -71,14 +71,16 @@ public class PptxExtractor_Tests
     [Fact]
     public async Task Escapes_metacharacters_in_an_image_caption()
     {
-        // #320: PPTX picture alt-text is escaped like the DOCX/PDF captions, so it can't inject a link.
+        // #320/#480: PPTX picture alt-text is escaped like the DOCX/PDF captions (block-escaped, placed before the
+        // *[Image OCR]* marker, no longer bolded), so it can't inject a link.
         StubOcr("TRANSCRIPT");
         var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
             .Image(Png(alt: "See [details](http://evil.example)", x: 100, y: 100)));
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
 
-        result.Markdown.ShouldContain("**See \\[details\\](http://evil.example)**");
+        result.Markdown.ShouldContain("See \\[details\\](http://evil.example)");
+        result.Markdown.ShouldNotContain("**See");
     }
 
     [Fact]
@@ -143,11 +145,12 @@ public class PptxExtractor_Tests
     }
 
     [Fact]
-    public async Task Retention_on_surfaces_the_source_image_and_prepends_the_reference()
+    public async Task Retention_on_surfaces_the_source_image_and_inlines_the_reference_in_span()
     {
-        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures and a standard
-        // Markdown figures/{hash} reference is prepended ahead of the (captioned) transcription (OpenXML figures
-        // carry no *[Image OCR]* markers); the native alt-text is kept on the retained figure.
+        // #477 on: the figure's source bytes are surfaced out-of-band on TextExtractionResult.Figures. #480: the
+        // figures/{hash} reference is inlined as the figure span's FIRST body line (INSIDE the *[Image OCR p:{slide}]*
+        // markers), matching the PDF path, so segmentation (#478) correlates it to the blob; the native alt-text
+        // caption is block-escaped BEFORE the open marker. The single slide here anchors the figure to p:1.
         StubOcr("FIGURE");
 
         var pptx = PptxFixtures.Build(new PptxFixtures.SlideSpec()
@@ -161,19 +164,42 @@ public class PptxExtractor_Tests
         var figure = result.Figures[0];
         figure.Content.Length.ShouldBeGreaterThan(0);
         figure.ContentType.ShouldStartWith("image/");
-        figure.PageNumber.ShouldBeNull();
+        figure.PageNumber.ShouldBe(1);
         figure.AltText.ShouldBe("Chart 1");
         figure.ContentHash.ShouldBe(Convert.ToHexString(SHA256.HashData(figure.Content)).ToLowerInvariant());
 
-        // In-band: the reference is prepended before the caption, which is before the transcription.
-        var reference = $"![figure](figures/{figure.ContentHash}.";
-        result.Markdown.ShouldContain(reference);
-        var referenceIndex = result.Markdown.IndexOf(reference, StringComparison.Ordinal);
+        // In-band order: caption (before the open marker) < open marker (slide-anchored) < reference (first body
+        // line) < transcription < close marker — byte-compatible with the PDF path.
         var caption = result.Markdown.IndexOf("Chart 1", StringComparison.Ordinal);
+        var open = result.Markdown.IndexOf("*[Image OCR p:1]*", StringComparison.Ordinal);
+        var reference = result.Markdown.IndexOf($"![figure](figures/{figure.ContentHash}.", StringComparison.Ordinal);
         var transcription = result.Markdown.IndexOf("FIGURE", StringComparison.Ordinal);
-        referenceIndex.ShouldBeGreaterThanOrEqualTo(0);
-        caption.ShouldBeGreaterThan(referenceIndex);
-        transcription.ShouldBeGreaterThan(caption);
+        var close = result.Markdown.IndexOf("*[End OCR]*", StringComparison.Ordinal);
+        caption.ShouldBeGreaterThanOrEqualTo(0);
+        open.ShouldBeGreaterThan(caption);
+        reference.ShouldBeGreaterThan(open);
+        transcription.ShouldBeGreaterThan(reference);
+        close.ShouldBeGreaterThan(transcription);
+    }
+
+    [Fact]
+    public async Task Anchors_the_figure_marker_to_its_slide_number()
+    {
+        // #480: PPTX figures carry the *[Image OCR p:{slide}]*…*[End OCR]* markers (slides are page-like), so
+        // ImageOcrMarkup.Contains fires the deterministic segmentation trigger and #478's figure FileOrigin applies.
+        // The anchor is the real 1-based slide ordinal — the image here is on the SECOND slide.
+        StubOcr("EMBEDDED DOC TEXT");
+
+        var pptx = PptxFixtures.Build(
+            new PptxFixtures.SlideSpec().Text("Intro slide"),
+            new PptxFixtures.SlideSpec().Image(Png(alt: null, x: 100, y: 1_000_000)));
+
+        var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
+
+        result.Markdown.ShouldContain("*[Image OCR p:2]*");
+        result.Markdown.ShouldContain("*[End OCR]*");
+        result.Markdown.ShouldNotContain("*[Image OCR p:1]*");
+        ImageOcrMarkup.Contains(result.Markdown).ShouldBeTrue();
     }
 
     [Fact]
@@ -186,10 +212,14 @@ public class PptxExtractor_Tests
 
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
 
-        result.Markdown.ShouldContain("**Quarterly Revenue Diagram**");
+        result.Markdown.ShouldContain("Quarterly Revenue Diagram");
+        result.Markdown.ShouldNotContain("**Quarterly Revenue Diagram**");
         var caption = result.Markdown.IndexOf("Quarterly Revenue Diagram", StringComparison.Ordinal);
+        var open = result.Markdown.IndexOf("*[Image OCR p:1]*", StringComparison.Ordinal);
         var body = result.Markdown.IndexOf("transcribed chart text", StringComparison.Ordinal);
-        body.ShouldBeGreaterThan(caption, "the alt-text caption labels the figure block above the transcription");
+        caption.ShouldBeGreaterThanOrEqualTo(0);
+        open.ShouldBeGreaterThan(caption, "the caption labels the figure block above the open marker");
+        body.ShouldBeGreaterThan(open, "the transcription sits inside the markers, below the caption");
     }
 
     [Fact]
@@ -717,7 +747,8 @@ public class PptxExtractor_Tests
         var result = await CreateExtractor().ExtractAsync(new MemoryStream(pptx), PptxContext());
 
         result.Markdown.ShouldContain("GROUPED_FIGURE_TEXT");
-        result.Markdown.ShouldContain("**Nested diagram**");
+        result.Markdown.ShouldContain("Nested diagram");
+        result.Markdown.ShouldNotContain("**Nested diagram**");
         await _ocr.Received(1).RecognizeAsync(
             Arg.Any<Stream>(), Arg.Any<OcrOptions>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
Closes #480.

DOCX/PPTX embedded-figure transcriptions now emit the same `*[Image OCR]*…*[End OCR]*` provenance markers as the PDF path (#371/#381), closing the historical #307/#308 ↔ #371 format gap where OpenXML figure inlining shipped before the markers existed and was never retrofitted.

## Consequences (previously PDF-only)
- `ImageOcrMarkup.Contains` now sees OpenXML figures → the deterministic segmentation routing arm (#379) covers DOCX/PPTX; a standalone document embedded in a Word/PPT file routes to its own sub-document without relying on the classifier's subjective `ContainsEmbeddedDocument` flag.
- `MarkdownSlicer` cuts OpenXML figures as Figure-kind spans → #478's shared-blob `FileOrigin` applies to OpenXML-originated figures for free.

## Implementation
- The shared `OpenXmlFigureTranscriber` emits `EscapeBlockText(caption) + "\n\n" + ImageOcrMarkup.Wrap(...)`, byte-identical to `PdfReadingOrder`. The caption is escaped as a block **before** the open marker and is no longer bolded (full PDF parity); the #477 retained-figure reference moves **in-span** (first body line) so segmentation correlates it to the blob.
- PPTX threads a 1-based slide ordinal (`PptxExtractionState.CurrentSlideNumber`) → `*[Image OCR p:{slide}]*` anchor and `ExtractedFigure.PageNumber`; DOCX is a flow document → bare page-less marker.
- The **PDF path is untouched** (byte-identical).

## Tests
Existing OpenXML figure tests updated for the unified format; added marker/`Contains` coverage (DOCX) and a two-slide `p:{slide}` anchor test (PPTX). Full solution builds clean; OpenXml suite 145 green.