### PR TITLE
refactor(segmentation): #487 follow-up — drop the dormant DocumentSegment.FigureContentHash / PageNumber

### DIFF
--- a/.claude/rules/sub-document-segmentation.md
+++ b/.claude/rules/sub-document-segmentation.md
@@ -66,12 +66,13 @@ default — the #364-class missed-branch bug, hardened in #379), not a license t
 | `SourceDocumentId`, `SegmentKey`, `Kind`, `Status`, `RoutedDocumentId`, `Ordinal` | **contract** | the idempotency + retraction lifecycle |
 | `RoutedDocumentId` | **keep explicit** | reconstructable from `(OriginDocumentId, OriginConstituentKey)`, but the explicit pointer is the ledger's purpose (idempotency + retraction clarity); reconstructing the join is more complex, not less |
 | `SliceText` | **transient one-way seed** | duplicated by `Document.Markdown` after parse; bounded duplication is accepted; **do not add a parse→segment writeback to clear it** (couples parse job to the ledger for a low-value saving) |
-| `PageNumber` | **retained provenance** | deliberate out-of-band anchor (Markdown-first "named, strongly-typed, nullable extension field" rule); write-only by design, not dead weight |
-| `FigureContentHash` | **spawn-input (resumable)** | #477/#478: SHA-256 of the retained figure's **image bytes** (≠ `SegmentKey`, the transcription-**text** hash), parsed at detection from the in-span `figures/{hash}` reference; read once at spawn to resolve the source's `FigureManifest` and point the child `FileOrigin` at the **shared** blob. `null` only for a `Text` slice — since #481 a `Figure` span with no resolvable reference is a **retention-off** case (routing requires `RetainFigureImages` ON) and is not persisted as a row at detection at all; a manifest miss discovered later at spawn time deletes the row instead of spawning a child with no blob. Every spawned child therefore carries a real, required `FileOrigin`: `Figure` → the shared retained blob, `Text` → the parent's own shared upload blob |
+
+_Removed by #487: `PageNumber` and `FigureContentHash`. Both were **figure-only**, and since #487 deleted the figure-image retention chain (Phase A) figure spans are **detected-but-skipped** — they no longer route to sub-documents — so neither column was ever written again. Dropped from the entity (+ EF config + `DocumentSegmentConsts.MaxFigureContentHashLength`) with the `V487_DropDormantSegmentFigureColumns` migration._
 
 Watch for accreted residue: a fast-iterated subsystem leaves write-only fields / never-assigned enum values / dead
 projections. #390 removed three (`DocumentSegmentStatus.NotADocument`, `DetectionContext.UploadedByUserName`,
-`PendingSegment.SliceText`). Re-run a dead-code sweep when adding the next iteration.
+`PendingSegment.SliceText`); #487 removed two more (`PageNumber`, `FigureContentHash`). Re-run a dead-code sweep when
+adding the next iteration.
 
 ## Cross-entity invariant (two coupled state machines)
 

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -419,7 +419,7 @@ public class DocumentSegmentationJob
 
         var snapshot = pending
             .OrderBy(s => s.Ordinal)
-            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Kind, s.FigureContentHash, s.PageNumber))
+            .Select(s => new PendingSegment(s.Id, s.SegmentKey, s.Kind))
             .ToList();
 
         await uow.CompleteAsync();
@@ -623,14 +623,12 @@ public class DocumentSegmentationJob
     /// Carries no slice text: the spawn path keys off <see cref="SegmentKey"/>, and the derived document's Markdown
     /// is seeded by <c>DocumentParseBackgroundJob</c> reading the segment's <c>SliceText</c> column fresh from the DB.
     /// Every spawn carries a null FileOrigin regardless of <see cref="Kind"/> — a derived sub-document has no file
-    /// of its own. <see cref="FigureContentHash"/> + <see cref="PageNumber"/> are retained provenance for a legacy
-    /// Figure-kind row.
+    /// of its own.
     /// #485: dropped the write-only <c>Ordinal</c> field (projected in <see cref="LoadPendingSegmentsAsync"/> but
     /// never read back off this record) — the reading-order sort there uses the source entity's own
     /// <c>Ordinal</c> column before the projection, so carrying a copy onto this snapshot served no purpose.</summary>
     protected sealed record PendingSegment(
-        Guid SegmentId, string SegmentKey, DocumentSegmentKind Kind,
-        string? FigureContentHash = null, int? PageNumber = null);
+        Guid SegmentId, string SegmentKey, DocumentSegmentKind Kind);
 }
 
 public class DocumentSegmentationJobArgs

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentSegmentConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentSegmentConsts.cs
@@ -13,11 +13,4 @@ public static class DocumentSegmentConsts
     /// which equals the spawned derived document's <c>OriginConstituentKey</c>.
     /// </summary>
     public static int MaxSegmentKeyLength { get; set; } = 64;
-
-    /// <summary>
-    /// Length of <see cref="DocumentSegment.FigureContentHash"/> (#478): the SHA-256 (lowercase hex) of the
-    /// retained figure's <b>image bytes</b> — distinct from <see cref="DocumentSegment.SegmentKey"/> (the hash of
-    /// the transcription <b>text</b>).
-    /// </summary>
-    public static int MaxFigureContentHashLength { get; set; } = 64;
 }

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/Segments/DocumentSegment.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/Segments/DocumentSegment.cs
@@ -68,30 +68,6 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
     public virtual DocumentSegmentKind Kind { get; private set; }
 
     /// <summary>
-    /// 1-based source page of a <see cref="DocumentSegmentKind.Figure"/> span (#371): a lightweight provenance anchor
-    /// parsed from the <c>*[Image OCR p:N]*</c> marker (the crop itself is not persisted, per Markdown-first). It
-    /// records <b>where</b> the figure came from; <b>no code re-parses the source to recover the image</b> — the
-    /// anchor only keeps that possible out-of-band should a future need arise. <c>null</c> for a
-    /// <see cref="DocumentSegmentKind.Text"/> span or a page-less source. Provenance only — never identity (#210).
-    /// </summary>
-    public virtual int? PageNumber { get; private set; }
-
-    /// <summary>
-    /// SHA-256 (lowercase hex) of the retained figure's <b>image bytes</b> (#477/#478), parsed from the in-span
-    /// <c>![figure](figures/{hash}.{ext})</c> reference of a <see cref="DocumentSegmentKind.Figure"/> slice at
-    /// detection time. <c>null</c> for a <see cref="DocumentSegmentKind.Text"/> slice; a
-    /// <see cref="DocumentSegmentKind.Figure"/> span carrying no reference (retention was off at parse time) is no
-    /// longer persisted as a row at all (#481 retention coupling) — so on any row that DOES exist, Figure implies
-    /// this is non-null. Persisted so the spawn phase is resumable: at spawn it resolves the source document's
-    /// retained-figure manifest by this hash and points the derived document's required <c>FileOrigin</c> at the
-    /// <b>shared</b> blob (<c>extraction-figures/{sourceId}/{hash}</c> — the image is never stored twice); a
-    /// manifest miss at spawn time deletes the row instead (#481) rather than spawning with a fabricated
-    /// FileOrigin. Distinct from <see cref="SegmentKey"/> (the hash of the transcription <b>text</b>, the
-    /// idempotency identity).
-    /// </summary>
-    public virtual string? FigureContentHash { get; private set; }
-
-    /// <summary>
     /// The derived <see cref="Document"/> spawned from this slice, or <c>null</c> when not (yet) spawned /
     /// classified as a non-document segment.
     /// </summary>
@@ -119,9 +95,7 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         string sliceText,
         int ordinal,
         DocumentSegmentKind kind,
-        DocumentSegmentStatus status = DocumentSegmentStatus.Pending,
-        int? pageNumber = null,
-        string? figureContentHash = null)
+        DocumentSegmentStatus status = DocumentSegmentStatus.Pending)
         : base(id)
     {
         TenantId = tenantId;
@@ -131,9 +105,6 @@ public class DocumentSegment : CreationAuditedAggregateRoot<Guid>, IMultiTenant
         Ordinal = ordinal;
         Kind = kind;
         Status = status;
-        PageNumber = pageNumber;
-        FigureContentHash = Check.Length(
-            figureContentHash, nameof(figureContentHash), DocumentSegmentConsts.MaxFigureContentHashLength);
     }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/EntityFrameworkCore/VaultExtractDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/EntityFrameworkCore/VaultExtractDbContextModelCreatingExtensions.cs
@@ -248,11 +248,6 @@ public static class VaultExtractDbContextModelCreatingExtensions
             b.Property(x => x.Kind).IsRequired();
             b.Property(x => x.Status).IsRequired();
 
-            // #478: SHA-256 (hex) of a Figure-kind slice's retained image bytes (#477), parsed from the in-span
-            // figures/{hash} reference; null for Text slices / retention off. Read back at spawn to resolve the
-            // source's retained-figure manifest; looked up per row, never scanned — not indexed.
-            b.Property(x => x.FigureContentHash).HasMaxLength(DocumentSegmentConsts.MaxFigureContentHashLength);
-
             // #346: born-digital slice -> container Document, FK + CASCADE so hard-deleting the container removes
             // its segment rows (mirrors the #306 DocumentFigure child-side declaration). RoutedDocumentId is a
             // soft pointer to the spawned derived Document with NO FK constraint: the derived document is a peer

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -67,7 +67,7 @@ public class DocumentAppService_Delete_Tests
 
         await _appService.DeleteAsync(doc.Id);
 
-        await _blobContainer.DidNotReceive().DeleteAsync(doc.FileOrigin.BlobName, Arg.Any<CancellationToken>());
+        await _blobContainer.DidNotReceive().DeleteAsync(doc.FileOrigin!.BlobName, Arg.Any<CancellationToken>());
         await _documentRepository.Received(1).DeleteAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
@@ -170,7 +170,7 @@ public class DocumentAppService_Delete_Tests
     {
         var existing = CreateDocumentWithContent([1, 2, 3]);
         _documentRepository.FindByContentHashAsync(
-                existing.FileOrigin.ContentHash,
+                existing.FileOrigin!.ContentHash,
                 Arg.Any<CancellationToken>())
             .Returns(existing);
 
@@ -188,7 +188,7 @@ public class DocumentAppService_Delete_Tests
         var existing = CreateDocumentWithContent([1, 2, 3]);
         existing.IsDeleted = true;
         _documentRepository.FindByContentHashAsync(
-                existing.FileOrigin.ContentHash,
+                existing.FileOrigin!.ContentHash,
                 Arg.Any<CancellationToken>())
             .Returns(existing);
 
@@ -384,7 +384,7 @@ public class DocumentAppService_Delete_Tests
 
         await _appService.PermanentDeleteAsync(doc.Id);
 
-        await _blobContainer.Received(1).DeleteAsync(doc.FileOrigin.BlobName, Arg.Any<CancellationToken>());
+        await _blobContainer.Received(1).DeleteAsync(doc.FileOrigin!.BlobName, Arg.Any<CancellationToken>());
     }
 
     private static Document CreateDocument()

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/ContainerReclassifyRetraction_Tests.cs
@@ -260,7 +260,7 @@ public class ContainerReclassifyRetraction_Tests
             var segment = new DocumentSegment(
                 figureSegmentId, tenantId: null, sourceDocumentId: containerId,
                 segmentKey: figureKey, sliceText: "INVOICE No 42 Total 100",
-                ordinal: 99, kind: DocumentSegmentKind.Figure, pageNumber: 1);
+                ordinal: 99, kind: DocumentSegmentKind.Figure);
             segment.MarkSpawned(figureChildId);
             await _segmentRepository.InsertAsync(segment, autoSave: true);
         });

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -397,12 +397,12 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
             // The source document the segment belongs to (the segment FK requires it to exist).
             await _documentRepository.InsertAsync(CreateDocument(sourceId), autoSave: true);
 
-            // The source segment whose slice text the derived document seeds from. Figure-kind: the span was an
-            // embedded image whose transcription seeds the spawned sub-document; PageNumber is a recovery anchor.
+            // The source segment whose slice text the derived document seeds from (the seed path is kind-agnostic;
+            // Figure kind is used here purely as a fixture — figure spans no longer route to sub-documents).
             await _segmentRepository.InsertAsync(new DocumentSegment(
                 _guidGenerator.Create(), tenantId: null, sourceDocumentId: sourceId,
                 segmentKey: segmentKey, sliceText: seed, ordinal: 0,
-                kind: DocumentSegmentKind.Figure, pageNumber: 2), autoSave: true);
+                kind: DocumentSegmentKind.Figure), autoSave: true);
 
             // A derived sub-document carries NO file of its own (FileOrigin null): the markdown-slice split does not
             // give children a source file. So the parse job MUST seed Markdown from the segment slice and never touch
@@ -427,11 +427,10 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
             derived.Markdown.ShouldBe(seed); // seeded from the segment slice, no OCR
             derived.FileOrigin.ShouldBeNull(); // a split sub-document has no source file of its own
 
-            // Kind / PageNumber round-trip through the DB on the source segment row.
+            // Kind round-trips through the DB on the source segment row.
             var segment = (await _segmentRepository.GetListAsync(s => s.SourceDocumentId == sourceId))
                 .ShouldHaveSingleItem();
             segment.Kind.ShouldBe(DocumentSegmentKind.Figure);
-            segment.PageNumber.ShouldBe(2);
             segment.SegmentKey.ShouldBe(segmentKey);
         });
 

--- a/host/src/Migrations/20260709144043_V487_DropDormantSegmentFigureColumns.Designer.cs
+++ b/host/src/Migrations/20260709144043_V487_DropDormantSegmentFigureColumns.Designer.cs
@@ -4,6 +4,7 @@ using Dignite.Vault.Extract.Host.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace Dignite.Vault.Extract.Host.Migrations
 {
     [DbContext(typeof(VaultExtractHostDbContext))]
-    partial class VaultExtractHostDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709144043_V487_DropDormantSegmentFigureColumns")]
+    partial class V487_DropDormantSegmentFigureColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/host/src/Migrations/20260709144043_V487_DropDormantSegmentFigureColumns.cs
+++ b/host/src/Migrations/20260709144043_V487_DropDormantSegmentFigureColumns.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dignite.Vault.Extract.Host.Migrations
+{
+    /// <inheritdoc />
+    public partial class V487_DropDormantSegmentFigureColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FigureContentHash",
+                table: "VaultDocumentSegments");
+
+            migrationBuilder.DropColumn(
+                name: "PageNumber",
+                table: "VaultDocumentSegments");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FigureContentHash",
+                table: "VaultDocumentSegments",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PageNumber",
+                table: "VaultDocumentSegments",
+                type: "int",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up cleanup to #487 (already merged/closed). Both `DocumentSegment.FigureContentHash` and `PageNumber` were figure-only columns; since #487 Phase A deleted the figure-image retention chain, figure spans are detected-but-skipped and never route to sub-documents, so neither column has been written since. Removes the properties, constructor params, `PendingSegment` projection fields, EF config, and `DocumentSegmentConsts.MaxFigureContentHashLength`. Migration `V487_DropDormantSegmentFigureColumns` drops both columns from `VaultDocumentSegments` (dev-only — the columns hold no data).

Also clears 4 nullable-dereference warnings in `DocumentAppService_Delete_Tests` introduced by the FileOrigin-nullable change.

Builds clean (0 errors; only the 4 pre-existing host warnings); EF Core 118 / Application 329 / Domain 186 green.

Deploy: `dotnet ef database update` for `V487_DropDormantSegmentFigureColumns`.