### PR TITLE
refactor(data-download): unify the multi-value separator, give the FieldDataType switch one home (#501 items 6, 8)

### DIFF
--- a/angular/packages/vault-extract/documents/src/lib/documents/document-list/export-current-view.spec.ts
+++ b/angular/packages/vault-extract/documents/src/lib/documents/document-list/export-current-view.spec.ts
@@ -46,7 +46,13 @@ describe('toExportDocumentsInput', () => {
     // DocumentListFilter reaches the export with no edit here. This pins that, since no type can.
     const withFutureKey = { creationTimeMin: '2026-01-01' } as unknown as DocumentListFilter;
 
-    const input = toExportDocumentsInput(TYPE, ExportFormat.Csv, withFutureKey) as Record<string, unknown>;
+    // Widen through `unknown` first: ExportDocumentsInput has no string index signature, so the direct
+    // assertion is a TS2352 compile error. That error made the whole `nx test vault-extract` target fail to
+    // build, and CI only runs `nx run-many -t lint`, so nothing said so.
+    const input = toExportDocumentsInput(TYPE, ExportFormat.Csv, withFutureKey) as unknown as Record<
+      string,
+      unknown
+    >;
 
     expect(input['creationTimeMin']).toBe('2026-01-01');
   });

--- a/angular/packages/vault-extract/documents/src/lib/shared/format-field-value.spec.ts
+++ b/angular/packages/vault-extract/documents/src/lib/shared/format-field-value.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { MULTI_VALUE_SEPARATOR, formatExtractedFieldValue } from './format-field-value';
+
+// #501 item 6: the screen and the exported file must render a multi-value field identically. The server-side
+// half of this pair is ExportCellRenderer.MultiValueSeparator, pinned by ExportCellRenderer_Tests. The constant
+// cannot cross the language boundary, so each side names the literal and these two tests hold them in step.
+describe('formatExtractedFieldValue', () => {
+  it('joins a multi-value field with the same separator the exported file uses', () => {
+    expect(formatExtractedFieldValue(['alpha', 'beta', 'gamma'])).toBe('alpha; beta; gamma');
+  });
+
+  it('pins the separator literal, which must equal ExportCellRenderer.MultiValueSeparator', () => {
+    // Not a comma: a comma is the CSV delimiter, so the writer would quote the cell and a consumer re-splitting
+    // it on commas would shred one field across several columns.
+    expect(MULTI_VALUE_SEPARATOR).toBe('; ');
+  });
+
+  it('renders a single-element array without a trailing separator', () => {
+    expect(formatExtractedFieldValue(['sole'])).toBe('sole');
+  });
+
+  it('renders an empty array as the em dash placeholder', () => {
+    expect(formatExtractedFieldValue([])).toBe('—');
+  });
+
+  it('renders null and undefined as the em dash placeholder', () => {
+    expect(formatExtractedFieldValue(null)).toBe('—');
+    expect(formatExtractedFieldValue(undefined)).toBe('—');
+  });
+
+  it('renders scalars through String()', () => {
+    expect(formatExtractedFieldValue('hello')).toBe('hello');
+    expect(formatExtractedFieldValue(1000.5)).toBe('1000.5');
+    expect(formatExtractedFieldValue(true)).toBe('true');
+  });
+
+  it('never lets an object surface as [object Object]', () => {
+    expect(formatExtractedFieldValue({ a: 1 })).toBe('{"a":1}');
+  });
+});

--- a/angular/packages/vault-extract/documents/src/lib/shared/format-field-value.ts
+++ b/angular/packages/vault-extract/documents/src/lib/shared/format-field-value.ts
@@ -1,16 +1,32 @@
 /**
+ * The separator a multi-value field's values are joined with for display.
+ *
+ * #501 item 6: this is the same separator the server writes into an exported CSV / XLSX cell
+ * (`ExportCellRenderer.MultiValueSeparator`). The screen used to join with `", "` while the file joined with
+ * `"; "`, so the same document's same field read `a, b, c` on screen and `a; b; c` in the file.
+ *
+ * The screen moved, not the file. A comma is the CSV delimiter: the writer would have to quote the cell, and a
+ * consumer re-splitting a quoted cell on commas shreds one field across several columns. The file already has
+ * consumers parsing it, and its bytes are the riskier thing to change.
+ *
+ * The constant cannot be shared across the language boundary. The two sides are held in step by naming the
+ * literal on each: `format-field-value.spec.ts` here, `ExportCellRenderer_Tests` there.
+ */
+export const MULTI_VALUE_SEPARATOR = '; ';
+
+/**
  * Renders an `ExtractedFields` value for display. Shared by the document list and detail views so
  * the two cannot drift (#212): multi-value fields arrive as JSON arrays, and a stray object must
  * never surface as `[object Object]`.
  * - null / undefined → "—"
- * - array → elements joined with ", " (empty array → "—")
+ * - array → elements joined with `MULTI_VALUE_SEPARATOR` (empty array → "—")
  * - object → JSON
  * - scalar → String(value)
  */
 export function formatExtractedFieldValue(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (Array.isArray(value)) {
-    return value.length > 0 ? value.map(v => String(v)).join(', ') : '—';
+    return value.length > 0 ? value.map(v => String(v)).join(MULTI_VALUE_SEPARATOR) : '—';
   }
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value);

--- a/angular/packages/vault-extract/project.json
+++ b/angular/packages/vault-extract/project.json
@@ -27,7 +27,8 @@
       "options": {
         "tsConfig": "packages/vault-extract/tsconfig.spec.json",
         "buildTarget": "vault-extract:build",
-        "runner": "vitest"
+        "runner": "vitest",
+        "include": ["**/*.spec.ts", "../documents/**/*.spec.ts", "../config/**/*.spec.ts"]
       }
     },
     "lint": {

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Exports/ExportCellRenderer.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Exports/ExportCellRenderer.cs
@@ -1,13 +1,13 @@
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Dignite.Vault.Extract.Documents.Fields;
 
 namespace Dignite.Vault.Extract.Documents.Exports;
 
 /// <summary>
-/// Renders one document's typed field-value rows into one export cell string.
+/// Joins one document's typed field-value rows into one export cell string. The per-<c>FieldDataType</c>
+/// rendering itself belongs to <see cref="FieldValueFormatter"/> (#501 item 8); what lives here is the
+/// multi-value join, which only the export performs.
 /// <para>
 /// Extracted from <c>DocumentExportAppService</c> so the ascending-<c>Order</c> join can actually be tested.
 /// It could not be, in place: the only tests that could reach it went through SQLite, which returns
@@ -20,6 +20,18 @@ namespace Dignite.Vault.Extract.Documents.Exports;
 internal static class ExportCellRenderer
 {
     /// <summary>
+    /// Joins a multi-value field's rows in one cell.
+    /// <para>
+    /// #501 item 6: the screen joins with this too (<c>formatExtractedFieldValue</c> in
+    /// <c>angular/…/shared/format-field-value.ts</c>). It cannot be a comma. A comma is the CSV delimiter, so the
+    /// writer would have to quote the cell, and a consumer re-splitting a quoted cell on commas shreds one field
+    /// across several columns. The screen moved to the file's separator rather than the reverse, because the file
+    /// already has consumers parsing it and its bytes are the riskier thing to change.
+    /// </para>
+    /// </summary>
+    public const string MultiValueSeparator = "; ";
+
+    /// <summary>
     /// Renders every value row of one field, ascending by <c>Order</c>, joined (#212). A single-value field has
     /// exactly one row, so the result is that value. Yields null — an empty cell — when the field holds no
     /// renderable value.
@@ -30,33 +42,10 @@ internal static class ExportCellRenderer
             // Never relies on the caller's sequence order: DocumentExportAppService buckets rows with ToLookup,
             // which preserves the source order, and that source order is the database's unspecified one.
             .OrderBy(f => f.Order)
-            .Select(f => FieldValueToString(f, dataType))
+            .Select(f => FieldValueFormatter.ToCellString(f, dataType))
             .Where(s => s != null)
             .ToList();
 
         return rendered.Count > 0 ? string.Join(MultiValueSeparator, rendered) : null;
     }
-
-    /// <summary>
-    /// Joins a multi-value field's rows in one cell. Not a comma: the CSV writer would then have to quote the
-    /// cell, and a consumer re-splitting on the delimiter would silently shred one field into several columns.
-    /// </summary>
-    public const string MultiValueSeparator = "; ";
-
-    // Render typed columns to cell strings by field type, using InvariantCulture and matching the canonical shape in DocumentExtractedField.ToJsonElement.
-    // Type comes from FieldDefinition.DataType (#208: not persisted on field value rows). Unknown type loud-fails, consistent with
-    // SetValue / ToJsonElement / ApplyFieldValueFilter. Never silently output an empty cell: if a new enum value misses this branch,
-    // tests / runtime should fail loudly instead of silently exporting wrong data.
-    private static string? FieldValueToString(ExtractedFieldProjection f, FieldDataType dataType) => dataType switch
-    {
-        FieldDataType.Text => f.TextValue,
-        FieldDataType.LongText => f.LongTextValue,
-        // Render Number in minimal shape ("0.######"): integer 1000 -> "1000", decimal 10.50 -> "10.5",
-        // without the six trailing zeros from decimal(38,6).
-        FieldDataType.Number => f.NumberValue?.ToString("0.######", CultureInfo.InvariantCulture),
-        FieldDataType.Boolean => f.BooleanValue == null ? null : (f.BooleanValue.Value ? "true" : "false"),
-        FieldDataType.Date => f.DateValue?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-        FieldDataType.DateTime => f.DateTimeValue?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
-        _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported field data type.")
-    };
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Exports/ExportProjection.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Exports/ExportProjection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Dignite.Vault.Extract.Documents.Fields;
 
 namespace Dignite.Vault.Extract.Documents.Exports;
 
@@ -30,8 +31,17 @@ internal sealed class ExportProjection
     public List<ExtractedFieldProjection> ExtractedFields { get; init; } = new();
 }
 
-/// <summary>Typed projection for one type-bound field value. Export renders the corresponding column cell string by field type (from FieldDefinition.DataType, #208) and matches field columns by <see cref="FieldDefinitionId"/> (#207).</summary>
-internal sealed class ExtractedFieldProjection
+/// <summary>
+/// Typed projection for one type-bound field value. Export renders the corresponding column cell string by field
+/// type (from FieldDefinition.DataType, #208) and matches field columns by <see cref="FieldDefinitionId"/> (#207).
+/// <para>
+/// Implements <see cref="IFieldValueColumns"/> (#501 item 8) so <see cref="FieldValueFormatter"/> renders it
+/// through the same switch it renders the persisted <c>DocumentExtractedField</c> through. This projection exists
+/// so the export never materializes that entity — doing so would pull <c>Markdown</c> into memory and into the
+/// change tracker for thousands of documents — which is why the rendering could not simply be a method on it.
+/// </para>
+/// </summary>
+internal sealed class ExtractedFieldProjection : IFieldValueColumns
 {
     public Guid FieldDefinitionId { get; init; }
 

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/ExtractedFieldValueValidator.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/ExtractedFieldValueValidator.cs
@@ -100,7 +100,10 @@ internal static class ExtractedFieldValueValidator
         return value.ValueKind == JsonValueKind.String &&
                DateTime.TryParseExact(
                    value.GetString(),
-                   "yyyy-MM-dd",
+                   // The same canonical shape DocumentExtractedField.SetValue parses with. This gate and that
+                   // parse must never disagree: a value this accepts and SetValue cannot read throws inside the
+                   // aggregate, past the point where the caller could correct it.
+                   FieldValueFormats.Date,
                    CultureInfo.InvariantCulture,
                    DateTimeStyles.None,
                    out _);

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/FieldFingerprintCalculator.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/FieldFingerprintCalculator.cs
@@ -96,10 +96,12 @@ public static class FieldFingerprintCalculator
     {
         FieldDataType.Text => NormalizeText(row.TextValue),
         FieldDataType.LongText => NormalizeText(row.LongTextValue),
+        // Full precision on purpose, unlike FieldValueFormats.CellNumber: two amounts differing beyond six
+        // decimals must not hash to the same fingerprint.
         FieldDataType.Number => row.NumberValue?.ToString("0.############################", CultureInfo.InvariantCulture),
         FieldDataType.Boolean => row.BooleanValue switch { true => "true", false => "false", null => null },
-        FieldDataType.Date => row.DateValue?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-        FieldDataType.DateTime => row.DateTimeValue?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
+        FieldDataType.Date => row.DateValue?.ToString(FieldValueFormats.Date, CultureInfo.InvariantCulture),
+        FieldDataType.DateTime => row.DateTimeValue?.ToString(FieldValueFormats.DateTime, CultureInfo.InvariantCulture),
         _ => null
     };
 

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Fields/FieldValueFormatter.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Fields/FieldValueFormatter.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Dignite.Vault.Extract.Documents.Fields;
+
+/// <summary>
+/// The one place typed field-value columns are turned back into something a reader can consume: the canonical
+/// JSON scalar of the egress contract, or the display string of an exported cell.
+/// <para>
+/// #501 item 8: these two switches, plus the inverse in <c>DocumentExtractedField.SetValue</c>, used to be three
+/// independent <see cref="FieldDataType"/> switches carrying their own copies of the date format literals — with
+/// a fourth copy in <c>FieldFingerprintCalculator</c>. Adding a <see cref="FieldDataType"/> member meant editing
+/// each, and forgetting one was silent. The literals now live in <see cref="FieldValueFormats"/> and every
+/// reader routes through here; <c>FieldValueFormatter_Tests</c> walks <c>Enum.GetValues&lt;FieldDataType&gt;()</c>
+/// so a new member that misses a branch reddens instead of shipping.
+/// </para>
+/// </summary>
+public static class FieldValueFormatter
+{
+    /// <summary>
+    /// Reconstructs the canonical <see cref="JsonElement"/> scalar for the <c>ExtractedFields</c> dictionary of
+    /// the REST / MCP / DTO egress. The inverse of <c>DocumentExtractedField.SetValue</c>; the two round-trip.
+    /// <para>
+    /// An unknown type loud-fails and never emits an <c>Undefined</c> <see cref="JsonElement"/>: once assembled
+    /// into a DTO, serializing that throws "Cannot write a JsonElement with ValueKind Undefined" and turns the
+    /// whole document read into a 500.
+    /// </para>
+    /// </summary>
+    public static JsonElement ToJsonElement(IFieldValueColumns columns, FieldDataType dataType) => dataType switch
+    {
+        FieldDataType.Text => JsonSerializer.SerializeToElement(columns.TextValue),
+        FieldDataType.LongText => JsonSerializer.SerializeToElement(columns.LongTextValue),
+        FieldDataType.Number => JsonSerializer.SerializeToElement(columns.NumberValue),
+        FieldDataType.Boolean => JsonSerializer.SerializeToElement(columns.BooleanValue),
+        FieldDataType.Date => JsonSerializer.SerializeToElement(
+            columns.DateValue?.ToString(FieldValueFormats.Date, CultureInfo.InvariantCulture)),
+        FieldDataType.DateTime => JsonSerializer.SerializeToElement(
+            columns.DateTimeValue?.ToString(FieldValueFormats.DateTime, CultureInfo.InvariantCulture)),
+        _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported field data type.")
+    };
+
+    /// <summary>
+    /// Renders one value row as the string an exported CSV / XLSX cell carries. Null means "this row holds no
+    /// value for that type" — an empty cell, not the text "null".
+    /// <para>
+    /// Loud-fails on an unknown type for the same reason: a silently empty cell in a file an operator hands to an
+    /// accountant is worse than an error.
+    /// </para>
+    /// </summary>
+    public static string? ToCellString(IFieldValueColumns columns, FieldDataType dataType) => dataType switch
+    {
+        FieldDataType.Text => columns.TextValue,
+        FieldDataType.LongText => columns.LongTextValue,
+        FieldDataType.Number => columns.NumberValue?.ToString(FieldValueFormats.CellNumber, CultureInfo.InvariantCulture),
+        FieldDataType.Boolean => columns.BooleanValue == null ? null : (columns.BooleanValue.Value ? "true" : "false"),
+        FieldDataType.Date => columns.DateValue?.ToString(FieldValueFormats.Date, CultureInfo.InvariantCulture),
+        FieldDataType.DateTime => columns.DateTimeValue?.ToString(FieldValueFormats.DateTime, CultureInfo.InvariantCulture),
+        _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported field data type.")
+    };
+}
+
+/// <summary>
+/// Format strings for rendering typed field-value columns.
+/// <para>
+/// <see cref="Date"/> and <see cref="DateTime"/> are <b>serialized contract</b>, not presentation: they are the
+/// canonical shapes <c>DocumentFieldValue</c> requires on the way in, that the REST / MCP <c>ExtractedFields</c>
+/// dictionary emits on the way out, and that the #411 field fingerprint hashes. Changing either value is a wire
+/// break and a silent re-hash of every stored fingerprint. They are <c>const</c> so a host cannot widen them.
+/// </para>
+/// </summary>
+public static class FieldValueFormats
+{
+    /// <summary>Canonical date shape, in and out. Frozen wire contract.</summary>
+    public const string Date = "yyyy-MM-dd";
+
+    /// <summary>Canonical offset-free date-time shape, in and out. Frozen wire contract.</summary>
+    public const string DateTime = "yyyy-MM-ddTHH:mm:ss";
+
+    /// <summary>
+    /// Minimal shape for a Number in an exported cell: integer 1000 -> "1000", decimal 10.50 -> "10.5", without
+    /// the six trailing zeros of <c>decimal(38,6)</c>. Presentation only — deliberately <b>not</b> the fingerprint's
+    /// number format, which keeps full precision so two values that differ beyond six decimals do not collide.
+    /// </summary>
+    public const string CellNumber = "0.######";
+}

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Fields/IFieldValueColumns.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Fields/IFieldValueColumns.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Dignite.Vault.Extract.Documents.Fields;
+
+/// <summary>
+/// The typed value columns of one field-value row, read-only. Exactly one is non-null, chosen by the owning
+/// <c>FieldDefinition.DataType</c> — the type is not persisted on the row (#208), so every reader must be told
+/// which <see cref="FieldDataType"/> to interpret these by.
+/// <para>
+/// #501 item 8: implemented by the persisted <c>DocumentExtractedField</c> entity <b>and</b> by the export's
+/// non-entity projection, so <see cref="FieldValueFormatter"/> can render either without a second copy of the
+/// <see cref="FieldDataType"/> switch. The projection exists precisely so the export does not load the entity
+/// (it would drag <c>Markdown</c> into memory and into the change tracker), which is why a method on the entity
+/// could not have served both.
+/// </para>
+/// </summary>
+public interface IFieldValueColumns
+{
+    string? TextValue { get; }
+
+    string? LongTextValue { get; }
+
+    bool? BooleanValue { get; }
+
+    decimal? NumberValue { get; }
+
+    DateOnly? DateValue { get; }
+
+    DateTime? DateTimeValue { get; }
+}

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentExtractedField.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentExtractedField.cs
@@ -39,7 +39,7 @@ namespace Dignite.Vault.Extract.Documents;
 /// </list>
 /// </para>
 /// </summary>
-public class DocumentExtractedField : Entity, IMultiTenant
+public class DocumentExtractedField : Entity, IMultiTenant, IFieldValueColumns
 {
     public virtual Guid? TenantId { get; private set; }
 
@@ -114,7 +114,7 @@ public class DocumentExtractedField : Entity, IMultiTenant
                 BooleanValue = element.GetBoolean();
                 break;
             case FieldDataType.Date:
-                DateValue = DateOnly.ParseExact(element.GetString()!, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                DateValue = DateOnly.ParseExact(element.GetString()!, FieldValueFormats.Date, CultureInfo.InvariantCulture);
                 break;
             case FieldDataType.DateTime:
                 DateTimeValue = DateTime.Parse(element.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.None);
@@ -130,20 +130,13 @@ public class DocumentExtractedField : Entity, IMultiTenant
     /// This is the inverse of <see cref="SetValue"/> and round-trips consistently.
     /// <paramref name="dataType"/> is supplied by the caller from the <see cref="FieldDefinition"/> referenced by this row
     /// because type is not persisted on this row (#208).
+    /// <para>
+    /// #501 item 8: the switch itself lives in <see cref="FieldValueFormatter"/>, shared with the export's
+    /// non-entity projection, which reads the same columns and cannot call a method on this entity. Loud-fail on
+    /// an unknown type is preserved there, symmetric with <see cref="SetValue"/>'s default branch.
+    /// </para>
     /// </summary>
-    public JsonElement ToJsonElement(FieldDataType dataType) => dataType switch
-    {
-        FieldDataType.Text => JsonSerializer.SerializeToElement(TextValue),
-        FieldDataType.LongText => JsonSerializer.SerializeToElement(LongTextValue),
-        FieldDataType.Number => JsonSerializer.SerializeToElement(NumberValue),
-        FieldDataType.Boolean => JsonSerializer.SerializeToElement(BooleanValue),
-        FieldDataType.Date => JsonSerializer.SerializeToElement(DateValue?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
-        FieldDataType.DateTime => JsonSerializer.SerializeToElement(DateTimeValue?.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)),
-        // Symmetric with SetValue's default branch: unknown type loud-fails and never emits a toxic Undefined value.
-        // Otherwise, once assembled into a DTO, response serialization would throw
-        // "Cannot write a JsonElement with ValueKind Undefined" and make the whole document read return 500.
-        _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported field data type.")
-    };
+    public JsonElement ToJsonElement(FieldDataType dataType) => FieldValueFormatter.ToJsonElement(this, dataType);
 
     public override object[] GetKeys() => new object[] { DocumentId, FieldDefinitionId, Order };
 }

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentFieldValue.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentFieldValue.cs
@@ -21,7 +21,9 @@ namespace Dignite.Vault.Extract.Documents;
 /// <para>
 /// <paramref name="Value"/> must be a canonical JSON <b>scalar</b> aligned with
 /// <paramref name="DataType"/>: numbers are bare JSON numbers, booleans are true/false, Date is a
-/// <c>"yyyy-MM-dd"</c> string, and DateTime is an offset-free <c>"yyyy-MM-ddThh:mm:ss"</c> string.
+/// <see cref="FieldValueFormats.Date"/> string, and DateTime is an offset-free
+/// <see cref="FieldValueFormats.DateTime"/> string (24-hour <c>HH</c>, not the <c>hh</c> this comment used to
+/// claim — the two format strings differ, and only the former round-trips).
 /// Misaligned values are filtered out / fail loudly in the App layer and never reach this point.
 /// </para>
 /// <para>

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldFingerprintCalculator_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldFingerprintCalculator_Tests.cs
@@ -40,6 +40,56 @@ public class FieldFingerprintCalculator_Tests
     private static DocumentFieldValue Number(Guid id, decimal value) =>
         new(id, FieldDataType.Number, JsonSerializer.SerializeToElement(value));
 
+    /// <summary>One canonical JSON scalar per data type, mirroring <c>FieldValueFormatter_Tests</c>.</summary>
+    private static readonly IReadOnlyDictionary<FieldDataType, string> CanonicalJson =
+        new Dictionary<FieldDataType, string>
+        {
+            [FieldDataType.Text] = "\"INV-001\"",
+            [FieldDataType.LongText] = "\"a longer body\"",
+            [FieldDataType.Number] = "1000.5",
+            [FieldDataType.Boolean] = "true",
+            [FieldDataType.Date] = "\"2026-03-04\"",
+            [FieldDataType.DateTime] = "\"2026-03-04T05:06:07\"",
+        };
+
+    [Fact]
+    public void Every_FieldDataType_member_canonicalizes_into_the_fingerprint()
+    {
+        // #501 item 8 follow-up. Canonicalize is the fourth FieldDataType switch, and the only one that still
+        // defaults SILENTLY (`_ => null`) rather than loud-failing. A null canonical makes Compute return null,
+        // so a new enum member used as a unique key would quietly switch duplicate detection OFF for every
+        // document of that type — a missed duplicate, reported as "no fingerprint", indistinguishable from a
+        // legitimately partial key.
+        //
+        // Left silent on purpose: this runs inside the #411 background-job fingerprint path, where throwing
+        // would rethrow into the retry loop. So the guard is this test rather than a throw. It walks the enum
+        // instead of naming members, so a new one reddens here.
+        foreach (var dataType in Enum.GetValues<FieldDataType>())
+        {
+            var definitionId = Guid.NewGuid();
+            var defs = new[] { Field(definitionId, "key", dataType, isUniqueKey: true) };
+            var values = Values(new DocumentFieldValue(definitionId, dataType, Json(CanonicalJson[dataType])));
+
+            FieldFingerprintCalculator.Compute(values, defs)
+                .ShouldNotBeNull($"{dataType} has no branch in FieldFingerprintCalculator.Canonicalize");
+        }
+    }
+
+    [Fact]
+    public void The_canonical_sample_set_covers_every_FieldDataType_member()
+    {
+        // Guards the guard: without a sample, the walk above would skip the new member instead of failing.
+        var missing = Enum.GetValues<FieldDataType>().Where(t => !CanonicalJson.ContainsKey(t)).ToList();
+
+        missing.ShouldBeEmpty($"add a canonical JSON sample for: {string.Join(", ", missing)}");
+    }
+
+    private static JsonElement Json(string raw)
+    {
+        using var document = JsonDocument.Parse(raw);
+        return document.RootElement.Clone();
+    }
+
     [Fact]
     public void No_Unique_Key_Fields_Returns_Null()
     {

--- a/core/test/Dignite.Vault.Extract.Domain.Tests/Documents/Fields/FieldValueFormatter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Domain.Tests/Documents/Fields/FieldValueFormatter_Tests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.Fields;
+using Shouldly;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Domain.Documents.Fields;
+
+/// <summary>
+/// #501 item 8. Rendering a typed field-value row used to be three independent <see cref="FieldDataType"/>
+/// switches — <c>DocumentExtractedField.SetValue</c> (JSON in), <c>DocumentExtractedField.ToJsonElement</c>
+/// (JSON out), and the export's cell renderer — each with its own copy of the date format literals. Adding an
+/// enum member meant editing all three, and forgetting one was silent: the value would either round-trip to
+/// <c>Undefined</c> (a 500 on the next document read) or land in the file as an empty cell.
+/// <para>
+/// The two read directions now live in <see cref="FieldValueFormatter"/>. These tests walk
+/// <c>Enum.GetValues&lt;FieldDataType&gt;()</c> rather than naming the members, so a new member that misses a
+/// branch reddens here rather than shipping. Add a member and run these before doing anything else.
+/// </para>
+/// </summary>
+public class FieldValueFormatter_Tests
+{
+    /// <summary>One canonical JSON scalar per data type, per the <c>DocumentFieldValue</c> contract.</summary>
+    private static readonly IReadOnlyDictionary<FieldDataType, string> CanonicalJson =
+        new Dictionary<FieldDataType, string>
+        {
+            [FieldDataType.Text] = "\"hello\"",
+            [FieldDataType.LongText] = "\"a longer body\"",
+            [FieldDataType.Number] = "1000.5",
+            [FieldDataType.Boolean] = "true",
+            [FieldDataType.Date] = "\"2026-03-04\"",
+            [FieldDataType.DateTime] = "\"2026-03-04T05:06:07\"",
+        };
+
+    [Fact]
+    public void The_canonical_sample_set_covers_every_FieldDataType_member()
+    {
+        // Guards the guard: a new enum member must be given a sample here, or the tests below would silently
+        // stop covering it instead of failing.
+        var missing = Enum.GetValues<FieldDataType>().Where(t => !CanonicalJson.ContainsKey(t)).ToList();
+
+        missing.ShouldBeEmpty(
+            $"add a canonical JSON sample for: {string.Join(", ", missing)} — then check every FieldDataType switch");
+    }
+
+    [Fact]
+    public void Every_FieldDataType_member_renders_a_cell_string()
+    {
+        foreach (var dataType in Enum.GetValues<FieldDataType>())
+        {
+            var row = RowFor(dataType);
+
+            // Not "does it throw ArgumentOutOfRangeException" only: a branch that returned null for a populated
+            // row would export a silently empty cell, which is the failure this loud-fail exists to prevent.
+            FieldValueFormatter.ToCellString(row, dataType)
+                .ShouldNotBeNull($"{dataType} has no branch in FieldValueFormatter.ToCellString");
+        }
+    }
+
+    [Fact]
+    public void Every_FieldDataType_member_renders_a_defined_json_element()
+    {
+        foreach (var dataType in Enum.GetValues<FieldDataType>())
+        {
+            var element = FieldValueFormatter.ToJsonElement(RowFor(dataType), dataType);
+
+            // Undefined is the toxic value: it serializes as "Cannot write a JsonElement with ValueKind
+            // Undefined" and turns the whole document read into a 500.
+            element.ValueKind.ShouldNotBe(JsonValueKind.Undefined, $"{dataType} emits an Undefined JsonElement");
+            element.ValueKind.ShouldNotBe(JsonValueKind.Null, $"{dataType} lost its value on the way out");
+        }
+    }
+
+    [Fact]
+    public void Every_FieldDataType_member_round_trips_from_canonical_json_and_back()
+    {
+        // The full loop, covering the third switch (DocumentExtractedField.SetValue) too: canonical JSON in via
+        // the aggregate root, canonical JSON out via the formatter. A date literal that drifted between the
+        // parse side and the render side reddens here.
+        foreach (var dataType in Enum.GetValues<FieldDataType>())
+        {
+            var fieldDefinitionId = Guid.NewGuid();
+            var document = NewDocument();
+
+            document.SetFields(new[]
+            {
+                new DocumentFieldValue(fieldDefinitionId, dataType, Json(CanonicalJson[dataType])),
+            });
+
+            var row = document.ExtractedFieldValues.ShouldHaveSingleItem();
+
+            row.ToJsonElement(dataType).GetRawText().ShouldBe(
+                Json(CanonicalJson[dataType]).GetRawText(),
+                $"{dataType} does not round-trip through SetValue -> ToJsonElement");
+        }
+    }
+
+    [Fact]
+    public void An_unknown_data_type_loud_fails_on_both_read_directions()
+    {
+        var row = RowFor(FieldDataType.Text);
+
+        Should.Throw<ArgumentOutOfRangeException>(() => FieldValueFormatter.ToCellString(row, (FieldDataType)99));
+        Should.Throw<ArgumentOutOfRangeException>(() => FieldValueFormatter.ToJsonElement(row, (FieldDataType)99));
+    }
+
+    [Fact]
+    public void The_canonical_date_shapes_are_the_frozen_wire_contract()
+    {
+        // These are not presentation. They are what DocumentFieldValue requires on the way in, what the REST /
+        // MCP ExtractedFields dictionary emits on the way out, and what the #411 fingerprint hashes. Changing
+        // either is a wire break plus a silent re-hash of every stored fingerprint.
+        FieldValueFormats.Date.ShouldBe("yyyy-MM-dd");
+        FieldValueFormats.DateTime.ShouldBe("yyyy-MM-ddTHH:mm:ss");
+    }
+
+    private static Document NewDocument() => new(
+        Guid.NewGuid(),
+        tenantId: null,
+        fileOrigin: new FileOrigin(
+            blobName: "blobs/x.pdf",
+            uploadedByUserName: "test-user",
+            contentType: "application/pdf",
+            contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+            fileSize: 1024,
+            originalFileName: "x.pdf"));
+
+    /// <summary>A row populated in exactly the column <paramref name="dataType"/> reads from.</summary>
+    private static IFieldValueColumns RowFor(FieldDataType dataType)
+    {
+        var document = NewDocument();
+        document.SetFields(new[] { new DocumentFieldValue(Guid.NewGuid(), dataType, Json(CanonicalJson[dataType])) });
+        return document.ExtractedFieldValues.Single();
+    }
+
+    private static JsonElement Json(string raw)
+    {
+        using var document = JsonDocument.Parse(raw);
+        return document.RootElement.Clone();
+    }
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTestData.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTestData.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Dignite.Vault.Extract.Documents;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents;
+
+/// <summary>
+/// Seeding atoms shared by the export test classes (#501 item 8, "related").
+/// <para>
+/// A static class rather than methods on <see cref="VaultExtractEntityFrameworkCoreTestBase"/>, which is where
+/// #501 proposed them: <c>DocumentExportListParity_Tests</c> needs its own ABP module (it substitutes the blob
+/// container so it can drive <c>DocumentAppService</c>), so it derives from
+/// <c>VaultExtractTestBase&lt;TModule&gt;</c> and cannot inherit them. A base class only unifies helpers for
+/// classes that happen to share the base; a static one unifies them for all callers.
+/// </para>
+/// </summary>
+internal static class DocumentTestData
+{
+    /// <summary>Stable id derived from a key, so a test can name the row it seeded without threading a Guid.</summary>
+    public static Guid DeterministicGuid(string key) => new(MD5.HashData(Encoding.UTF8.GetBytes(key)));
+
+    public static FileOrigin NewFileOrigin(Guid documentId, string originalFileName = "invoice.pdf") => new(
+        blobName: $"blobs/{documentId:N}.pdf",
+        uploadedByUserName: "test-user",
+        contentType: "application/pdf",
+        // Unique per call: Document has a ContentHash-based duplicate gate (#411), and two seeded rows sharing a
+        // hash would flag each other as suspected duplicates and change what the review filters select.
+        contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+        fileSize: 1024,
+        originalFileName: originalFileName);
+
+    /// <summary>
+    /// Simulates the post-classification state (#207: the document is associated to its type by the internal
+    /// <c>DocumentTypeId</c>). The setter is private on the aggregate because only the pipeline may classify.
+    /// </summary>
+    public static void MarkClassified(Document document, Guid documentTypeId) =>
+        SetPrivate(document, nameof(Document.DocumentTypeId), documentTypeId);
+
+    /// <summary>Simulates the title extracted from Markdown. <c>Document.SetTitle</c> is internal to Domain.</summary>
+    public static void SetTitle(Document document, string? title) =>
+        SetPrivate(document, nameof(Document.Title), title);
+
+    public static void SetLifecycleStatus(Document document, DocumentLifecycleStatus status) =>
+        SetPrivate(document, nameof(Document.LifecycleStatus), status);
+
+    /// <summary>
+    /// Pins <c>CreationTime</c> so seeded rows can be made to tie. ABP's audit interceptor fills it on insert
+    /// only when it is still <c>default</c>, so a pinned value survives.
+    /// </summary>
+    public static void SetCreationTime(Document document, DateTime creationTime) =>
+        SetPrivate(document, nameof(Document.CreationTime), creationTime);
+
+    private static void SetPrivate(Document document, string propertyName, object? value) =>
+        typeof(Document).GetProperty(propertyName)!.SetValue(document, value);
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportAppService_Filter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportAppService_Filter_Tests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Documents;
@@ -253,7 +251,7 @@ public class DocumentExportAppService_Filter_Tests : VaultExtractEntityFramework
     private Task SeedDocumentAsync(decimal amount, Action<Document>? configure = null, Guid? id = null)
     {
         var documentId = id ?? Guid.NewGuid();
-        var doc = new Document(documentId, _currentTenant.Id, NewFileOrigin(documentId));
+        var doc = new Document(documentId, _currentTenant.Id, DocumentTestData.NewFileOrigin(documentId));
         return PersistAsync(doc, amount, configure);
     }
 
@@ -262,14 +260,14 @@ public class DocumentExportAppService_Filter_Tests : VaultExtractEntityFramework
         var documentId = Guid.NewGuid();
         // A sub-document has no file of its own (#487 reverted FileOrigin to nullable); it is a Markdown slice
         // reached through OriginDocumentId.
-        var doc = Document.CreateDerived(documentId, _currentTenant.Id, fileOrigin: null, originDocumentId, constituentKey);
+        var doc = Document.CreateDerived(
+            documentId, _currentTenant.Id, fileOrigin: null, originDocumentId, originConstituentKey: constituentKey);
         return PersistAsync(doc, amount, configure: null);
     }
 
     private async Task PersistAsync(Document doc, decimal amount, Action<Document>? configure)
     {
-        // DocumentTypeId has a Domain private setter; simulate the classified state (#207 internal relation by Id).
-        typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(doc, TypeId);
+        DocumentTestData.MarkClassified(doc, TypeId);
         doc.SetFields(new[]
         {
             new DocumentFieldValue(AmountFieldId, FieldDataType.Number, JsonSerializer.SerializeToElement(amount)),
@@ -280,15 +278,6 @@ public class DocumentExportAppService_Filter_Tests : VaultExtractEntityFramework
         await _documentRepository.InsertAsync(doc, autoSave: true);
     }
 
-    private static FileOrigin NewFileOrigin(Guid documentId) => new(
-        blobName: $"blobs/{documentId:N}.pdf",
-        uploadedByUserName: "test-user",
-        contentType: "application/pdf",
-        contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
-        fileSize: 1024,
-        originalFileName: "invoice.pdf");
-
-    private static Guid TypeId => DeterministicGuid("type:" + TypeCode);
-    private static Guid AmountFieldId => DeterministicGuid("field:amount");
-    private static Guid DeterministicGuid(string key) => new(MD5.HashData(Encoding.UTF8.GetBytes(key)));
+    private static Guid TypeId => DocumentTestData.DeterministicGuid("type:" + TypeCode);
+    private static Guid AmountFieldId => DocumentTestData.DeterministicGuid("field:amount");
 }

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportListParity_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExportListParity_Tests.cs
@@ -144,8 +144,7 @@ public class DocumentExportListParity_Tests : VaultExtractTestBase<DocumentExpor
             // "Plain" matches no filter below; each of the others matches exactly one.
             await SeedAsync(Guid.NewGuid(), "Plain");
             await SeedAsync(Guid.NewGuid(), "Failed", configure: d =>
-                typeof(Document).GetProperty(nameof(Document.LifecycleStatus))!
-                    .SetValue(d, DocumentLifecycleStatus.Failed));
+                DocumentTestData.SetLifecycleStatus(d, DocumentLifecycleStatus.Failed));
             await SeedAsync(Guid.NewGuid(), "Filed", configure: d => d.SetCabinet(CabinetId));
             await SeedAsync(Guid.NewGuid(), "Queued", configure: d =>
                 d.SetReviewReason(DocumentReviewReasons.MissingRequiredFields, present: true));
@@ -231,7 +230,7 @@ public class DocumentExportListParity_Tests : VaultExtractTestBase<DocumentExpor
         _documentTypeRepository.InsertAsync(new DocumentType(TypeId, null, TypeCode, "Invoice"), autoSave: true);
 
     private Task SeedAsync(Guid id, string title, Action<Document>? configure = null) =>
-        PersistAsync(new Document(id, tenantId: null, NewFileOrigin(id)), title, configure);
+        PersistAsync(new Document(id, tenantId: null, DocumentTestData.NewFileOrigin(id)), title, configure);
 
     private Task SeedDerivedAsync(Guid id, Guid originDocumentId, string title) =>
         PersistAsync(
@@ -240,23 +239,13 @@ public class DocumentExportListParity_Tests : VaultExtractTestBase<DocumentExpor
 
     private Task PersistAsync(Document document, string title, Action<Document>? configure)
     {
-        // DocumentTypeId / Title / LifecycleStatus have private setters; tests reflect to simulate a classified,
-        // titled document. CreationTime is pinned so every seeded row ties: ABP's audit interceptor only fills it
-        // when it is still default.
-        typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(document, TypeId);
-        typeof(Document).GetProperty(nameof(Document.Title))!.SetValue(document, title);
-        typeof(Document).GetProperty(nameof(Document.CreationTime))!.SetValue(document, SharedCreationTime);
+        // Simulate a classified, titled document. CreationTime is pinned so every seeded row ties.
+        DocumentTestData.MarkClassified(document, TypeId);
+        DocumentTestData.SetTitle(document, title);
+        DocumentTestData.SetCreationTime(document, SharedCreationTime);
 
         configure?.Invoke(document);
 
         return _documentRepository.InsertAsync(document, autoSave: true);
     }
-
-    private static FileOrigin NewFileOrigin(Guid documentId) => new(
-        blobName: $"blobs/{documentId:N}.pdf",
-        uploadedByUserName: "test-user",
-        contentType: "application/pdf",
-        contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
-        fileSize: 1024,
-        originalFileName: "invoice.pdf");
 }

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExport_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Exports/DocumentExport_Tests.cs
@@ -450,20 +450,10 @@ public class DocumentExport_Tests : VaultExtractEntityFrameworkCoreTestBase
         IEnumerable<DocumentFieldValue>? fields,
         DocumentReviewReasons reviewReasons = DocumentReviewReasons.None)
     {
-        var document = new Document(
-            id,
-            tenantId: null,
-            fileOrigin: new FileOrigin(
-                blobName: $"blobs/{id:N}.pdf",
-                uploadedByUserName: "test-user",
-                contentType: "application/pdf",
-                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
-                fileSize: 1024,
-                originalFileName: "f.pdf"));
+        var document = new Document(id, tenantId: null, DocumentTestData.NewFileOrigin(id, originalFileName: "f.pdf"));
 
-        // DocumentTypeId / Title have private setters; tests use reflection to simulate "classified + title extracted".
-        typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(document, documentTypeId);
-        typeof(Document).GetProperty(nameof(Document.Title))!.SetValue(document, title);
+        DocumentTestData.MarkClassified(document, documentTypeId);
+        DocumentTestData.SetTitle(document, title);
 
         if (reviewReasons != DocumentReviewReasons.None)
         {

--- a/docs/en/egress/data-download.md
+++ b/docs/en/egress/data-download.md
@@ -25,7 +25,9 @@ POST /api/vault-extract/documents/export
 ### Columns
 
 - **Fixed system columns** — always emitted, never configurable: `LifecycleStatus`, `ReviewStatus`, `ReviewReasons`, `Title`. These are the channel's stable metadata contract.
-- **Field columns** — one per **live** `FieldDefinition` of the requested type, in `DisplayOrder` (ties broken by `Name`, so the order is total). Headers are the field's `DisplayName`, so renaming a field follows through automatically. Values come from the document's `DocumentExtractedField` rows, rendered from the typed column per the field's `DataType`; a multi-value field joins its values by `Order` with `"; "`.
+- **Field columns** — one per **live** `FieldDefinition` of the requested type, in `DisplayOrder` (ties broken by `Name`, so the order is total). Headers are the field's `DisplayName`, so renaming a field follows through automatically. Values come from the document's `DocumentExtractedField` rows, rendered from the typed column per the field's `DataType`; a multi-value field joins its values by `Order` with `"; "` — **the same separator the operator screen shows**, so a cell reads identically in both places.
+
+> **Why a semicolon, not a comma.** A comma is the CSV delimiter. The writer would have to quote the cell, and a consumer re-splitting a quoted cell on commas would shred one field across several columns. The screen was changed to match the file rather than the other way round (#501 item 6).
 
 There is **no saved column projection.** #499 deleted the export-template layer: a template persisted only "which of this type's fields, in what order", and ordering was already owned by `DisplayOrder` — the same axis the operator list renders its columns by. Two axes over the same fields could disagree, so there is now one. If you want a different column order, change `FieldDefinition.DisplayOrder`; the list and the file move together.
 


### PR DESCRIPTION
Implements #501 items 6 and 8 — the cleanup the issue allows to land as one PR. Item 7 stays open (it needs a live host).

> #505 (items 1–5) is merged, and this was retargeted from its branch to `main`. It now carries only its own two commits.

## Item 6 — one separator

The same document's same multi-value field read `a, b, c` on screen and `a; b; c` in the file. They are one separator now, and **the screen is what moved**.

A comma is the CSV delimiter. The writer would have to quote the cell, and a consumer re-splitting a quoted cell on commas shreds one field across several columns. The file already has consumers parsing it, and its bytes are the riskier thing to change. The issue offered "accept and document the difference" as the alternative; unifying costs one string in one TS file, so there was no reason to accept it.

The constant cannot cross the language boundary. Each side names the literal and each side has a test that pins it.

## Item 8 — one home for the `FieldDataType` switch

The issue counted three copies of "typed columns → X", each with its own date format literals. There were **five**:

| Switch | Direction | Was |
|---|---|---|
| `DocumentExtractedField.SetValue` | JSON → columns | own `"yyyy-MM-dd"` |
| `DocumentExtractedField.ToJsonElement` | columns → JSON | own literals |
| the export's `FieldValueToString` | columns → cell | own literals |
| `FieldFingerprintCalculator.Canonicalize` | columns → hash input | own literals (uncounted) |
| `ExtractedFieldValueValidator.IsValidDateString` | JSON → bool | own literal (uncounted, found by verifying) |

The two read directions now live in `FieldValueFormatter`, over a new `IFieldValueColumns` implemented by both the persisted entity and the export's projection. **That interface is why "sink it onto `DocumentExtractedField`" could not work**: the export deliberately never materializes the entity, because that would pull `Markdown` into memory and into the change tracker for thousands of documents.

The literals live in `FieldValueFormats`, where their status is finally stated. `Date` and `DateTime` are **frozen wire contract** — the `DocumentFieldValue` input shape, the REST/MCP `ExtractedFields` output shape, and the #411 fingerprint's hash input. The export's number format is presentation, and deliberately differs from the fingerprint's full-precision one; that distinction was previously implicit in two unrelated files.

The validator matters most of the five: it gates values on their way to `SetValue`, so the two must never disagree. A value the gate accepts and `SetValue` cannot parse throws *inside the aggregate*, past the point where the caller could correct it.

### Nothing re-hashed

Every literal was checked byte-for-byte against all five former sites, and `FieldFingerprintCalculator`'s `"0.############################"` (28 `#`) is untouched. The fingerprint tests pass unchanged. No `Extract:*` code, localization key, config section, or container name moved.

## The guards

`FieldValueFormatter_Tests` and the new `FieldFingerprintCalculator_Tests` case walk `Enum.GetValues<FieldDataType>()` rather than naming members, so **a new member that misses a branch reddens** instead of shipping. Mutation-tested: adding a `Currency` member reddens four of six formatter tests (including the round-trip that covers `SetValue`) and both fingerprint completeness tests.

`Canonicalize` stays silently defaulting (`_ => null`) rather than throwing — it runs in the #411 background-job fingerprint path, where a throw would rethrow into the retry loop. So its guard is a test. Worth knowing what it protects: a `null` canonical makes `Compute` return `null`, which reads as "partial key", so a new enum member used as a unique key would quietly switch duplicate detection **off** for its whole document type — a missed duplicate, indistinguishable from a key that failed to extract.

## Related, and two drive-bys

- Three EF export test classes each re-derived `DeterministicGuid` / `NewFileOrigin` / the reflection-based seeding. `DocumentTestData` collects them. A static class, **not** methods on `VaultExtractEntityFrameworkCoreTestBase` as #501 proposed: `DocumentExportListParity_Tests` needs its own ABP module and cannot inherit that base.
- `export-current-view.spec.ts` asserted `as Record<string, unknown>` on a type with no string index signature (TS2352). Nothing caught it: CI runs the specs through plain vitest, which strips types without checking them.
- `nx test vault-extract` executed 2 of the 8 spec files — the runner discovers specs under `sourceRoot` (`packages/vault-extract/src`), and six live under the `documents/` sub-entry-point. Widened the target's `include`. To be clear, **CI was never affected**: it runs `npx vitest run`, which always covered all 8. This only fixes the target a developer would reach for locally and be misled by.

Also corrected `DocumentFieldValue`'s doc comment, which named the DateTime shape as `"yyyy-MM-ddThh:mm:ss"` — lowercase `hh` is 12-hour, and the actual (only round-tripping) format is `HH`.

## Verification

1166 .NET tests, 78 Angular tests, `nx run-many -t lint` clean. Architecture review of the main commit found no hard-constraint violations; its one recommendation (cover `Canonicalize` with the enum walk) is implemented here.

No egress contract change.

