### PR TITLE
refactor(data-download): share the export/list filter chain, restore a column ceiling (#501 items 1-5)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -791,45 +791,41 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         return await MapToDtoAsync(document);
     }
 
+    /// <summary>
+    /// Narrows the list by its metadata filters through the shared <see cref="DocumentQueries.ApplyMetadataFilter"/>
+    /// chain — the same one <c>DocumentExportAppService</c> runs, so "download the current view" cannot drift from
+    /// the view (#501 item 1). The list's own <c>IsDeleted</c> (recycle bin) stays out of the shared chain and is
+    /// applied by <see cref="ExecuteListQueryAsync"/> inside <c>DataFilter.Disable&lt;ISoftDelete&gt;()</c>.
+    /// </summary>
     protected virtual IQueryable<Document> ApplyFilter(
         IQueryable<Document> query, GetDocumentListInput input, Guid? documentTypeId)
     {
-        if (input.LifecycleStatus.HasValue)
-            query = query.Where(x => x.LifecycleStatus == input.LifecycleStatus.Value);
-
-        // Type filtering uses the resolved internal DocumentTypeId (#207).
-        if (documentTypeId.HasValue)
-            query = query.Where(x => x.DocumentTypeId == documentTypeId.Value);
-
-        if (input.CabinetId.HasValue)
-            query = query.Where(x => x.CabinetId == input.CabinetId.Value);
-
-        // Sub-document provenance filter (#354): list the documents derived from a given source (e.g. a
-        // container's children). The IMultiTenant global filter still applies, so both ends stay tenant-scoped.
-        if (input.OriginDocumentId.HasValue)
-            query = query.Where(x => x.OriginDocumentId == input.OriginDocumentId.Value);
-
-        // Filter by manual-review disposition phase (#284). Rejected documents have ReviewDisposition=Rejected and can be queried explicitly.
-        if (input.ReviewDisposition.HasValue)
-            query = query.Where(d => d.ReviewDisposition == input.ReviewDisposition.Value);
-
-        // Operator review queue (#284): any unresolved review reason (unresolved classification + missing required fields, one queue) and not rejected.
-        // Rejected documents have already been handled by the operator, so they are not in the work queue; they can still be queried separately by ReviewDisposition=Rejected.
-        // Uses the canonical DocumentReviewQueries.RequiresAttention predicate, shared with the overview
-        // needs-review statistic (#333) so the queue and the count never drift.
-        if (input.HasReviewReasons == true)
-            query = query.Where(DocumentReviewQueries.RequiresAttention);
-
-        return query;
+        return query.ApplyMetadataFilter(new DocumentMetadataFilter
+        {
+            // Type filtering uses the resolved internal DocumentTypeId (#207), not input.DocumentTypeCode.
+            DocumentTypeId = documentTypeId,
+            LifecycleStatus = input.LifecycleStatus,
+            CabinetId = input.CabinetId,
+            OriginDocumentId = input.OriginDocumentId,
+            ReviewDisposition = input.ReviewDisposition,
+            HasReviewReasons = input.HasReviewReasons,
+            // The list contract exposes no date range; the export's does. Leaving these null keeps the shared
+            // chain's semantics single-sourced without widening this DTO.
+        });
     }
 
+    /// <summary>
+    /// Orders through the shared <see cref="DocumentQueries.OrderByCreationTime"/>, which appends the <c>Id</c>
+    /// tiebreaker the export already had (#501 item 5). Without it a <c>CreationTime</c> tie — ordinary for a
+    /// batch upload — leaves the order to the database, and a tied row on a page boundary can appear on two
+    /// pages or none.
+    /// </summary>
     protected virtual IQueryable<Document> ApplySorting(IQueryable<Document> query, string? sorting)
     {
         return sorting?.Trim().ToLowerInvariant() switch
         {
-            "creationtime" or "creationtime asc" => query.OrderBy(x => x.CreationTime),
-            "creationtime desc" => query.OrderByDescending(x => x.CreationTime),
-            _ => query.OrderByDescending(x => x.CreationTime)
+            "creationtime" or "creationtime asc" => query.OrderByCreationTime(descending: false),
+            _ => query.OrderByCreationTime(descending: true)
         };
     }
 

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentFieldQueryResolver.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentFieldQueryResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Documents.Fields;
 using Volo.Abp;
@@ -21,16 +22,38 @@ namespace Dignite.Vault.Extract.Documents;
 /// </summary>
 public static class DocumentFieldQueryResolver
 {
+    /// <summary>
+    /// Resolves <paramref name="filters"/> against the live field definitions of <paramref name="documentTypeId"/>.
+    /// <para>
+    /// <paramref name="knownDefinitions"/> (#501 item 4) is an optional cache of definitions the caller has
+    /// <b>already</b> loaded for this same type — the export loads all of them to build its columns, and would
+    /// otherwise re-fetch each filtered name from the database (<c>FindByNameAsync</c> is a
+    /// <c>FirstOrDefaultAsync(predicate)</c>, which EF's identity map does not short-circuit; only <c>Find(key)</c>
+    /// does). A cache <b>hit</b> skips the round-trip; a <b>miss</b> still asks the repository before failing.
+    /// </para>
+    /// <para>
+    /// That fallback is the whole point, not defensive padding: the cache is matched with
+    /// <see cref="StringComparison.Ordinal"/>, whereas <c>FindByNameAsync</c> compares in SQL, where the column's
+    /// collation decides — SQL Server's default is case-<i>insensitive</i>. Loud-failing on an ordinal miss would
+    /// therefore reject a name the database (and the list path, which has no cache) still accepts, quietly
+    /// re-creating between the file and the screen the very divergence #501 item 1 removes. Only the database
+    /// gets to say a field does not exist.
+    /// </para>
+    /// </summary>
     public static async Task<List<DocumentFieldQuery>> ResolveAsync(
         IFieldDefinitionRepository fieldDefinitionRepository,
         IReadOnlyList<DocumentFieldFilter> filters,
         Guid documentTypeId,
-        string documentTypeCode)
+        string documentTypeCode,
+        IReadOnlyList<FieldDefinition>? knownDefinitions = null)
     {
         var queries = new List<DocumentFieldQuery>(filters.Count);
         foreach (var filter in filters)
         {
-            var definition = await fieldDefinitionRepository.FindByNameAsync(documentTypeId, filter.Name!);
+            var definition =
+                knownDefinitions?.FirstOrDefault(d => string.Equals(d.Name, filter.Name, StringComparison.Ordinal))
+                ?? await fieldDefinitionRepository.FindByNameAsync(documentTypeId, filter.Name!);
+
             if (definition == null)
             {
                 throw new BusinessException(VaultExtractErrorCodes.ExtractedField.Unknown)

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Exports/DocumentExportAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Exports/DocumentExportAppService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -60,39 +59,46 @@ public class DocumentExportAppService : VaultExtractAppService, IDocumentExportA
         // used to traverse soft-delete to resolve columns it explicitly referenced; nothing references them now.
         var fieldDefinitions = await _fieldDefinitionRepository.GetListAsync(documentType.Id);
 
+        // #501 item 2: the column count is bounded explicitly, symmetric with the row bound below. The template
+        // layer capped its saved projection at ExportTemplateConsts.MaxColumnCount = 100; #499 deleted the
+        // template and derived the columns from the type's live fields instead, and nothing else caps the number
+        // of fields a type may carry. A very wide export is built synchronously and held in memory as one
+        // ClosedXML cell object per (row, column) before SaveAs, so it fails fast here rather than degrading.
+        if (fieldDefinitions.Count > DocumentExportConsts.MaxColumnCount)
+        {
+            throw new BusinessException(VaultExtractErrorCodes.Export.ColumnLimitExceeded)
+                .WithData("count", fieldDefinitions.Count)
+                .WithData("max", DocumentExportConsts.MaxColumnCount);
+        }
+
         // Tenant isolation is enforced by the ambient IMultiTenant filter, including GetQueryableAsync below.
         var query = await _documentRepository.GetQueryableAsync();
-        query = query.Where(d => d.DocumentTypeId == documentType.Id);
 
-        if (input.LifecycleStatus.HasValue)
-            query = query.Where(d => d.LifecycleStatus == input.LifecycleStatus.Value);
-        if (input.CabinetId.HasValue)
-            query = query.Where(d => d.CabinetId == input.CabinetId.Value);
-
-        // Sub-document provenance (#354): only the children derived from this source document.
-        if (input.OriginDocumentId.HasValue)
-            query = query.Where(d => d.OriginDocumentId == input.OriginDocumentId.Value);
-        // Operator review queue (#284 / #395): reuses the canonical DocumentReviewQueries.RequiresAttention
-        // expression the list and the needs-review badge already run. A second, hand-rolled "needs review"
-        // predicate here is precisely how the exported file and the screen would quietly disagree.
-        if (input.HasReviewReasons == true)
-            query = query.Where(DocumentReviewQueries.RequiresAttention);
-
-        if (input.CreationTimeMin.HasValue)
-            query = query.Where(d => d.CreationTime >= input.CreationTimeMin.Value.Date);
-        // Upper time bound includes the full Max date (< Max + 1 day), matching date picker intuition.
-        if (input.CreationTimeMax.HasValue)
-            query = query.Where(d => d.CreationTime < input.CreationTimeMax.Value.Date.AddDays(1));
+        // #501 item 1: the metadata predicates are the shared DocumentQueries.ApplyMetadataFilter chain, the one
+        // the operator list runs. Hand-writing a second copy here is how "download the current view" silently
+        // stops downloading the view — the #496 bug class, one layer down. Filters the export contract does not
+        // expose (ReviewDisposition) stay null; the recycle bin is fail-closed by never disabling ISoftDelete.
+        query = query.ApplyMetadataFilter(new DocumentMetadataFilter
+        {
+            DocumentTypeId = documentType.Id,
+            LifecycleStatus = input.LifecycleStatus,
+            CabinetId = input.CabinetId,
+            OriginDocumentId = input.OriginDocumentId,
+            HasReviewReasons = input.HasReviewReasons,
+            CreationTimeMin = input.CreationTimeMin,
+            CreationTimeMax = input.CreationTimeMax,
+        });
 
         // Extracted-field-value filters, AND-combined with the metadata filters above. Resolve the field names
         // against the type (unknown field loud-fails via the shared resolver — the same path the document list /
         // MCP search use), match document ids through the EXISTS query (GetFieldMatchedIdsAsync; the ambient
         // IMultiTenant filter keeps it in the caller's layer), then intersect. The Take(limit + 1) below still
-        // bounds the export size.
+        // bounds the export size. fieldDefinitions is passed as the already-loaded lookup (#501 item 4).
         if (input.FieldFilters is { Count: > 0 })
         {
             var fieldQueries = await DocumentFieldQueryResolver.ResolveAsync(
-                _fieldDefinitionRepository, input.FieldFilters, documentType.Id, documentType.TypeCode);
+                _fieldDefinitionRepository, input.FieldFilters, documentType.Id, documentType.TypeCode,
+                knownDefinitions: fieldDefinitions);
             var matchedIds = await _documentRepository.GetFieldMatchedIdsAsync(documentType.Id, fieldQueries);
             query = query.Where(d => matchedIds.Contains(d.Id));
         }
@@ -103,11 +109,9 @@ public class DocumentExportAppService : VaultExtractAppService, IDocumentExportA
         var limit = DocumentExportConsts.MaxExportDocumentCount;
         var rows = await AsyncExecuter.ToListAsync(
             query
-                // ThenByDescending(Id) for the same reason the columns are ordered by (DisplayOrder, Name):
-                // CreationTime ties are ordinary for a batch upload, and without a tiebreaker the same data
-                // exports in a different row order run to run.
-                .OrderByDescending(d => d.CreationTime)
-                .ThenByDescending(d => d.Id)
+                // The list's default order, from the one shared implementation (#501 item 5) — including the Id
+                // tiebreaker, for the same reason the columns are ordered by (DisplayOrder, Name).
+                .OrderByCreationTime(descending: true)
                 .Select(d => new ExportProjection
                 {
                     Title = d.Title,
@@ -147,6 +151,12 @@ public class DocumentExportAppService : VaultExtractAppService, IDocumentExportA
         var dataRows = rows
             .Select(r =>
             {
+                // #501 item 3: bucket this row's field values by FieldDefinitionId once, in one pass. Each cell
+                // is then an O(1) bucket lookup instead of a Where + OrderBy rescan of every value the document
+                // holds — the old shape cost O(columns x values) per row, and #499 grew `columns` from an
+                // operator-chosen subset capped at 100 to every live field the type declares.
+                var valuesByField = r.ExtractedFields.ToLookup(f => f.FieldDefinitionId);
+
                 var cells = new string?[headers.Count];
                 cells[0] = r.LifecycleStatus.ToString();
                 cells[1] = r.ReviewDisposition.ToString();
@@ -156,7 +166,9 @@ public class DocumentExportAppService : VaultExtractAppService, IDocumentExportA
                 cells[3] = r.Title;
                 for (var i = 0; i < fieldDefinitions.Count; i++)
                 {
-                    cells[systemCount + i] = GetExtractedValue(r, fieldDefinitions[i].Id, fieldDefinitions[i].DataType);
+                    // The ILookup indexer yields an empty sequence for a field this document has no value for.
+                    cells[systemCount + i] = ExportCellRenderer.RenderCell(
+                        valuesByField[fieldDefinitions[i].Id], fieldDefinitions[i].DataType);
                 }
                 return cells;
             })
@@ -178,36 +190,4 @@ public class DocumentExportAppService : VaultExtractAppService, IDocumentExportA
 
         return new RemoteStreamContent(new MemoryStream(bytes), fileName, contentType);
     }
-
-    private static string? GetExtractedValue(ExportProjection d, Guid fieldDefinitionId, FieldDataType dataType)
-    {
-        // Render all value rows for this field by Order ascending, then join (#212). Single-value fields have exactly one row,
-        // so the result is that value. Multi-value fields join rows with "; ", preserving all values deterministically
-        // without relying on DB row order for child subqueries without explicit ordering.
-        var rendered = d.ExtractedFields
-            .Where(f => f.FieldDefinitionId == fieldDefinitionId)
-            .OrderBy(f => f.Order)
-            .Select(f => FieldValueToString(f, dataType))
-            .Where(s => s != null)
-            .ToList();
-
-        return rendered.Count > 0 ? string.Join("; ", rendered) : null;
-    }
-
-    // Render typed columns to cell strings by field type, using InvariantCulture and matching the canonical shape in DocumentExtractedField.ToJsonElement.
-    // Type comes from FieldDefinition.DataType (#208: not persisted on field value rows). Unknown type loud-fails, consistent with
-    // SetValue / ToJsonElement / ApplyFieldValueFilter. Never silently output an empty cell: if a new enum value misses this branch,
-    // tests / runtime should fail loudly instead of silently exporting wrong data.
-    private static string? FieldValueToString(ExtractedFieldProjection f, FieldDataType dataType) => dataType switch
-    {
-        FieldDataType.Text => f.TextValue,
-        FieldDataType.LongText => f.LongTextValue,
-        // Render Number in minimal shape ("0.######"): integer 1000 -> "1000", decimal 10.50 -> "10.5",
-        // without the six trailing zeros from decimal(38,6).
-        FieldDataType.Number => f.NumberValue?.ToString("0.######", CultureInfo.InvariantCulture),
-        FieldDataType.Boolean => f.BooleanValue == null ? null : (f.BooleanValue.Value ? "true" : "false"),
-        FieldDataType.Date => f.DateValue?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-        FieldDataType.DateTime => f.DateTimeValue?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
-        _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported field data type.")
-    };
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Exports/ExportCellRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Exports/ExportCellRenderer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Dignite.Vault.Extract.Documents.Fields;
+
+namespace Dignite.Vault.Extract.Documents.Exports;
+
+/// <summary>
+/// Renders one document's typed field-value rows into one export cell string.
+/// <para>
+/// Extracted from <c>DocumentExportAppService</c> so the ascending-<c>Order</c> join can actually be tested.
+/// It could not be, in place: the only tests that could reach it went through SQLite, which returns
+/// <c>DocumentExtractedField</c> child rows in primary-key order <c>(DocumentId, FieldDefinitionId, Order)</c> —
+/// already ascending by <c>Order</c>. Deleting the sort left every test green. The row order of a child
+/// subquery with no <c>ORDER BY</c> is unspecified, not "whatever SQLite does", so the guard belongs here, over
+/// an input sequence a test controls.
+/// </para>
+/// </summary>
+internal static class ExportCellRenderer
+{
+    /// <summary>
+    /// Renders every value row of one field, ascending by <c>Order</c>, joined (#212). A single-value field has
+    /// exactly one row, so the result is that value. Yields null — an empty cell — when the field holds no
+    /// renderable value.
+    /// </summary>
+    public static string? RenderCell(IEnumerable<ExtractedFieldProjection> values, FieldDataType dataType)
+    {
+        var rendered = values
+            // Never relies on the caller's sequence order: DocumentExportAppService buckets rows with ToLookup,
+            // which preserves the source order, and that source order is the database's unspecified one.
+            .OrderBy(f => f.Order)
+            .Select(f => FieldValueToString(f, dataType))
+            .Where(s => s != null)
+            .ToList();
+
+        return rendered.Count > 0 ? string.Join(MultiValueSeparator, rendered) : null;
+    }
+
+    /// <summary>
+    /// Joins a multi-value field's rows in one cell. Not a comma: the CSV writer would then have to quote the
+    /// cell, and a consumer re-splitting on the delimiter would silently shred one field into several columns.
+    /// </summary>
+    public const string MultiValueSeparator = "; ";
+
+    // Render typed columns to cell strings by field type, using InvariantCulture and matching the canonical shape in DocumentExtractedField.ToJsonElement.
+    // Type comes from FieldDefinition.DataType (#208: not persisted on field value rows). Unknown type loud-fails, consistent with
+    // SetValue / ToJsonElement / ApplyFieldValueFilter. Never silently output an empty cell: if a new enum value misses this branch,
+    // tests / runtime should fail loudly instead of silently exporting wrong data.
+    private static string? FieldValueToString(ExtractedFieldProjection f, FieldDataType dataType) => dataType switch
+    {
+        FieldDataType.Text => f.TextValue,
+        FieldDataType.LongText => f.LongTextValue,
+        // Render Number in minimal shape ("0.######"): integer 1000 -> "1000", decimal 10.50 -> "10.5",
+        // without the six trailing zeros from decimal(38,6).
+        FieldDataType.Number => f.NumberValue?.ToString("0.######", CultureInfo.InvariantCulture),
+        FieldDataType.Boolean => f.BooleanValue == null ? null : (f.BooleanValue.Value ? "true" : "false"),
+        FieldDataType.Date => f.DateValue?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        FieldDataType.DateTime => f.DateTimeValue?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
+        _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported field data type.")
+    };
+}

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Exports/DocumentExportConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Exports/DocumentExportConsts.cs
@@ -4,4 +4,22 @@ public static class DocumentExportConsts
 {
     /// <summary>Hard limit for documents in one synchronous export, preventing broad filters from exhausting memory or generating oversized files. Hosts may override it.</summary>
     public static int MaxExportDocumentCount { get; set; } = 10000;
+
+    /// <summary>
+    /// Hard limit for type-bound field columns in one export — the row bound's missing twin (#501 item 2).
+    /// <para>
+    /// The deleted template layer capped its saved column projection at <c>ExportTemplateConsts.MaxColumnCount = 100</c>,
+    /// enforced by <c>ExportTemplate.SetColumns</c>. #499 replaced that projection with the type's live
+    /// <c>FieldDefinition</c> list, and nothing caps how many fields a document type may declare
+    /// (<c>FieldDefinitionConsts</c> bounds name length and uniqueness, never the per-type count) — so the column
+    /// count became unbounded while the row count stayed at 10 000. The export is built synchronously, holding
+    /// one ClosedXML cell object per (row, column) in memory before <c>SaveAs</c>. Carries over the old value.
+    /// Hosts may override it.
+    /// </para>
+    /// <para>
+    /// The four fixed system columns are not counted: they are not configurable, so a host raising this limit is
+    /// reasoning about the fields it declared, not about an implementation detail of the header row.
+    /// </para>
+    /// </summary>
+    public static int MaxColumnCount { get; set; } = 100;
 }

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -388,6 +388,7 @@
     "Extract:FieldTypeDoesNotSupportRange": "Field '{FieldName}' is of type {DataType}, which supports only equality matching, not range (min/max) queries.",
     "Extract:FieldTypeNotQueryable": "Field '{FieldName}' is of type {DataType} (long-form text), which cannot be used as a search filter.",
     "Extract:ExportDocumentLimitExceeded": "The download matches {count} documents, exceeding the per-download limit of {max}. Narrow the filter or select fewer documents.",
+    "Extract:ExportColumnLimitExceeded": "This document type defines {count} fields, exceeding the per-download column limit of {max}. Ask an administrator to archive the fields this type no longer needs.",
     "ExportFormat:Csv": "CSV",
     "ExportFormat:Xlsx": "Excel (XLSX)",
     "Extract:InvalidCabinetName": "Cabinet name '{name}' contains control characters (newlines, tabs, etc.), which are not allowed.",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -388,6 +388,7 @@
     "Extract:FieldTypeDoesNotSupportRange": "フィールド '{FieldName}' は型 {DataType} で、等価一致のみ対応しており、範囲（最小/最大）クエリには対応していません。",
     "Extract:FieldTypeNotQueryable": "フィールド '{FieldName}' は型 {DataType}（長文テキスト）で、検索フィルターとして使用できません。",
     "Extract:ExportDocumentLimitExceeded": "このダウンロードは {count} 件のドキュメントに一致し、1 回あたりの上限 {max} 件を超えています。フィルターを絞り込むか、選択するドキュメントを減らしてください。",
+    "Extract:ExportColumnLimitExceeded": "このドキュメントタイプは {count} 個のフィールドを定義しており、1 回あたりの列数の上限 {max} を超えています。不要になったフィールドのアーカイブを管理者に依頼してください。",
     "ExportFormat:Csv": "CSV",
     "ExportFormat:Xlsx": "Excel (XLSX)",
     "Extract:InvalidCabinetName": "キャビネット名 '{name}' に制御文字（改行、タブなど）が含まれており、使用できません。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -388,6 +388,7 @@
     "Extract:FieldTypeDoesNotSupportRange": "字段 '{FieldName}' 类型为 {DataType}，仅支持等值匹配，不支持区间（min/max）查询。",
     "Extract:FieldTypeNotQueryable": "字段 '{FieldName}' 类型为 {DataType}（长文本），不能作为检索条件。",
     "Extract:ExportDocumentLimitExceeded": "本次下载匹配到 {count} 个文档，超过单次上限 {max}。请缩小筛选范围或减少勾选数量。",
+    "Extract:ExportColumnLimitExceeded": "该文档类型定义了 {count} 个字段，超过单次下载的列数上限 {max}。请联系管理员归档该类型不再需要的字段。",
     "ExportFormat:Csv": "CSV",
     "ExportFormat:Xlsx": "Excel (XLSX)",
     "Extract:InvalidCabinetName": "文件柜名称 '{name}' 包含换行 / 制表符等控制字符，不允许使用。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -388,6 +388,7 @@
     "Extract:FieldTypeDoesNotSupportRange": "欄位 '{FieldName}' 類型為 {DataType}，僅支援等值比對，不支援區間（min/max）查詢。",
     "Extract:FieldTypeNotQueryable": "欄位 '{FieldName}' 類型為 {DataType}（長文字），無法作為搜尋條件。",
     "Extract:ExportDocumentLimitExceeded": "本次下載比對到 {count} 份文件，超過單次上限 {max}。請縮小篩選範圍或減少勾選數量。",
+    "Extract:ExportColumnLimitExceeded": "此文件類型定義了 {count} 個欄位，超過單次下載的欄數上限 {max}。請聯絡管理員封存此類型不再需要的欄位。",
     "ExportFormat:Csv": "CSV",
     "ExportFormat:Xlsx": "Excel (XLSX)",
     "Extract:InvalidCabinetName": "文件櫃名稱 '{name}' 包含換行 / 定位字元等控制字元，不允許使用。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -85,6 +85,10 @@ public static class VaultExtractErrorCodes
         // The five Extract:ExportTemplate* codes died with the template layer (#499). The wire value below is
         // frozen and unchanged.
         public const string DocumentLimitExceeded = "Extract:ExportDocumentLimitExceeded";
+
+        // #501 item 2: the column bound, restored after #499 deleted ExportTemplateConsts.MaxColumnCount along
+        // with the template that enforced it. Keeps the "Extract:Export*" shape of its row-bound twin above.
+        public const string ColumnLimitExceeded = "Extract:ExportColumnLimitExceeded";
     }
 
     // Cabinets (#194).

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentQueries.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentQueries.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+
+namespace Dignite.Vault.Extract.Documents;
+
+/// <summary>
+/// The single implementation of the document metadata predicate chain and of the default row order, shared by
+/// the operator list (<c>DocumentAppService</c>) and the data download (<c>DocumentExportAppService</c>).
+/// <para>
+/// #501 item 1: the two call sites used to hand-write the same four predicates
+/// (<c>LifecycleStatus</c> / <c>DocumentTypeId</c> / <c>CabinetId</c> / <c>OriginDocumentId</c>) independently, and
+/// had already drifted. #500's client-side round-trip guard compares filter <b>key names</b> and is blind to
+/// predicate <b>semantics</b>: widen <see cref="DocumentMetadataFilter.CabinetId"/> to include child cabinets on
+/// the list, and a second literal <c>d.CabinetId == id</c> in the export would not follow — the file and the
+/// screen diverge with nothing to catch it. That is the #496 bug class, one layer down. There is now one
+/// implementation, so a change to any predicate reaches both egress paths or neither.
+/// </para>
+/// <para>
+/// The <b>filter shape</b> is deliberately wider than either caller's DTO. Each caller populates only the knobs
+/// its own contract exposes (the list has no date range; the export has no review disposition) and leaves the
+/// rest null. Sharing the shape single-sources the <i>semantics</i> of every predicate without forcing the two
+/// contracts to expose the same knobs.
+/// </para>
+/// <para>
+/// Soft-delete is <b>not</b> part of this chain. The list opens <c>DataFilter.Disable&lt;ISoftDelete&gt;()</c> for the
+/// recycle-bin view; the export never does, so deleted documents cannot reach a file. That asymmetry is
+/// fail-closed and intentional — expressing it here as a nullable <c>IsDeleted</c> knob would invite a caller to
+/// set it without opening the ambient filter, which silently returns nothing.
+/// </para>
+/// </summary>
+public static class DocumentQueries
+{
+    /// <summary>
+    /// Narrows <paramref name="query"/> by every non-null member of <paramref name="filter"/>, AND-combined.
+    /// Null members are absent filters, never a filter for "none".
+    /// </summary>
+    public static IQueryable<Document> ApplyMetadataFilter(
+        this IQueryable<Document> query, DocumentMetadataFilter filter)
+    {
+        if (filter.LifecycleStatus.HasValue)
+            query = query.Where(d => d.LifecycleStatus == filter.LifecycleStatus.Value);
+
+        // Type filtering uses the resolved internal DocumentTypeId (#207), never the external TypeCode.
+        if (filter.DocumentTypeId.HasValue)
+            query = query.Where(d => d.DocumentTypeId == filter.DocumentTypeId.Value);
+
+        if (filter.CabinetId.HasValue)
+            query = query.Where(d => d.CabinetId == filter.CabinetId.Value);
+
+        // Sub-document provenance (#354): only the children derived from this source document. The IMultiTenant
+        // global filter still applies, so both ends stay tenant-scoped.
+        if (filter.OriginDocumentId.HasValue)
+            query = query.Where(d => d.OriginDocumentId == filter.OriginDocumentId.Value);
+
+        // Manual-review disposition phase (#284). Rejected documents carry ReviewDisposition=Rejected and can be
+        // queried explicitly, which is why this is a separate axis from the queue predicate below.
+        if (filter.ReviewDisposition.HasValue)
+            query = query.Where(d => d.ReviewDisposition == filter.ReviewDisposition.Value);
+
+        // Operator review queue (#284 / #333 / #395): the canonical DocumentReviewQueries.RequiresAttention
+        // predicate, shared with the overview needs-review statistic. A second, hand-rolled "needs review"
+        // predicate is precisely how a screen and a file quietly disagree.
+        if (filter.HasReviewReasons == true)
+            query = query.Where(DocumentReviewQueries.RequiresAttention);
+
+        if (filter.CreationTimeMin.HasValue)
+            query = query.Where(d => d.CreationTime >= filter.CreationTimeMin.Value.Date);
+        // The upper bound includes the whole Max date (< Max + 1 day), matching date-picker intuition.
+        if (filter.CreationTimeMax.HasValue)
+            query = query.Where(d => d.CreationTime < filter.CreationTimeMax.Value.Date.AddDays(1));
+
+        return query;
+    }
+
+    /// <summary>
+    /// The default document order: by <c>CreationTime</c>, then by <c>Id</c> as a tiebreaker.
+    /// <para>
+    /// #501 item 5: <c>CreationTime</c> ties are ordinary for a batch upload, and without a tiebreaker the
+    /// order is whatever the database happens to return — the same data lists (and exports) in a different order
+    /// run to run, and a tied row sitting on a <c>Skip</c>/<c>Take</c> page boundary can appear on two pages or
+    /// none. Both egress paths order through here so the file and the screen agree on ties too.
+    /// </para>
+    /// </summary>
+    public static IQueryable<Document> OrderByCreationTime(this IQueryable<Document> query, bool descending)
+    {
+        return descending
+            ? query.OrderByDescending(d => d.CreationTime).ThenByDescending(d => d.Id)
+            : query.OrderBy(d => d.CreationTime).ThenBy(d => d.Id);
+    }
+}
+
+/// <summary>
+/// The metadata filters a document query can express, shared by the operator list and the data download so the
+/// predicate behind each one has exactly one implementation (see <see cref="DocumentQueries"/>). A null member
+/// is an absent filter.
+/// </summary>
+public class DocumentMetadataFilter
+{
+    /// <summary>Internal type id (#207), already resolved from the caller's external <c>DocumentTypeCode</c>.</summary>
+    public Guid? DocumentTypeId { get; set; }
+
+    public DocumentLifecycleStatus? LifecycleStatus { get; set; }
+
+    /// <summary>Cabinet (#194): the manual filing dimension, orthogonal to the pipeline.</summary>
+    public Guid? CabinetId { get; set; }
+
+    /// <summary>Provenance (#354): the sub-documents derived from this source document.</summary>
+    public Guid? OriginDocumentId { get; set; }
+
+    /// <summary>Review <b>disposition</b> axis (#284): confirmed / rejected / not reviewed.</summary>
+    public DocumentReviewDisposition? ReviewDisposition { get; set; }
+
+    /// <summary>Review <b>reason</b> axis (#284): true selects the operator review queue.</summary>
+    public bool? HasReviewReasons { get; set; }
+
+    public DateTime? CreationTimeMin { get; set; }
+
+    public DateTime? CreationTimeMax { get; set; }
+}

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Exports/ExportCellRenderer_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Exports/ExportCellRenderer_Tests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Dignite.Vault.Extract.Documents.Fields;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Documents.Exports;
+
+/// <summary>
+/// Unit tests for <see cref="ExportCellRenderer"/>. Internal and visible through InternalsVisibleTo; a pure
+/// function, so no DB and no mocks.
+/// <para>
+/// These exist because the equivalent assertions could not be made through the EF export tests. SQLite hands
+/// back <c>DocumentExtractedField</c> child rows in primary-key order <c>(DocumentId, FieldDefinitionId, Order)</c>,
+/// which is already ascending by <c>Order</c> — so the integration test that claims to prove the multi-value
+/// join "never relies on the DB's return order" stayed green with the sort deleted. Here the input sequence is
+/// the test's to choose, so the sort is genuinely pinned.
+/// </para>
+/// </summary>
+public class ExportCellRenderer_Tests
+{
+    [Fact]
+    public void Renders_a_multi_value_field_ascending_by_Order_whatever_order_the_rows_arrive_in()
+    {
+        // Deliberately 2, 0, 1 — the sequence a caller could receive from an unordered child subquery.
+        var values = new List<ExtractedFieldProjection>
+        {
+            new() { Order = 2, TextValue = "2026" },
+            new() { Order = 0, TextValue = "urgent" },
+            new() { Order = 1, TextValue = "legal" },
+        };
+
+        ExportCellRenderer.RenderCell(values, FieldDataType.Text).ShouldBe("urgent; legal; 2026");
+    }
+
+    [Fact]
+    public void Renders_a_single_value_field_as_the_bare_value_with_no_separator()
+    {
+        var values = new List<ExtractedFieldProjection> { new() { Order = 0, TextValue = "sole" } };
+
+        ExportCellRenderer.RenderCell(values, FieldDataType.Text).ShouldBe("sole");
+    }
+
+    [Fact]
+    public void Renders_no_values_as_an_empty_cell()
+    {
+        ExportCellRenderer.RenderCell(Array.Empty<ExtractedFieldProjection>(), FieldDataType.Text).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Skips_a_row_whose_typed_column_for_this_data_type_is_null()
+    {
+        // A row carrying no value for the declared type contributes nothing — and must not leave a stray
+        // separator behind.
+        var values = new List<ExtractedFieldProjection>
+        {
+            new() { Order = 0, TextValue = "kept" },
+            new() { Order = 1, TextValue = null },
+        };
+
+        ExportCellRenderer.RenderCell(values, FieldDataType.Text).ShouldBe("kept");
+    }
+
+    [Fact]
+    public void Renders_each_data_type_in_its_canonical_shape()
+    {
+        // ExtractedFieldProjection is internal, so rows are built inline rather than passed as theory data —
+        // an internal type may not appear in a public test method's signature.
+        Render(new() { TextValue = "hello" }, FieldDataType.Text).ShouldBe("hello");
+        Render(new() { LongTextValue = "body" }, FieldDataType.LongText).ShouldBe("body");
+
+        // Minimal shape: no six trailing zeros from decimal(38,6).
+        Render(new() { NumberValue = 1000m }, FieldDataType.Number).ShouldBe("1000");
+        Render(new() { NumberValue = 10.50m }, FieldDataType.Number).ShouldBe("10.5");
+
+        Render(new() { BooleanValue = true }, FieldDataType.Boolean).ShouldBe("true");
+        Render(new() { BooleanValue = false }, FieldDataType.Boolean).ShouldBe("false");
+
+        Render(new() { DateValue = new DateOnly(2026, 3, 4) }, FieldDataType.Date).ShouldBe("2026-03-04");
+        Render(new() { DateTimeValue = new DateTime(2026, 3, 4, 5, 6, 7) }, FieldDataType.DateTime)
+            .ShouldBe("2026-03-04T05:06:07");
+    }
+
+    private static string? Render(ExtractedFieldProjection row, FieldDataType dataType)
+        => ExportCellRenderer.RenderCell(new[] { row }, dataType);
+
+    [Fact]
+    public void Loud_fails_on_a_data_type_it_does_not_know_rather_than_exporting_an_empty_cell()
+    {
+        // A new FieldDataType member that misses the switch must break loudly. A silently empty cell in a file
+        // handed to an accountant is worse than an error.
+        var values = new[] { new ExtractedFieldProjection { TextValue = "x" } };
+
+        Should.Throw<ArgumentOutOfRangeException>(() => ExportCellRenderer.RenderCell(values, (FieldDataType)99));
+    }
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportAppService_Filter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportAppService_Filter_Tests.cs
@@ -176,6 +176,55 @@ public class DocumentExportAppService_Filter_Tests : VaultExtractEntityFramework
         csv.ShouldNotContain("300");
     }
 
+    [Fact]
+    public async Task Field_filter_resolution_falls_back_to_the_repository_when_the_preloaded_cache_misses()
+    {
+        // #501 item 4: the export hands its already-loaded field definitions to DocumentFieldQueryResolver so a
+        // filtered name costs no extra round-trip. The cache is matched with StringComparison.Ordinal; the
+        // repository compares in SQL, where the column collation decides — SQL Server's default is
+        // case-INsensitive. Loud-failing on an ordinal miss would therefore reject a name the database, and the
+        // list path that has no cache, still accept: a fresh file-vs-screen divergence, which is the one thing
+        // #501 item 1 exists to prevent. Only the database gets to say a field does not exist.
+        //
+        // An empty cache stands in for the miss, because SQLite cannot be made case-insensitive here. Delete the
+        // `?? await fieldDefinitionRepository.FindByNameAsync(...)` fallback and this reddens.
+        await WithUnitOfWorkAsync(SeedSchemaAsync);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var queries = await DocumentFieldQueryResolver.ResolveAsync(
+                _fieldDefinitionRepository,
+                new List<DocumentFieldFilter> { new() { Name = "amount", Value = "100" } },
+                TypeId,
+                TypeCode,
+                knownDefinitions: new List<FieldDefinition>());
+
+            queries.ShouldHaveSingleItem().FieldDefinitionId.ShouldBe(AmountFieldId);
+        });
+    }
+
+    [Fact]
+    public async Task Field_filter_resolution_uses_the_preloaded_definition_when_it_hits()
+    {
+        // The hit path must resolve to the same FieldDefinitionId the repository would have returned — the cache
+        // is an optimisation, never a second source of truth.
+        await WithUnitOfWorkAsync(SeedSchemaAsync);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var definitions = await _fieldDefinitionRepository.GetListAsync(TypeId);
+
+            var queries = await DocumentFieldQueryResolver.ResolveAsync(
+                _fieldDefinitionRepository,
+                new List<DocumentFieldFilter> { new() { Name = "amount", Value = "100" } },
+                TypeId,
+                TypeCode,
+                knownDefinitions: definitions);
+
+            queries.ShouldHaveSingleItem().FieldDefinitionId.ShouldBe(AmountFieldId);
+        });
+    }
+
     private static ExportDocumentsInput NewInput(Action<ExportDocumentsInput>? configure = null)
     {
         var input = new ExportDocumentsInput { DocumentTypeCode = TypeCode };

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportListParity_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportListParity_Tests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.Cabinets;
+using Dignite.Vault.Extract.Documents.Exports;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp.Application.Dtos;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents.Exports;
+
+/// <summary>
+/// <c>DocumentAppService</c> resolves a blob container and a background-job manager it never reaches on the read
+/// path; the export service needs neither. Substituting both is what lets one test class drive the list and the
+/// export against the same SQLite database, which is the point.
+/// </summary>
+[DependsOn(typeof(VaultExtractEntityFrameworkCoreTestModule))]
+public class DocumentExportListParityTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// #501 item 1 + item 5: "the file is the view" is a claim about the <b>server</b>, and this is where it is
+/// held. <c>DocumentAppService</c> and <c>DocumentExportAppService</c> used to hand-write the same metadata
+/// predicates independently; #500's round-trip guard lives in TypeScript and compares filter <b>key names</b>,
+/// so it stays green while the two predicate chains mean different things. These tests compare what the two
+/// services actually <b>select</b> and in what <b>order</b>, which is the property the operator experiences.
+/// <para>
+/// Re-inline a predicate in either service and change it — <c>CabinetId</c> to include child cabinets is the
+/// example #501 gives — and the parity test below reddens. That is the whole job: the shared
+/// <c>DocumentQueries.ApplyMetadataFilter</c> chain makes the drift impossible, and this pins the behaviour so
+/// a future refactor cannot quietly undo it.
+/// </para>
+/// </summary>
+public class DocumentExportListParity_Tests : VaultExtractTestBase<DocumentExportListParityTestModule>
+{
+    private const string TypeCode = "invoice.general";
+
+    private static readonly Guid TypeId = new("00000000-0000-0000-0000-0000000000ff");
+    private static readonly Guid CabinetId = new("00000000-0000-0000-0000-0000000000c1");
+
+    // Ids chosen so that descending-Id order (C, B, A) differs from the insertion order (B, A, C). Without a
+    // tiebreaker the list returns whatever the database volunteers — in practice insertion order — while the
+    // export has always ordered by Id. On a CreationTime tie the two therefore disagree.
+    private static readonly Guid IdA = new("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid IdB = new("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid IdC = new("33333333-3333-3333-3333-333333333333");
+
+    private static readonly DateTime SharedCreationTime = new(2026, 3, 4, 5, 6, 7, DateTimeKind.Unspecified);
+
+    private readonly IDocumentAppService _documentAppService;
+    private readonly IDocumentExportAppService _exportAppService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly ICabinetRepository _cabinetRepository;
+
+    public DocumentExportListParity_Tests()
+    {
+        _documentAppService = GetRequiredService<IDocumentAppService>();
+        _exportAppService = GetRequiredService<IDocumentExportAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _cabinetRepository = GetRequiredService<ICabinetRepository>();
+    }
+
+    [Fact]
+    public async Task List_and_export_agree_on_row_order_when_creation_times_tie()
+    {
+        // #501 item 5. CreationTime ties are ordinary for a batch upload; ApplySorting had no tiebreaker in any
+        // branch, so the screen's order was database-determined while the file's was Id descending.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAsync();
+            await SeedAsync(IdB, "Doc B");
+            await SeedAsync(IdA, "Doc A");
+            await SeedAsync(IdC, "Doc C");
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            // Guard the premise: if ABP's audit interceptor had overwritten the seeded CreationTime, every row
+            // would carry a distinct Clock.Now and this test would prove nothing about ties.
+            var seeded = await _documentRepository.GetListAsync();
+            seeded.Select(d => d.CreationTime).Distinct().Count()
+                .ShouldBe(1, "the three documents must share one CreationTime for this to exercise the tiebreaker");
+        });
+
+        var listTitles = await ListTitlesAsync(new GetDocumentListInput { DocumentTypeCode = TypeCode });
+        var exportTitles = await ExportTitlesAsync(new ExportDocumentsInput { DocumentTypeCode = TypeCode });
+
+        listTitles.Count.ShouldBe(3);
+        exportTitles.ShouldBe(listTitles);
+    }
+
+    [Fact]
+    public async Task List_and_export_agree_on_row_order_when_creation_times_tie_under_ascending_sort()
+    {
+        // The ascending branch of ApplySorting needs the mirrored tiebreaker, not just the default branch.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAsync();
+            await SeedAsync(IdB, "Doc B");
+            await SeedAsync(IdA, "Doc A");
+            await SeedAsync(IdC, "Doc C");
+        });
+
+        var ascending = await ListTitlesAsync(
+            new GetDocumentListInput { DocumentTypeCode = TypeCode, Sorting = "creationTime asc" });
+        var descending = await ListTitlesAsync(
+            new GetDocumentListInput { DocumentTypeCode = TypeCode, Sorting = "creationTime desc" });
+
+        // A total order both ways: reversing the sort reverses the rows exactly.
+        ascending.ShouldBe(descending.AsEnumerable().Reverse().ToList());
+    }
+
+    [Theory]
+    [InlineData(nameof(DocumentLifecycleStatus))]
+    [InlineData(nameof(CabinetId))]
+    [InlineData("OriginDocumentId")]
+    [InlineData("HasReviewReasons")]
+    public async Task List_and_export_select_the_same_documents_for_a_shared_filter(string filter)
+    {
+        var containerId = Guid.NewGuid();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAsync();
+            await _cabinetRepository.InsertAsync(new Cabinet(CabinetId, null, "Filed"), autoSave: true);
+
+            // "Plain" matches no filter below; each of the others matches exactly one.
+            await SeedAsync(Guid.NewGuid(), "Plain");
+            await SeedAsync(Guid.NewGuid(), "Failed", configure: d =>
+                typeof(Document).GetProperty(nameof(Document.LifecycleStatus))!
+                    .SetValue(d, DocumentLifecycleStatus.Failed));
+            await SeedAsync(Guid.NewGuid(), "Filed", configure: d => d.SetCabinet(CabinetId));
+            await SeedAsync(Guid.NewGuid(), "Queued", configure: d =>
+                d.SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: true));
+
+            await SeedAsync(containerId, "Container");
+            await SeedDerivedAsync(Guid.NewGuid(), containerId, "Child");
+        });
+
+        var (listInput, exportInput) = filter switch
+        {
+            nameof(DocumentLifecycleStatus) => (
+                new GetDocumentListInput { LifecycleStatus = DocumentLifecycleStatus.Failed },
+                new ExportDocumentsInput { LifecycleStatus = DocumentLifecycleStatus.Failed }),
+            nameof(CabinetId) => (
+                new GetDocumentListInput { CabinetId = CabinetId },
+                new ExportDocumentsInput { CabinetId = CabinetId }),
+            "OriginDocumentId" => (
+                new GetDocumentListInput { OriginDocumentId = containerId },
+                new ExportDocumentsInput { OriginDocumentId = containerId }),
+            _ => (
+                new GetDocumentListInput { HasReviewReasons = true },
+                new ExportDocumentsInput { HasReviewReasons = true }),
+        };
+
+        listInput.DocumentTypeCode = TypeCode;
+        exportInput.DocumentTypeCode = TypeCode;
+
+        var listTitles = await ListTitlesAsync(listInput);
+        var exportTitles = await ExportTitlesAsync(exportInput);
+
+        // Non-empty, so a filter that accidentally matches nothing cannot pass by vacuous agreement.
+        listTitles.ShouldNotBeEmpty();
+        exportTitles.ShouldBe(listTitles);
+    }
+
+    [Fact]
+    public async Task Export_never_reaches_a_soft_deleted_document()
+    {
+        // Deliberately NOT parity: the list can open DataFilter.Disable<ISoftDelete>() for the recycle bin, the
+        // export never does. #501 verified this as fail-closed and it must stay that way — a deleted document
+        // may not leave through a file.
+        var deletedId = Guid.NewGuid();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAsync();
+            await SeedAsync(deletedId, "Deleted");
+            await SeedAsync(Guid.NewGuid(), "Live");
+        });
+
+        await WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(deletedId, autoSave: true));
+
+        var exportTitles = await ExportTitlesAsync(new ExportDocumentsInput { DocumentTypeCode = TypeCode });
+
+        exportTitles.ShouldBe(new[] { "Live" });
+    }
+
+    private async Task<List<string?>> ListTitlesAsync(GetDocumentListInput input)
+    {
+        PagedResultDto<DocumentListItemDto> page = null!;
+        await WithUnitOfWorkAsync(async () => page = await _documentAppService.GetListAsync(input));
+        return page.Items.Select(i => i.Title).ToList();
+    }
+
+    private async Task<List<string?>> ExportTitlesAsync(ExportDocumentsInput input)
+    {
+        string csv = null!;
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var content = await _exportAppService.ExportAsync(input);
+            using var reader = new StreamReader(content.GetStream());
+            csv = await reader.ReadToEndAsync();
+        });
+
+        // Column 3 is the fixed Title system column. Seeded titles contain no comma, so no unquoting is needed.
+        return csv
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Skip(1)
+            .Select(line => (string?)line.TrimEnd('\r').Split(',')[3])
+            .ToList();
+    }
+
+    private Task SeedTypeAsync() =>
+        _documentTypeRepository.InsertAsync(new DocumentType(TypeId, null, TypeCode, "Invoice"), autoSave: true);
+
+    private Task SeedAsync(Guid id, string title, Action<Document>? configure = null) =>
+        PersistAsync(new Document(id, tenantId: null, NewFileOrigin(id)), title, configure);
+
+    private Task SeedDerivedAsync(Guid id, Guid originDocumentId, string title) =>
+        PersistAsync(
+            Document.CreateDerived(id, tenantId: null, fileOrigin: null, originDocumentId, originConstituentKey: "seg-1"),
+            title, configure: null);
+
+    private Task PersistAsync(Document document, string title, Action<Document>? configure)
+    {
+        // DocumentTypeId / Title / LifecycleStatus have private setters; tests reflect to simulate a classified,
+        // titled document. CreationTime is pinned so every seeded row ties: ABP's audit interceptor only fills it
+        // when it is still default.
+        typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(document, TypeId);
+        typeof(Document).GetProperty(nameof(Document.Title))!.SetValue(document, title);
+        typeof(Document).GetProperty(nameof(Document.CreationTime))!.SetValue(document, SharedCreationTime);
+
+        configure?.Invoke(document);
+
+        return _documentRepository.InsertAsync(document, autoSave: true);
+    }
+
+    private static FileOrigin NewFileOrigin(Guid documentId) => new(
+        blobName: $"blobs/{documentId:N}.pdf",
+        uploadedByUserName: "test-user",
+        contentType: "application/pdf",
+        contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+        fileSize: 1024,
+        originalFileName: "invoice.pdf");
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExport_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExport_Tests.cs
@@ -256,6 +256,127 @@ public class DocumentExport_Tests : VaultExtractEntityFrameworkCoreTestBase
     }
 
     [Fact]
+    public async Task Export_fails_fast_when_the_type_declares_more_fields_than_the_column_cap()
+    {
+        // #501 item 2: #499 derived the columns from the type's live fields and deleted the template layer that
+        // used to cap them at 100, leaving rows bounded and columns unbounded. Three fields, cap of two.
+        var originalMax = DocumentExportConsts.MaxColumnCount;
+        DocumentExportConsts.MaxColumnCount = 2;
+        try
+        {
+            var typeId = _guidGenerator.Create();
+            await WithUnitOfWorkAsync(async () =>
+            {
+                await SeedTypeAsync(typeId);
+                await SeedFieldAsync(_guidGenerator.Create(), typeId, "a", "A", FieldDataType.Text, displayOrder: 0);
+                await SeedFieldAsync(_guidGenerator.Create(), typeId, "b", "B", FieldDataType.Text, displayOrder: 1);
+                await SeedFieldAsync(_guidGenerator.Create(), typeId, "c", "C", FieldDataType.Text, displayOrder: 2);
+            });
+
+            await WithUnitOfWorkAsync(async () =>
+            {
+                var ex = await Should.ThrowAsync<BusinessException>(() => _appService.ExportAsync(NewInput()));
+                ex.Code.ShouldBe(VaultExtractErrorCodes.Export.ColumnLimitExceeded);
+            });
+        }
+        finally
+        {
+            DocumentExportConsts.MaxColumnCount = originalMax;
+        }
+    }
+
+    [Fact]
+    public async Task Export_allows_a_type_declaring_exactly_the_column_cap()
+    {
+        // The bound is inclusive. Pinned separately because an off-by-one here rejects a legal export, and the
+        // fail-fast test above passes either way.
+        var originalMax = DocumentExportConsts.MaxColumnCount;
+        DocumentExportConsts.MaxColumnCount = 2;
+        try
+        {
+            var typeId = _guidGenerator.Create();
+            await WithUnitOfWorkAsync(async () =>
+            {
+                await SeedTypeAsync(typeId);
+                await SeedFieldAsync(_guidGenerator.Create(), typeId, "a", "A", FieldDataType.Text, displayOrder: 0);
+                await SeedFieldAsync(_guidGenerator.Create(), typeId, "b", "B", FieldDataType.Text, displayOrder: 1);
+            });
+
+            var csv = await ExportCsvAsync();
+
+            // The four fixed system columns do not count against the cap; only the type-bound fields do.
+            csv.ShouldContain("LifecycleStatus,ReviewStatus,ReviewReasons,Title,A,B");
+        }
+        finally
+        {
+            DocumentExportConsts.MaxColumnCount = originalMax;
+        }
+    }
+
+    [Fact]
+    public async Task Export_keeps_each_fields_values_in_its_own_column()
+    {
+        // #501 item 3 replaced the per-cell rescan of every value the document holds with one ILookup per row.
+        // A bucket keyed or sorted wrongly would smear one field's values into another's column, or lose the
+        // ascending-Order join that Export_renders_a_multi_value_field_as_an_ordered_join pins.
+        var typeId = _guidGenerator.Create();
+        var tagsFieldId = _guidGenerator.Create();
+        var amountFieldId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAsync(typeId);
+            await _fieldDefinitionRepository.InsertAsync(
+                new FieldDefinition(tagsFieldId, null, typeId, "tags", "Tags", "extract",
+                    FieldDataType.Text, displayOrder: 0, allowMultiple: true),
+                autoSave: true);
+            await SeedFieldAsync(amountFieldId, typeId, "amount", "Amount", FieldDataType.Text, displayOrder: 1);
+
+            await _documentRepository.InsertAsync(
+                CreateDocument(_guidGenerator.Create(), typeId, "Doc X", new[]
+                {
+                    new DocumentFieldValue(amountFieldId, FieldDataType.Text, Json("42"), 0),
+                    new DocumentFieldValue(tagsFieldId, FieldDataType.Text, Json("beta"), 1),
+                    new DocumentFieldValue(tagsFieldId, FieldDataType.Text, Json("alpha"), 0),
+                }),
+                autoSave: true);
+        });
+
+        var csv = await ExportCsvAsync();
+
+        // Tags joins its own two rows in Order; Amount carries only its own value, never a neighbour's.
+        csv.ShouldContain("Doc X,alpha; beta,42");
+    }
+
+    [Fact]
+    public async Task Export_leaves_an_empty_cell_for_a_field_the_document_has_no_value_for()
+    {
+        // The ILookup indexer must yield an empty bucket (not throw, not borrow another field's rows) for a field
+        // this document never had extracted.
+        var typeId = _guidGenerator.Create();
+        var amountFieldId = _guidGenerator.Create();
+        var missingFieldId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAsync(typeId);
+            await SeedFieldAsync(amountFieldId, typeId, "amount", "Amount", FieldDataType.Text, displayOrder: 0);
+            await SeedFieldAsync(missingFieldId, typeId, "absent", "Absent", FieldDataType.Text, displayOrder: 1);
+
+            await _documentRepository.InsertAsync(
+                CreateDocument(_guidGenerator.Create(), typeId, "Doc Y", new[]
+                {
+                    new DocumentFieldValue(amountFieldId, FieldDataType.Text, Json("7"), 0),
+                }),
+                autoSave: true);
+        });
+
+        var csv = await ExportCsvAsync();
+
+        csv.ShouldContain("Doc Y,7,");
+    }
+
+    [Fact]
     public async Task Export_loud_fails_on_an_unknown_document_type_rather_than_emitting_an_empty_file()
     {
         // A header-only CSV would be a silent lie about what the layer contains. The list may legitimately show an

--- a/docs/en/egress/data-download.md
+++ b/docs/en/egress/data-download.md
@@ -13,7 +13,8 @@ POST /api/vault-extract/documents/export
   { documentTypeCode, format, …the document list's filters }
         │
         │  ambient IMultiTenant filter; narrowed to documentTypeCode
-        │  matched rows > MaxExportDocumentCount ? → fail (Extract:ExportDocumentLimitExceeded)
+        │  type's live fields > MaxColumnCount ?    → fail (Extract:ExportColumnLimitExceeded)
+        │  matched rows > MaxExportDocumentCount ?  → fail (Extract:ExportDocumentLimitExceeded)
         ▼
   4 fixed system columns + one column per live FieldDefinition of that type (DisplayOrder, Name)
         │
@@ -32,7 +33,9 @@ There is **no saved column projection.** #499 deleted the export-template layer:
 
 ### Scope
 
-The export takes exactly the filters the operator document list can express — lifecycle status, cabinet, creation-time range, needs-review, sub-documents of a source, and extracted-field-value filters — so the file is the view. `documentTypeCode` is **required**: extracted fields are type-scoped, and the columns *are* that type's field definitions, so a mixed-type view has nothing to emit. An unknown type code fails loudly rather than returning a header-only file.
+The export takes the filters the operator document list can express — lifecycle status, cabinet, needs-review, sub-documents of a source, and extracted-field-value filters — so the file is the view. It also accepts a creation-time range, which the list contract does not yet expose. `documentTypeCode` is **required**: extracted fields are type-scoped, and the columns *are* that type's field definitions, so a mixed-type view has nothing to emit. An unknown type code fails loudly rather than returning a header-only file.
+
+"The file is the view" is enforced on the server, not by convention: both services narrow through the one shared `DocumentQueries.ApplyMetadataFilter` chain and order through the one shared `DocumentQueries.OrderByCreationTime` (`CreationTime` descending, `Id` as tiebreaker, so a batch upload's ties do not reshuffle between the screen and the file). Neither service hand-writes a predicate of its own. The soft-delete recycle bin is the one deliberate asymmetry: the list can open it, the export never does, so a deleted document cannot leave through a file.
 
 ## Formats
 
@@ -52,6 +55,7 @@ JSON file export is intentionally **not** offered — programmatic consumers sho
 
 - **Tenant isolation** is enforced by ABP's ambient `IMultiTenant` global filter on the `Documents` query, per the `CLAUDE.md` security conventions.
 - **Per-export document cap** (`DocumentExportConsts.MaxExportDocumentCount`, default 10000): if the filters match more rows than the cap, the export **fails** (`Extract:ExportDocumentLimitExceeded`) rather than silently truncating — for accounting data, dropping vouchers is more dangerous than an error. Narrow the filter.
+- **Per-export column cap** (`DocumentExportConsts.MaxColumnCount`, default 100): if the requested type declares more live field definitions than the cap, the export **fails** (`Extract:ExportColumnLimitExceeded`). The file is built synchronously and held in memory as one cell per (row, column), so the columns are bounded like the rows. The four fixed system columns do not count against it. Archive the fields the type no longer needs.
 - **Permission**: `VaultExtract.Documents.Export`. (The old `VaultExtract.Documents.Templates.*` keys were removed with the template layer; grants naming them are inert.)
 
 ## Example: composing a freee-style import CSV


### PR DESCRIPTION
Implements #501 items 1–5. Items 6–8 stay open on the issue (see "Not in this PR" below), so this deliberately avoids a closing keyword.

## What changed

**Item 1 — the "file is the view" invariant now has server-side enforcement.**
`DocumentAppService.ApplyFilter` and `DocumentExportAppService.ExportAsync` hand-wrote the same four metadata predicates independently, and had already drifted. #500's `LIST_FILTERS_ROUND_TRIP` guard is a client-side, key-name check — it stays green while the two predicate chains mean different things. Both now narrow through one shared `DocumentQueries.ApplyMetadataFilter` chain in Domain, next to the `DocumentReviewQueries` expression they already shared.

The filter shape is deliberately wider than either DTO: each caller fills the knobs its own contract exposes and leaves the rest null. That single-sources the *semantics* of every predicate without forcing the two contracts to expose the same knobs, so no DTO changed and **no proxy regeneration is needed**.

Soft-delete stays out of the shared chain: the list can open `DataFilter.Disable<ISoftDelete>()` for the recycle bin, the export never does. #501 verified that as fail-closed, and there is now a test pinning it.

**Item 5 — the row-order tiebreaker.** `ApplySorting` had none in any branch, while the export ordered by `(CreationTime desc, Id desc)`. On a `CreationTime` tie — ordinary for a batch upload — the screen's order was database-determined and the file's was not. Both now order through `DocumentQueries.OrderByCreationTime`.

**Item 3 — the per-cell rescan.** `GetExtractedValue` did `Where(...).OrderBy(...)` over every value the document holds, once per (row, column). One `ToLookup` per row makes each cell an O(1) bucket lookup.

**Item 4 — the redundant round-trips**, with one correction to the issue's framing. Removing them is *not* free. The cache is matched with `StringComparison.Ordinal`; `FindByNameAsync` compares in SQL, where the column's collation decides, and SQL Server's default is case-**in**sensitive. Loud-failing on an ordinal miss would reject a field name the database — and the list path, which has no cache — still accepts: a fresh file-vs-screen divergence, which is the one thing item 1 exists to prevent. So the cache is a fast path and **a miss still falls back to the repository**. Only the database gets to say a field does not exist.

**Item 2 — the column ceiling.** Restored as `DocumentExportConsts.MaxColumnCount` (default 100, carried over from the deleted `ExportTemplateConsts`, host-overridable), with `Extract:ExportColumnLimitExceeded` and four-language localization. Symmetric with the row cap. The four fixed system columns do not count against it.

## A hollow guard found on the way

Cell rendering moved to an internal `ExportCellRenderer`. It had to. `Export_renders_a_multi_value_field_as_an_ordered_join` claims to prove the join "never relies on the DB's return order" — it inserts rows 2, 0, 1 and asserts the join. **It passes with the `OrderBy(f => f.Order)` deleted.** SQLite returns `DocumentExtractedField` child rows in primary-key order `(DocumentId, FieldDefinitionId, Order)`, which is already ascending by `Order`, so no test going through EF can distinguish. The sort is now pinned by a unit test over an input sequence the test chooses.

## Tests

Every guard here was mutation-tested — each fix was reverted and the test that claims to hold it was watched redden:

| Reverted | Reddens |
|---|---|
| list tiebreaker | both ordering-parity tests |
| export drops `HasReviewReasons` | exactly the `HasReviewReasons` parity case |
| column guard | `Export_fails_fast_when_the_type_declares_more_fields_than_the_column_cap` |
| resolver's repository fallback | `Field_filter_resolution_falls_back_to_the_repository_when_the_preloaded_cache_misses` |
| `OrderBy(f => f.Order)` | `Renders_a_multi_value_field_ascending_by_Order_whatever_order_the_rows_arrive_in` |

Full solution suite green: 1158 tests, 12 projects.

## Not in this PR

- **Item 6** (separator `"; "` vs `", "`) and **item 8** (the third copy of the `FieldDataType` switch) — the issue allows these as a single cleanup PR. `ExportCellRenderer` now gives the switch one home on the export side, which is the setup for item 8's real fix.
- **Item 7** (`generate-proxy.json` still describes the deleted controller) — a deploy-time chore needing a live host, and regenerating would sweep in the uncommitted #444/#447 regen. No contract changed here, so it stays independent.

No egress contract change, per #501's acceptance note.
