### PR TITLE
refactor(mcp): review-driven cleanup of tenant-scoped MCP (#519 follow-up)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/CabinetResourceUri.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/CabinetResourceUri.cs
@@ -9,19 +9,19 @@ namespace Dignite.Vault.Extract.Mcp.Documents;
 /// </summary>
 public static class CabinetResourceUri
 {
-    private const string Prefix = "vault-extract://cabinets/";
-    private const string TenantPrefix = "vault-extract://tenants/";
+    private const string Segment = "cabinets";
+    private const string Prefix = VaultExtractMcpConsts.UriScheme + Segment + "/";
 
     /// <summary>Resource URI template used by the MCP resource scanner.</summary>
     public const string Template = Prefix + "{id}";
 
     /// <summary>Explicit-tenant resource URI template.</summary>
-    public const string TenantTemplate = TenantPrefix + "{tenantId}/cabinets/{id}";
+    public const string TenantTemplate = VaultExtractMcpConsts.TenantUriRoot + "{tenantId}/" + Segment + "/{id}";
 
     public static string Format(Guid cabinetId) => Prefix + cabinetId;
 
     public static string Format(Guid cabinetId, Guid? tenantId) =>
         tenantId.HasValue
-            ? TenantPrefix + tenantId.Value + "/cabinets/" + cabinetId
+            ? VaultExtractMcpConsts.TenantUriRoot + tenantId.Value + "/" + Segment + "/" + cabinetId
             : Format(cabinetId);
 }

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/CabinetTools.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/CabinetTools.cs
@@ -22,7 +22,7 @@ public sealed class CabinetTools
         + "instructions.")]
     public static async Task<CabinetListResult> ListAsync(
         ICabinetReadAppService cabinetReadAppService,
-        [Description("Optional tenant id (UUID). When supplied, list only that tenant and return tenant-scoped resource uris.")]
+        [Description("Optional tenant id (UUID). When supplied, list only that tenant and return tenant-scoped resource URIs.")]
         string? tenantId = null,
         CancellationToken cancellationToken = default,
         IServiceProvider? serviceProvider = null)

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentDetailResult.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentDetailResult.cs
@@ -40,8 +40,8 @@ public sealed record DocumentDetailResult
     /// <summary>
     /// Whether <see cref="Markdown"/> was clipped to <c>VaultExtractMcpConsts.MaxDocumentMarkdownChars</c> (#491).
     /// Mirrors the <c>Truncated</c> signal on <c>DocumentSearchResult</c> / <c>DocumentTypeListResult</c>: an LLM must
-    /// never mistake a clipped body for the whole document. Read the resource
-    /// ambient or explicitly tenant-scoped document resource for the same (also capped) body, or the REST API for the full text.
+    /// never mistake a clipped body for the whole document. Read the ambient or explicitly
+    /// tenant-scoped document resource for the same (also capped) body, or the REST API for the full text.
     /// </summary>
     public required bool MarkdownTruncated { get; init; }
 

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentResourceUri.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentResourceUri.cs
@@ -9,19 +9,19 @@ namespace Dignite.Vault.Extract.Mcp.Documents;
 /// </summary>
 public static class DocumentResourceUri
 {
-    private const string Prefix = "vault-extract://documents/";
-    private const string TenantPrefix = "vault-extract://tenants/";
+    private const string Segment = "documents";
+    private const string Prefix = VaultExtractMcpConsts.UriScheme + Segment + "/";
 
     /// <summary>Resource URI template. Used by <c>[McpServerResource(UriTemplate = ...)]</c> and must be a compile-time constant.</summary>
     public const string Template = Prefix + "{id}";
 
     /// <summary>Explicit-tenant resource URI template. The tenant is carried in the URI so a later resources/read keeps the selected scope.</summary>
-    public const string TenantTemplate = TenantPrefix + "{tenantId}/documents/{id}";
+    public const string TenantTemplate = VaultExtractMcpConsts.TenantUriRoot + "{tenantId}/" + Segment + "/{id}";
 
     public static string Format(Guid documentId) => Prefix + documentId;
 
     public static string Format(Guid documentId, Guid? tenantId) =>
         tenantId.HasValue
-            ? TenantPrefix + tenantId.Value + "/documents/" + documentId
+            ? VaultExtractMcpConsts.TenantUriRoot + tenantId.Value + "/" + Segment + "/" + documentId
             : Format(documentId);
 }

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentSearchTool.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentSearchTool.cs
@@ -71,7 +71,7 @@ public sealed class DocumentSearchTool
         List<DocumentFieldFilter>? fieldFilters = null,
         [Description("Max rows to return (1-50). Defaults to 50.")]
         int? maxResultCount = null,
-        [Description("Optional tenant id (UUID). When supplied, search only that tenant and returned resource URIs retain this tenant scope.")]
+        [Description("Optional tenant id (UUID). When supplied, search only that tenant and return tenant-scoped resource URIs.")]
         string? tenantId = null,
         CancellationToken cancellationToken = default,
         IServiceProvider? serviceProvider = null)

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTools.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTools.cs
@@ -35,7 +35,7 @@ public sealed class DocumentTools
         [Description("The document id (UUID) to read. Obtain it from search_documents results.")]
         string id,
         IDocumentAppService documentAppService,
-        [Description("Optional tenant id (UUID). When supplied, read only that tenant and return a tenant-scoped resource uri.")]
+        [Description("Optional tenant id (UUID). When supplied, read only that tenant and return tenant-scoped resource URIs.")]
         string? tenantId = null,
         CancellationToken cancellationToken = default,
         IServiceProvider? serviceProvider = null)

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeResourceUri.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeResourceUri.cs
@@ -12,19 +12,19 @@ namespace Dignite.Vault.Extract.Mcp.Documents;
 /// </summary>
 public static class DocumentTypeResourceUri
 {
-    private const string Prefix = "vault-extract://document-types/";
-    private const string TenantPrefix = "vault-extract://tenants/";
+    private const string Segment = "document-types";
+    private const string Prefix = VaultExtractMcpConsts.UriScheme + Segment + "/";
 
     /// <summary>Resource URI template. Used by <c>[McpServerResource(UriTemplate = ...)]</c> and must be a compile-time constant.</summary>
     public const string Template = Prefix + "{code}";
 
     /// <summary>Explicit-tenant resource URI template.</summary>
-    public const string TenantTemplate = TenantPrefix + "{tenantId}/document-types/{code}";
+    public const string TenantTemplate = VaultExtractMcpConsts.TenantUriRoot + "{tenantId}/" + Segment + "/{code}";
 
     public static string Format(string typeCode) => Prefix + typeCode;
 
     public static string Format(string typeCode, Guid? tenantId) =>
         tenantId.HasValue
-            ? TenantPrefix + tenantId.Value + "/document-types/" + typeCode
+            ? VaultExtractMcpConsts.TenantUriRoot + tenantId.Value + "/" + Segment + "/" + typeCode
             : Format(typeCode);
 }

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeResources.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeResources.cs
@@ -98,10 +98,12 @@ public sealed class DocumentTypeResources
         var fields = await fieldDefinitionAppService.GetListAsync(
             new GetFieldDefinitionListInput { DocumentTypeId = documentType.Id });
 
+        var uri = DocumentTypeResourceUri.Format(documentType.TypeCode, tenantId);
+
         var schema = new DocumentTypeSchema
         {
             TypeCode = documentType.TypeCode,
-            Uri = DocumentTypeResourceUri.Format(documentType.TypeCode, tenantId),
+            Uri = uri,
             // DisplayName is admin-configured user-derived text, so PromptBoundary wrapping prevents
             // indirect prompt injection. TypeCode / field Name / DataType are system-controlled
             // values (whitelist / enum), so they are emitted raw.
@@ -121,7 +123,7 @@ public sealed class DocumentTypeResources
 
         return new TextResourceContents
         {
-            Uri = DocumentTypeResourceUri.Format(documentType.TypeCode, tenantId),
+            Uri = uri,
             MimeType = "application/json",
             Text = JsonSerializer.Serialize(schema)
         };

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeSchema.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeSchema.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 namespace Dignite.Vault.Extract.Mcp.Documents;
 
 /// <summary>
-/// Document type field schema: the LLM-facing read projection for MCP resource
-/// a document-type resource URI, ambient or explicitly tenant-scoped. It lets downstream AI clients discover which fields a type
+/// Document type field schema: the LLM-facing read projection for the MCP document-type resource
+/// (ambient or explicitly tenant-scoped). It lets downstream AI clients discover which fields a type
 /// has and what data types they use, so they can populate the search tool's <c>fieldFilters</c> /
 /// <c>includeFields</c> with correct field names. <see cref="DisplayName"/> is admin-configured
 /// user-derived text and is already wrapped with <c>PromptBoundary.WrapField</c> to prevent indirect

--- a/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeTools.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Documents/DocumentTypeTools.cs
@@ -34,7 +34,7 @@ public sealed class DocumentTypeTools
     public static async Task<DocumentTypeListResult> ListAsync(
         IDocumentTypeAppService documentTypeAppService,
         IFieldDefinitionAppService fieldDefinitionAppService,
-        [Description("Optional tenant id (UUID). When supplied, list only that tenant and return tenant-scoped resource uris.")]
+        [Description("Optional tenant id (UUID). When supplied, list only that tenant and return tenant-scoped resource URIs.")]
         string? tenantId = null,
         CancellationToken cancellationToken = default,
         IServiceProvider? serviceProvider = null)

--- a/core/src/Dignite.Vault.Extract.Mcp/VaultExtractMcpConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/VaultExtractMcpConsts.cs
@@ -9,6 +9,19 @@ namespace Dignite.Vault.Extract.Mcp;
 public static class VaultExtractMcpConsts
 {
     /// <summary>
+    /// Root of the MCP resource URI scheme. Single source every per-resource URI helper derives from,
+    /// so the scheme cannot drift across resource kinds.
+    /// </summary>
+    public const string UriScheme = "vault-extract://";
+
+    /// <summary>
+    /// Root for explicit-tenant resource URIs (<c>vault-extract://tenants/{tenantId}/...</c>). Shared by
+    /// every per-resource URI helper so the tenant URI shape cannot drift per resource kind, and so a
+    /// helper's <c>Format</c> output and its registered resource template stay in lockstep.
+    /// </summary>
+    public const string TenantUriRoot = UriScheme + "tenants/";
+
+    /// <summary>
     /// Hard cap on the number of document types returned in one document type enumeration
     /// (<c>list_document_types</c> tool and <c>resources/list</c>). Tenant admins can create any number
     /// of document types; unbounded enumeration can blow up LLM context and create a cost-attack

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/CabinetResources_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/CabinetResources_Tests.cs
@@ -42,7 +42,6 @@ public class CabinetResources_Tests : VaultExtractTestBase<CabinetResourcesTestM
         var tenantId = Guid.NewGuid();
         var cabinetId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
         _cabinetReadAppService.GetAsync(cabinetId).Returns(_ =>
         {
             currentTenant.Id.ShouldBe(tenantId);
@@ -59,7 +58,10 @@ public class CabinetResources_Tests : VaultExtractTestBase<CabinetResourcesTestM
         contents.Uri.ShouldBe(CabinetResourceUri.Format(cabinetId, tenantId));
         var schema = JsonSerializer.Deserialize<CabinetSchema>(contents.Text)!;
         schema.Uri.ShouldBe(CabinetResourceUri.Format(cabinetId, tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the resource read is an async method, so
+        // the ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/CabinetTools_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/CabinetTools_Tests.cs
@@ -37,7 +37,6 @@ public class CabinetTools_Tests : VaultExtractTestBase<CabinetToolsTestModule>
         var tenantId = Guid.NewGuid();
         var cabinetId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
         _cabinetReadAppService.GetListAsync().Returns(_ =>
         {
             currentTenant.Id.ShouldBe(tenantId);
@@ -51,7 +50,10 @@ public class CabinetTools_Tests : VaultExtractTestBase<CabinetToolsTestModule>
             serviceProvider: ServiceProvider);
 
         result.Items[0].Uri.ShouldBe(CabinetResourceUri.Format(cabinetId, tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the tool is an async method, so the
+        // ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentResources_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentResources_Tests.cs
@@ -46,7 +46,6 @@ public class DocumentResources_Tests : VaultExtractTestBase<DocumentResourcesTes
         var tenantId = Guid.NewGuid();
         var documentId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
         _documentAppService.GetAsync(documentId).Returns(_ =>
         {
             currentTenant.Id.ShouldBe(tenantId);
@@ -66,7 +65,10 @@ public class DocumentResources_Tests : VaultExtractTestBase<DocumentResourcesTes
             serviceProvider: ServiceProvider);
 
         ((TextResourceContents)result).Uri.ShouldBe(DocumentResourceUri.Format(documentId, tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the resource read is an async method, so
+        // the ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentSearchTool_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentSearchTool_Tests.cs
@@ -85,7 +85,6 @@ public class DocumentSearchTool_Tests : VaultExtractTestBase<DocumentSearchToolT
         var tenantId = Guid.NewGuid();
         var documentId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
 
         _documentAppService
             .GetListAsync(Arg.Any<GetDocumentListInput>())
@@ -110,7 +109,10 @@ public class DocumentSearchTool_Tests : VaultExtractTestBase<DocumentSearchToolT
             serviceProvider: ServiceProvider);
 
         result.Items[0].Uri.ShouldBe(DocumentResourceUri.Format(documentId, tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the tool is an async method, so the
+        // ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentTools_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentTools_Tests.cs
@@ -45,7 +45,6 @@ public class DocumentTools_Tests : VaultExtractTestBase<DocumentToolsTestModule>
         var tenantId = Guid.NewGuid();
         var documentId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
         _documentAppService.GetAsync(documentId).Returns(_ =>
         {
             currentTenant.Id.ShouldBe(tenantId);
@@ -65,7 +64,10 @@ public class DocumentTools_Tests : VaultExtractTestBase<DocumentToolsTestModule>
             serviceProvider: ServiceProvider);
 
         result.Uri.ShouldBe(DocumentResourceUri.Format(documentId, tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the tool is an async method, so the
+        // ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     /// <summary>

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentTypeResources_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentTypeResources_Tests.cs
@@ -56,7 +56,6 @@ public class DocumentTypeResources_Tests : VaultExtractTestBase<DocumentTypeReso
         var tenantId = Guid.NewGuid();
         var typeId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
         _documentTypeAppService.GetVisibleAsync().Returns(_ =>
         {
             currentTenant.Id.ShouldBe(tenantId);
@@ -77,7 +76,10 @@ public class DocumentTypeResources_Tests : VaultExtractTestBase<DocumentTypeReso
         contents.Uri.ShouldBe(DocumentTypeResourceUri.Format("contract.general", tenantId));
         var schema = JsonSerializer.Deserialize<DocumentTypeSchema>(contents.Text)!;
         schema.Uri.ShouldBe(DocumentTypeResourceUri.Format("contract.general", tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the resource read is an async method, so
+        // the ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentTypeTools_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Documents/DocumentTypeTools_Tests.cs
@@ -49,7 +49,6 @@ public class DocumentTypeTools_Tests : VaultExtractTestBase<DocumentTypeToolsTes
         var tenantId = Guid.NewGuid();
         var typeId = Guid.NewGuid();
         var currentTenant = GetRequiredService<ICurrentTenant>();
-        var ambientTenantId = currentTenant.Id;
         _documentTypeAppService.GetVisibleAsync().Returns(_ =>
         {
             currentTenant.Id.ShouldBe(tenantId);
@@ -73,7 +72,10 @@ public class DocumentTypeTools_Tests : VaultExtractTestBase<DocumentTypeToolsTes
             serviceProvider: ServiceProvider);
 
         result.Types[0].Uri.ShouldBe(DocumentTypeResourceUri.Format("contract.general", tenantId));
-        currentTenant.Id.ShouldBe(ambientTenantId);
+        // No post-await ambient check — it would be a tautology: the tool is an async method, so the
+        // ICurrentTenant.Change it makes internally never flows back to this caller's ExecutionContext,
+        // and the assertion would pass even if the using-scope were removed. The stubbed callback above
+        // asserts the scope was actually applied during the call.
     }
 
     [Fact]


### PR DESCRIPTION
Post-merge cleanup from the #519 code review — batch three (quality-only, no behavior or wire change).

## What changed

- **Tests (hollow guard):** the 7 tenant-scope tests each ended with `currentTenant.Id.ShouldBe(ambientTenantId)` after `await`-ing the tool/resource. An async method's internal `ICurrentTenant.Change` never flows back to the caller's ExecutionContext, so that assertion passes even if the `using` scope is removed — it cannot catch the disposal it claims to verify. Removed it (with an explanatory comment); the stubbed-callback assertion that the scope was applied *during* the call is the real check and stays.
- **URI helpers:** hoisted the shared scheme / tenant root into `VaultExtractMcpConsts` (`UriScheme`, `TenantUriRoot`) and derived each `*ResourceUri` from a single `Segment` const, so a helper's `Format` output and its registered resource template can no longer drift apart.
- **`DocumentTypeResources`:** compute the resource URI once per read instead of twice.
- **Docs / wording:** fixed two garbled XML doc comments; unified the four tools' `tenantId` parameter descriptions (`uris` / `URIs` / singular drift).

## Not in this PR

The security-boundary findings from the same review — ungated tenant switch, no tenant existence/active validation, and the missing authorization-denial test — touch the channel security contract and are tracked in #524 (fail-closed switch + admission seam).

## Validation

- `dotnet build` — 0 warnings, 0 errors.
- MCP unit suite — **73/73 pass**.
- All URI string values unchanged (the resource-template contract tests pass against the same constants).
