### PR TITLE
Fix tenant context in document background jobs

### DIFF
--- a/core/src/Dignite.Vault.Extract.Application/Documents/Cabinets/DocumentCabinetSuggestionBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Cabinets/DocumentCabinetSuggestionBackgroundJob.cs
@@ -71,6 +71,14 @@ public class DocumentCabinetSuggestionBackgroundJob
 
     public override async Task ExecuteAsync(DocumentCabinetSuggestionJobArgs args)
     {
+        using (_currentTenant.Change(args.TenantId))
+        {
+            await ExecuteInTenantAsync(args);
+        }
+    }
+
+    private async Task ExecuteInTenantAsync(DocumentCabinetSuggestionJobArgs args)
+    {
         try
         {
             var workItem = await PrepareAsync(args.DocumentId);
@@ -206,4 +214,5 @@ public class DocumentCabinetSuggestionBackgroundJob
 public class DocumentCabinetSuggestionJobArgs
 {
     public Guid DocumentId { get; set; }
+    public Guid? TenantId { get; set; }
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Classification/DocumentClassificationBackgroundJob.cs
@@ -56,6 +56,14 @@ public class DocumentClassificationBackgroundJob
 
     public override async Task ExecuteAsync(DocumentClassificationJobArgs args)
     {
+        using (_currentTenant.Change(args.TenantId))
+        {
+            await ExecuteInTenantAsync(args);
+        }
+    }
+
+    private async Task ExecuteInTenantAsync(DocumentClassificationJobArgs args)
+    {
         var workItem = await BeginRunAsync(args);
 
         try
@@ -175,7 +183,7 @@ public class DocumentClassificationBackgroundJob
             // atomically via the outbox. The unified pass (#371) reads Document.Markdown and splits both text and
             // figure spans — there is no separate figure-routing job anymore.
             await _backgroundJobManager.EnqueueAsync(
-                new DocumentSegmentationJobArgs { SourceDocumentId = document.Id });
+                new DocumentSegmentationJobArgs { SourceDocumentId = document.Id, TenantId = document.TenantId });
             return;
         }
 
@@ -238,7 +246,7 @@ public class DocumentClassificationBackgroundJob
         if (shouldRoute)
         {
             await _backgroundJobManager.EnqueueAsync(
-                new DocumentSegmentationJobArgs { SourceDocumentId = document.Id });
+                new DocumentSegmentationJobArgs { SourceDocumentId = document.Id, TenantId = document.TenantId });
         }
     }
 
@@ -253,5 +261,6 @@ public class DocumentClassificationBackgroundJob
 public class DocumentClassificationJobArgs
 {
     public Guid DocumentId { get; set; }
+    public Guid? TenantId { get; set; }
     public Guid? PipelineRunId { get; set; }
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/DocumentPipelineJobScheduler.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/DocumentPipelineJobScheduler.cs
@@ -42,13 +42,14 @@ public class DocumentPipelineJobScheduler : ITransientDependency
         var run = await _pipelineRunManager.QueueAsync(document, pipelineCode);
 
         await _documentRepository.UpdateAsync(document, autoSave: true);
-        await EnqueueAsync(document.Id, pipelineCode, run.Id, delay);
+        await EnqueueAsync(document.Id, document.TenantId, pipelineCode, run.Id, delay);
 
         return run;
     }
 
     protected virtual Task EnqueueAsync(
         Guid documentId,
+        Guid? tenantId,
         string pipelineCode,
         Guid pipelineRunId,
         TimeSpan? delay = null)
@@ -60,6 +61,7 @@ public class DocumentPipelineJobScheduler : ITransientDependency
                 new DocumentParseJobArgs
                 {
                     DocumentId = documentId,
+                    TenantId = tenantId,
                     PipelineRunId = pipelineRunId
                 },
                 delay: effectiveDelay),
@@ -67,6 +69,7 @@ public class DocumentPipelineJobScheduler : ITransientDependency
                 new DocumentClassificationJobArgs
                 {
                     DocumentId = documentId,
+                    TenantId = tenantId,
                     PipelineRunId = pipelineRunId
                 },
                 delay: effectiveDelay),
@@ -74,6 +77,7 @@ public class DocumentPipelineJobScheduler : ITransientDependency
                 new DocumentFieldExtractionJobArgs
                 {
                     DocumentId = documentId,
+                    TenantId = tenantId,
                     PipelineRunId = pipelineRunId
                 },
                 delay: effectiveDelay),

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/DocumentFieldExtractionBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/DocumentFieldExtractionBackgroundJob.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Uow;
 
 namespace Dignite.Vault.Extract.Documents.Pipelines.FieldExtraction;
@@ -33,6 +34,7 @@ public class DocumentFieldExtractionBackgroundJob
     : DocumentPipelineBackgroundJobBase<DocumentFieldExtractionJobArgs>, ITransientDependency
 {
     private readonly FieldExtractionService _fieldExtractionService;
+    private readonly ICurrentTenant _currentTenant;
 
     public DocumentFieldExtractionBackgroundJob(
         IDocumentRepository documentRepository,
@@ -40,13 +42,23 @@ public class DocumentFieldExtractionBackgroundJob
         DocumentPipelineRunManager pipelineRunManager,
         DocumentPipelineRunAccessor pipelineRunAccessor,
         IUnitOfWorkManager unitOfWorkManager,
-        FieldExtractionService fieldExtractionService)
+        FieldExtractionService fieldExtractionService,
+        ICurrentTenant currentTenant)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _fieldExtractionService = fieldExtractionService;
+        _currentTenant = currentTenant;
     }
 
     public override async Task ExecuteAsync(DocumentFieldExtractionJobArgs args)
+    {
+        using (_currentTenant.Change(args.TenantId))
+        {
+            await ExecuteInTenantAsync(args);
+        }
+    }
+
+    private async Task ExecuteInTenantAsync(DocumentFieldExtractionJobArgs args)
     {
         var (documentId, runId, tenantId) = await BeginRunAsync(args);
 
@@ -95,6 +107,7 @@ public class DocumentFieldExtractionBackgroundJob
 public class DocumentFieldExtractionJobArgs
 {
     public Guid DocumentId { get; set; }
+    public Guid? TenantId { get; set; }
     public Guid? PipelineRunId { get; set; }
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/FieldExtractionEventHandler.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/FieldExtractionEventHandler.cs
@@ -45,6 +45,7 @@ public class FieldExtractionEventHandler
             new DocumentFieldExtractionJobArgs
             {
                 DocumentId = eventData.DocumentId,
+                TenantId = eventData.TenantId,
                 ExpectedEventTypeCode = eventData.DocumentTypeCode
             });
     }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Parse/DocumentParseBackgroundJob.cs
@@ -18,6 +18,7 @@ using Volo.Abp.BlobStoring;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Threading;
 using Volo.Abp.Timing;
 using Volo.Abp.Uow;
@@ -52,6 +53,7 @@ public class DocumentParseBackgroundJob
     private readonly ICancellationTokenProvider _cancellationTokenProvider;
     // #346/#371: born-digital container slices / figure spans; looked up in the Begin phase to seed a derived sub-document's Markdown.
     private readonly IRepository<DocumentSegment, Guid> _documentSegmentRepository;
+    private readonly ICurrentTenant _currentTenant;
 
     public DocumentParseBackgroundJob(
         IDocumentRepository documentRepository,
@@ -69,7 +71,8 @@ public class DocumentParseBackgroundJob
         IPromptProvider promptProvider,
         IOptions<VaultExtractBehaviorOptions> behaviorOptions,
         ICancellationTokenProvider cancellationTokenProvider,
-        IRepository<DocumentSegment, Guid> documentSegmentRepository)
+        IRepository<DocumentSegment, Guid> documentSegmentRepository,
+        ICurrentTenant currentTenant)
         : base(documentRepository, runRepository, pipelineRunManager, pipelineRunAccessor, unitOfWorkManager)
     {
         _pipelineJobScheduler = pipelineJobScheduler;
@@ -83,9 +86,18 @@ public class DocumentParseBackgroundJob
         _behaviorOptions = behaviorOptions.Value;
         _cancellationTokenProvider = cancellationTokenProvider;
         _documentSegmentRepository = documentSegmentRepository;
+        _currentTenant = currentTenant;
     }
 
     public override async Task ExecuteAsync(DocumentParseJobArgs args)
+    {
+        using (_currentTenant.Change(args.TenantId))
+        {
+            await ExecuteInTenantAsync(args);
+        }
+    }
+
+    private async Task ExecuteInTenantAsync(DocumentParseJobArgs args)
     {
         var workItem = await BeginRunAsync(args);
 
@@ -238,7 +250,7 @@ public class DocumentParseBackgroundJob
         // Do not gate by AttemptNumber==1: that would miss the first-success case where the first attempt failed and retry succeeded
         // with successful run AttemptNumber > 1.
         await _backgroundJobManager.EnqueueAsync(
-            new DocumentCabinetSuggestionJobArgs { DocumentId = document.Id });
+            new DocumentCabinetSuggestionJobArgs { DocumentId = document.Id, TenantId = document.TenantId });
 
         await uow.CompleteAsync();
     }
@@ -379,5 +391,6 @@ public class DocumentParseBackgroundJob
 public class DocumentParseJobArgs
 {
     public Guid DocumentId { get; set; }
+    public Guid? TenantId { get; set; }
     public Guid? PipelineRunId { get; set; }
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Reprocessing/DocumentFieldReextractionDispatcherJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Reprocessing/DocumentFieldReextractionDispatcherJob.cs
@@ -87,7 +87,7 @@ public class DocumentFieldReextractionDispatcherJob
                     // state is consistent; the worst case is one extra LLM cost, the same accepted cost
                     // as chained dispatcher forking in this file.
                     await _backgroundJobManager.EnqueueAsync(
-                        new DocumentFieldExtractionJobArgs { DocumentId = id });
+                        new DocumentFieldExtractionJobArgs { DocumentId = id, TenantId = args.TenantId });
                 }
 
                 // Full batch means there may be a next page: cursor = last ID in this batch and chain

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Reprocessing/DocumentReclassificationDispatcherJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Reprocessing/DocumentReclassificationDispatcherJob.cs
@@ -74,7 +74,7 @@ public class DocumentReclassificationDispatcherJob
                     // PipelineRunId=null makes the job's BeginOrStartAsync call StartAsync and create
                     // a new classification attempt.
                     await _backgroundJobManager.EnqueueAsync(
-                        new DocumentClassificationJobArgs { DocumentId = id });
+                        new DocumentClassificationJobArgs { DocumentId = id, TenantId = args.TenantId });
                 }
 
                 if (ids.Count == batchSize)

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/Segmentation/DocumentSegmentationJob.cs
@@ -103,6 +103,16 @@ public class DocumentSegmentationJob
 
     public override async Task ExecuteAsync(DocumentSegmentationJobArgs args)
     {
+        // Background workers do not preserve the request tenant. Restore the queued document's
+        // layer before any repository access so ABP's IMultiTenant filter remains the isolation boundary.
+        using (_currentTenant.Change(args.TenantId))
+        {
+            await ExecuteInTenantAsync(args);
+        }
+    }
+
+    private async Task ExecuteInTenantAsync(DocumentSegmentationJobArgs args)
+    {
         var cancellationToken = _cancellationTokenProvider.Token;
 
         var context = await LoadAsync(args.SourceDocumentId);
@@ -644,4 +654,5 @@ public class DocumentSegmentationJobArgs
 {
     /// <summary>The source document whose Markdown (with inline figure markers, #381) should be analyzed for standalone sub-documents.</summary>
     public Guid SourceDocumentId { get; set; }
+    public Guid? TenantId { get; set; }
 }

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineBackgroundJobPersistence_Tests.cs
@@ -11,6 +11,7 @@ using Dignite.Vault.Extract.Documents.Pipelines;
 using Dignite.Vault.Extract.Documents.Pipelines.Classification;
 using Dignite.Vault.Extract.Documents.Pipelines.Parse;
 using Dignite.Vault.Extract.Documents.Segments;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -18,9 +19,11 @@ using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.BlobStoring;
+using Volo.Abp.Content;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Guids;
 using Volo.Abp.Modularity;
+using Volo.Abp.MultiTenancy;
 using Volo.Abp.Uow;
 using Xunit;
 
@@ -60,6 +63,8 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
     private readonly IUnitOfWorkManager _unitOfWorkManager;
     private readonly IDocumentAppService _documentAppService;
     private readonly IRepository<DocumentSegment, Guid> _segmentRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly ICurrentTenant _currentTenant;
 
     public DocumentPipelineBackgroundJobPersistence_Tests()
     {
@@ -74,6 +79,66 @@ public class DocumentPipelineBackgroundJobPersistence_Tests
         _unitOfWorkManager = GetRequiredService<IUnitOfWorkManager>();
         _documentAppService = GetRequiredService<IDocumentAppService>();
         _segmentRepository = GetRequiredService<IRepository<DocumentSegment, Guid>>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _currentTenant = GetRequiredService<ICurrentTenant>();
+    }
+
+    [Fact]
+    public async Task Tenant_Uploaded_Document_Parse_Job_Should_Restore_Queued_Tenant_And_Succeed()
+    {
+        var tenantId = _guidGenerator.Create();
+        var documentId = Guid.Empty;
+
+        using (_currentTenant.Change(tenantId))
+        {
+            await WithUnitOfWorkAsync(async () =>
+            {
+                await _documentTypeRepository.InsertAsync(
+                    new DocumentType(_guidGenerator.Create(), tenantId, "test.document", "Test document"),
+                    autoSave: true);
+
+                var uploaded = await _documentAppService.UploadAsync(new UploadDocumentInput
+                {
+                    File = new RemoteStreamContent(
+                        new MemoryStream([1, 2, 3]), "tenant.pdf", "application/pdf", disposeStream: true)
+                });
+                documentId = uploaded.Id;
+            });
+        }
+
+        // The scheduled payload, not an ambient request scope, carries the tenant into the worker.
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentParseJobArgs>(x => x.DocumentId == documentId && x.TenantId == tenantId),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+
+        _currentTenant.Id.ShouldBeNull(); // simulate a host-scoped background worker
+        StubExtraction("# Tenant document", usedOcr: false);
+
+        await _textExtractionJob.ExecuteAsync(new DocumentParseJobArgs
+        {
+            DocumentId = documentId,
+            TenantId = tenantId
+        });
+
+        using (_currentTenant.Change(tenantId))
+        {
+            await WithUnitOfWorkAsync(async () =>
+            {
+                var document = await _documentRepository.GetAsync(documentId, includeDetails: false);
+                document.Markdown.ShouldBe("# Tenant document");
+            });
+        }
+
+        // Parse's two fan-out paths must keep the same tenant for later document-ID lookups.
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentClassificationJobArgs>(x => x.DocumentId == documentId && x.TenantId == tenantId),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DocumentCabinetSuggestionJobArgs>(x => x.DocumentId == documentId && x.TenantId == tenantId),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Added `TenantId` to document-ID based background job args and enqueue sites across parsing, classification, field extraction, segmentation, cabinet suggestion, and reprocessing dispatch chains.
- Restored tenant context at each job's outer `ExecuteAsync` boundary with `ICurrentTenant.Change(args.TenantId)`, preserving host compatibility when `TenantId` is null.
- Added a regression test covering tenant upload followed by background parsing from a worker with no ambient tenant.

## Root Cause
Tenant-scoped documents were created correctly during upload, but background jobs executed without `CurrentTenant`. ABP's `IMultiTenant` query filter therefore excluded the tenant document when jobs queried by document ID, causing `EntityNotFoundException`.

## Validation
- `dotnet test core\test\Dignite.Vault.Extract.Application.Tests\Dignite.Vault.Extract.Application.Tests.csproj --no-restore --filter "FullyQualifiedName~DocumentClassificationBackgroundJob_Tests|FullyQualifiedName~DocumentCabinetSuggestionBackgroundJob_Tests|FullyQualifiedName~DocumentReprocessing_Tests|FullyQualifiedName~FieldExtractionEventHandler_Tests"`
- `dotnet test core\test\Dignite.Vault.Extract.EntityFrameworkCore.Tests\Dignite.Vault.Extract.EntityFrameworkCore.Tests.csproj --no-restore --filter "FullyQualifiedName~DocumentSegmentationJob_Tests|FullyQualifiedName~DocumentFieldExtractionBackgroundJob_Tests|FullyQualifiedName~DocumentPipelineBackgroundJobPersistence_Tests"`
- `git diff --check`

Fixes #520