### PR TITLE
fix(pipelines): avoid concurrent upload deadlock

### DIFF
--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/Pipelines/EfCoreDocumentPipelineRunRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/Pipelines/EfCoreDocumentPipelineRunRepository.cs
@@ -50,24 +50,32 @@ public class EfCoreDocumentPipelineRunRepository
         }
 
         var dbContext = await GetDbContextAsync();
+        var result = new Dictionary<string, DocumentPipelineRun>();
 
-        // Pick the run with the largest AttemptNumber per PipelineCode. EF Core 8+ translates
-        // GroupBy(...).Select(g => g.OrderByDescending(...).First()) to SQL Server ROW_NUMBER() OVER
-        // (PARTITION BY PipelineCode ORDER BY AttemptNumber DESC) WHERE rn = 1, so only one row per
-        // code is returned. This does not rely on a "small row count + in-memory GroupBy" assumption.
-        var latest = await dbContext.Set<DocumentPipelineRun>()
-            .Where(r => r.DocumentId == documentId && pipelineCodes.Contains(r.PipelineCode))
-            .GroupBy(r => r.PipelineCode)
-            .Select(g => g.OrderByDescending(r => r.AttemptNumber).First())
-            .ToListAsync(GetCancellationToken(cancellationToken));
-
-        var result = latest.ToDictionary(r => r.PipelineCode);
+        // #532: use one bounded latest-attempt lookup per pipeline code. The former grouped query
+        // translated to ROW_NUMBER() and SQL Server chose a clustered-index scan while the table was
+        // small. Concurrent upload transactions had each already inserted an uncommitted run, so the
+        // scans read into one another's write locks and formed a deadlock cycle. TOP (1) + descending
+        // AttemptNumber is satisfied by the portable (DocumentId, PipelineCode, AttemptNumber) index
+        // shape and keeps each read inside its own document/pipeline key range. Lifecycle derivation
+        // requests exactly the three core key pipelines, so the number of round trips stays bounded.
+        foreach (var pipelineCode in pipelineCodes.Distinct())
+        {
+            var run = await FindLatestByDocumentAndCodeAsync(
+                documentId,
+                pipelineCode,
+                cancellationToken);
+            if (run != null)
+            {
+                result[run.PipelineCode] = run;
+            }
+        }
 
         // Merge change-tracker entities that have not been flushed in this UoW. DeriveLifecycle runs
         // immediately after Manager UpdateAsync(run) (autoSave:false) / Insert calls, so the run's
         // post-change state may exist only in the tracker while the DB still has the old value, or
-        // the new run has not been persisted yet. The GroupBy above chooses rows in the DB by the
-        // persisted AttemptNumber and cannot see those unflushed changes. Explicitly merge Added /
+        // the new run has not been persisted yet. The DB lookups above choose rows by the persisted
+        // AttemptNumber and cannot see those unflushed changes. Explicitly merge Added /
         // Modified Local entries, keeping the largest AttemptNumber per PipelineCode, so the
         // responsibility for seeing the unflushed view stays in Infrastructure. Domain
         // DeriveLifecycleAsync therefore no longer needs the caller to pass the just-changed run

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineRunAggregatePersistence_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentPipelineRunAggregatePersistence_Tests.cs
@@ -71,7 +71,7 @@ public class DocumentPipelineRunAggregatePersistence_Tests
 
         await WithUnitOfWorkAsync(async () =>
         {
-            // Insert a run in the same UoW with autoSave:false and intentionally do not flush it. DB-side GroupBy
+            // Insert a run in the same UoW with autoSave:false and intentionally do not flush it. DB-side queries
             // cannot see the uncommitted row because it is not in the database, and the EF identity map cannot
             // materialize it from the query. Only GetLatestRunsByCodesAsync can see it by merging Added entries
             // from the change tracker. This locks #216 follow-up #1: removing that merge foreach in the repository
@@ -92,6 +92,105 @@ public class DocumentPipelineRunAggregatePersistence_Tests
             latest.ShouldContainKey(VaultExtractPipelines.Classification);
             latest[VaultExtractPipelines.Classification].Id.ShouldBe(run.Id);
             latest[VaultExtractPipelines.Classification].Status.ShouldBe(PipelineRunStatus.Pending);
+        });
+    }
+
+    [Fact]
+    public async Task GetLatestRunsByCodes_Returns_Latest_Attempt_For_Each_Requested_Code()
+    {
+        var documentId = _guidGenerator.Create();
+        var latestParseRunId = _guidGenerator.Create();
+        var classificationRunId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _documentRepository.InsertAsync(CreateDocument(documentId), autoSave: true);
+            await _runRepository.InsertAsync(
+                NewRun(documentId, VaultExtractPipelines.Parse, attemptNumber: 1),
+                autoSave: false);
+            await _runRepository.InsertAsync(
+                new DocumentPipelineRun(
+                    latestParseRunId,
+                    documentId,
+                    tenantId: null,
+                    VaultExtractPipelines.Parse,
+                    attemptNumber: 2),
+                autoSave: false);
+            await _runRepository.InsertAsync(
+                new DocumentPipelineRun(
+                    classificationRunId,
+                    documentId,
+                    tenantId: null,
+                    VaultExtractPipelines.Classification,
+                    attemptNumber: 1),
+                autoSave: false);
+            await _runRepository.InsertAsync(
+                NewRun(documentId, VaultExtractPipelines.FieldExtraction, attemptNumber: 1),
+                autoSave: false);
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var latest = await _runRepository.GetLatestRunsByCodesAsync(
+                documentId,
+                new[]
+                {
+                    VaultExtractPipelines.Parse,
+                    VaultExtractPipelines.Classification
+                });
+
+            latest.Count.ShouldBe(2);
+            latest[VaultExtractPipelines.Parse].Id.ShouldBe(latestParseRunId);
+            latest[VaultExtractPipelines.Parse].AttemptNumber.ShouldBe(2);
+            latest[VaultExtractPipelines.Classification].Id.ShouldBe(classificationRunId);
+            latest.ShouldNotContainKey(VaultExtractPipelines.FieldExtraction);
+        });
+    }
+
+    [Fact]
+    public async Task GetLatestRunsByCodes_Surfaces_Unflushed_Modified_Run_In_Same_Uow()
+    {
+        var documentId = _guidGenerator.Create();
+        var runId = _guidGenerator.Create();
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _documentRepository.InsertAsync(CreateDocument(documentId), autoSave: true);
+            await _runRepository.InsertAsync(
+                new DocumentPipelineRun(
+                    runId,
+                    documentId,
+                    tenantId: null,
+                    VaultExtractPipelines.Classification,
+                    attemptNumber: 1),
+                autoSave: true);
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var run = await _runRepository.GetAsync(runId);
+            run.MarkRunning(DateTime.UtcNow);
+            await _runRepository.UpdateAsync(run, autoSave: false);
+
+            var latest = await _runRepository.GetLatestRunsByCodesAsync(
+                documentId,
+                new[] { VaultExtractPipelines.Classification });
+
+            latest[VaultExtractPipelines.Classification].Id.ShouldBe(runId);
+            latest[VaultExtractPipelines.Classification].Status.ShouldBe(PipelineRunStatus.Running);
+        });
+    }
+
+    [Fact]
+    public async Task GetLatestRunsByCodes_Returns_Empty_For_Empty_Code_Set()
+    {
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var latest = await _runRepository.GetLatestRunsByCodesAsync(
+                _guidGenerator.Create(),
+                Array.Empty<string>());
+
+            latest.ShouldBeEmpty();
         });
     }
 
@@ -126,13 +225,16 @@ public class DocumentPipelineRunAggregatePersistence_Tests
         ex.Code.ShouldBe(VaultExtractErrorCodes.Pipeline.RetryInProgress);
     }
 
-    private DocumentPipelineRun NewRun(Guid documentId, int attemptNumber)
+    private DocumentPipelineRun NewRun(
+        Guid documentId,
+        string pipelineCode = VaultExtractPipelines.Classification,
+        int attemptNumber = 1)
     {
         return new DocumentPipelineRun(
             _guidGenerator.Create(),
             documentId,
             tenantId: null,
-            VaultExtractPipelines.Classification,
+            pipelineCode,
             attemptNumber);
     }
 


### PR DESCRIPTION
## Summary

- replace the grouped latest-pipeline-run query with one bounded latest-attempt lookup per pipeline code
- keep Added/Modified change-tracker entries visible inside the current UoW
- add repository integration coverage for latest attempts, requested-code filtering, unflushed changes, and empty input

## Root cause

Concurrent uploads each inserted an uncommitted `DocumentPipelineRun` and then executed the grouped `ROW_NUMBER` lifecycle query. SQL Server chose a clustered-index scan for the small table, so concurrent transactions read into one another's write locks and formed a 1205 deadlock cycle.

The new `TOP 1 ... ORDER BY AttemptNumber DESC` lookup uses the existing `(DocumentId, PipelineCode, AttemptNumber)` index shape and confines reads to the relevant document/pipeline key range.

## Validation

- `DocumentPipelineRunAggregatePersistence_Tests`: 6/6 passed
- full `Dignite.Vault.Extract.EntityFrameworkCore.Tests`: 156/156 passed
- `DocumentPipelineRunManagerTests`: 20/20 passed
- `git diff --check`: passed

No REST, event, serialized contract, migration, or Document boundary changes.

Closes #532