### PR TITLE
fix(segmentation/documents): #481 shared-FileOrigin follow-ups — container figure-drop data loss, ETO size double-count, restore duplicate-identity, deploy-window hardening (#485)

### DIFF
--- a/.claude/rules/integration-events.md
+++ b/.claude/rules/integration-events.md
@@ -31,6 +31,8 @@ paths:
 
 **Payload design**: event payloads are uniformly thin (ID + key metadata); downstream pulls detailed data back via REST/MCP.
 
+> **Derived sub-documents report no independent upload descriptors** (#481/#485): a derived document (`OriginDocumentId` set) shares its source's blob — a figure sub-document the shared `extraction-figures/{ownerId}/{hash}` blob, a text-slice sub-document the parent's upload blob — so it contributes **no independent storage**. Its `DocumentUploadedEto` therefore carries `FileName = null`, `FileSize = 0`, `ContentType = null` (a consumer wanting the child's descriptors pulls them by `DocumentId` via REST/MCP). This mirrors `GetStatisticsAsync`, which excludes derived rows from the byte sum, so a consumer accumulating `DocumentUploadedEto.FileSize` for storage/quota does not N×-count the shared bytes. Normal (non-derived) uploads carry real descriptors as before.
+
 ## Ready gate (classification confidence + manual review)
 
 - **Design intent**: only a document whose type is confirmed is a trustworthy signal downstream — documents the classifier is unsure about are not auto-released

--- a/.cursor/rules/project/integration-events.mdc
+++ b/.cursor/rules/project/integration-events.mdc
@@ -31,6 +31,8 @@ globs:
 
 **Payload design**: event payloads are uniformly thin (ID + key metadata); downstream pulls detailed data back via REST/MCP.
 
+> **Derived sub-documents report no independent upload descriptors** (#481/#485): a derived document (`OriginDocumentId` set) shares its source's blob — a figure sub-document the shared `extraction-figures/{ownerId}/{hash}` blob, a text-slice sub-document the parent's upload blob — so it contributes **no independent storage**. Its `DocumentUploadedEto` therefore carries `FileName = null`, `FileSize = 0`, `ContentType = null` (a consumer wanting the child's descriptors pulls them by `DocumentId` via REST/MCP). This mirrors `GetStatisticsAsync`, which excludes derived rows from the byte sum, so a consumer accumulating `DocumentUploadedEto.FileSize` for storage/quota does not N×-count the shared bytes. Normal (non-derived) uploads carry real descriptors as before.
+
 ## Ready gate (classification confidence + manual review)
 
 - **Design intent**: only a document whose type is confirmed is a trustworthy signal downstream — documents the classifier is unsure about are not auto-released

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -317,6 +317,13 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         // Only fetch the blob stream: scalar fields + owned FileOrigin are loaded with the entity, and no child collection is needed.
         var document = await _documentRepository.GetAsync(id, includeDetails: false);
 
+        // #485: FileOrigin is required on every Document going forward (#481), but a legacy pre-#481 derived row
+        // (persisted before that migration's backfill ran) is still reachable during the documented binaries-first
+        // deploy window. Fail with a clean, mapped exception instead of an NRE/500 on FileOrigin.BlobName below.
+        if (document.FileOrigin is null)
+            throw new BusinessException(VaultExtractErrorCodes.Document.NoSourceBlob)
+                .WithData("DocumentId", id);
+
         var stream = await _blobContainer.GetAsync(document.FileOrigin.BlobName);
 
         return new RemoteStreamContent(
@@ -391,6 +398,10 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         // ShouldReclaimFileOriginBlobAsync applies the identical check there — while the parent (or a sibling slice)
         // is still alive, AnyWithFileOriginBlobNameAsync(exclude self) is true and this delete skips reclaim;
         // whichever referencing side is permanently deleted last reclaims it.
+        // #485: the `is not null` guard is kept (null-safe, not dead) for the SAME legacy reason B1 re-added the
+        // GetBlobAsync guard — a pre-#481 derived row with a null FileOrigin is reachable in the binaries-first
+        // deploy window; here it simply means "no blob to reclaim", so skip reclaim rather than NRE inside
+        // ShouldReclaimFileOriginBlobAsync (which dereferences FileOrigin.BlobName).
         if (document.FileOrigin is not null && await ShouldReclaimFileOriginBlobAsync(document))
         {
             try
@@ -475,6 +486,18 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
     /// skip; once the owner is hard-deleted (its reclaim skipped this blob because this document still referenced
     /// it), the last borrower to be permanently deleted reclaims it — unless a sibling still references it.
     /// Net: deleted exactly once, by whichever referencing side dies last; no leak in either order.
+    /// <para>
+    /// #485 known limitation (documented, no behavior change): this "whoever dies last reclaims it" logic is
+    /// itself check-then-act, so two <b>concurrent</b> <see cref="PermanentDeleteAsync"/> calls on rows that share
+    /// one blob (now routine post-#481: every parent + its text-slice children share the parent's upload blob) can
+    /// each run <see cref="IDocumentRepository.AnyWithFileOriginBlobNameAsync"/> before the other's
+    /// <see cref="IDocumentRepository.HardDeleteAsync"/> commits — under RCSI (or an equivalent read-committed
+    /// isolation level) both sides can observe the other row as "still present" and both skip reclaim, orphaning
+    /// the blob (accepted-rare-race posture, the same trade-off as the #221 content-hash upload race); under a
+    /// stricter locking read-committed level the two deletes may instead serialize/block on each other rather than
+    /// race. A stronger single-owner reclaim (e.g. electing exactly one referencing row to own cleanup) is a
+    /// possible follow-up, not implemented here.
+    /// </para>
     /// </summary>
     protected virtual async Task<bool> ShouldReclaimFileOriginBlobAsync(Document document)
     {
@@ -527,6 +550,24 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         return Guid.TryParse(rest[..slash], out var ownerId) ? ownerId : null;
     }
 
+    /// <summary>
+    /// Restores a soft-deleted document from the recycle bin (#194).
+    /// <para>
+    /// #485 fail-close: when the document being restored is a DERIVED sub-document (both
+    /// <see cref="Document.OriginDocumentId"/> and <see cref="Document.OriginConstituentKey"/> set), restoring it
+    /// is rejected with <see cref="VaultExtractErrorCodes.Document.RestoreConflict"/> if another LIVE document
+    /// already occupies the same <c>(OriginDocumentId, OriginConstituentKey)</c> identity. #481 dropped the
+    /// DB-level filtered-unique index that used to make this scenario impossible for free (before that, a
+    /// container→type retraction (#349/#364) soft-deletes a stale child, and a later re-split — e.g. a
+    /// type→container→type round trip — can legitimately spawn a fresh successor sharing the same content-hash
+    /// key; restoring the old, retracted child back to life while its successor is live would silently create a
+    /// duplicate). This is the application-layer replacement for that fail-close.
+    /// </para>
+    /// This whole method runs inside <see cref="DataFilter.Disable{TFilter}"/>(<see cref="ISoftDelete"/>) to load
+    /// the soft-deleted row itself, so that ambient disabled filter is ALSO in effect for the duplicate check
+    /// below — <see cref="IDocumentRepository.AnyLiveDerivedDuplicateAsync"/> therefore explicitly re-excludes
+    /// soft-deleted siblings itself rather than relying on the (here, disabled) global filter.
+    /// </summary>
     [Authorize(VaultExtractPermissions.Documents.Restore)]
     public virtual async Task RestoreAsync(Guid id)
     {
@@ -536,6 +577,17 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
             if (!document.IsDeleted)
             {
                 return;
+            }
+
+            if (document.OriginDocumentId.HasValue && !string.IsNullOrEmpty(document.OriginConstituentKey))
+            {
+                var hasLiveDuplicate = await _documentRepository.AnyLiveDerivedDuplicateAsync(
+                    document.OriginDocumentId.Value, document.OriginConstituentKey, document.Id);
+                if (hasLiveDuplicate)
+                {
+                    throw new BusinessException(VaultExtractErrorCodes.Document.RestoreConflict)
+                        .WithData("DocumentId", id);
+                }
             }
 
             document.IsDeleted = false;
@@ -578,7 +630,10 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         if (document.IsDeleted)
         {
             throw new BusinessException(VaultExtractErrorCodes.Document.InRecycleBin)
-                .WithData("FileName", document.FileOrigin.BlobName);
+                // #485: null-safe -- a legacy pre-#481 derived row can still carry a null FileOrigin during the
+                // documented deploy window; avoid an NRE while building this diagnostic (and CS8604, since
+                // .WithData's value parameter is non-nullable).
+                .WithData("FileName", document.FileOrigin?.BlobName ?? string.Empty);
         }
 
         var latestRun = await _pipelineRunManager.EnsureRetryableAsync(id, input.PipelineCode);
@@ -608,7 +663,10 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         if (document.IsDeleted)
         {
             throw new BusinessException(VaultExtractErrorCodes.Document.InRecycleBin)
-                .WithData("FileName", document.FileOrigin.BlobName);
+                // #485: null-safe -- a legacy pre-#481 derived row can still carry a null FileOrigin during the
+                // documented deploy window; avoid an NRE while building this diagnostic (and CS8604, since
+                // .WithData's value parameter is non-nullable).
+                .WithData("FileName", document.FileOrigin?.BlobName ?? string.Empty);
         }
 
         // Automatic classification input is Document.Markdown. If text extraction has not produced text yet, reclassification cannot run.
@@ -642,7 +700,10 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         if (document.IsDeleted)
         {
             throw new BusinessException(VaultExtractErrorCodes.Document.InRecycleBin)
-                .WithData("FileName", document.FileOrigin.BlobName);
+                // #485: null-safe -- a legacy pre-#481 derived row can still carry a null FileOrigin during the
+                // documented deploy window; avoid an NRE while building this diagnostic (and CS8604, since
+                // .WithData's value parameter is non-nullable).
+                .WithData("FileName", document.FileOrigin?.BlobName ?? string.Empty);
         }
 
         // Field extraction hangs off DocumentType; unclassified documents have nothing to extract against.

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/DerivedDocumentSpawner.cs
@@ -128,21 +128,33 @@ public class DerivedDocumentSpawner : ITransientDependency
 
             await markSpawned(candidate, derivedDocumentId);
 
+            // #485: a derived document only ever SHARES its source's blob (#481) -- it contributes no independent
+            // storage of its own -- so the upload event reports 0 / null here (restoring the pre-#481 semantics),
+            // NOT fileOrigin.OriginalFileName/FileSize/ContentType. Otherwise a downstream consumer accumulating
+            // storage/quota over DocumentUploadedEto.FileSize would N×-count the same bytes once per sub-document,
+            // contradicting IDocumentRepository.GetStatisticsAsync's own exclusion of derived rows
+            // (OriginDocumentId != null) from its byte sum. fileOrigin itself is still required just above for
+            // Document.CreateDerived -- only these ETO fields are affected.
             await _distributedEventBus.PublishAsync(
                 new DocumentUploadedEto
                 {
                     DocumentId = derived.Id,
                     TenantId = derived.TenantId,
                     EventTime = _clock.Now,
-                    FileName = fileOrigin.OriginalFileName,
-                    FileSize = fileOrigin.FileSize,
-                    ContentType = fileOrigin.ContentType
+                    FileName = null,
+                    FileSize = 0,
+                    ContentType = null
                 });
 
             // Run the derived document through the full normal pipeline. Its text-extraction job seeds Markdown from
             // the constituent (figure transcription / segment slice) instead of re-extracting it.
             await _pipelineJobScheduler.QueueAsync(derived, VaultExtractPipelines.Parse);
 
+            // #485: this insert + the DocumentUploadedEto publish above roll back TOGETHER for a concurrent loser
+            // (see the isTransactional: true note above) only because ABP's transactional outbox is enabled for
+            // this DbContext -- the event write is just another row in the same DB transaction as the Document
+            // insert. That guarantee breaks if a future change publishes DocumentUploadedEto outside the outbox
+            // (e.g. a direct message-bus send) for this or any other path sharing this UoW.
             await uow.CompleteAsync();
             return derivedDocumentId;
         }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -102,7 +102,7 @@ public class DocumentSegmentationJob
         var context = await LoadAsync(args.SourceDocumentId);
         if (context is null)
         {
-            return; // document removed before the pass ran
+            return; // document removed before the pass ran, or (#485) LoadAsync already skipped a legacy null-FileOrigin source
         }
 
         // Phase A: detect once. Skip the LLM split when the document is already marked segmented (#377) — a precise
@@ -138,7 +138,7 @@ public class DocumentSegmentationJob
         }
     }
 
-    /// <summary>Load phase (short UoW): snapshot the source's tenant, Document.Markdown (with inline figure markers, #381), container flag, parent context, and whether the document is already marked segmented (#377, the precise resume gate).</summary>
+    /// <summary>Load phase (short UoW): snapshot the source's tenant, Document.Markdown (with inline figure markers, #381), container flag, parent context, and whether the document is already marked segmented (#377, the precise resume gate). #485: also guards a legacy pre-#481 null <see cref="Document.FileOrigin"/> source here (marks it segmented as a no-op and returns null, treated by the caller exactly like a removed document) instead of letting a later spawn's <c>Check.NotNull</c> throw and fault the job into an endless ABP retry.</summary>
     protected virtual async Task<DetectionContext?> LoadAsync(Guid sourceDocumentId)
     {
         Document? source;
@@ -154,6 +154,27 @@ public class DocumentSegmentationJob
                 Logger.LogInformation(
                     "Document {SourceId} is missing (removed after this job was enqueued); skipping sub-document detection.",
                     sourceDocumentId);
+                return null;
+            }
+
+            // #485: a legacy pre-#481 derived row can still carry a null FileOrigin during the documented
+            // binaries-first deploy window (FileOrigin became required only once that migration's backfill ran).
+            // Every downstream spawn path requires a real FileOrigin (Check.NotNull inside the Document constructor
+            // / Document.CreateDerived), so letting this source reach Phase A/B would spawn a Text-kind child with a
+            // null fileOrigin, throw there, leave the segment Pending, and fault the whole job into an ABP retry
+            // loop that can never succeed on its own (the source never gains a FileOrigin by itself). Skip cleanly
+            // instead: mark it segmented — the same "nothing to route" no-op convention as
+            // MarkDocumentSegmentedAsync below — so a later re-enqueue does not repeat the same doomed attempt, log
+            // a warning for operator visibility, and return null so the caller's existing "no context -> return"
+            // path handles it exactly like a removed document (no throw, no retry).
+            if (source.FileOrigin is null)
+            {
+                Logger.LogWarning(
+                    "Document {SourceId} has no FileOrigin (legacy pre-#481 row); skipping sub-document detection.",
+                    sourceDocumentId);
+                source.MarkSegmented();
+                await _documentRepository.UpdateAsync(source);
+                await uow.CompleteAsync();
                 return null;
             }
 
@@ -291,14 +312,26 @@ public class DocumentSegmentationJob
             // from the RAW slice (the clean seed above deliberately drops the reference line). Null for a Text span.
             var figureContentHash = isFigure ? ExtractFigureContentHash(slice.Text) : null;
 
-            // #481 retention coupling (b): a Figure span with no in-span figures/{hash} reference means retention
-            // was OFF at parse time (the #477 RetainFigureImages toggle) — there is no blob for the child's
-            // FileOrigin to point at, and FileOrigin is required on every Document now, so this span is SKIPPED
-            // outright: no segment row is persisted at all (not even with a null hash). The transcription stays
-            // inline in the parent's Markdown — no data loss, just no spawned sub-document. Text spans are
-            // unaffected. Ordinal continuity is not a contract (only per-source uniqueness, see the
+            // #481 retention coupling (b), TIGHTENED by #485: a Figure span is SKIPPED outright (no segment row
+            // persisted at all) unless it BOTH carries an in-span figures/{hash} reference AND that hash resolves
+            // against the source's retained-figure manifest right here, at detection. The pre-#485 gate only
+            // checked for a non-null hash, parsed from the raw slice regardless of manifest state — so a figure
+            // whose archive write FAILED (retention ON, blob write error / over size cap) still parsed a non-null
+            // hash, passed detection, counted toward the >=2 real-bundle floor below, and was discovered
+            // unresolvable only later at spawn time (BuildFigureFileOrigin's manifest miss), where the segment was
+            // silently deleted (DeleteUnresolvableFigureSegmentAsync) — a container could end up Ready with fewer
+            // than 2 (or 0) surviving sub-documents and NO SegmentationIncomplete flag, silently losing the
+            // figure's transcription from egress (container Ready is suppressed, #346). Resolving the manifest
+            // HERE makes an archive-failed figure behave exactly like retention-off, so the existing floor + flag
+            // below correctly catch the degraded container instead of spawning it short. FileOrigin is required on
+            // every Document either way, so there is still no blob for the child's FileOrigin to point at. The
+            // transcription stays inline in the parent's Markdown — no data loss, just no spawned sub-document.
+            // Text spans are unaffected. Ordinal continuity is not a contract (only per-source uniqueness, see the
             // (SourceDocumentId, Ordinal) index below), so skipping a slice mid-loop is safe.
-            if (isFigure && figureContentHash is null)
+            var figureResolvesInManifest = figureContentHash is not null
+                && context.FigureManifest?.Any(
+                    f => string.Equals(f.ContentHash, figureContentHash, StringComparison.Ordinal)) == true;
+            if (isFigure && !figureResolvesInManifest)
             {
                 continue;
             }
@@ -449,7 +482,7 @@ public class DocumentSegmentationJob
 
         var snapshot = pending
             .OrderBy(s => s.Ordinal)
-            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Ordinal, s.Kind, s.FigureContentHash, s.PageNumber))
+            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Kind, s.FigureContentHash, s.PageNumber))
             .ToList();
 
         await uow.CompleteAsync();
@@ -504,7 +537,19 @@ public class DocumentSegmentationJob
                 }
 
             case DocumentSegmentKind.Text:
-                fileOrigin = context.SourceFileOrigin;
+                // #485: construct a FRESH FileOrigin copying context.SourceFileOrigin's 6 fields (still the SAME
+                // shared BlobName -- one blob, no copy) instead of handing out the parent's own OWNED-ENTITY
+                // INSTANCE by reference. EF Core's owned-entity model shadow-keys an owned instance to its single
+                // owner; letting a second (derived) Document's change-tracked graph reference the parent's actual
+                // FileOrigin instance is a latent "owned entity cannot be shared" fragility this removes outright,
+                // at the cost of one extra allocation per Text-kind spawn.
+                fileOrigin = new FileOrigin(
+                    context.SourceFileOrigin.BlobName,
+                    context.SourceFileOrigin.UploadedByUserName,
+                    context.SourceFileOrigin.ContentType,
+                    context.SourceFileOrigin.ContentHash,
+                    context.SourceFileOrigin.FileSize,
+                    context.SourceFileOrigin.OriginalFileName);
                 break;
 
             default:
@@ -543,7 +588,19 @@ public class DocumentSegmentationJob
     /// <summary>
     /// #481: deletes a Figure-kind segment row whose #478 content hash could not be resolved against the source's
     /// retained-figure manifest at spawn time — figure routing REQUIRES a real shared blob (the #477
-    /// <c>RetainFigureImages</c> toggle), so there is nothing left to spawn. Reloads + re-checks
+    /// <c>RetainFigureImages</c> toggle), so there is nothing left to spawn.
+    /// <para>
+    /// #485: the PRIMARY gate now lives at <b>detection</b> (<see cref="DetectAndPersistAsync"/> already skips
+    /// persisting a Figure segment row whose hash does not resolve against the manifest there), so a container's
+    /// ">=2 real bundle" floor and <see cref="DocumentReviewReasons.SegmentationIncomplete"/> flag correctly react
+    /// to a degraded figure up front instead of a Ready container silently losing it later. This spawn-time path
+    /// is now only a defensive backstop for the rare CROSS-RUN case: the manifest resolved when a prior execution's
+    /// Phase A persisted the row, but has since drifted by the time THIS execution's <see cref="LoadAsync"/>
+    /// re-reads <see cref="Document.ExtractionMetadata"/> fresh (e.g. a re-extraction rewrote it) — within one
+    /// execution, Phase A and Phase B share the same loaded <see cref="DetectionContext.FigureManifest"/>, so this
+    /// cannot happen there. Should rarely fire in practice.
+    /// </para>
+    /// Reloads + re-checks
     /// <see cref="DocumentSegmentStatus.Pending"/> inside its own short UoW first (a concurrent worker may already
     /// have spawned or deleted it between <see cref="LoadPendingSegmentsAsync"/>'s snapshot and here). The parent
     /// keeps the transcription inline in its own Markdown either way — this is a routing no-op, not a fault, so it
@@ -730,11 +787,15 @@ public class DocumentSegmentationJob
     /// <see cref="DocumentSegment.FigureContentHash"/> against the source's retained-figure manifest (#477) — the
     /// manifest is authoritative (its own stored blob key / content type / size; the key is never rebuilt from
     /// parsed input), and the blob is <b>shared</b> with the source (never copied). Returns <c>null</c> on a
-    /// manifest miss (retention was off at parse time, or the archive write failed, between detection and spawn;
-    /// a null <see cref="PendingSegment.FigureContentHash"/> should not reach here since #481 skips persisting a
-    /// hash-less Figure segment at detection, but is handled the same defensive way) — the caller
-    /// (<see cref="SpawnDerivedDocumentAsync"/>) deletes the segment row instead of spawning with a fabricated
-    /// FileOrigin, since #481 requires a real shared blob for figure routing.
+    /// manifest miss — since #485 the PRIMARY gate for this (retention off at parse time, or an archive write
+    /// failure) is at <b>detection</b> (<see cref="DetectAndPersistAsync"/> no longer persists a Figure segment row
+    /// unless it already resolves against the manifest there), so reaching this method with an unresolvable hash
+    /// should only happen in the rare CROSS-RUN case where the manifest drifted between that detection pass and
+    /// this spawn (e.g. a re-extraction rewrote <see cref="Document.ExtractionMetadata"/> after Phase A persisted
+    /// the row but before this later execution's Phase B ran); a null <see cref="PendingSegment.FigureContentHash"/>
+    /// is handled the same defensive way. The caller (<see cref="SpawnDerivedDocumentAsync"/>) deletes the segment
+    /// row instead of spawning with a fabricated FileOrigin, since #481 requires a real shared blob for figure
+    /// routing.
     /// </summary>
     private FileOrigin? BuildFigureFileOrigin(PendingSegment segment, DetectionContext context)
     {
@@ -789,9 +850,12 @@ public class DocumentSegmentationJob
     /// Carries no slice text: the spawn path keys off <see cref="SegmentKey"/>, and the derived document's Markdown
     /// is seeded by <c>DocumentParseBackgroundJob</c> reading the segment's <c>SliceText</c> column fresh from the DB.
     /// <see cref="Kind"/> decides the #481 FileOrigin source (shared parent blob for Text, resolved retained blob
-    /// for Figure); <see cref="FigureContentHash"/> + <see cref="PageNumber"/> feed that #478 figure resolution.</summary>
+    /// for Figure); <see cref="FigureContentHash"/> + <see cref="PageNumber"/> feed that #478 figure resolution.
+    /// #485: dropped the write-only <c>Ordinal</c> field (projected in <see cref="LoadPendingSegmentsAsync"/> but
+    /// never read back off this record) — the reading-order sort there uses the source entity's own
+    /// <c>Ordinal</c> column before the projection, so carrying a copy onto this snapshot served no purpose.</summary>
     protected sealed record PendingSegment(
-        Guid SegmentId, string SegmentKey, int Ordinal, DocumentSegmentKind Kind,
+        Guid SegmentId, string SegmentKey, DocumentSegmentKind Kind,
         string? FigureContentHash = null, int? PageNumber = null);
 }
 

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -370,6 +370,8 @@
     "Extract:DocumentFileTooLarge": "File '{FileName}' exceeds the maximum allowed size of {MaxBytes} bytes.",
     "Extract:DocumentUnsupportedFileType": "File '{FileName}' has an unsupported type ('{ContentType}'). Please upload a supported image, PDF, CSV/TSV, DOCX, PPTX, TXT, or XLSX file.",
     "Extract:DocumentFigureNotFound": "The requested figure '{FileName}' was not found for this document.",
+    "Extract:DocumentNoSourceBlob": "This document has no source file available for download.",
+    "Extract:DocumentRestoreConflict": "Cannot restore document '{DocumentId}': a live sub-document with the same source constituent already exists. The restore is rejected to avoid a duplicate.",
     "Extract:UnknownPipelineCode": "Pipeline '{PipelineCode}' is not retryable.",
     "Extract:PipelineNeverRan": "Pipeline '{PipelineCode}' has not started yet.",
     "Extract:PipelineRetryInProgress": "Pipeline '{PipelineCode}' already has an attempt in progress.",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -370,6 +370,8 @@
     "Extract:DocumentFileTooLarge": "ファイル '{FileName}' は許可されている最大サイズ {MaxBytes} バイトを超えています。",
     "Extract:DocumentUnsupportedFileType": "ファイル '{FileName}' のタイプ（'{ContentType}'）はサポートされていません。対応している画像、PDF、CSV/TSV、DOCX、PPTX、TXT、または XLSX ファイルをアップロードしてください。",
     "Extract:DocumentFigureNotFound": "要求された図 '{FileName}' はこのドキュメントに見つかりませんでした。",
+    "Extract:DocumentNoSourceBlob": "このドキュメントにはダウンロードできるソースファイルがありません。",
+    "Extract:DocumentRestoreConflict": "ドキュメント '{DocumentId}' を復元できません：同じソース構成要素を共有する別のライブなサブドキュメントが既に存在します。重複を避けるため、復元は拒否されました。",
     "Extract:UnknownPipelineCode": "パイプライン '{PipelineCode}' は再試行できません。",
     "Extract:PipelineNeverRan": "パイプライン '{PipelineCode}' はまだ開始されていません。",
     "Extract:PipelineRetryInProgress": "パイプライン '{PipelineCode}' には既に進行中の試行があります。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -370,6 +370,8 @@
     "Extract:DocumentFileTooLarge": "文件 '{FileName}' 超过了允许的最大大小 {MaxBytes} 字节。",
     "Extract:DocumentUnsupportedFileType": "文件 '{FileName}' 的类型 ('{ContentType}') 不受支持。请上传支持的图片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 文件。",
     "Extract:DocumentFigureNotFound": "未在该文档中找到请求的图片 '{FileName}'。",
+    "Extract:DocumentNoSourceBlob": "该文档没有可供下载的源文件。",
+    "Extract:DocumentRestoreConflict": "无法恢复文档 '{DocumentId}'：已存在另一份共享同一来源片段的在用子文档。为避免产生重复，已拒绝本次恢复。",
     "Extract:UnknownPipelineCode": "流水线 '{PipelineCode}' 不支持重试。",
     "Extract:PipelineNeverRan": "流水线 '{PipelineCode}' 尚未运行。",
     "Extract:PipelineRetryInProgress": "流水线 '{PipelineCode}' 已有进行中的尝试。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -370,6 +370,8 @@
     "Extract:DocumentFileTooLarge": "檔案 '{FileName}' 超過了允許的大小上限 {MaxBytes} 位元組。",
     "Extract:DocumentUnsupportedFileType": "檔案 '{FileName}' 的類型（'{ContentType}'）不受支援。請上傳支援的圖片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 檔案。",
     "Extract:DocumentFigureNotFound": "未在此文件中找到請求的圖片 '{FileName}'。",
+    "Extract:DocumentNoSourceBlob": "此文件沒有可供下載的來源檔案。",
+    "Extract:DocumentRestoreConflict": "無法還原文件 '{DocumentId}'：已存在另一份共享同一來源片段的在用子文件。為避免產生重複，已拒絕本次還原。",
     "Extract:UnknownPipelineCode": "管線 '{PipelineCode}' 不支援重試。",
     "Extract:PipelineNeverRan": "管線 '{PipelineCode}' 尚未執行。",
     "Extract:PipelineRetryInProgress": "管線 '{PipelineCode}' 已有進行中的嘗試。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -28,6 +28,14 @@ public static class VaultExtractErrorCodes
         // #477: a figures/{hash} egress request whose hash is not in the document's retained-figure manifest
         // (retention was off when it was processed, or a stale / invalid reference).
         public const string FigureNotFound = "Extract:DocumentFigureNotFound";
+        // #485 (B1): re-added after #481 removed it assuming FileOrigin can never be null. Same string as before
+        // #481 (nothing consumed it in the interim, so this is not a wire break) — a legacy pre-#481 derived row
+        // can still carry a null FileOrigin during the documented binaries-first deploy window.
+        public const string NoSourceBlob = "Extract:DocumentNoSourceBlob";
+        // #485 (A3): restoring a derived document is rejected when another LIVE document already occupies the
+        // same (OriginDocumentId, OriginConstituentKey) identity — the application-layer fail-close that replaces
+        // the fail-close the #481-dropped #391 filtered-unique index used to give for free at restore time.
+        public const string RestoreConflict = "Extract:DocumentRestoreConflict";
     }
 
     public static class DocumentType

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
@@ -8,6 +8,15 @@ namespace Dignite.Vault.Extract.Documents;
 
 public interface IDocumentRepository : IRepository<Document, Guid>
 {
+    /// <summary>
+    /// Finds a <b>non-derived</b> document by exact <c>FileOrigin.BlobName</c> (#485, mirroring
+    /// <see cref="FindByContentHashAsync"/>'s #481 scoping fix). Since #481 a text-slice sub-document SHARES its
+    /// parent's whole upload blob (never a copy), so an unscoped lookup could nondeterministically resolve to a
+    /// child row instead of the parent that owns the blob as its own identity. Scoped to
+    /// <c>OriginDocumentId == null</c>. Does not traverse soft delete (unlike <see cref="FindByContentHashAsync"/>
+    /// / <see cref="AnyWithFileOriginBlobNameAsync"/>): only an active, non-recycle-bin document's own blob name
+    /// resolves.
+    /// </summary>
     Task<Document?> FindByBlobNameAsync(
         string blobName,
         CancellationToken cancellationToken = default);
@@ -46,6 +55,31 @@ public interface IDocumentRepository : IRepository<Document, Guid>
     Task<bool> AnyWithFileOriginBlobNameAsync(
         string blobName,
         Guid? excludeDocumentId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether another LIVE document already shares the derived-document identity
+    /// <c>(OriginDocumentId, OriginConstituentKey)</c> — the #485 restore-time fail-close used by
+    /// <c>DocumentAppService.RestoreAsync</c>, replacing the fail-close the #481-dropped #391 filtered-unique index
+    /// used to give for free (a retracted, soft-deleted child and a later re-spawned successor may now freely
+    /// share the same <c>OriginConstituentKey</c> per #481, but restoring the retracted one back to life while a
+    /// live successor already occupies that identity would create a duplicate). Existence-only (SQL <c>EXISTS</c>,
+    /// no row materialization).
+    /// <para>
+    /// Filters <c>OriginDocumentId == originDocumentId &amp;&amp; OriginConstituentKey == originConstituentKey
+    /// &amp;&amp; Id != excludeDocumentId &amp;&amp; !IsDeleted</c>. Unlike <see cref="AnyWithFileOriginBlobNameAsync"/>
+    /// this deliberately does <b>not</b> disable the <c>ISoftDelete</c> filter itself — soft-deleted siblings must
+    /// NOT count here — but the caller (<c>RestoreAsync</c>) runs inside its own
+    /// <c>DataFilter.Disable&lt;ISoftDelete&gt;()</c> scope to load the row being restored, so that ambient
+    /// disabled state also reaches this call; the explicit <c>!IsDeleted</c> predicate re-excludes soft-deleted
+    /// rows regardless of the ambient filter state. <c>IMultiTenant</c> still applies by ambient state (a source
+    /// and its derived documents share a tenant).
+    /// </para>
+    /// </summary>
+    Task<bool> AnyLiveDerivedDuplicateAsync(
+        Guid originDocumentId,
+        string originConstituentKey,
+        Guid excludeDocumentId,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -31,9 +31,12 @@ public class EfCoreDocumentRepository
         CancellationToken cancellationToken = default)
     {
         var dbSet = await GetDbSetAsync();
+        // #485: scoped to non-derived rows (OriginDocumentId == null), mirroring FindByContentHashAsync's #481
+        // fix — a text-slice sub-document now shares its parent's whole BlobName (never a copy), so an unscoped
+        // lookup could nondeterministically resolve to a child row instead of the parent that owns the blob.
         return await dbSet
             .FirstOrDefaultAsync(
-                d => d.FileOrigin.BlobName == blobName,
+                d => d.FileOrigin.BlobName == blobName && d.OriginDocumentId == null,
                 GetCancellationToken(cancellationToken));
     }
 
@@ -71,6 +74,26 @@ public class EfCoreDocumentRepository
                     && (excludeDocumentId == null || d.Id != excludeDocumentId),
                 GetCancellationToken(cancellationToken));
         }
+    }
+
+    public virtual async Task<bool> AnyLiveDerivedDuplicateAsync(
+        Guid originDocumentId,
+        string originConstituentKey,
+        Guid excludeDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        // #485: the caller (DocumentAppService.RestoreAsync) runs inside DataFilter.Disable<ISoftDelete>() to load
+        // the soft-deleted row being restored, so that ambient state reaches this query too -- unlike
+        // AnyWithFileOriginBlobNameAsync above, a soft-deleted sibling must NOT count as a live duplicate here, so
+        // filter explicitly on d.IsDeleted rather than relying on the (here, disabled) global ISoftDelete filter.
+        // IMultiTenant still applies by ambient state.
+        var dbSet = await GetDbSetAsync();
+        return await dbSet.AnyAsync(
+            d => d.OriginDocumentId == originDocumentId
+                && d.OriginConstituentKey == originConstituentKey
+                && d.Id != excludeDocumentId
+                && !d.IsDeleted,
+            GetCancellationToken(cancellationToken));
     }
 
     public virtual async Task<List<DuplicateCandidateModel>> FindDuplicateCandidatesAsync(

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentRestoreConflict_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentRestoreConflict_Tests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Abstractions.Documents;
+using Dignite.Vault.Extract.Documents;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Entities;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(VaultExtractEntityFrameworkCoreTestModule))]
+public class DocumentRestoreConflictTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // RestoreAsync itself touches neither blob storage nor background jobs, but the wider DocumentAppService
+        // constructor graph does; substitute them so the test exercises the real DB (mirrors DocumentParentDelete_Tests).
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// Integration tests for the #485 restore-time fail-close: <c>DocumentAppService.RestoreAsync</c> rejects
+/// restoring a derived document whose <c>(OriginDocumentId, OriginConstituentKey)</c> identity is already occupied
+/// by another LIVE document — the application-layer replacement for the fail-close the #481-dropped #391
+/// filtered-unique index used to give for free. Runs against the real SQLite DB (not a mocked repository) so
+/// <see cref="IDocumentRepository.AnyLiveDerivedDuplicateAsync"/>'s explicit soft-delete exclusion, run inside the
+/// caller's <c>DataFilter.Disable&lt;ISoftDelete&gt;()</c> scope, is genuinely exercised.
+/// </summary>
+public class DocumentRestoreConflict_Tests : VaultExtractTestBase<DocumentRestoreConflictTestModule>
+{
+    private readonly IDocumentAppService _appService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDistributedEventBus _eventBus;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IDataFilter _dataFilter;
+
+    public DocumentRestoreConflict_Tests()
+    {
+        _appService = GetRequiredService<IDocumentAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _eventBus = GetRequiredService<IDistributedEventBus>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _dataFilter = GetRequiredService<IDataFilter>();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Rejects_A_SoftDeleted_Child_When_A_Live_Successor_Shares_Its_Identity()
+    {
+        // C_old: a retracted child (e.g. a container->type retraction, #349/#364) later soft-deleted.
+        // C_new: a live re-spawned successor sharing the SAME (OriginDocumentId, OriginConstituentKey) -- #481
+        // dropped the DB-level filtered-unique index that used to make this pair impossible, so both rows coexist.
+        var sourceId = _guidGenerator.Create();
+        var oldChildId = _guidGenerator.Create();
+        var newChildId = _guidGenerator.Create();
+        const string constituentKey = "slice-1";
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _documentRepository.InsertAsync(
+                NewDerivedDocument(oldChildId, sourceId, constituentKey), autoSave: true);
+            await _documentRepository.InsertAsync(
+                NewDerivedDocument(newChildId, sourceId, constituentKey), autoSave: true);
+        });
+
+        await WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(oldChildId));
+
+        var exception = await Should.ThrowAsync<BusinessException>(
+            () => _appService.RestoreAsync(oldChildId));
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.RestoreConflict);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                (await _documentRepository.GetAsync(oldChildId)).IsDeleted.ShouldBeTrue();
+            }
+        });
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentRestoredEto>());
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Succeeds_And_Publishes_DocumentRestoredEto_When_No_Live_Duplicate_Exists()
+    {
+        var sourceId = _guidGenerator.Create();
+        var childId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(() => _documentRepository.InsertAsync(
+            NewDerivedDocument(childId, sourceId, "slice-1"), autoSave: true));
+        await WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(childId));
+
+        await _appService.RestoreAsync(childId);
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(childId)).IsDeleted.ShouldBeFalse());
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentRestoredEto>(e => e.DocumentId == childId));
+    }
+
+    private Document NewDerivedDocument(Guid id, Guid sourceId, string constituentKey) =>
+        Document.CreateDerived(
+            id,
+            tenantId: null,
+            fileOrigin: new FileOrigin(
+                blobName: $"blobs/{sourceId:N}.pdf",
+                uploadedByUserName: "test-user",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
+                fileSize: 2048,
+                originalFileName: "bundle.pdf"),
+            originDocumentId: sourceId,
+            originConstituentKey: constituentKey);
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentSegmentationJob_Tests.cs
@@ -116,6 +116,33 @@ public class DocumentSegmentationJob_Tests : VaultExtractTestBase<DocumentSegmen
     }
 
     [Fact]
+    public async Task Spawned_Derived_Document_Reports_Zero_Size_Upload_Event()
+    {
+        // #485 (A2): a derived document only ever SHARES its source's blob (#481) -- it contributes no
+        // independent storage of its own -- so DocumentUploadedEto must report FileSize 0 / FileName null /
+        // ContentType null, even though the spawned Document's own FileOrigin is still the parent's whole
+        // (non-null, non-zero) snapshot. Otherwise a downstream consumer accumulating storage/quota over
+        // DocumentUploadedEto.FileSize would N×-count the same bytes once per sub-document, contradicting
+        // IDocumentRepository.GetStatisticsAsync's own exclusion of derived rows from the byte sum.
+        var containerId = await ArrangeContainerAsync("Invoice A first\nInvoice B second");
+        StubSplit(("Invoice A", true), ("Invoice B", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
+
+        await _eventBus.Received(2).PublishAsync(Arg.Is<DocumentUploadedEto>(
+            e => e.FileSize == 0 && e.FileName == null && e.ContentType == null));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var parent = await _documentRepository.GetAsync(containerId);
+            var derived = await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId);
+            // The derived Document's own FileOrigin (persisted state, distinct from the upload EVENT above) is
+            // still the parent's whole shared snapshot, non-zero.
+            derived.ShouldAllBe(d => d.FileOrigin.FileSize == parent.FileOrigin.FileSize && d.FileOrigin.FileSize > 0);
+        });
+    }
+
+    [Fact]
     public async Task Embedded_Figure_Span_Without_A_Retained_Reference_Spawns_Nothing()
     {
         // #481: figure sub-document routing now REQUIRES the #477 RetainFigureImages toggle (a real shared blob to
@@ -222,6 +249,51 @@ public class DocumentSegmentationJob_Tests : VaultExtractTestBase<DocumentSegmen
             var parent = await _documentRepository.GetAsync(docId);
             parent.IsContainer.ShouldBeFalse();
             parent.ReviewReasons.ShouldBe(DocumentReviewReasons.None);
+        });
+
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentUploadedEto>());
+    }
+
+    [Fact]
+    public async Task Figure_Span_With_No_Manifest_Match_Is_Skipped_At_Detection_In_A_Container()
+    {
+        // #485 (A1 fix): before this fix, the #481 skip condition at DETECTION time only checked
+        // "isFigure && figureContentHash is null" -- a Figure span whose in-span figures/{hash} reference has a
+        // hash with NO matching FigureManifest entry (e.g. the archive write failed between extraction and this
+        // detection pass) still parsed a non-null hash, so it passed detection, counted toward the container's
+        // >=2 real-bundle floor, and was discovered unresolvable only later at SPAWN time (BuildFigureFileOrigin's
+        // manifest miss), where DeleteUnresolvableFigureSegmentAsync silently deleted the row -- a container could
+        // then end up Ready with fewer than 2 (here: 1, then 0) surviving sub-documents and NO
+        // SegmentationIncomplete flag, silently losing the figure's transcription from egress entirely (container
+        // Ready is suppressed, #346). After the fix, a Figure span must ALSO resolve against
+        // context.FigureManifest at DETECTION -- so it is skipped there instead, exactly like retention-off, and
+        // the pre-existing <2 floor correctly flags the container up front instead of spawning it degraded.
+        // Contrast Figure_Sub_Document_Gets_Its_FileOrigin_From_The_Shared_Retained_Blob (kept green), where the
+        // manifest DOES match and the figure spawns normally.
+        // LANDMINE: this test class caps MaxSegmentationMarkdownLength=130 -- keep the hash short.
+        var missingHash = "zz9";
+        var marked = $"Invoice A\n{ImageOcrMarkup.Wrap("INV B", 1, $"figures/{missingHash}.png")}";
+        var containerId = await ArrangeContainerAsync(
+            markdown: "Invoice A\nINV B", asContainer: true, markedMarkdown: marked,
+            // The manifest EXISTS but carries a DIFFERENT hash -- the in-span reference does not resolve.
+            extractionMetadata: new DocumentParseMetadata(
+                "PdfPig", null,
+                figures: new[] { new FigureManifestEntry("extraction-figures/x/other1", "other1", "image/png", 1024) }));
+
+        StubSplit(("Invoice A", true), (ImageOcrMarkup.OpenPagePrefix + "1]*", true));
+
+        await _job.ExecuteAsync(new DocumentSegmentationJobArgs { SourceDocumentId = containerId });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // The figure span never becomes a row (skipped at detection, like retention-off); the lone surviving
+            // text slice alone is not a 2-constituent bundle either, so the WHOLE batch is rejected -- same
+            // "nothing persisted" behavior as Fewer_Than_Two_Document_Slices_Flags_Container.
+            (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == containerId)).ShouldBeEmpty();
+            (await _documentRepository.GetListAsync(d => d.OriginDocumentId == containerId)).ShouldBeEmpty();
+
+            var container = await _documentRepository.GetAsync(containerId);
+            container.ReviewReasons.ShouldBe(DocumentReviewReasons.SegmentationIncomplete);
         });
 
         await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentUploadedEto>());

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryContentHash_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryContentHash_Tests.cs
@@ -41,21 +41,13 @@ public class EfCoreDocumentRepositoryContentHash_Tests : VaultExtractEntityFrame
                     originalFileName: "bundle.pdf"));
             await _documentRepository.InsertAsync(parent, autoSave: true);
 
-            // A text-slice child shares the parent's FileOrigin wholesale (#481), including ContentHash. Built as an
-            // equal-valued (not same-reference) FileOrigin: EF's owned-entity change tracker does not allow
-            // attaching the SAME tracked FileOrigin CLR instance to two Document rows within one DbContext (its
-            // shadow key includes the owner's Id) — in production this is a non-issue because the parent is loaded
-            // in an earlier, already-disposed UoW/DbContext before the derived document's own UoW begins.
+            // A text-slice child shares the parent's FileOrigin wholesale (#481), including ContentHash. CloneFileOrigin
+            // (#485) builds an equal-valued (not same-reference) copy -- see its XML doc for why a same-reference
+            // FileOrigin instance cannot be attached to two Document rows within one DbContext.
             var child = Document.CreateDerived(
                 Guid.NewGuid(),
                 tenantId: null,
-                fileOrigin: new FileOrigin(
-                    blobName: parent.FileOrigin.BlobName,
-                    uploadedByUserName: parent.FileOrigin.UploadedByUserName,
-                    contentType: parent.FileOrigin.ContentType,
-                    contentHash: parent.FileOrigin.ContentHash,
-                    fileSize: parent.FileOrigin.FileSize,
-                    originalFileName: parent.FileOrigin.OriginalFileName),
+                fileOrigin: CloneFileOrigin(parent.FileOrigin),
                 originDocumentId: parentId,
                 originConstituentKey: "slice-1");
             await _documentRepository.InsertAsync(child, autoSave: true);

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
@@ -175,21 +175,13 @@ public class EfCoreDocumentRepositoryStatistics_Tests : VaultExtractEntityFramew
             parent.TransitionLifecycle(DocumentLifecycleStatus.Ready);
             await _documentRepository.InsertAsync(parent, autoSave: true);
 
-            // Shares the parent's FileOrigin wholesale, including FileSize (#481). Built as an equal-valued (not
-            // same-reference) FileOrigin: EF's owned-entity change tracker does not allow attaching the SAME tracked
-            // FileOrigin CLR instance to two Document rows within one DbContext (its shadow key includes the
-            // owner's Id) — in production this is a non-issue because the parent is loaded in an earlier,
-            // already-disposed UoW/DbContext before the derived document's own UoW begins.
+            // Shares the parent's FileOrigin wholesale, including FileSize (#481). CloneFileOrigin (#485) builds an
+            // equal-valued (not same-reference) copy -- see its XML doc for why a same-reference FileOrigin instance
+            // cannot be attached to two Document rows within one DbContext.
             var child = Document.CreateDerived(
                 _guidGenerator.Create(),
                 _currentTenant.Id,
-                new FileOrigin(
-                    blobName: parent.FileOrigin.BlobName,
-                    uploadedByUserName: parent.FileOrigin.UploadedByUserName,
-                    contentType: parent.FileOrigin.ContentType,
-                    contentHash: parent.FileOrigin.ContentHash,
-                    fileSize: parent.FileOrigin.FileSize,
-                    originalFileName: parent.FileOrigin.OriginalFileName),
+                CloneFileOrigin(parent.FileOrigin),
                 originDocumentId: parent.Id,
                 originConstituentKey: "slice-1");
             child.TransitionLifecycle(DocumentLifecycleStatus.Ready);

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/VaultExtractEntityFrameworkCoreTestBase.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/VaultExtractEntityFrameworkCoreTestBase.cs
@@ -1,8 +1,28 @@
+using Dignite.Vault.Extract.Documents;
+
 namespace Dignite.Vault.Extract.EntityFrameworkCore;
 
 /* This class can be used as a base class for EF Core integration tests.
  */
 public abstract class VaultExtractEntityFrameworkCoreTestBase : VaultExtractTestBase<VaultExtractEntityFrameworkCoreTestModule>
 {
-
+    /// <summary>
+    /// #485: builds an EQUAL-VALUED (not same-reference) copy of <paramref name="source"/>'s 6 fields, for tests
+    /// that seed a parent Document plus a derived child SHARING the parent's <see cref="FileOrigin"/> (#481) within
+    /// the same DbContext / UoW. EF Core's owned-entity change tracker does not allow attaching the SAME tracked
+    /// <see cref="FileOrigin"/> CLR instance to two <see cref="Document"/> rows (its shadow key includes the
+    /// owner's Id) — production code never hits this because the parent is loaded in an earlier, already-disposed
+    /// UoW/DbContext before a derived document's own UoW begins (mirrors the same reasoning behind
+    /// <c>DocumentSegmentationJob</c>'s #485 fix, which constructs a fresh <see cref="FileOrigin"/> for exactly
+    /// this reason on its Text-kind spawn path). Shared by <c>EfCoreDocumentRepositoryContentHash_Tests</c> and
+    /// <c>EfCoreDocumentRepositoryStatistics_Tests</c> so neither hand-clones <see cref="FileOrigin"/> field-by-field.
+    /// </summary>
+    protected static FileOrigin CloneFileOrigin(FileOrigin source)
+        => new(
+            blobName: source.BlobName,
+            uploadedByUserName: source.UploadedByUserName,
+            contentType: source.ContentType,
+            contentHash: source.ContentHash,
+            fileSize: source.FileSize,
+            originalFileName: source.OriginalFileName);
 }


### PR DESCRIPTION
Closes #485. Follow-ups from the max-effort review of #481, verified in code.

## What changed
**Correctness**
- **A1** — figure segments persist at detection only if their hash resolves in the retained-figure manifest → closes a silent container data-loss + missing-review-flag path when a retention-ON figure's blob archive fail-opened.
- **A2** — a derived doc's `DocumentUploadedEto` reports `FileName=null`/`FileSize=0`/`ContentType=null` (shares the source blob) instead of the parent bundle's values → no N× storage double-count downstream.
- **A3** — `RestoreAsync` fail-closes with new `Extract:DocumentRestoreConflict` when a live sibling shares `(OriginDocumentId, OriginConstituentKey)`.

**Hardening**
- **B1** — re-added `Extract:DocumentNoSourceBlob` + `GetBlobAsync` null guard (legacy null-FileOrigin row reachable in the binaries-first deploy window → clean 4xx, not an NRE); recycle-bin builders + `PermanentDeleteAsync` reclaim made null-safe.
- **B2** — a null-FileOrigin source no longer throws into an infinite retry loop; segmentation skips it cleanly.
- **B3** — documented the concurrent permanent-delete blob-reclaim race as an accepted rare-race (no behavior change).

**Cleanup** — C1 `FindByBlobNameAsync` scoped to non-derived · C2 fresh `FileOrigin` per text-slice spawn (removes latent EF owned-entity aliasing) · C5 removed write-only `PendingSegment.Ordinal` · C6/C7 test helper + comment · integration-events.md note (+ .cursor twin).

## Verification
Full solution builds 0 errors / 0 new warnings. EF **120→124** (+A1/A2/A3 tests), Application 342, Domain 191; Mcp/HttpApi/Parse suites unchanged. `integration-events-reviewer` → clean GO. Localization complete across en/ja/zh-Hans/zh-Hant. New error codes are additive (frozen-`Extract:`-string rule respected).

## Notes
- **A2/A3 decisions were signed off** before coding (ETO reports 0/null; RestoreAsync fail-closes) — see #485.
- **Residual (documented in #485, not fixed here):** the concurrent permanent-delete race (B3) is accepted, not fixed; the migration `Down()` still recreates the unique index the #481 runtime no longer maintains (forward-only in practice). No new migration in this PR.
