### PR TITLE
fix(documents): restore the sub-document delete guard on both soft and permanent delete (#508)

### DIFF
--- a/.claude/rules/sub-document-segmentation.md
+++ b/.claude/rules/sub-document-segmentation.md
@@ -47,6 +47,16 @@ downloads the parent's blob (a frontend concern). The parse job seeds a derived 
 `SliceText` and **never touches a blob** (its `FileOrigin?.BlobName` is null) — see
 `Text_Extraction_Seeds_Derived_Document_From_Segment_Slice`.
 
+**Therefore the source outlives its children (#508).** Because `OriginDocumentId` is a sub-document's *only* route to
+a source file, `DocumentAppService` fail-closes on both delete paths: `DeleteAsync` throws
+`Extract:DocumentHasSubDocuments` while any **live** child exists, and `PermanentDeleteAsync` throws
+`Extract:DocumentHasSubDocumentsPermanentDelete` while **any** child exists — recycle-bin ones included, since hard
+delete reclaims the parent's blob and a soft-deleted child is restorable. The asymmetry is carried entirely by the
+ambient `ISoftDelete` filter around `IDocumentRepository.AnyByOriginAsync` (permanent delete runs it inside its
+`DataFilter.Disable<ISoftDelete>()` scope). Neither guard cascades, and neither sits on the retraction path: #349 /
+#364 soft-delete children through `IDocumentRepository` directly. #481 had removed this guard on the premise that
+children own their own `FileOrigin`; #487 reverted that premise, so #508 restored it.
+
 _#487 Phase A deleted the retention chain **and**, in the same pass, the routing of embedded standalone documents —
 but only the retention chain was the thing being abandoned. **#494 restored the routing** (it is v0.2.0's behaviour,
 unchanged): once `FileOrigin` went back to nullable, a figure child became exactly what a text child already is — a

--- a/.cursor/rules/project/sub-document-segmentation.mdc
+++ b/.cursor/rules/project/sub-document-segmentation.mdc
@@ -36,10 +36,32 @@ Therefore `DocumentSegment` is a **durable internal ledger**, **not** a transien
 
 The fields mirrored between the two representations are intentional copies made at spawn time:
 `DocumentSegment.SegmentKey → Document.OriginConstituentKey`, `SourceDocumentId → OriginDocumentId`,
-`SliceText → Document.Markdown` (one-way seed), `TenantId → TenantId`. `Document.FileOrigin` is required at spawn
-too (#481) but is not a segment-field copy: a `Figure` child's `FileOrigin` resolves from the source's
-`FigureManifest` (the shared `extraction-figures/{sourceId}/{hash}` blob, #477/#478); a `Text` child's `FileOrigin`
-is the parent's own shared upload blob, copied wholesale.
+`SliceText → Document.Markdown` (one-way seed), `TenantId → TenantId`. A derived sub-document of **either kind**
+carries **no `FileOrigin` of its own** — `Document.FileOrigin` is nullable again and a spawned sub-document is
+created with `fileOrigin: null`. The markdown-slice split does not give children a source file: **#487 decided
+against physically splitting the source** (the cost of a per-child faithful file was not worth it), which reverted
+#481's required-`FileOrigin` back to the pre-#481 nullable design, and Phase A of #487 deleted the #477/#478
+figure-image retention chain (no retained blob, no `FigureManifest`) — a figure's transcription stays **inline** in
+the parent Markdown. To reach a sub-document's source, a consumer follows `OriginDocumentId` to the parent and
+downloads the parent's blob (a frontend concern). The parse job seeds a derived document's Markdown from its
+`SliceText` and **never touches a blob** (its `FileOrigin?.BlobName` is null) — see
+`Text_Extraction_Seeds_Derived_Document_From_Segment_Slice`.
+
+**Therefore the source outlives its children (#508).** Because `OriginDocumentId` is a sub-document's *only* route to
+a source file, `DocumentAppService` fail-closes on both delete paths: `DeleteAsync` throws
+`Extract:DocumentHasSubDocuments` while any **live** child exists, and `PermanentDeleteAsync` throws
+`Extract:DocumentHasSubDocumentsPermanentDelete` while **any** child exists — recycle-bin ones included, since hard
+delete reclaims the parent's blob and a soft-deleted child is restorable. The asymmetry is carried entirely by the
+ambient `ISoftDelete` filter around `IDocumentRepository.AnyByOriginAsync` (permanent delete runs it inside its
+`DataFilter.Disable<ISoftDelete>()` scope). Neither guard cascades, and neither sits on the retraction path: #349 /
+#364 soft-delete children through `IDocumentRepository` directly. #481 had removed this guard on the premise that
+children own their own `FileOrigin`; #487 reverted that premise, so #508 restored it.
+
+_#487 Phase A deleted the retention chain **and**, in the same pass, the routing of embedded standalone documents —
+but only the retention chain was the thing being abandoned. **#494 restored the routing** (it is v0.2.0's behaviour,
+unchanged): once `FileOrigin` went back to nullable, a figure child became exactly what a text child already is — a
+Markdown slice with no blob. A figure span whose LLM verdict is `isSubDocument` therefore spawns again, its
+transcription living both inline in the parent's Markdown and as the seed of its own sub-document._
 
 ## 🚦 RED LINE: the subsystem assumes exactly two Kinds {Text, Figure}
 
@@ -61,12 +83,24 @@ default — the #364-class missed-branch bug, hardened in #379), not a license t
 | `SourceDocumentId`, `SegmentKey`, `Kind`, `Status`, `RoutedDocumentId`, `Ordinal` | **contract** | the idempotency + retraction lifecycle |
 | `RoutedDocumentId` | **keep explicit** | reconstructable from `(OriginDocumentId, OriginConstituentKey)`, but the explicit pointer is the ledger's purpose (idempotency + retraction clarity); reconstructing the join is more complex, not less |
 | `SliceText` | **transient one-way seed** | duplicated by `Document.Markdown` after parse; bounded duplication is accepted; **do not add a parse→segment writeback to clear it** (couples parse job to the ledger for a low-value saving) |
-| `PageNumber` | **retained provenance** | deliberate out-of-band anchor (Markdown-first "named, strongly-typed, nullable extension field" rule); write-only by design, not dead weight |
-| `FigureContentHash` | **spawn-input (resumable)** | #477/#478: SHA-256 of the retained figure's **image bytes** (≠ `SegmentKey`, the transcription-**text** hash), parsed at detection from the in-span `figures/{hash}` reference; read once at spawn to resolve the source's `FigureManifest` and point the child `FileOrigin` at the **shared** blob. `null` only for a `Text` slice — since #481 a `Figure` span with no resolvable reference is a **retention-off** case (routing requires `RetainFigureImages` ON) and is not persisted as a row at detection at all; a manifest miss discovered later at spawn time deletes the row instead of spawning a child with no blob. Every spawned child therefore carries a real, required `FileOrigin`: `Figure` → the shared retained blob, `Text` → the parent's own shared upload blob |
+
+_Removed by #487: `PageNumber` and `FigureContentHash`, dropped from the entity (+ EF config + `DocumentSegmentConsts.MaxFigureContentHashLength`) with the `V487_DropDormantSegmentFigureColumns` migration. Both were **figure-only**; `FigureContentHash` belonged to the deleted retention chain, and `PageNumber` was **write-only even at v0.2.0** (nothing in `core/src` ever read it back). #494's restored figure routing needs neither — a figure child is identified by the SHA-256 of its transcription like any other slice — so there is **no migration to undo**._
+
+_**`Kind = Figure` is live again (#494).** Fresh detection writes it for every standalone figure span, exactly as at
+v0.2.0. Both kinds are first-class: a **Text** row's premise is the container bundle (`IsContainerIndependent()`
+false — it goes inert if the source is reclassified to a concrete type, and #364 retracts its already-spawned
+child), while a **Figure** row is container-independent (an embedded standalone document stands on its own, so it
+spawns whether the parent is a bundle or a concrete document, and #364 keeps it). **Do not delete Figure rows
+out-of-band** (e.g. a cleanup migration, or a "legacy leftover" guard in the spawn path — #487 briefly had one, and
+#494 removed it): a Spawned row's `SegmentKey` is the **sole duplicate-spawn barrier** (#481 moved spawn idempotency
+entirely onto this ledger after dropping the Document-side unique index), and a still-Pending row is a real
+constituent whose spawn simply has not happened yet. The "live routed child ⟺ its ledger row exists (while the
+source lives)" invariant is what keeps re-splits idempotent and the ≥2 bundle count honest._
 
 Watch for accreted residue: a fast-iterated subsystem leaves write-only fields / never-assigned enum values / dead
 projections. #390 removed three (`DocumentSegmentStatus.NotADocument`, `DetectionContext.UploadedByUserName`,
-`PendingSegment.SliceText`). Re-run a dead-code sweep when adding the next iteration.
+`PendingSegment.SliceText`); #487 removed two more (`PageNumber`, `FigureContentHash`). Re-run a dead-code sweep when
+adding the next iteration.
 
 ## Cross-entity invariant (two coupled state machines)
 

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -333,14 +333,35 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
             disposeStream: true);
     }
 
+    /// <summary>
+    /// Soft-deletes a document into the recycle bin.
+    /// <para>
+    /// #508 guard: a source must not enter the recycle bin while it still has <b>live</b> derived sub-documents.
+    /// Since #487 a sub-document carries no <see cref="Document.FileOrigin"/> of its own — it is a Markdown slice
+    /// that reaches its source only by following <see cref="Document.OriginDocumentId"/> to the parent's blob — so
+    /// soft-deleting the parent strands it behind a provenance pointer that no longer resolves. (#481 removed this
+    /// guard on the premise that children own their own FileOrigin; #487 reverted that premise but left the guard
+    /// out.) Children already in the recycle bin do not count: the ambient <c>ISoftDelete</c> filter excludes them,
+    /// so a source whose sub-documents are all already deleted stays deletable.
+    /// </para>
+    /// <para>
+    /// The guard is deliberately <b>not</b> a cascade — deleting a parent never auto-deletes children. The operator
+    /// removes the sub-documents first (the list's "view sub-documents" filter surfaces them by
+    /// <see cref="Document.OriginDocumentId"/>). The #349 / #364 container→type reclassify retraction is unaffected:
+    /// it soft-deletes children through <see cref="IDocumentRepository"/> directly, not through this service.
+    /// </para>
+    /// </summary>
     [Authorize(VaultExtractPermissions.Documents.Delete)]
     public virtual async Task DeleteAsync(Guid id)
     {
         var document = await _documentRepository.GetAsync(id);
 
-        // #481: children own a real FileOrigin and a fully independent lifecycle; a dangling OriginDocumentId
-        // provenance pointer on a deleted source is accepted (downstream consumes provenance at Ready time).
-        // Deleting a parent never cascades to children.
+        if (await _documentRepository.AnyByOriginAsync(id))
+        {
+            throw new BusinessException(VaultExtractErrorCodes.Document.HasSubDocuments)
+                .WithData("DocumentId", id);
+        }
+
         await _documentRepository.DeleteAsync(id);
 
         // Notify downstream consumers: the Document entered the trash bin, so derived data should move to a recoverable archived state.
@@ -353,6 +374,19 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
             });
     }
 
+    /// <summary>
+    /// Permanently deletes a document: hard-deletes the row and reclaims its blobs.
+    /// <para>
+    /// #508 guard, the strictly stronger twin of <see cref="DeleteAsync"/>'s: this blocks while <b>any</b>
+    /// sub-document exists, including ones already in the recycle bin. Hard-deleting the source destroys the blob
+    /// its children reach through <see cref="Document.OriginDocumentId"/> (they carry no
+    /// <see cref="Document.FileOrigin"/> of their own since #487, and #487 also dropped the shared-blob reference
+    /// check on the grounds that no shared blobs remain) — and a recycle-bin child is restorable, so restoring it
+    /// afterwards would yield a document that can never reach its source. The existence check therefore runs
+    /// inside the <see cref="ISoftDelete"/>-disabled scope below, which is exactly what makes it count recycle-bin
+    /// children; <c>IMultiTenant</c> stays on, so it never leaves this document's layer.
+    /// </para>
+    /// </summary>
     [Authorize(VaultExtractPermissions.Documents.PermanentDelete)]
     public virtual async Task PermanentDeleteAsync(Guid id)
     {
@@ -361,6 +395,13 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
         {
             // Permanent delete needs only scalar fields + owned FileOrigin (blob name); no child collections are needed.
             document = await _documentRepository.GetAsync(id, includeDetails: false);
+
+            // Ambient ISoftDelete is disabled here, so this counts recycle-bin sub-documents too (see the remarks).
+            if (await _documentRepository.AnyByOriginAsync(id))
+            {
+                throw new BusinessException(VaultExtractErrorCodes.Document.HasSubDocumentsPermanentDelete)
+                    .WithData("DocumentId", id);
+            }
         }
 
         await _documentRepository.HardDeleteAsync(id);

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -377,6 +377,8 @@
     "Extract:DocumentUnsupportedFileType": "File '{FileName}' has an unsupported type ('{ContentType}'). Please upload a supported image, PDF, CSV/TSV, DOCX, PPTX, TXT, or XLSX file.",
     "Extract:DocumentNoSourceBlob": "This document has no source file available for download.",
     "Extract:DocumentRestoreConflict": "Cannot restore document '{DocumentId}': a live sub-document with the same source constituent already exists. The restore is rejected to avoid a duplicate.",
+    "Extract:DocumentHasSubDocuments": "This document still has sub-documents derived from it. Delete its sub-documents first, then delete this document.",
+    "Extract:DocumentHasSubDocumentsPermanentDelete": "This document still has sub-documents derived from it, including any already in the recycle bin. Sub-documents have no source file of their own and reach it through this document, so permanently delete them first.",
     "Extract:UnknownPipelineCode": "Pipeline '{PipelineCode}' is not retryable.",
     "Extract:PipelineNeverRan": "Pipeline '{PipelineCode}' has not started yet.",
     "Extract:PipelineRetryInProgress": "Pipeline '{PipelineCode}' already has an attempt in progress.",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -377,6 +377,8 @@
     "Extract:DocumentUnsupportedFileType": "ファイル '{FileName}' のタイプ（'{ContentType}'）はサポートされていません。対応している画像、PDF、CSV/TSV、DOCX、PPTX、TXT、または XLSX ファイルをアップロードしてください。",
     "Extract:DocumentNoSourceBlob": "このドキュメントにはダウンロードできるソースファイルがありません。",
     "Extract:DocumentRestoreConflict": "ドキュメント '{DocumentId}' を復元できません：同じソース構成要素を共有する別のライブなサブドキュメントが既に存在します。重複を避けるため、復元は拒否されました。",
+    "Extract:DocumentHasSubDocuments": "このドキュメントには、まだそこから派生したサブドキュメントがあります。先にサブドキュメントを削除してから、このドキュメントを削除してください。",
+    "Extract:DocumentHasSubDocumentsPermanentDelete": "このドキュメントには、まだそこから派生したサブドキュメントがあります（ごみ箱内のものを含む）。サブドキュメントは自身のソースファイルを持たず、このドキュメントを通じて参照するため、先にサブドキュメントを完全に削除してください。",
     "Extract:UnknownPipelineCode": "パイプライン '{PipelineCode}' は再試行できません。",
     "Extract:PipelineNeverRan": "パイプライン '{PipelineCode}' はまだ開始されていません。",
     "Extract:PipelineRetryInProgress": "パイプライン '{PipelineCode}' には既に進行中の試行があります。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -377,6 +377,8 @@
     "Extract:DocumentUnsupportedFileType": "文件 '{FileName}' 的类型 ('{ContentType}') 不受支持。请上传支持的图片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 文件。",
     "Extract:DocumentNoSourceBlob": "该文档没有可供下载的源文件。",
     "Extract:DocumentRestoreConflict": "无法恢复文档 '{DocumentId}'：已存在另一份共享同一来源片段的在用子文档。为避免产生重复，已拒绝本次恢复。",
+    "Extract:DocumentHasSubDocuments": "该文档仍有由其拆分出的子文档。请先删除这些子文档，再删除该文档。",
+    "Extract:DocumentHasSubDocumentsPermanentDelete": "该文档仍有由其拆分出的子文档（含已在回收站中的）。子文档没有自己的源文件，需通过该文档才能访问，请先彻底删除这些子文档。",
     "Extract:UnknownPipelineCode": "流水线 '{PipelineCode}' 不支持重试。",
     "Extract:PipelineNeverRan": "流水线 '{PipelineCode}' 尚未运行。",
     "Extract:PipelineRetryInProgress": "流水线 '{PipelineCode}' 已有进行中的尝试。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -377,6 +377,8 @@
     "Extract:DocumentUnsupportedFileType": "檔案 '{FileName}' 的類型（'{ContentType}'）不受支援。請上傳支援的圖片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 檔案。",
     "Extract:DocumentNoSourceBlob": "此文件沒有可供下載的來源檔案。",
     "Extract:DocumentRestoreConflict": "無法還原文件 '{DocumentId}'：已存在另一份共享同一來源片段的在用子文件。為避免產生重複，已拒絕本次還原。",
+    "Extract:DocumentHasSubDocuments": "此文件仍有由其分割出的子文件。請先刪除這些子文件，再刪除此文件。",
+    "Extract:DocumentHasSubDocumentsPermanentDelete": "此文件仍有由其分割出的子文件（含已在回收筒中的）。子文件沒有自己的來源檔案，需透過此文件才能存取，請先永久刪除這些子文件。",
     "Extract:UnknownPipelineCode": "管線 '{PipelineCode}' 不支援重試。",
     "Extract:PipelineNeverRan": "管線 '{PipelineCode}' 尚未執行。",
     "Extract:PipelineRetryInProgress": "管線 '{PipelineCode}' 已有進行中的嘗試。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -33,6 +33,16 @@ public static class VaultExtractErrorCodes
         // same (OriginDocumentId, OriginConstituentKey) identity — the application-layer fail-close that replaces
         // the fail-close the #481-dropped #391 filtered-unique index used to give for free at restore time.
         public const string RestoreConflict = "Extract:DocumentRestoreConflict";
+        // #508: a source still has LIVE derived sub-documents, so soft-deleting it is blocked — they would be left
+        // with a dangling OriginDocumentId, which since #487 is their ONLY route to a source file (they carry no
+        // FileOrigin of their own). Same string as before #481 removed it; nothing consumed it in the interim,
+        // so re-adding it is not a wire break.
+        public const string HasSubDocuments = "Extract:DocumentHasSubDocuments";
+        // #508: the permanent-delete twin of the above, and strictly stronger — children already in the recycle bin
+        // count too, because hard-deleting the source reclaims the blob they reach through OriginDocumentId and a
+        // recycle-bin child is restorable. A distinct code because the remedy differs: the operator must look in
+        // the recycle bin, not just the document list.
+        public const string HasSubDocumentsPermanentDelete = "Extract:DocumentHasSubDocumentsPermanentDelete";
     }
 
     public static class DocumentType

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/Document.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/Document.cs
@@ -161,16 +161,27 @@ public class Document : FullAuditedAggregateRoot<Guid>, IMultiTenant
     /// <summary>
     /// When this document was derived from a constituent of another document (#306 / #346, Scenario B), the id of
     /// that <b>source</b> document; <c>null</c> for normally-uploaded documents. A peer back-reference
-    /// (reference-by-id, no navigation property, no FK cascade): the derived document has a fully independent
-    /// lifecycle and outlives the source. Exposed at the egress so downstream can follow it for provenance.
+    /// (reference-by-id, no navigation property, no FK cascade), and passive provenance at the DB level (#481).
+    /// <para>
+    /// It is nonetheless the derived document's <b>only</b> route to a source file: since #487 a sub-document
+    /// carries no <see cref="FileOrigin"/> of its own, so a consumer follows this pointer to the parent and
+    /// downloads the parent's blob. The source therefore outlives its children, an invariant the #508
+    /// <c>DocumentAppService</c> delete guards enforce at the application layer (no FK, no DB cascade).
+    /// </para>
+    /// Exposed at the egress so downstream can follow it for provenance.
     /// </summary>
     public virtual Guid? OriginDocumentId { get; private set; }
 
     /// <summary>
     /// Content-derived stable key of the source constituent this document was derived from (#306 figure path /
-    /// #346 born-digital path): the SHA-256 of the Markdown slice text. NOT bbox (which drifts, #210). Unique
-    /// together with <see cref="OriginDocumentId"/> so re-extraction / routing retry never duplicate-spawn.
+    /// #346 born-digital path): the SHA-256 of the Markdown slice text. NOT bbox (which drifts, #210).
     /// <c>null</c> for normally-uploaded documents.
+    /// <para>
+    /// #481 moved spawn idempotency off this pair and onto the <c>DocumentSegment</c> ledger's unique
+    /// <c>(SourceDocumentId, SegmentKey)</c> index, so nothing on <c>Document</c> enforces uniqueness over
+    /// <c>(OriginDocumentId, OriginConstituentKey)</c> any more; <c>DocumentParseBackgroundJob</c> consumes this
+    /// key to look up the seed slice, and <c>RestoreAsync</c> fail-closes on it (#485).
+    /// </para>
     /// </summary>
     public virtual string? OriginConstituentKey { get; private set; }
 

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
@@ -47,11 +47,47 @@ public interface IDocumentRepository : IRepository<Document, Guid>
     /// rows regardless of the ambient filter state. <c>IMultiTenant</c> still applies by ambient state (a source
     /// and its derived documents share a tenant).
     /// </para>
+    /// <para>
+    /// Contrast <see cref="AnyByOriginAsync"/>, whose soft-delete visibility is left to the caller's ambient filter
+    /// state precisely because its two callers want opposite semantics. The divergence is deliberate, not drift.
+    /// </para>
     /// </summary>
     Task<bool> AnyLiveDerivedDuplicateAsync(
         Guid originDocumentId,
         string originConstituentKey,
         Guid excludeDocumentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether any <see cref="Document"/> carries <paramref name="originDocumentId"/> as its
+    /// <see cref="Document.OriginDocumentId"/> — i.e. whether that source still has derived sub-documents.
+    /// Existence-only (compiles to SQL <c>EXISTS</c>, no row materialization), served by the leading (and only)
+    /// column of the plain <c>OriginDocumentId</c> index.
+    /// <para>
+    /// Backs both <c>DocumentAppService</c> delete guards (#508). Soft-delete visibility is the <b>caller's</b>
+    /// choice, expressed through the ambient <c>IDataFilter</c> state rather than a parameter:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description><c>DeleteAsync</c> calls it with the <c>ISoftDelete</c> filter ON, so only <b>live</b>
+    /// children count — a source whose sub-documents are all already in the recycle bin stays soft-deletable.</description></item>
+    /// <item><description><c>PermanentDeleteAsync</c> calls it from inside its
+    /// <c>DataFilter.Disable&lt;ISoftDelete&gt;()</c> scope, so recycle-bin children count too — hard-deleting the
+    /// source reclaims the blob they reach through <c>OriginDocumentId</c>, and a recycle-bin child is
+    /// restorable.</description></item>
+    /// </list>
+    /// <para>
+    /// <c>IMultiTenant</c> always applies by ambient state (a source and its derived documents share a tenant), so
+    /// the check never leaves the source's own layer.
+    /// </para>
+    /// <para>
+    /// Contrast <see cref="AnyLiveDerivedDuplicateAsync"/>, which deliberately pins <c>!IsDeleted</c> in its own
+    /// predicate: it has a single caller that always wants live-only yet runs inside a
+    /// <c>Disable&lt;ISoftDelete&gt;()</c> scope. This method has two callers wanting opposite semantics, so it must
+    /// <b>not</b> pin the predicate. Both directions of that choice are locked by <c>DocumentParentDelete_Tests</c>.
+    /// </para>
+    /// </summary>
+    Task<bool> AnyByOriginAsync(
+        Guid originDocumentId,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -72,6 +72,22 @@ public class EfCoreDocumentRepository
             GetCancellationToken(cancellationToken));
     }
 
+    public virtual async Task<bool> AnyByOriginAsync(
+        Guid originDocumentId,
+        CancellationToken cancellationToken = default)
+    {
+        // #508 delete guards: does this source still have derived sub-documents? Both global filters are left at
+        // their AMBIENT state on purpose -- that is the whole contract of this method. IMultiTenant keeps the check
+        // inside the source's own layer, and ISoftDelete decides whether recycle-bin children count: DeleteAsync
+        // calls this with the filter on (live children only), PermanentDeleteAsync from inside its
+        // DataFilter.Disable<ISoftDelete>() scope (recycle-bin children count too, since hard-deleting the source
+        // reclaims the blob they reach through OriginDocumentId). Index-served by the plain OriginDocumentId index.
+        var dbSet = await GetDbSetAsync();
+        return await dbSet.AnyAsync(
+            d => d.OriginDocumentId == originDocumentId,
+            GetCancellationToken(cancellationToken));
+    }
+
     public virtual async Task<List<DuplicateCandidateModel>> FindDuplicateCandidatesAsync(
         Guid documentId,
         Guid documentTypeId,

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/EntityFrameworkCore/VaultExtractDbContextModelCreatingExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/EntityFrameworkCore/VaultExtractDbContextModelCreatingExtensions.cs
@@ -122,17 +122,18 @@ public static class VaultExtractDbContextModelCreatingExtensions
             b.HasIndex(x => x.CreationTime);
 
             // #306 / #346 Scenario B back-reference (#481: no longer a uniqueness constraint here). OriginDocumentId
-            // is PASSIVE provenance (Option A) — this plain, non-unique, non-filtered index serves only the #354
-            // "list a source's derived documents" read (OriginDocumentId is the leading and only column; it is also
-            // portable across every DB provider, unlike the retired SQL-Server-only HasFilter). Spawn idempotency no
-            // longer lives on this table: it is now the DocumentSegment ledger's unique (SourceDocumentId,
-            // SegmentKey) index plus the segment row's Status transition + optimistic concurrency (see
-            // DerivedDocumentSpawner) that makes a sequential retry abort cleanly and a concurrent double-spawn lose
-            // on the ConcurrencyStamp at commit. This also dissolves the #391 soft-delete-filtered-unique-index
-            // complication: a retracted (soft-deleted) child and its re-spawned successor may now freely share the
-            // same OriginConstituentKey, since nothing on Document enforces uniqueness over that pair any more. No FK
-            // on OriginDocumentId: it is a soft provenance pointer, not a constraint, so the derived document
-            // outlives the source (the source may be hard-deleted while derived ones remain).
+            // is PASSIVE provenance (Option A) — this plain, non-unique, non-filtered index serves the #354
+            // "list a source's derived documents" read and the #508 delete-guard EXISTS (OriginDocumentId is the
+            // leading and only column; it is also portable across every DB provider, unlike the retired
+            // SQL-Server-only HasFilter). Spawn idempotency no longer lives on this table: it is now the
+            // DocumentSegment ledger's unique (SourceDocumentId, SegmentKey) index plus the segment row's Status
+            // transition + optimistic concurrency (see DerivedDocumentSpawner) that makes a sequential retry abort
+            // cleanly and a concurrent double-spawn lose on the ConcurrencyStamp at commit. This also dissolves the
+            // #391 soft-delete-filtered-unique-index complication: a retracted (soft-deleted) child and its
+            // re-spawned successor may now freely share the same OriginConstituentKey, since nothing on Document
+            // enforces uniqueness over that pair any more. Still no FK on OriginDocumentId: it is a soft provenance
+            // pointer, not a constraint — the invariant that a source outlives its children is enforced at the
+            // application layer by the #508 DocumentAppService delete guards, not by the database.
             b.HasIndex(x => x.OriginDocumentId);
 
             // #411: duplicate-detection fingerprint (SHA-256 hex of this type's normalized unique-key field values).

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/DocumentAppService_Delete_Tests.cs
@@ -88,31 +88,32 @@ public class DocumentAppService_Delete_Tests
     }
 
     [Fact]
-    public async Task DeleteAsync_Succeeds_Even_When_Document_Still_Has_Live_SubDocuments()
+    public async Task DeleteAsync_Is_Blocked_When_Document_Still_Has_SubDocuments()
     {
-        // #481: the former guard (block soft-delete of a source while it still has live derived sub-documents) is
-        // removed. Children now own a real FileOrigin and a fully independent lifecycle; a dangling OriginDocumentId
-        // provenance pointer on a deleted source is accepted (downstream consumes provenance at Ready time).
-        // Deleting a parent never cascades to children: exactly one DocumentDeletedEto fires, for the parent only.
+        // #508: a source must not enter the recycle bin while derived sub-documents still point at it. Fail-closed
+        // before any mutation — no soft delete, no DocumentDeletedEto. Which children count as "still there" is
+        // decided by the ambient ISoftDelete filter inside AnyByOriginAsync, so that distinction is exercised
+        // against the real DB in DocumentParentDelete_Tests, not here.
         var doc = CreateDocument();
         _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(doc);
+        _documentRepository.AnyByOriginAsync(doc.Id, Arg.Any<CancellationToken>()).Returns(true);
 
-        await _appService.DeleteAsync(doc.Id);
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.DeleteAsync(doc.Id));
 
-        await _documentRepository.Received(1).DeleteAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await _distributedEventBus.Received(1).PublishAsync(
-            Arg.Is<DocumentDeletedEto>(e => e.DocumentId == doc.Id),
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.HasSubDocuments);
+        await _documentRepository.DidNotReceive().DeleteAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await _distributedEventBus.DidNotReceive().PublishAsync(
+            Arg.Any<DocumentDeletedEto>(),
             Arg.Any<bool>());
     }
 
     [Fact]
-    public async Task DeleteAsync_Succeeds_When_SubDocuments_Are_All_Already_Deleted()
+    public async Task DeleteAsync_Succeeds_When_The_Document_Has_No_SubDocuments()
     {
-        // A source whose sub-documents are all already deleted (or that never had any) is always deletable — the
-        // plain success path, now indistinguishable at this mocked-repository layer from the "still has live
-        // children" case above since #481 removed the guard entirely (the real DB-level distinction between live vs.
-        // already-deleted children lives in DocumentParentDelete_Tests).
+        // The mock's AnyByOriginAsync default (false) is the "no sub-documents survive the guard's filter" case:
+        // either the source never had children, or they are all already in the recycle bin.
         var doc = CreateDocument();
         _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(doc);
@@ -385,6 +386,28 @@ public class DocumentAppService_Delete_Tests
         await _appService.PermanentDeleteAsync(doc.Id);
 
         await _blobContainer.Received(1).DeleteAsync(doc.FileOrigin!.BlobName, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Is_Blocked_When_Document_Still_Has_SubDocuments()
+    {
+        // #508: hard-deleting a source reclaims the blob its children reach through OriginDocumentId (they carry no
+        // FileOrigin of their own since #487). Fail-closed before the hard delete AND before the blob reclaim, so a
+        // blocked call is a complete no-op. Unlike DeleteAsync, this guard also counts recycle-bin children — that
+        // is an ambient-DataFilter behaviour, covered against the real DB in DocumentParentDelete_Tests.
+        var doc = CreateDocument();
+        _documentRepository.GetAsync(doc.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(doc);
+        _documentRepository.AnyByOriginAsync(doc.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.PermanentDeleteAsync(doc.Id));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.HasSubDocumentsPermanentDelete);
+        await _documentRepository.DidNotReceive().HardDeleteAsync(doc.Id, Arg.Any<CancellationToken>());
+        await _blobContainer.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _distributedEventBus.DidNotReceive().PublishAsync(
+            Arg.Any<DocumentPermanentlyDeletedEto>(),
+            Arg.Any<bool>());
     }
 
     private static Document CreateDocument()

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentParentDelete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentParentDelete_Tests.cs
@@ -1,12 +1,16 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Abstractions.Documents;
 using Dignite.Vault.Extract.Documents;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
+using Volo.Abp;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
+using Volo.Abp.Data;
+using Volo.Abp.Domain.Entities;
 using Volo.Abp.EventBus.Distributed;
 using Volo.Abp.Guids;
 using Volo.Abp.Modularity;
@@ -19,8 +23,8 @@ public class DocumentParentDeleteTestModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        // DeleteAsync publishes a DocumentDeletedEto and the wider app-service graph touches these out-of-process
-        // collaborators; substitute them so the test exercises the real DB.
+        // The delete paths publish lifecycle ETOs and the wider app-service graph touches these out-of-process
+        // collaborators; substitute them so the test exercises the real DB + the real AnyByOriginAsync guard query.
         context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
         context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
         context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
@@ -28,65 +32,203 @@ public class DocumentParentDeleteTestModule : AbpModule
 }
 
 /// <summary>
-/// Integration tests for <c>DocumentAppService.DeleteAsync</c> against a source document that still has derived
-/// sub-documents (#481, formerly <c>DocumentDeleteGuard_Tests</c>): the guard that used to block this soft-delete
-/// is removed entirely — children now own a real <see cref="Document.FileOrigin"/> and a fully independent
-/// lifecycle, so deleting a parent never cascades to them, and a dangling <see cref="Document.OriginDocumentId"/>
-/// provenance pointer left on a soft-deleted source is accepted (downstream consumes provenance at Ready time).
-/// Runs against the real SQLite DB so the source's soft-delete and the children's untouched liveness are actually
-/// exercised (the AppService unit tests only mock the repository).
+/// Integration tests for the #508 <c>DocumentAppService</c> sub-document delete guards, against the real SQLite DB
+/// so the <c>AnyByOriginAsync</c> EXISTS query and its interaction with the ambient <c>ISoftDelete</c> filter are
+/// actually exercised (the AppService unit tests only mock the repository).
+/// <para>
+/// The two guards differ in exactly one respect, and that asymmetry is what most of these tests pin down:
+/// </para>
+/// <list type="bullet">
+/// <item><description><c>DeleteAsync</c> (soft) blocks on <b>live</b> children only. It is reversible and leaves
+/// the blob intact, so children already in the recycle bin are irrelevant to it.</description></item>
+/// <item><description><c>PermanentDeleteAsync</c> blocks on <b>any</b> child, recycle-bin ones included: it
+/// destroys the blob they reach through <c>OriginDocumentId</c>, and a recycle-bin child is restorable.</description></item>
+/// </list>
+/// Neither guard cascades: a blocked delete leaves the source and every child exactly as they were.
 /// </summary>
 public class DocumentParentDelete_Tests
     : VaultExtractTestBase<DocumentParentDeleteTestModule>
 {
     private readonly IDocumentAppService _appService;
     private readonly IDocumentRepository _documentRepository;
+    private readonly IBlobContainer<VaultExtractDocumentContainer> _blobContainer;
     private readonly IDistributedEventBus _eventBus;
     private readonly IGuidGenerator _guidGenerator;
+    private readonly IDataFilter _dataFilter;
 
     public DocumentParentDelete_Tests()
     {
         _appService = GetRequiredService<IDocumentAppService>();
         _documentRepository = GetRequiredService<IDocumentRepository>();
+        _blobContainer = GetRequiredService<IBlobContainer<VaultExtractDocumentContainer>>();
         _eventBus = GetRequiredService<IDistributedEventBus>();
         _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _dataFilter = GetRequiredService<IDataFilter>();
     }
 
+    // === DeleteAsync (soft) ===
+
     [Fact]
-    public async Task DeleteAsync_Succeeds_While_The_Source_Still_Has_Live_SubDocuments()
+    public async Task DeleteAsync_Is_Blocked_While_The_Source_Has_Live_SubDocuments()
     {
         var (sourceId, childIds) = await ArrangeSourceWithChildrenAsync(childCount: 2);
 
-        // No guard trips — the delete just succeeds.
-        await _appService.DeleteAsync(sourceId);
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.DeleteAsync(sourceId));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.HasSubDocuments);
 
         await WithUnitOfWorkAsync(async () =>
         {
-            // The source itself is soft-deleted (invisible under the ambient ISoftDelete filter).
-            (await _documentRepository.FindAsync(sourceId)).ShouldBeNull();
-
-            // Deleting the parent never cascades (#481): each child remains fully live, and its OriginDocumentId
-            // provenance pointer still resolves to the (now soft-deleted) source id — a dangling-but-accepted
-            // pointer, not a broken one.
+            // Nothing moved: the source is still live and every child is untouched.
+            (await _documentRepository.FindAsync(sourceId)).ShouldNotBeNull();
             foreach (var childId in childIds)
             {
-                var child = await _documentRepository.GetAsync(childId);
-                child.IsDeleted.ShouldBeFalse();
-                child.OriginDocumentId.ShouldBe(sourceId);
+                (await _documentRepository.GetAsync(childId)).IsDeleted.ShouldBeFalse();
             }
         });
 
-        // Exactly one DocumentDeletedEto fired, for the source only — no cascade publish to children either.
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentDeletedEto>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Succeeds_When_The_Source_Has_No_SubDocuments()
+    {
+        var (sourceId, _) = await ArrangeSourceWithChildrenAsync(childCount: 0);
+
+        await _appService.DeleteAsync(sourceId);
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.FindAsync(sourceId)).ShouldBeNull());
+
         await _eventBus.Received(1).PublishAsync(
             Arg.Is<DocumentDeletedEto>(e => e.DocumentId == sourceId));
     }
 
+    [Fact]
+    public async Task DeleteAsync_Succeeds_When_The_SubDocuments_Are_All_Already_In_The_Recycle_Bin()
+    {
+        // The ambient ISoftDelete filter excludes recycle-bin children from the guard's EXISTS, so a source whose
+        // sub-documents are all already deleted stays soft-deletable. This is the DeleteAsync half of the asymmetry:
+        // the same arrangement blocks PermanentDeleteAsync (see the twin test below).
+        var (sourceId, childIds) = await ArrangeSourceWithChildrenAsync(childCount: 2);
+        await SoftDeleteChildrenAsync(childIds);
+
+        await _appService.DeleteAsync(sourceId);
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.FindAsync(sourceId)).ShouldBeNull());
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentDeletedEto>(e => e.DocumentId == sourceId));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Ignores_SubDocuments_Of_A_Different_Source()
+    {
+        // The guard filters on OriginDocumentId, so another source's children never block this one.
+        var (otherSourceId, _) = await ArrangeSourceWithChildrenAsync(childCount: 2);
+        var (sourceId, _) = await ArrangeSourceWithChildrenAsync(childCount: 0);
+
+        await _appService.DeleteAsync(sourceId);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.FindAsync(sourceId)).ShouldBeNull();
+            (await _documentRepository.FindAsync(otherSourceId)).ShouldNotBeNull();
+        });
+    }
+
+    // === PermanentDeleteAsync (hard delete + blob reclaim) ===
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Is_Blocked_While_The_Source_Has_Live_SubDocuments()
+    {
+        var (sourceId, _) = await ArrangeSourceWithChildrenAsync(childCount: 2);
+
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.PermanentDeleteAsync(sourceId));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.HasSubDocumentsPermanentDelete);
+
+        // The guard runs before any mutation: the row survives and its blob was never reclaimed.
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.FindAsync(sourceId)).ShouldNotBeNull());
+
+        await _blobContainer.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentPermanentlyDeletedEto>());
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Is_Blocked_When_The_SubDocuments_Are_Only_In_The_Recycle_Bin()
+    {
+        // The other half of the asymmetry, and the reason PermanentDeleteAsync runs its guard inside the
+        // ISoftDelete-disabled scope: hard-deleting the source reclaims the blob its children reach through
+        // OriginDocumentId, and a recycle-bin child is restorable — restoring it afterwards would yield a document
+        // that can never reach its source.
+        var (sourceId, childIds) = await ArrangeSourceWithChildrenAsync(childCount: 2);
+        await SoftDeleteChildrenAsync(childIds);
+
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+            await _appService.PermanentDeleteAsync(sourceId));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.HasSubDocumentsPermanentDelete);
+
+        await _blobContainer.DidNotReceive().DeleteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Succeeds_Once_Every_SubDocument_Is_Permanently_Deleted()
+    {
+        // The escape hatch the guard leaves open, so the operator is never deadlocked: a sub-document has no
+        // children of its own, so its own permanent delete is unguarded. Purge the children, then the source goes.
+        var (sourceId, childIds) = await ArrangeSourceWithChildrenAsync(childCount: 2);
+
+        foreach (var childId in childIds)
+        {
+            await _appService.PermanentDeleteAsync(childId);
+        }
+
+        await _appService.PermanentDeleteAsync(sourceId);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                (await _documentRepository.FindAsync(sourceId)).ShouldBeNull();
+                foreach (var childId in childIds)
+                {
+                    (await _documentRepository.FindAsync(childId)).ShouldBeNull();
+                }
+            }
+        });
+
+        // Only the source owns a blob (a sub-document carries no FileOrigin since #487), so exactly one reclaim.
+        await _blobContainer.Received(1).DeleteAsync(SourceBlobName(sourceId), Arg.Any<CancellationToken>());
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentPermanentlyDeletedEto>(e => e.DocumentId == sourceId));
+    }
+
+    [Fact]
+    public async Task PermanentDeleteAsync_Succeeds_When_The_Source_Has_No_SubDocuments()
+    {
+        var (sourceId, _) = await ArrangeSourceWithChildrenAsync(childCount: 0);
+
+        await _appService.PermanentDeleteAsync(sourceId);
+
+        await _blobContainer.Received(1).DeleteAsync(SourceBlobName(sourceId), Arg.Any<CancellationToken>());
+    }
+
+    // === Arrangement ===
+
+    private static string SourceBlobName(Guid sourceId) => $"blobs/{sourceId:N}.pdf";
+
     /// <summary>
     /// Seeds one source document plus <paramref name="childCount"/> derived sub-documents
-    /// (<see cref="Document.CreateDerived"/>, <c>OriginDocumentId</c> == source). FileOrigin is required on every
-    /// document (#481); this guard test only cares about the OriginDocumentId back-reference, so the child's
-    /// FileOrigin is a fake stand-in, not the real #481 shared-parent-blob value <c>DerivedDocumentSpawner</c>
-    /// produces. Returns the source id and the child ids.
+    /// (<see cref="Document.CreateDerived"/>, <c>OriginDocumentId</c> == source). Each child is spawned with
+    /// <c>fileOrigin: null</c>, matching what <c>DerivedDocumentSpawner</c> actually produces since #487 — that
+    /// nullness is the whole reason the guard exists, so the fixture must not paper over it with a stand-in.
+    /// Returns the source id and the child ids.
     /// </summary>
     private async Task<(Guid SourceId, Guid[] ChildIds)> ArrangeSourceWithChildrenAsync(int childCount)
     {
@@ -99,7 +241,7 @@ public class DocumentParentDelete_Tests
                 sourceId,
                 tenantId: null,
                 fileOrigin: new FileOrigin(
-                    blobName: $"blobs/{sourceId:N}.pdf",
+                    blobName: SourceBlobName(sourceId),
                     uploadedByUserName: "test-user",
                     contentType: "application/pdf",
                     contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
@@ -114,13 +256,7 @@ public class DocumentParentDelete_Tests
                 var derived = Document.CreateDerived(
                     childId,
                     tenantId: null,
-                    fileOrigin: new FileOrigin(
-                        blobName: $"blobs/{sourceId:N}.pdf",
-                        uploadedByUserName: "test-user",
-                        contentType: "application/pdf",
-                        contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}"[..64],
-                        fileSize: 2048,
-                        originalFileName: "bundle.pdf"),
+                    fileOrigin: null,
                     originDocumentId: sourceId,
                     originConstituentKey: $"constituent-{i}");
                 await _documentRepository.InsertAsync(derived, autoSave: true);
@@ -128,5 +264,17 @@ public class DocumentParentDelete_Tests
         });
 
         return (sourceId, childIds);
+    }
+
+    /// <summary>Sends the given children to the recycle bin (soft delete), bypassing the app service.</summary>
+    private async Task SoftDeleteChildrenAsync(Guid[] childIds)
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            foreach (var childId in childIds)
+            {
+                await _documentRepository.DeleteAsync(childId, autoSave: true);
+            }
+        });
     }
 }


### PR DESCRIPTION
Closes #508.

## What was broken

Deleting a source document that still had live sub-documents just succeeded. #481 removed the `HasSubDocuments` guard on the premise that *"children own their FileOrigin and lifecycle"*. #487 then reverted required-`FileOrigin` — a sub-document now spawns with `fileOrigin: null` and reaches its source **only** by following `OriginDocumentId` to the parent's blob — but kept the guard removal, calling it "independent of FileOrigin". Children owning a `FileOrigin` *was* the premise. The guard stayed gone while the condition that justified removing it no longer held.

## The fix

Restored on **both** delete paths, with deliberately different soft-delete visibility:

| Path | Blocks when | Error code |
| --- | --- | --- |
| `DeleteAsync` | any **live** sub-document exists | `Extract:DocumentHasSubDocuments` |
| `PermanentDeleteAsync` | any sub-document exists, **live or in the recycle bin** | `Extract:DocumentHasSubDocumentsPermanentDelete` |

Soft delete is reversible and leaves the blob intact, so recycle-bin children are irrelevant to it — a source whose sub-documents are all already deleted stays deletable. Permanent delete destroys the blob (#487 dropped the shared-blob reference check on the grounds that no shared blobs remain), and a recycle-bin child is restorable: restoring it afterwards would yield a document that can never reach its source. Distinct codes because the remedy differs — look in the recycle bin, not the document list.

The asymmetry is carried entirely by the ambient `ISoftDelete` filter around the restored `IDocumentRepository.AnyByOriginAsync` (existence-only `EXISTS`, served by the plain `OriginDocumentId` index #481 left behind). `PermanentDeleteAsync` runs it inside its existing `DataFilter.Disable<ISoftDelete>()` scope; `DeleteAsync` does not. `IMultiTenant` stays on in both.

Neither guard cascades (a parent never auto-deletes children), neither sits on the #349/#364 retraction path (that deletes through `IDocumentRepository` directly), and no deadlock is reachable: a sub-document has no children of its own, so its permanent delete is unguarded and any subtree drains bottom-up.

## Both guards are mutation-tested

Not just "a guard exists" — the tests were verified to fail when the guard is broken, and to fail *specifically*:

- Disabling the `DeleteAsync` guard reddens exactly `DeleteAsync_Is_Blocked_*` (EF + Application), 7/8 others stay green.
- Moving the `PermanentDeleteAsync` guard **outside** the `ISoftDelete`-disabled scope reddens exactly `PermanentDeleteAsync_Is_Blocked_When_The_SubDocuments_Are_Only_In_The_Recycle_Bin` and nothing else — so that test pins the `DataFilter` scope, not merely the guard's existence.

## Comment rot fixed in passing

`DocumentAppService.DeleteAsync`, `Document.OriginDocumentId` (plus its `OriginConstituentKey` uniqueness claim, which #481 falsified), and the `VaultExtractDbContextModelCreatingExtensions` index note all still asserted that children own a `FileOrigin` / that the source may be hard-deleted while derived ones remain.

The `.cursor` twin of the `sub-document-segmentation` rule was last synced at #481 and still described the deleted #477/#478 retention chain and required `FileOrigin`. Its body is regenerated from the `.claude` source of truth, which also gains the delete contract.

## Notes

- **No migration.** No proxy regeneration — no signature change, and `Extract:*` codes already map to `VaultExtractResource` via `AbpExceptionLocalizationOptions`, so the operator UI surfaces the localized message as-is.
- Error codes localized across `en` / `ja` / `zh-Hans` / `zh-Hant`; all four key sets verified identical.
- `Extract:DocumentHasSubDocuments` re-uses the pre-#481 string. Nothing consumed it in the interim, so this is not a wire break.
- Suites green: Domain 191, Application 354, EF Core 149, HttpApi 3, Mcp 86, Mcp.Integration 3.
- Reviewed by `abp-architecture-reviewer`: no hard violations. Its one suggestion — cross-reference the deliberate soft-delete-handling divergence between `AnyByOriginAsync` and `AnyLiveDerivedDuplicateAsync` — is applied.
- The Host project could not be rebuilt locally (a running IIS Express worker holds its DLLs); it is untouched by this change and CI will build it.
