### PR TITLE
fix(host): keep appsettings.secrets.json out of dotnet publish output

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -28317,8 +28317,8 @@
     },
     "packages/vault-extract": {
       "name": "@dignite/vault-extract",
-      "version": "0.2.0-preview.3",
-      "license": "Apache-2.0",
+      "version": "0.3.0-preview.1",
+      "license": "LGPL-3.0-only",
       "dependencies": {
         "@abp/ng.core": "~10.2.0",
         "@abp/ng.theme.shared": "~10.2.0",

--- a/host/src/Data/VaultExtractHostDbContextFactory.cs
+++ b/host/src/Data/VaultExtractHostDbContextFactory.cs
@@ -25,6 +25,7 @@ public class VaultExtractHostDbContextFactory : IDesignTimeDbContextFactory<Vaul
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: false)
             .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddJsonFile("appsettings.secrets.json", optional: true)
             .AddEnvironmentVariables();
 
         return builder.Build();

--- a/host/src/Dignite.Vault.Extract.Host.csproj
+++ b/host/src/Dignite.Vault.Extract.Host.csproj
@@ -156,6 +156,18 @@
     <Content Remove="$(UserProfile)\.nuget\packages\*\*\contentFiles\any\*\*.abppkg*" />
   </ItemGroup>
 
+  <!-- appsettings.secrets.json is a gitignored, per-developer local override (points at a dev SQL Server).
+       The Web SDK's default appsettings.*.json glob still picks it up as Content, so without this it
+       silently rides along into `dotnet publish` output and can override the deployed server's
+       appsettings.Production.json / environment variables at runtime (AddAppSettingsSecretsJson is
+       unconditional and appended last in the config chain). Keep it out of the publish payload only;
+       CopyToOutputDirectory (build/run) is untouched so local dev still picks it up. -->
+  <ItemGroup>
+    <Content Update="appsettings.secrets.json">
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <ProjectExtensions><VisualStudio><UserProperties appsettings_1development_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 
 </Project>


### PR DESCRIPTION
## Summary
- `appsettings.secrets.json` (gitignored, per-developer local override) was still being picked up by the Web SDK's default `appsettings.*.json` content glob and rode along into `dotnet publish` output — since `AddAppSettingsSecretsJson` is unconditional and appended last in the config chain, this could silently override `appsettings.Production.json` / environment variables at runtime on a deployed server.
- Adds `CopyToPublishDirectory=Never` for that file (build/run `CopyToOutputDirectory` untouched, so local dev is unaffected).
- Design-time `DbContext` factory now also loads `appsettings.secrets.json`, for parity with the runtime config chain.
- Synced `angular/package-lock.json`'s `vault-extract` package entry to the already-committed `0.3.0-preview.1` / `LGPL-3.0-only` bump (lockfile just hadn't been regenerated).

## Test plan
- [ ] `dotnet publish host/src` and confirm `appsettings.secrets.json` is absent from the output folder
- [ ] Local `dotnet run` / EF Core design-time commands still pick up `appsettings.secrets.json` as before