### PR TITLE
feat(documents): add DocumentLifecycleStatus.PendingReview (#510)

### DIFF
--- a/angular/packages/vault-extract/documents/src/lib/documents/document-detail/document-detail.component.ts
+++ b/angular/packages/vault-extract/documents/src/lib/documents/document-detail/document-detail.component.ts
@@ -935,6 +935,7 @@ export class DocumentDetailComponent implements OnInit {
     switch (status) {
       case DocumentLifecycleStatus.Uploaded:   return 'badge bg-secondary';
       case DocumentLifecycleStatus.Processing: return 'badge bg-warning text-dark';
+      case DocumentLifecycleStatus.PendingReview: return 'badge bg-info text-dark';
       case DocumentLifecycleStatus.Ready:      return 'badge bg-success';
       case DocumentLifecycleStatus.Failed:     return 'badge bg-danger';
       default:                                 return 'badge bg-secondary';
@@ -951,6 +952,7 @@ export class DocumentDetailComponent implements OnInit {
     switch (status) {
       case DocumentLifecycleStatus.Uploaded:   return '::Document:Status:Uploaded';
       case DocumentLifecycleStatus.Processing: return '::Document:Status:Processing';
+      case DocumentLifecycleStatus.PendingReview: return '::Document:Status:PendingReview';
       case DocumentLifecycleStatus.Ready:      return '::Document:Status:Ready';
       case DocumentLifecycleStatus.Failed:     return '::Document:Status:Failed';
       default:                                 return '::Document:Status:Unknown';

--- a/angular/packages/vault-extract/documents/src/lib/documents/document-list/document-list.component.html
+++ b/angular/packages/vault-extract/documents/src/lib/documents/document-list/document-list.component.html
@@ -80,6 +80,7 @@
       <option [ngValue]="undefined">{{ '::Document:Filter:AllStatuses' | abpLocalization }}</option>
       <option [ngValue]="DocumentLifecycleStatus.Uploaded">{{ '::Document:Status:Uploaded' | abpLocalization }}</option>
       <option [ngValue]="DocumentLifecycleStatus.Processing">{{ '::Document:Status:Processing' | abpLocalization }}</option>
+      <option [ngValue]="DocumentLifecycleStatus.PendingReview">{{ '::Document:Status:PendingReview' | abpLocalization }}</option>
       <option [ngValue]="DocumentLifecycleStatus.Ready">{{ '::Document:Status:Ready' | abpLocalization }}</option>
       <option [ngValue]="DocumentLifecycleStatus.Failed">{{ '::Document:Status:Failed' | abpLocalization }}</option>
     </select>

--- a/angular/packages/vault-extract/documents/src/lib/documents/document-list/document-list.component.ts
+++ b/angular/packages/vault-extract/documents/src/lib/documents/document-list/document-list.component.ts
@@ -781,6 +781,8 @@ export class DocumentListComponent implements OnInit {
         return 'badge bg-secondary';
       case DocumentLifecycleStatus.Processing:
         return 'badge bg-warning text-dark';
+      case DocumentLifecycleStatus.PendingReview:
+        return 'badge bg-info text-dark';
       case DocumentLifecycleStatus.Ready:
         return 'badge bg-success';
       case DocumentLifecycleStatus.Failed:
@@ -796,6 +798,9 @@ export class DocumentListComponent implements OnInit {
     const reasons = doc.reviewReasons ?? DocumentReviewReasons.None;
     if ((reasons & DocumentReviewReasons.UnresolvedClassification) !== DocumentReviewReasons.None) {
       return '::Document:ReviewReason:UnresolvedClassification';
+    }
+    if ((reasons & DocumentReviewReasons.DuplicateSuspected) !== DocumentReviewReasons.None) {
+      return '::Document:ReviewReason:DuplicateSuspected';
     }
     if ((reasons & DocumentReviewReasons.MissingRequiredFields) !== DocumentReviewReasons.None) {
       return '::Document:ReviewReason:MissingRequiredFields';
@@ -815,6 +820,8 @@ export class DocumentListComponent implements OnInit {
         return '::Document:Status:Uploaded';
       case DocumentLifecycleStatus.Processing:
         return '::Document:Status:Processing';
+      case DocumentLifecycleStatus.PendingReview:
+        return '::Document:Status:PendingReview';
       case DocumentLifecycleStatus.Ready:
         return '::Document:Status:Ready';
       case DocumentLifecycleStatus.Failed:

--- a/angular/packages/vault-extract/src/lib/proxy-contract.spec.ts
+++ b/angular/packages/vault-extract/src/lib/proxy-contract.spec.ts
@@ -49,6 +49,7 @@ describe('proxy enum contract (smoke)', () => {
   it('DocumentLifecycleStatus matches backend values', () => {
     expect(DocumentLifecycleStatus.Uploaded).toBe(10);
     expect(DocumentLifecycleStatus.Processing).toBe(20);
+    expect(DocumentLifecycleStatus.PendingReview).toBe(25);
     expect(DocumentLifecycleStatus.Ready).toBe(30);
     expect(DocumentLifecycleStatus.Failed).toBe(99);
   });

--- a/angular/packages/vault-extract/src/lib/proxy/documents/document-lifecycle-status.enum.ts
+++ b/angular/packages/vault-extract/src/lib/proxy/documents/document-lifecycle-status.enum.ts
@@ -3,6 +3,7 @@ import { mapEnumToOptions } from '@abp/ng.core';
 export enum DocumentLifecycleStatus {
   Uploaded = 10,
   Processing = 20,
+  PendingReview = 25,
   Ready = 30,
   Failed = 99,
 }

--- a/angular/packages/vault-extract/src/lib/proxy/documents/models.ts
+++ b/angular/packages/vault-extract/src/lib/proxy/documents/models.ts
@@ -60,6 +60,7 @@ export interface DocumentStatisticsDto {
   totalCount?: number;
   uploadedCount?: number;
   processingCount?: number;
+  pendingReviewCount?: number;
   readyCount?: number;
   failedCount?: number;
   needsReviewCount?: number;

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentStatisticsDto.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentStatisticsDto.cs
@@ -8,7 +8,7 @@ namespace Dignite.Vault.Extract.Documents;
 /// </summary>
 public class DocumentStatisticsDto
 {
-    /// <summary>All non-deleted documents in the current layer. Equals the sum of the four lifecycle counts.</summary>
+    /// <summary>All non-deleted documents in the current layer. Equals the sum of the five lifecycle counts.</summary>
     public long TotalCount { get; set; }
 
     /// <summary>Stored but not yet started by any pipeline (<see cref="DocumentLifecycleStatus.Uploaded"/>).</summary>
@@ -16,6 +16,13 @@ public class DocumentStatisticsDto
 
     /// <summary>At least one critical pipeline is still running (<see cref="DocumentLifecycleStatus.Processing"/>).</summary>
     public long ProcessingCount { get; set; }
+
+    /// <summary>
+    /// Pipelines finished but a blocking review reason withholds Ready — waiting on the operator
+    /// (<see cref="DocumentLifecycleStatus.PendingReview"/>, #510). Overlaps <see cref="NeedsReviewCount"/>
+    /// (a PendingReview document always needs attention) but, unlike it, is part of the <see cref="TotalCount"/> partition.
+    /// </summary>
+    public long PendingReviewCount { get; set; }
 
     /// <summary>All critical pipelines succeeded (<see cref="DocumentLifecycleStatus.Ready"/>).</summary>
     public long ReadyCount { get; set; }

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentLifecycleStatus.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/DocumentLifecycleStatus.cs
@@ -9,6 +9,17 @@ public enum DocumentLifecycleStatus
     Processing = 20,
 
     /// <summary>
+    /// Every critical pipeline has run as far as it can, but a <b>blocking</b> review reason
+    /// (one of <see cref="ReviewReasonPolicy.Blocking"/>) withholds <see cref="Ready"/> — the document is
+    /// waiting on an operator decision, not on the pipeline (#510). Distinct from <see cref="Processing"/>
+    /// ("a critical pipeline is still running"), so the operator UI stops showing a spinner for a document that
+    /// has actually finished processing and now needs a human. Because it is <b>not</b> <see cref="Ready"/>,
+    /// <c>DocumentReadyEto</c> is not fired and the document is not released to downstream consumers — the same
+    /// withholding as <see cref="Processing"/>, only with an honest appearance.
+    /// </summary>
+    PendingReview = 25,
+
+    /// <summary>
     /// All critical pipelines, Parse and Classification, completed successfully.
     /// The document is available to business workflows; non-critical pipelines such as embedding may
     /// still be running.

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -162,6 +162,7 @@
 
     "Document:Status:Uploaded": "Uploaded",
     "Document:Status:Processing": "Processing",
+    "Document:Status:PendingReview": "Awaiting review",
     "Document:Status:Ready": "Ready",
     "Document:Status:Failed": "Failed",
     "Document:Status:Unknown": "Unknown",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -162,6 +162,7 @@
 
     "Document:Status:Uploaded": "アップロード済み",
     "Document:Status:Processing": "処理中",
+    "Document:Status:PendingReview": "確認待ち",
     "Document:Status:Ready": "準備完了",
     "Document:Status:Failed": "失敗",
     "Document:Status:Unknown": "不明",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -162,6 +162,7 @@
 
     "Document:Status:Uploaded": "已上传",
     "Document:Status:Processing": "处理中",
+    "Document:Status:PendingReview": "待放行",
     "Document:Status:Ready": "就绪",
     "Document:Status:Failed": "失败",
     "Document:Status:Unknown": "未知",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -162,6 +162,7 @@
 
     "Document:Status:Uploaded": "已上傳",
     "Document:Status:Processing": "處理中",
+    "Document:Status:PendingReview": "待放行",
     "Document:Status:Ready": "就緒",
     "Document:Status:Failed": "失敗",
     "Document:Status:Unknown": "未知",

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentStatisticsModel.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/DocumentStatisticsModel.cs
@@ -14,6 +14,8 @@ public class DocumentStatisticsModel
 
     public long ProcessingCount { get; set; }
 
+    public long PendingReviewCount { get; set; }
+
     public long ReadyCount { get; set; }
 
     public long FailedCount { get; set; }

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/Pipelines/DocumentPipelineRunManager.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/Pipelines/DocumentPipelineRunManager.cs
@@ -362,14 +362,24 @@ public class DocumentPipelineRunManager : DomainService
             }
         }
 
-        // #284: Ready gate changed from "has confirmed type" to "has no blocking review reasons". Equivalence:
-        // the low-confidence path sets UnresolvedClassification (blocking) and clears DocumentTypeId together, so !HasValue <=> UC set.
-        // Benefit: the gate is extensible. Future blocking reasons cost nothing, and non-blocking reasons such as missing required fields naturally do not block Ready.
-        if (derivedStatus != DocumentLifecycleStatus.Failed &&
-            allSucceeded &&
-            !ReviewReasonPolicy.HasBlocking(document.ReviewReasons))
+        // #284: Ready gate is "no blocking review reason" (ReviewReasonPolicy.Blocking is the single declaration
+        // point). #510: split the not-Ready availability appearance in two. A document that carries a blocking
+        // reason is PendingReview — it has run as far as it can but is withheld from Ready waiting on the operator
+        // (low-confidence classification, suspected duplicate, oversized-for-field-extraction). That is distinct
+        // from Processing, which now means only "a key pipeline is still running / has not started" (no blocking
+        // reason yet). Both withhold downstream release identically — only the transition to Ready fires
+        // DocumentReadyEto — so PendingReview changes the operator-facing status without touching the egress gate.
+        // Failed still dominates both (a failed key pipeline, or an operator rejection via RejectReview).
+        if (derivedStatus != DocumentLifecycleStatus.Failed)
         {
-            derivedStatus = DocumentLifecycleStatus.Ready;
+            if (ReviewReasonPolicy.HasBlocking(document.ReviewReasons))
+            {
+                derivedStatus = DocumentLifecycleStatus.PendingReview;
+            }
+            else if (allSucceeded)
+            {
+                derivedStatus = DocumentLifecycleStatus.Ready;
+            }
         }
 
         document.TransitionLifecycle(derivedStatus);

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -278,6 +278,7 @@ public class EfCoreDocumentRepository
             TotalCount = byStatus.Sum(b => b.Count),
             UploadedCount = CountOf(DocumentLifecycleStatus.Uploaded),
             ProcessingCount = CountOf(DocumentLifecycleStatus.Processing),
+            PendingReviewCount = CountOf(DocumentLifecycleStatus.PendingReview),
             ReadyCount = CountOf(DocumentLifecycleStatus.Ready),
             FailedCount = CountOf(DocumentLifecycleStatus.Failed),
             NeedsReviewCount = byStatus.Sum(b => b.NeedsReview),

--- a/core/test/Dignite.Vault.Extract.Domain.Tests/Documents/DocumentPipelineRunManagerTests.cs
+++ b/core/test/Dignite.Vault.Extract.Domain.Tests/Documents/DocumentPipelineRunManagerTests.cs
@@ -135,7 +135,9 @@ public class DocumentPipelineRunManagerTests : VaultExtractDomainTestBase<VaultE
         doc.SetReviewReason(DocumentReviewReasons.DuplicateSuspected, present: true);
         await _manager.CompleteAsync(doc, fieldRun);
 
-        doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.Processing);
+        // #510: all three key pipelines succeeded but DuplicateSuspected (blocking) withholds Ready, so the
+        // availability appearance is PendingReview (waiting on the operator), not Processing (still running).
+        doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.PendingReview);
 
         // Operator decides it is not a duplicate -> clearing the reason + re-deriving releases it to Ready.
         doc.AllowDuplicate();
@@ -298,7 +300,10 @@ public class DocumentPipelineRunManagerTests : VaultExtractDomainTestBase<VaultE
 
         doc.ReviewReasons.ShouldBe(DocumentReviewReasons.UnresolvedClassification);
         doc.DocumentTypeId.ShouldBeNull();
-        doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.Processing);
+        // #510 (Semantics B): a blocking reason alone makes it PendingReview, not Processing — even though
+        // field-extraction never ran (no confirmed type), the machine has gone as far as it can and is waiting
+        // on the operator to confirm a type. Still not Ready, so DocumentReadyEto is not fired.
+        doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.PendingReview);
     }
 
     // ────────────────────────────────────────────────────────────────────────────

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFieldExtractionBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFieldExtractionBackgroundJob_Tests.cs
@@ -171,7 +171,8 @@ public class DocumentFieldExtractionBackgroundJob_Tests
             doc!.ExtractedFieldValues.ShouldBeEmpty();
             doc.ReviewReasons.HasFlag(DocumentReviewReasons.FieldExtractionIncomplete).ShouldBeTrue();
             ReviewReasonPolicy.HasBlocking(doc.ReviewReasons).ShouldBeTrue();
-            doc.LifecycleStatus.ShouldNotBe(DocumentLifecycleStatus.Ready);
+            // #510: a blocking reason (FieldExtractionIncomplete) withholds Ready -> PendingReview, not Processing.
+            doc.LifecycleStatus.ShouldBe(DocumentLifecycleStatus.PendingReview);
         });
     }
 

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/EfCoreDocumentRepositoryStatistics_Tests.cs
@@ -50,6 +50,8 @@ public class EfCoreDocumentRepositoryStatistics_Tests : VaultExtractEntityFramew
             await SeedDocAsync(DocumentLifecycleStatus.Ready, 300);
             await SeedDocAsync(DocumentLifecycleStatus.Ready, 400);
             await SeedDocAsync(DocumentLifecycleStatus.Failed, 500);
+            // #510: PendingReview always carries a blocking review reason, so it also counts as needs-review.
+            await SeedDocAsync(DocumentLifecycleStatus.PendingReview, 700, needsReview: true);
             // Needs review: an unresolved reason is set and it is not rejected; lifecycle stays Uploaded.
             await SeedDocAsync(DocumentLifecycleStatus.Uploaded, 50, needsReview: true);
             // Rejected: carries a reason but disposition == Rejected, so it does NOT count as needs-review;
@@ -65,13 +67,14 @@ public class EfCoreDocumentRepositoryStatistics_Tests : VaultExtractEntityFramew
 
         var stats = await WithUnitOfWorkAsync(() => _documentRepository.GetStatisticsAsync());
 
-        stats.TotalCount.ShouldBe(7);            // 8 active inserts - 1 soft-deleted
+        stats.TotalCount.ShouldBe(8);            // 9 active inserts - 1 soft-deleted
         stats.UploadedCount.ShouldBe(2);         // plain Uploaded + needs-review (still Uploaded)
         stats.ProcessingCount.ShouldBe(1);
+        stats.PendingReviewCount.ShouldBe(1);    // #510: the PendingReview-seeded document
         stats.ReadyCount.ShouldBe(2);
         stats.FailedCount.ShouldBe(2);           // explicit Failed + rejected (-> Failed)
-        stats.NeedsReviewCount.ShouldBe(1);      // the rejected one is excluded
-        stats.TotalStorageBytes.ShouldBe(1610);  // 100+200+300+400+500+50+60
+        stats.NeedsReviewCount.ShouldBe(2);      // the PendingReview seed (blocking reason) + the Uploaded needs-review; the rejected one is excluded
+        stats.TotalStorageBytes.ShouldBe(2310);  // 100+200+300+400+500+700+50+60
     }
 
     [Fact]


### PR DESCRIPTION
Closes #510.

## What

Splits the not-Ready availability appearance in two. A document whose pipelines have run as far as they can but that carries a **blocking** review reason (`ReviewReasonPolicy.Blocking`: `UnresolvedClassification` / `DuplicateSuspected` / `FieldExtractionIncomplete`) now derives to a new `PendingReview` state instead of falling back to `Processing`. `Processing` now means only "a key pipeline is still running / has not started".

Motivation: a document that finished all pipeline work but is withheld pending an operator decision showed `Processing` + spinner — looking stuck when it was actually waiting on a human, and redundant next to the review badge. Instance: `be5b563c-…` (a `DuplicateSuspected` sub-document whose three key pipelines all Succeeded).

## Semantics (Option B, per the issue)

- `PendingReview` = `HasBlocking(ReviewReasons)` and not `Failed`
- `Processing` = no blocking reason and not all key pipelines succeeded yet
- `Ready` = no blocking reason and all key pipelines succeeded

The egress gate is unchanged — only the transition to `Ready` fires `DocumentReadyEto`, so `PendingReview` withholds downstream release exactly as `Processing` did. No new event.

## Changes

- `DocumentLifecycleStatus.PendingReview = 25` (between `Processing` and `Ready`)
- `DeriveLifecycleAsync`: `HasBlocking → PendingReview; else allSucceeded → Ready; else Processing`
- statistics: `DocumentStatisticsModel/Dto.PendingReviewCount` + repository bucket, keeping `TotalCount = Σ lifecycle buckets`
- localization `Document:Status:PendingReview` in en/ja/zh-Hans/zh-Hant, worded distinctly from the review badge (en "Awaiting review", zh "待放行", ja "確認待ち")
- Angular: proxy enum + stats model, list/detail status label + badge (`bg-info`, **no spinner**), lifecycle-filter option, `proxy-contract.spec`; also adds the missing `DuplicateSuspected` review-badge label
- tests flip `Processing → PendingReview` for the duplicate / low-confidence / oversized-field-extraction cases; statistics test covers the new bucket

## Verification

- Backend: Domain **191** / Application **354** / EF Core **149** — all green
- Angular: vitest **80** pass, `nx build vault-extract` clean (contract spec locks `PendingReview = 25`)
- Live dev row `be5b563c` re-derived **20 → 25** via a guarded update whose predicate encodes `DeriveLifecycleAsync` (matched exactly 1 row); `DuplicateSuspected` reason intact

## Deploy

No EF migration (int column). Existing rows sitting at `Processing` that are really blocked won't reflect `PendingReview` until re-derived — the dev DB's one such row (`be5b563c`) was already re-derived. The proxy was hand-edited to match generator output (a regen against a not-yet-redeployed host would drop `25`); it is a no-op on the next real regen. Host binary + SPA need a rebuild to serve / render the new value.
