### PR TITLE
test(mcp): restore real-permission-pipeline coverage for the MCP egress (#516)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
       - name: Run MCP tests
         run: dotnet test core/test/Dignite.Vault.Extract.Mcp.Tests/Dignite.Vault.Extract.Mcp.Tests.csproj --no-build --configuration Release --verbosity normal
 
+      # Real ABP permission pipeline (PermissionManagement Domain+EF on in-memory SQLite, NO AddAlwaysAllowAuthorization):
+      # proves the MCP egress's fail-closed CheckPolicyAsync gate denies an ungranted principal (#516).
+      - name: Run MCP integration tests
+        run: dotnet test core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj --no-build --configuration Release --verbosity normal
+
       # Pure unit tests: mocked IChatClient + IPdfRasterizer; no native PDFium or external LLM dependency.
       - name: Run OCR VisionLlm tests
         run: dotnet test core/test/Dignite.Vault.Extract.Ocr.VisionLlm.Tests/Dignite.Vault.Extract.Ocr.VisionLlm.Tests.csproj --no-build --configuration Release --verbosity normal

--- a/Dignite.Vault.Extract.slnx
+++ b/Dignite.Vault.Extract.slnx
@@ -28,6 +28,7 @@
         <Project Path="core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/Dignite.Vault.Extract.EntityFrameworkCore.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Application.Tests/Dignite.Vault.Extract.Application.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Mcp.Tests/Dignite.Vault.Extract.Mcp.Tests.csproj" />
+        <Project Path="core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Ocr.VisionLlm.Tests/Dignite.Vault.Extract.Ocr.VisionLlm.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Ocr.PaddleOcr.Tests/Dignite.Vault.Extract.Ocr.PaddleOcr.Tests.csproj" />
         <Project Path="core/test/Dignite.Vault.Extract.Ocr.AzureDocumentIntelligence.Tests/Dignite.Vault.Extract.Ocr.AzureDocumentIntelligence.Tests.csproj" />

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Dignite.Vault.Extract.Mcp.Integration.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\..\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Dignite.Vault.Extract</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- DocumentSearchTool (MCP SDK attributes) + the synthetic ClaimsPrincipal compile through the shared framework. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.extensibility.execution" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Volo.Abp.Autofac" />
+    <PackageReference Include="Volo.Abp.Authorization" />
+    <PackageReference Include="Volo.Abp.TestBase" />
+    <!-- The point of this project: a REAL permission checker + store (no AddAlwaysAllowAuthorization), so an
+         authenticated principal resolves grants through ABP's genuine permission pipeline — the MCP egress's
+         fail-closed gate. Re-established in #516 after #514 removed the #432 project with the X-Api-Key channel. -->
+    <PackageReference Include="Volo.Abp.PermissionManagement.EntityFrameworkCore" />
+    <PackageReference Include="Volo.Abp.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dignite.Vault.Extract.Mcp\Dignite.Vault.Extract.Mcp.csproj" />
+    <ProjectReference Include="..\..\src\Dignite.Vault.Extract.Application\Dignite.Vault.Extract.Application.csproj" />
+    <ProjectReference Include="..\..\src\Dignite.Vault.Extract.EntityFrameworkCore\Dignite.Vault.Extract.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Documents/McpPermissionResolution_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/Documents/McpPermissionResolution_Tests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.Cabinets;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Permissions;
+using Shouldly;
+using Volo.Abp.Authorization;
+using Volo.Abp.Guids;
+using Volo.Abp.PermissionManagement;
+using Volo.Abp.Security.Claims;
+using Volo.Abp.Users;
+using Xunit;
+
+namespace Dignite.Vault.Extract.Mcp.Documents;
+
+/// <summary>
+/// #516: the MCP egress's fail-closed permission gate, verified end-to-end against a REAL ABP permission pipeline
+/// (no <c>AddAlwaysAllowAuthorization</c>; real <c>PermissionChecker</c> + EF <c>PermissionStore</c>). This is the
+/// coverage the deleted #432 project held, which #514 removed together with the X-Api-Key channel it was built
+/// around — re-established here without that channel: the principal is a <b>bare</b> <see cref="ClaimsPrincipal"/>
+/// carrying only <c>AbpClaimTypes.UserId</c> (all ABP permission resolution reads) plus a non-empty authentication
+/// type, so the test is independent of how an authenticated caller was produced. These tests drive the real
+/// <c>search_documents</c> / <c>list_cabinets</c> tools as that principal and assert:
+///   (a) granted the minimal <c>Documents.Default</c> -> <c>CheckPolicyAsync</c> passes and a search returns rows;
+///   (b) NOT granted -> fail-closed <see cref="AbpAuthorizationException"/> (the LLM tool-dispatch path is not a privilege-escalation channel);
+///   (c) <c>CurrentUser.Id</c> == the service account.
+/// </summary>
+public class McpPermissionResolution_Tests : McpPermissionPipelineTestBase<McpPermissionPipelineTestModule>
+{
+    private const string TypeCode = "contract.integration";
+
+    // The service account that is granted the permission, and a second, ungranted account for the fail-closed case.
+    private static readonly Guid GrantedServiceAccountId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid UngrantedServiceAccountId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private readonly IDocumentAppService _documentAppService;
+    private readonly ICabinetReadAppService _cabinetReadAppService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly ICabinetRepository _cabinetRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IPermissionGrantRepository _permissionGrantRepository;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly ICurrentPrincipalAccessor _principalAccessor;
+    private readonly ICurrentUser _currentUser;
+
+    public McpPermissionResolution_Tests()
+    {
+        _documentAppService = GetRequiredService<IDocumentAppService>();
+        _cabinetReadAppService = GetRequiredService<ICabinetReadAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _cabinetRepository = GetRequiredService<ICabinetRepository>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _permissionGrantRepository = GetRequiredService<IPermissionGrantRepository>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _principalAccessor = GetRequiredService<ICurrentPrincipalAccessor>();
+        _currentUser = GetRequiredService<ICurrentUser>();
+    }
+
+    [Fact]
+    public async Task Granted_principal_resolves_permissions_and_search_returns_rows()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAndDocumentAsync();
+            await GrantDocumentsDefaultAsync(GrantedServiceAccountId);
+        });
+
+        using (_principalAccessor.Change(ServiceAccountPrincipal(GrantedServiceAccountId)))
+        {
+            await WithUnitOfWorkAsync(async () =>
+            {
+                // (c) the ambient principal really is the mapped service account.
+                _currentUser.Id.ShouldBe(GrantedServiceAccountId);
+
+                // (a) drive the real MCP tool: CheckPolicyAsync(Documents.Default) inside GetListAsync passes and
+                // the search returns the seeded document — proving the store grant resolves from the user-id claim.
+                var result = await DocumentSearchTool.SearchAsync(_documentAppService, documentTypeCode: TypeCode);
+
+                result.Items.ShouldNotBeEmpty();
+                result.Items.ShouldContain(i => i.DocumentTypeCode == TypeCode);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task Ungranted_principal_is_fail_closed_denied()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await SeedTypeAndDocumentAsync();
+            // Grant the OTHER account only, so the store has grants but not for this principal — proving the check
+            // is keyed on the principal's user id, not merely "some grant exists".
+            await GrantDocumentsDefaultAsync(GrantedServiceAccountId);
+        });
+
+        using (_principalAccessor.Change(ServiceAccountPrincipal(UngrantedServiceAccountId)))
+        {
+            await Should.ThrowAsync<AbpAuthorizationException>(() =>
+                WithUnitOfWorkAsync(() => DocumentSearchTool.SearchAsync(_documentAppService, documentTypeCode: TypeCode)));
+        }
+    }
+
+    [Fact]
+    public async Task Documents_only_principal_can_discover_cabinets_without_cabinet_admin_permission()
+    {
+        var cabinetId = Guid.NewGuid();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _cabinetRepository.InsertAsync(
+                new Cabinet(cabinetId, tenantId: null, "Legal", "Contracts"),
+                autoSave: true);
+            await GrantDocumentsDefaultAsync(GrantedServiceAccountId);
+        });
+
+        using (_principalAccessor.Change(ServiceAccountPrincipal(GrantedServiceAccountId)))
+        {
+            await WithUnitOfWorkAsync(async () =>
+            {
+                // #473 permission decision: cabinet discovery is document-read metadata. A service account with
+                // exactly Documents.Default and no Cabinets.* grant can still discover cabinets.
+                var result = await CabinetTools.ListAsync(_cabinetReadAppService);
+
+                result.Items.ShouldContain(c => c.Id == cabinetId);
+            });
+        }
+    }
+
+    // Seeds the searched document type plus one document classified to it (DocumentTypeId has a Domain private
+    // setter; mirror the EF search tests and set it via reflection to simulate the classified state).
+    private async Task SeedTypeAndDocumentAsync()
+    {
+        var typeId = Guid.NewGuid();
+        await _documentTypeRepository.InsertAsync(
+            new DocumentType(typeId, tenantId: null, TypeCode, "Integration Contract"), autoSave: true);
+
+        var document = new Document(
+            Guid.NewGuid(),
+            tenantId: null,
+            fileOrigin: new FileOrigin(
+                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
+                uploadedByUserName: "svc",
+                contentType: "application/pdf",
+                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
+                fileSize: 1024,
+                originalFileName: "integration.pdf"));
+
+        typeof(Document).GetProperty(nameof(Document.DocumentTypeId))!.SetValue(document, typeId);
+
+        await _documentRepository.InsertAsync(document, autoSave: true);
+    }
+
+    // ABP's user-scoped permission value provider name (UserPermissionValueProvider.ProviderName == "U"). We
+    // write the grant row straight to the store rather than through IPermissionManager.SetAsync, because the "U"
+    // *management* provider (the SetAsync dispatch target) lives in the Identity-integration package; the *check*
+    // still runs through the real UserPermissionValueProvider + PermissionStore, which is the seam under test.
+    private const string UserProviderName = "U";
+
+    private async Task GrantDocumentsDefaultAsync(Guid userId)
+    {
+        // Direct user-level grant (provider "U", no roles) — exactly the least-privilege model the egress requires.
+        await _permissionGrantRepository.InsertAsync(
+            new PermissionGrant(
+                _guidGenerator.Create(),
+                VaultExtractPermissions.Documents.Default,
+                UserProviderName,
+                userId.ToString(),
+                tenantId: null),
+            autoSave: true);
+    }
+
+    // The claim shape ABP's permission pipeline actually reads: only AbpClaimTypes.UserId, plus a non-empty
+    // authentication type so the identity is IsAuthenticated == true. Permissions are NOT stamped as claims — the
+    // real PermissionChecker resolves them from the store by user id at CheckPolicyAsync time. This is the shape
+    // any authenticated MCP caller carries; the assertion under test is independent of how it was obtained.
+    private static ClaimsPrincipal ServiceAccountPrincipal(Guid userId)
+    {
+        var identity = new ClaimsIdentity(
+            new[] { new Claim(AbpClaimTypes.UserId, userId.ToString()) },
+            authenticationType: "IntegrationTest");
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpPermissionPipelineTestBase.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpPermissionPipelineTestBase.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
+using Volo.Abp.Modularity;
+using Volo.Abp.Testing;
+using Volo.Abp.Uow;
+
+namespace Dignite.Vault.Extract.Mcp;
+
+/// <summary>Base for the #516 integration tests: an Autofac ABP host with a real permission pipeline.</summary>
+public abstract class McpPermissionPipelineTestBase<TStartupModule> : AbpIntegratedTest<TStartupModule>
+    where TStartupModule : IAbpModule
+{
+    protected override void SetAbpApplicationCreationOptions(AbpApplicationCreationOptions options)
+    {
+        options.UseAutofac();
+    }
+
+    protected virtual async Task WithUnitOfWorkAsync(Func<Task> action)
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var uowManager = scope.ServiceProvider.GetRequiredService<IUnitOfWorkManager>();
+        using var uow = uowManager.Begin(new AbpUnitOfWorkOptions());
+        await action();
+        await uow.CompleteAsync();
+    }
+}

--- a/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpPermissionPipelineTestModule.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Integration.Tests/McpPermissionPipelineTestModule.cs
@@ -1,0 +1,91 @@
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Volo.Abp;
+using Volo.Abp.Autofac;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore.Sqlite;
+using Volo.Abp.Modularity;
+using Volo.Abp.PermissionManagement;
+using Volo.Abp.PermissionManagement.EntityFrameworkCore;
+using Volo.Abp.Testing;
+using Volo.Abp.Uow;
+
+namespace Dignite.Vault.Extract.Mcp;
+
+/// <summary>
+/// Integration-test host for the MCP egress's permission gate (#516). Unlike the shared <c>VaultExtractTestBase</c>,
+/// this module <b>does not</b> call <c>AddAlwaysAllowAuthorization</c>: it boots the real Application + EF stack plus
+/// real ABP PermissionManagement (Domain + EF), so the permission checker resolves grants from the store by the
+/// principal's user id — the seam the LLM tool-dispatch path depends on, which every AlwaysAllow-based suite
+/// short-circuits and cannot cover. Two DbContexts (Extract + PermissionManagement) share one in-memory SQLite
+/// connection so a granted user id and the searched documents live in the same database.
+/// </summary>
+[DependsOn(
+    typeof(AbpAutofacModule),
+    typeof(AbpTestBaseModule),
+    typeof(VaultExtractApplicationModule),
+    typeof(VaultExtractEntityFrameworkCoreModule),
+    typeof(AbpEntityFrameworkCoreSqliteModule),
+    typeof(AbpPermissionManagementDomainModule),
+    typeof(AbpPermissionManagementEntityFrameworkCoreModule)
+)]
+public class McpPermissionPipelineTestModule : AbpModule
+{
+    public override void PreConfigureServices(ServiceConfigurationContext context)
+    {
+        PreConfigure<AbpSqliteOptions>(x => x.BusyTimeout = null);
+    }
+
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Keep permissions purely code-based (static providers): no DB-persisted permission definitions and no
+        // dynamic store, so the test needs no definition seeding / distributed lock — only grant rows matter.
+        Configure<PermissionManagementOptions>(options =>
+        {
+            options.SaveStaticPermissionsToDatabase = false;
+            options.IsDynamicPermissionStoreEnabled = false;
+        });
+
+        // DocumentAppService depends on the document BLOB container; this test never touches blob storage
+        // (it only searches), so substitute it rather than wiring a real provider — same pattern as the
+        // Application/EF tests. The real repositories + real DB stay in place for the search path.
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+
+        context.Services.AddAlwaysDisableUnitOfWorkTransaction();
+
+        var sqliteConnection = CreateDatabaseAndGetConnection();
+
+        Configure<AbpDbContextOptions>(options =>
+        {
+            options.Configure(configurationContext =>
+            {
+                configurationContext.UseSqlite(sqliteConnection);
+            });
+        });
+    }
+
+    private static SqliteConnection CreateDatabaseAndGetConnection()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        // Create both schemas on the SAME open in-memory connection: Extract tables (documents / types) and the
+        // ABP permission-grant tables. The connection stays open for the app lifetime so the schema persists.
+        new VaultExtractDbContext(
+            new DbContextOptionsBuilder<VaultExtractDbContext>().UseSqlite(connection).Options
+        ).GetService<IRelationalDatabaseCreator>().CreateTables();
+
+        new PermissionManagementDbContext(
+            new DbContextOptionsBuilder<PermissionManagementDbContext>().UseSqlite(connection).Options
+        ).GetService<IRelationalDatabaseCreator>().CreateTables();
+
+        return connection;
+    }
+}


### PR DESCRIPTION
Re-establishes the real-permission-pipeline test coverage that #514 removed when it deleted the #432 integration project along with the X-Api-Key channel. Closes #516.

## Why
The deleted project was the **only** test in the repo that exercised the real ABP permission store — every other suite runs under `AddAlwaysAllowAuthorization`, which short-circuits authorization. That left the MCP egress's fail-closed `CheckPolicyAsync` gate — the sole defense on the LLM tool-dispatch path, since `[Authorize]` doesn't fire there (`.claude/rules/llm-call-anti-patterns.md`, anti-pattern B) — with zero automated coverage.

## What
The same module/base scaffolding as #432 (real Application + EF + PermissionManagement Domain/EF on one in-memory SQLite connection, **no** `AddAlwaysAllowAuthorization`), minus the key channel. The principal is now a bare `ClaimsPrincipal` carrying only `AbpClaimTypes.UserId` — all ABP permission resolution reads — so the test is independent of how an authenticated caller was produced. Drives the real `search_documents` / `list_cabinets` tools and asserts:

- granted `Documents.Default` → `CheckPolicyAsync` passes, search returns rows, `CurrentUser.Id` == the account;
- **ungranted → fail-closed `AbpAuthorizationException`** (a *second* account is granted, proving the check is keyed on this principal's id, not merely "some grant exists");
- `Documents.Default` alone discovers cabinets with no `Cabinets.*` grant, per #473.

## Wiring + verification
- Added to the slnx **and to ci.yml** — the deleted project was built by the slnx but never run in CI, so it only ever gated locally. This one runs.
- **Mutation-verified**: removing the `CheckPolicyAsync` in `DocumentAppService.GetListAsync` turns the ungranted test red (2 pass / 1 fail); reverted after. The guard is real, not hollow.
- 3/3 green; full `slnx` build clean.

Closes #516.
