### PR TITLE
fix(documents): account for recycle-bin documents in document-type and cabinet deletion (#531 + #530)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Application/Documents/Cabinets/CabinetAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Cabinets/CabinetAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Permissions;
 using Microsoft.AspNetCore.Authorization;
+using Volo.Abp;
 using Volo.Abp.Domain.Entities;
 
 namespace Dignite.Vault.Extract.Documents.Cabinets;
@@ -81,18 +82,28 @@ public class CabinetAppService : VaultExtractAppService, ICabinetAppService
         // Atomically clear CabinetId on documents in this cabinet before deleting it, truly unfiling
         // them. Otherwise documents would dangle to a deleted cabinet (stale ID, and recreating a
         // cabinet with the same name cannot restore membership). Unlike DocumentType InUse protection,
-        // deletion is not blocked. Only active documents are cleared; stale CabinetId on soft-deleted
-        // documents is harmless because the frontend cannot map it and displays uncategorized. Switch
-        // to ExecuteUpdateAsync if one cabinet can contain very many documents.
-        var orphans = await _documentRepository.GetListAsync(
-            d => d.TenantId == CurrentTenant.Id && d.CabinetId == entity.Id);
-        if (orphans.Count > 0)
+        // deletion is not blocked: cabinet membership is optional organization metadata, not document
+        // identity or pipeline state, so "delete cabinet" clears references rather than failing closed.
+        // Switch to ExecuteUpdateAsync if one cabinet can contain very many documents.
+        //
+        // #530: the cleanup runs with ISoftDelete disabled so RECYCLE-BIN documents are unfiled too. Clearing only
+        // live documents made "delete cabinet" mean two different things depending on document lifecycle state — a
+        // binned document kept hidden membership and came back filed into a deleted cabinet on restore, which active
+        // cabinet reads cannot resolve, so the UI shows it as unfiled while the persisted CabinetId still points at
+        // the deleted row. IMultiTenant stays on, so the cleanup never leaves this cabinet's own layer. Unfiling is
+        // idempotent (SetCabinet(null) on an already-unfiled document is a no-op), so a retry is safe.
+        using (DataFilter.Disable<ISoftDelete>())
         {
-            foreach (var doc in orphans)
+            var orphans = await _documentRepository.GetListAsync(
+                d => d.TenantId == CurrentTenant.Id && d.CabinetId == entity.Id);
+            if (orphans.Count > 0)
             {
-                doc.UnassignCabinet();
+                foreach (var doc in orphans)
+                {
+                    doc.UnassignCabinet();
+                }
+                await _documentRepository.UpdateManyAsync(orphans, autoSave: true);
             }
-            await _documentRepository.UpdateManyAsync(orphans, autoSave: true);
         }
 
         await _repository.DeleteAsync(entity);

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Cabinets/CabinetAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Cabinets/CabinetAppService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Permissions;
 using Microsoft.AspNetCore.Authorization;
-using Volo.Abp;
 using Volo.Abp.Domain.Entities;
 
 namespace Dignite.Vault.Extract.Documents.Cabinets;
@@ -84,27 +83,16 @@ public class CabinetAppService : VaultExtractAppService, ICabinetAppService
         // cabinet with the same name cannot restore membership). Unlike DocumentType InUse protection,
         // deletion is not blocked: cabinet membership is optional organization metadata, not document
         // identity or pipeline state, so "delete cabinet" clears references rather than failing closed.
-        // Switch to ExecuteUpdateAsync if one cabinet can contain very many documents.
         //
         // #530: the cleanup runs with ISoftDelete disabled so RECYCLE-BIN documents are unfiled too. Clearing only
         // live documents made "delete cabinet" mean two different things depending on document lifecycle state — a
         // binned document kept hidden membership and came back filed into a deleted cabinet on restore, which active
         // cabinet reads cannot resolve, so the UI shows it as unfiled while the persisted CabinetId still points at
         // the deleted row. IMultiTenant stays on, so the cleanup never leaves this cabinet's own layer. Unfiling is
-        // idempotent (SetCabinet(null) on an already-unfiled document is a no-op), so a retry is safe.
-        using (DataFilter.Disable<ISoftDelete>())
-        {
-            var orphans = await _documentRepository.GetListAsync(
-                d => d.TenantId == CurrentTenant.Id && d.CabinetId == entity.Id);
-            if (orphans.Count > 0)
-            {
-                foreach (var doc in orphans)
-                {
-                    doc.UnassignCabinet();
-                }
-                await _documentRepository.UpdateManyAsync(orphans, autoSave: true);
-            }
-        }
+        // idempotent (setting null again changes no row), so a retry is safe. The repository performs one set-based
+        // UPDATE instead of materializing every Document/Markdown payload into the delete request; cabinet cleanup
+        // is explicitly allowed to be bulk state reconciliation and emits no document pipeline events.
+        await _documentRepository.UnassignCabinetDocumentsAsync(entity.Id);
 
         await _repository.DeleteAsync(entity);
     }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentAppService.cs
@@ -468,10 +468,20 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
     /// key; restoring the old, retracted child back to life while its successor is live would silently create a
     /// duplicate). This is the application-layer replacement for that fail-close.
     /// </para>
+    /// <para>
+    /// #531 fail-close: a document whose <see cref="Document.DocumentTypeId"/> references a type that is no longer
+    /// active in its layer is rejected with <see cref="VaultExtractErrorCodes.Document.RestoreTypeDeleted"/> rather
+    /// than revived as a live document carrying deleted schema identity (the UI could then only fall back to the raw
+    /// type code, its fields would not be editable, and field re-extraction would silently skip it).
+    /// <c>DocumentTypeAppService.DeleteAsync</c>'s guard — which since #531 counts recycle-bin documents too — makes
+    /// this unreachable going forward, so this is defense-in-depth for legacy rows, manual DB edits, and a
+    /// delete/classification race. The remedy is to restore the document type first.
+    /// </para>
     /// This whole method runs inside <see cref="DataFilter.Disable{TFilter}"/>(<see cref="ISoftDelete"/>) to load
-    /// the soft-deleted row itself, so that ambient disabled filter is ALSO in effect for the duplicate check
-    /// below — <see cref="IDocumentRepository.AnyLiveDerivedDuplicateAsync"/> therefore explicitly re-excludes
-    /// soft-deleted siblings itself rather than relying on the (here, disabled) global filter.
+    /// the soft-deleted row itself, so that ambient disabled filter is ALSO in effect for both checks below —
+    /// <see cref="IDocumentRepository.AnyLiveDerivedDuplicateAsync"/> therefore explicitly re-excludes soft-deleted
+    /// siblings itself rather than relying on the (here, disabled) global filter, and the #531 type check pins its
+    /// own <c>IsDeleted</c> test for the same reason.
     /// </summary>
     [Authorize(VaultExtractPermissions.Documents.Restore)]
     public virtual async Task RestoreAsync(Guid id)
@@ -492,6 +502,25 @@ public class DocumentAppService : VaultExtractAppService, IDocumentAppService
                 {
                     throw new BusinessException(VaultExtractErrorCodes.Document.RestoreConflict)
                         .WithData("DocumentId", id);
+                }
+            }
+
+            // #531: DocumentType is schema identity, so a document may only come back to life while the type it
+            // references is still active in its own layer. Note this runs inside the ISoftDelete-disabled scope above,
+            // so FindAsync resolves a soft-deleted type row too — the IsDeleted test is therefore pinned explicitly
+            // rather than delegated to the (here, disabled) global filter, mirroring how
+            // AnyLiveDerivedDuplicateAsync pins its own !IsDeleted predicate for the same reason. IMultiTenant stays
+            // on, so a type belonging to another layer never resolves and correctly fails closed. A null row means the
+            // type was physically removed (legacy data / manual DB edit), which fails closed the same way.
+            if (document.DocumentTypeId.HasValue)
+            {
+                var documentType = await _documentTypeRepository.FindAsync(document.DocumentTypeId.Value);
+                if (documentType is null || documentType.IsDeleted)
+                {
+                    // Null-safe like the RetryPipelineAsync diagnostic above: a physically removed type has no
+                    // TypeCode to name, and .WithData's value parameter is non-nullable.
+                    throw new BusinessException(VaultExtractErrorCodes.Document.RestoreTypeDeleted)
+                        .WithData("TypeCode", documentType?.TypeCode ?? string.Empty);
                 }
             }
 

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
@@ -129,9 +129,21 @@ public class DocumentTypeAppService : VaultExtractAppService, IDocumentTypeAppSe
         // GetAsync and document queries are both automatically filtered to the current layer.
         // Note: soft delete is an UPDATE and does not trigger FKs. Since this application-layer gate has no DocumentType -> Document FK,
         // explicitly block deletion of in-use types here.
-        var documentQueryable = await _documentRepository.GetQueryableAsync();
-        var inUse = await AsyncExecuter.AnyAsync(
-            documentQueryable.Where(d => d.DocumentTypeId == entity.Id));
+        //
+        // #531: the check runs with ISoftDelete disabled so RECYCLE-BIN documents count as references too. A document
+        // type is schema identity, not optional organization metadata (contrast CabinetAppService.DeleteAsync, which
+        // clears references instead of blocking), and a recycle-bin document is restorable — counting only live
+        // documents let an operator bin every referencing document, delete the type, then restore one back into a live
+        // document referencing a deleted type. IMultiTenant stays on, so the check never leaves this type's own layer.
+        // Permanently deleted documents are physically gone and correctly do not count.
+        bool inUse;
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            var documentQueryable = await _documentRepository.GetQueryableAsync();
+            inUse = await AsyncExecuter.AnyAsync(
+                documentQueryable.Where(d => d.DocumentTypeId == entity.Id));
+        }
+
         if (inUse)
         {
             throw new BusinessException(VaultExtractErrorCodes.DocumentType.InUse)

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -412,6 +412,7 @@
     "Extract:DocumentRestoreConflict": "Cannot restore document '{DocumentId}': a live sub-document with the same source constituent already exists. The restore is rejected to avoid a duplicate.",
     "Extract:DocumentHasSubDocuments": "This document still has sub-documents derived from it. Delete its sub-documents first, then delete this document.",
     "Extract:DocumentHasSubDocumentsPermanentDelete": "This document still has sub-documents derived from it, including any already in the recycle bin. Sub-documents have no source file of their own and reach it through this document, so permanently delete them first.",
+    "Extract:DocumentRestoreTypeDeleted": "Cannot restore this document: its document type '{TypeCode}' has been deleted. Restore that document type first, then restore this document.",
     "Extract:UnknownPipelineCode": "Pipeline '{PipelineCode}' is not retryable.",
     "Extract:PipelineNeverRan": "Pipeline '{PipelineCode}' has not started yet.",
     "Extract:PipelineRetryInProgress": "Pipeline '{PipelineCode}' already has an attempt in progress.",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -410,6 +410,7 @@
     "Extract:DocumentUnsupportedFileType": "ファイル '{FileName}' のタイプ（'{ContentType}'）はサポートされていません。対応している画像、PDF、CSV/TSV、DOCX、PPTX、TXT、または XLSX ファイルをアップロードしてください。",
     "Extract:DocumentNoSourceBlob": "このドキュメントにはダウンロードできるソースファイルがありません。",
     "Extract:DocumentRestoreConflict": "ドキュメント '{DocumentId}' を復元できません：同じソース構成要素を共有する別のライブなサブドキュメントが既に存在します。重複を避けるため、復元は拒否されました。",
+    "Extract:DocumentRestoreTypeDeleted": "このドキュメントを復元できません：ドキュメントタイプ '{TypeCode}' は削除されています。先にそのドキュメントタイプを復元してから、このドキュメントを復元してください。",
     "Extract:DocumentHasSubDocuments": "このドキュメントには、まだそこから派生したサブドキュメントがあります。先にサブドキュメントを削除してから、このドキュメントを削除してください。",
     "Extract:DocumentHasSubDocumentsPermanentDelete": "このドキュメントには、まだそこから派生したサブドキュメントがあります（ごみ箱内のものを含む）。サブドキュメントは自身のソースファイルを持たず、このドキュメントを通じて参照するため、先にサブドキュメントを完全に削除してください。",
     "Extract:UnknownPipelineCode": "パイプライン '{PipelineCode}' は再試行できません。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -410,6 +410,7 @@
     "Extract:DocumentUnsupportedFileType": "文件 '{FileName}' 的类型 ('{ContentType}') 不受支持。请上传支持的图片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 文件。",
     "Extract:DocumentNoSourceBlob": "该文档没有可供下载的源文件。",
     "Extract:DocumentRestoreConflict": "无法恢复文档 '{DocumentId}'：已存在另一份共享同一来源片段的在用子文档。为避免产生重复，已拒绝本次恢复。",
+    "Extract:DocumentRestoreTypeDeleted": "无法恢复此文档：其文档类型 '{TypeCode}' 已被删除。请先恢复该文档类型，再恢复此文档。",
     "Extract:DocumentHasSubDocuments": "该文档仍有由其拆分出的子文档。请先删除这些子文档，再删除该文档。",
     "Extract:DocumentHasSubDocumentsPermanentDelete": "该文档仍有由其拆分出的子文档（含已在回收站中的）。子文档没有自己的源文件，需通过该文档才能访问，请先彻底删除这些子文档。",
     "Extract:UnknownPipelineCode": "流水线 '{PipelineCode}' 不支持重试。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -410,6 +410,7 @@
     "Extract:DocumentUnsupportedFileType": "檔案 '{FileName}' 的類型（'{ContentType}'）不受支援。請上傳支援的圖片、PDF、CSV/TSV、DOCX、PPTX、TXT 或 XLSX 檔案。",
     "Extract:DocumentNoSourceBlob": "此文件沒有可供下載的來源檔案。",
     "Extract:DocumentRestoreConflict": "無法還原文件 '{DocumentId}'：已存在另一份共享同一來源片段的在用子文件。為避免產生重複，已拒絕本次還原。",
+    "Extract:DocumentRestoreTypeDeleted": "無法還原此文件：其文件類型 '{TypeCode}' 已被刪除。請先還原該文件類型，再還原此文件。",
     "Extract:DocumentHasSubDocuments": "此文件仍有由其分割出的子文件。請先刪除這些子文件，再刪除此文件。",
     "Extract:DocumentHasSubDocumentsPermanentDelete": "此文件仍有由其分割出的子文件（含已在回收筒中的）。子文件沒有自己的來源檔案，需透過此文件才能存取，請先永久刪除這些子文件。",
     "Extract:UnknownPipelineCode": "管線 '{PipelineCode}' 不支援重試。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -43,6 +43,14 @@ public static class VaultExtractErrorCodes
         // recycle-bin child is restorable. A distinct code because the remedy differs: the operator must look in
         // the recycle bin, not just the document list.
         public const string HasSubDocumentsPermanentDelete = "Extract:DocumentHasSubDocumentsPermanentDelete";
+        // #531: the document carries a DocumentTypeId whose type is no longer active in its layer, so restoring it
+        // would revive a live document referencing a deleted type — the UI can then only fall back to the raw type
+        // code, its fields cannot be edited, and field re-extraction silently skips it. DocumentType is schema
+        // identity, not optional metadata, so restore fails closed rather than reviving a partially usable document.
+        // DocumentTypeAppService.DeleteAsync's all-document guard makes this unreachable going forward; this is the
+        // defense-in-depth for legacy rows, manual DB edits, and a delete/classification race. Remedy: restore the
+        // type first, then the document.
+        public const string RestoreTypeDeleted = "Extract:DocumentRestoreTypeDeleted";
     }
 
     public static class DocumentType

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
@@ -30,6 +30,17 @@ public interface IDocumentRepository : IRepository<Document, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Clears <see cref="Document.CabinetId"/> for every document in the ambient tenant layer that references
+    /// <paramref name="cabinetId"/> (#530). Traverses <c>ISoftDelete</c> so recycle-bin documents are unfiled too,
+    /// while retaining the ambient <c>IMultiTenant</c> boundary. Implemented as one set-based update: cabinet
+    /// membership is optional organization metadata, and its removal publishes no document pipeline events.
+    /// Returns the number of affected rows and is idempotent/retry-safe.
+    /// </summary>
+    Task<int> UnassignCabinetDocumentsAsync(
+        Guid cabinetId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Whether another LIVE document already shares the derived-document identity
     /// <c>(OriginDocumentId, OriginConstituentKey)</c> — the #485 restore-time fail-close used by
     /// <c>DocumentAppService.RestoreAsync</c>, replacing the fail-close the #481-dropped #391 filtered-unique index

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -53,6 +53,23 @@ public class EfCoreDocumentRepository
         }
     }
 
+    public virtual async Task<int> UnassignCabinetDocumentsAsync(
+        Guid cabinetId,
+        CancellationToken cancellationToken = default)
+    {
+        // #530: clear live + recycle-bin references without loading an unbounded set of aggregate payloads. Only
+        // ISoftDelete is disabled; ABP's ambient IMultiTenant predicate remains part of the generated UPDATE.
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            var dbSet = await GetDbSetAsync();
+            return await dbSet
+                .Where(document => document.CabinetId == cabinetId)
+                .ExecuteUpdateAsync(
+                    setters => setters.SetProperty(document => document.CabinetId, (Guid?)null),
+                    GetCancellationToken(cancellationToken));
+        }
+    }
+
     public virtual async Task<bool> AnyLiveDerivedDuplicateAsync(
         Guid originDocumentId,
         string originConstituentKey,

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Cabinets/CabinetAppService_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Cabinets/CabinetAppService_Tests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,22 +46,20 @@ public class CabinetAppService_Tests : VaultExtractApplicationTestBase<CabinetAp
         _cabinetRepository.GetAsync(cabinet.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(cabinet);
 
-        var doc1 = CreateDocumentInCabinet(cabinet.Id);
-        var doc2 = CreateDocumentInCabinet(cabinet.Id);
-        _documentRepository.GetListAsync(
-                Arg.Any<Expression<Func<Document, bool>>>(),
-                Arg.Any<bool>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new List<Document> { doc1, doc2 });
+        _documentRepository.UnassignCabinetDocumentsAsync(cabinet.Id, Arg.Any<CancellationToken>())
+            .Returns(2);
 
         await _appService.DeleteAsync(cabinet.Id);
 
-        // Assignment is cleared, falling back to unclassified: no dangling pointer to a deleted cabinet,
-        // and recreating a same-name cabinet will not accidentally absorb old documents.
-        doc1.CabinetId.ShouldBeNull();
-        doc2.CabinetId.ShouldBeNull();
-        await _documentRepository.Received(1).UpdateManyAsync(
-            Arg.Any<IEnumerable<Document>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        // The repository owns the set-based reconciliation. Its EF integration tests pin the affected
+        // live/recycle-bin rows; this application test pins ordering before the cabinet deletion.
+        await _documentRepository.Received(1).UnassignCabinetDocumentsAsync(
+            cabinet.Id, Arg.Any<CancellationToken>());
+        Received.InOrder(() =>
+        {
+            _documentRepository.UnassignCabinetDocumentsAsync(cabinet.Id, Arg.Any<CancellationToken>());
+            _cabinetRepository.DeleteAsync(cabinet, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        });
         await _cabinetRepository.Received(1).DeleteAsync(cabinet, Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
@@ -73,16 +69,14 @@ public class CabinetAppService_Tests : VaultExtractApplicationTestBase<CabinetAp
         var cabinet = new Cabinet(Guid.NewGuid(), null, "Empty");
         _cabinetRepository.GetAsync(cabinet.Id, Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(cabinet);
-        _documentRepository.GetListAsync(
-                Arg.Any<Expression<Func<Document, bool>>>(),
-                Arg.Any<bool>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new List<Document>());
+
+        _documentRepository.UnassignCabinetDocumentsAsync(cabinet.Id, Arg.Any<CancellationToken>())
+            .Returns(0);
 
         await _appService.DeleteAsync(cabinet.Id);
 
-        await _documentRepository.DidNotReceive().UpdateManyAsync(
-            Arg.Any<IEnumerable<Document>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await _documentRepository.Received(1).UnassignCabinetDocumentsAsync(
+            cabinet.Id, Arg.Any<CancellationToken>());
         await _cabinetRepository.Received(1).DeleteAsync(cabinet, Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
@@ -98,24 +92,9 @@ public class CabinetAppService_Tests : VaultExtractApplicationTestBase<CabinetAp
         await Should.ThrowAsync<EntityNotFoundException>(async () =>
             await _appService.DeleteAsync(tenantCabinet.Id));
 
-        await _documentRepository.DidNotReceive().UpdateManyAsync(
-            Arg.Any<IEnumerable<Document>>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await _documentRepository.DidNotReceive().UnassignCabinetDocumentsAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
         await _cabinetRepository.DidNotReceive().DeleteAsync(
             Arg.Any<Cabinet>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-    }
-
-    private static Document CreateDocumentInCabinet(Guid cabinetId)
-    {
-        return new Document(
-            Guid.NewGuid(),
-            tenantId: null,
-            fileOrigin: new FileOrigin(
-                blobName: $"blobs/{Guid.NewGuid():N}.pdf",
-                uploadedByUserName: "test-user",
-                contentType: "application/pdf",
-                contentHash: $"{Guid.NewGuid():N}{Guid.NewGuid():N}",
-                fileSize: 1024,
-                originalFileName: "test.pdf"),
-            cabinetId: cabinetId);
     }
 }

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Cabinets/CabinetDelete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Cabinets/CabinetDelete_Tests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Abstractions.Documents;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.Cabinets;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Data;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Volo.Abp.MultiTenancy;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(VaultExtractEntityFrameworkCoreTestModule))]
+public class CabinetDeleteTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // The restore path publishes a lifecycle ETO and the wider DocumentAppService graph touches these
+        // out-of-process collaborators; substitute them so the test exercises the real DB + the real cleanup query.
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// Integration tests for the #530 cabinet-deletion cleanup, run against the real SQLite DB so the unfile query
+/// actually meets ABP's ambient <c>ISoftDelete</c> / <c>IMultiTenant</c> global filters. The pre-existing
+/// <c>CabinetAppService_Tests</c> mock the repository, which cannot observe a global filter at all — they would stay
+/// green with this fix removed, so the behaviour is pinned here instead.
+/// <para>
+/// The invariant: cabinet membership is optional organization metadata, not document identity or pipeline state, so
+/// deleting a cabinet is always allowed and means "unfile every referencing document in this layer" — including the
+/// ones already in the recycle bin. Contrast <c>DocumentTypeDelete_Tests</c>, where schema identity makes the same
+/// situation fail closed instead.
+/// </para>
+/// </summary>
+public class CabinetDelete_Tests : VaultExtractTestBase<CabinetDeleteTestModule>
+{
+    private readonly ICabinetAppService _cabinetAppService;
+    private readonly IDocumentAppService _documentAppService;
+    private readonly ICabinetRepository _cabinetRepository;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IDataFilter _dataFilter;
+    private readonly ICurrentTenant _currentTenant;
+
+    private static readonly Guid OtherTenantId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    public CabinetDelete_Tests()
+    {
+        _cabinetAppService = GetRequiredService<ICabinetAppService>();
+        _documentAppService = GetRequiredService<IDocumentAppService>();
+        _cabinetRepository = GetRequiredService<ICabinetRepository>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _dataFilter = GetRequiredService<IDataFilter>();
+        _currentTenant = GetRequiredService<ICurrentTenant>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Unfiles_Every_Live_Document_In_The_Cabinet()
+    {
+        var cabinetId = await ArrangeCabinetAsync();
+        var firstId = await ArrangeDocumentAsync(cabinetId);
+        var secondId = await ArrangeDocumentAsync(cabinetId);
+
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(cabinetId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentRepository.GetAsync(firstId)).CabinetId.ShouldBeNull();
+            (await _documentRepository.GetAsync(secondId)).CabinetId.ShouldBeNull();
+            (await _cabinetRepository.FindAsync(cabinetId)).ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Unfiles_Recycle_Bin_Documents_Too()
+    {
+        // #530 itself. Before the fix the cleanup ran under the ambient ISoftDelete filter, so only live documents
+        // were unfiled and "delete cabinet" meant two different things depending on lifecycle state: a binned
+        // document kept hidden membership in a soft-deleted cabinet, which no active cabinet read can resolve — the
+        // UI shows it as unfiled while the persisted CabinetId still points at the deleted row.
+        var cabinetId = await ArrangeCabinetAsync();
+        var documentId = await ArrangeDocumentAsync(cabinetId);
+        await SoftDeleteDocumentAsync(documentId);
+
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(cabinetId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                var document = await _documentRepository.GetAsync(documentId);
+                document.CabinetId.ShouldBeNull();
+                // Unfiling a recycle-bin document must not resurrect it: only CabinetId moves.
+                document.IsDeleted.ShouldBeTrue();
+            }
+        });
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Leaves_A_Restored_Document_Unfiled()
+    {
+        // The user-visible symptom #530 reports: the document comes back from the recycle bin filed into a cabinet
+        // that no longer exists. After the fix it comes back genuinely unfiled.
+        var cabinetId = await ArrangeCabinetAsync();
+        var documentId = await ArrangeDocumentAsync(cabinetId);
+        await SoftDeleteDocumentAsync(documentId);
+
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(cabinetId));
+        await WithUnitOfWorkAsync(() => _documentAppService.RestoreAsync(documentId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(documentId)).CabinetId.ShouldBeNull());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Does_Not_Touch_Documents_In_Another_Cabinet()
+    {
+        var deletedCabinetId = await ArrangeCabinetAsync("Legal");
+        var survivingCabinetId = await ArrangeCabinetAsync("Finance");
+        var survivorId = await ArrangeDocumentAsync(survivingCabinetId);
+
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(deletedCabinetId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.GetAsync(survivorId)).CabinetId.ShouldBe(survivingCabinetId));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Does_Not_Touch_Another_Layers_Documents()
+    {
+        // The risk the #530 change itself introduces: disabling ISoftDelete for the cleanup must NOT take
+        // IMultiTenant down with it. Another layer's document must never be read or written by this cleanup.
+        var cabinetId = await ArrangeCabinetAsync();
+        var otherLayerDocumentId = await ArrangeDocumentAsync(cabinetId, tenantId: OtherTenantId);
+
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(cabinetId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(OtherTenantId))
+            {
+                (await _documentRepository.GetAsync(otherLayerDocumentId)).CabinetId.ShouldBe(cabinetId);
+            }
+        });
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Succeeds_For_An_Empty_Cabinet()
+    {
+        var cabinetId = await ArrangeCabinetAsync();
+
+        await WithUnitOfWorkAsync(() => _cabinetAppService.DeleteAsync(cabinetId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _cabinetRepository.FindAsync(cabinetId)).ShouldBeNull());
+    }
+
+    // === Arrangement ===
+
+    private async Task<Guid> ArrangeCabinetAsync(string name = "Legal")
+    {
+        var cabinetId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(() =>
+            _cabinetRepository.InsertAsync(new Cabinet(cabinetId, tenantId: null, name), autoSave: true));
+        return cabinetId;
+    }
+
+    private async Task<Guid> ArrangeDocumentAsync(Guid cabinetId, Guid? tenantId = null)
+    {
+        var documentId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(tenantId))
+            {
+                await _documentRepository.InsertAsync(
+                    new Document(documentId, tenantId, DocumentTestData.NewFileOrigin(documentId), cabinetId),
+                    autoSave: true);
+            }
+        });
+        return documentId;
+    }
+
+    private Task SoftDeleteDocumentAsync(Guid documentId) =>
+        WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(documentId, autoSave: true));
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTypes/DocumentTypeDelete_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTypes/DocumentTypeDelete_Tests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Abstractions.Documents;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Documents.Fields;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Data;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Volo.Abp.MultiTenancy;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(VaultExtractEntityFrameworkCoreTestModule))]
+public class DocumentTypeDeleteTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Restore publishes a lifecycle ETO and the wider DocumentAppService graph touches these out-of-process
+        // collaborators; substitute them so the test exercises the real DB + the real guard queries.
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// Integration tests for the #531 document-type deletion guard and its restore-side twin, run against the real
+/// SQLite DB so the in-use <c>EXISTS</c> query actually meets ABP's ambient <c>ISoftDelete</c> / <c>IMultiTenant</c>
+/// global filters. These behaviours cannot be pinned against a mocked <c>IDocumentRepository</c> at all — a
+/// substitute returns whatever it was told to regardless of the ambient filter state, so a mock-based test would stay
+/// green with the fix removed.
+/// <para>
+/// The invariant: a document type is schema identity, not optional organization metadata, so deletion fails closed
+/// while <b>any restorable</b> document still references it — recycle-bin documents included. That is the whole
+/// difference from <c>CabinetAppService.DeleteAsync</c>, whose membership is optional and which therefore clears
+/// references instead of blocking (see <c>CabinetDelete_Tests</c>). Only a permanently deleted document stops
+/// counting, because it can never come back.
+/// </para>
+/// </summary>
+public class DocumentTypeDelete_Tests : VaultExtractTestBase<DocumentTypeDeleteTestModule>
+{
+    private readonly IDocumentTypeAppService _documentTypeAppService;
+    private readonly IDocumentAppService _documentAppService;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+    private readonly IDistributedEventBus _eventBus;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IDataFilter _dataFilter;
+    private readonly ICurrentTenant _currentTenant;
+
+    private static readonly Guid OtherTenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    public DocumentTypeDelete_Tests()
+    {
+        _documentTypeAppService = GetRequiredService<IDocumentTypeAppService>();
+        _documentAppService = GetRequiredService<IDocumentAppService>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _fieldDefinitionRepository = GetRequiredService<IFieldDefinitionRepository>();
+        _eventBus = GetRequiredService<IDistributedEventBus>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _dataFilter = GetRequiredService<IDataFilter>();
+        _currentTenant = GetRequiredService<ICurrentTenant>();
+    }
+
+    // === DeleteAsync (the in-use guard) ===
+
+    [Fact]
+    public async Task DeleteAsync_Is_Blocked_While_A_Live_Document_References_The_Type()
+    {
+        var typeId = await ArrangeTypeAsync();
+        await ArrangeDocumentAsync(typeId);
+
+        var exception = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _documentTypeAppService.DeleteAsync(typeId)));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.DocumentType.InUse);
+        await AssertTypeIsLiveAsync(typeId);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Is_Blocked_When_The_Referencing_Documents_Are_Only_In_The_Recycle_Bin()
+    {
+        // #531 itself. Before the fix the in-use EXISTS ran under the ambient ISoftDelete filter, so recycle-bin
+        // documents did not count: an operator could bin every referencing document, delete the type (cascading its
+        // field definitions away), then restore one — ending up with a live document whose schema identity points at
+        // a deleted type. The UI could then only fall back to the raw type code, its fields were not editable, and
+        // field re-extraction silently skipped it.
+        var typeId = await ArrangeTypeAsync();
+        var documentId = await ArrangeDocumentAsync(typeId);
+        await SoftDeleteDocumentAsync(documentId);
+
+        var exception = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _documentTypeAppService.DeleteAsync(typeId)));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.DocumentType.InUse);
+        await AssertTypeIsLiveAsync(typeId);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Succeeds_And_Cascades_To_Field_Definitions_When_No_Document_References_The_Type()
+    {
+        var typeId = await ArrangeTypeAsync();
+        var fieldId = await ArrangeFieldAsync(typeId);
+
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.DeleteAsync(typeId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _documentTypeRepository.FindAsync(typeId)).ShouldBeNull();
+            (await _fieldDefinitionRepository.FindAsync(fieldId)).ShouldBeNull();
+
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                // Soft-deleted, not physically gone: RestoreAsync must still be able to find both rows.
+                (await _documentTypeRepository.GetAsync(typeId)).IsDeleted.ShouldBeTrue();
+                (await _fieldDefinitionRepository.GetAsync(fieldId)).IsDeleted.ShouldBeTrue();
+            }
+        });
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Ignores_A_Permanently_Deleted_Document()
+    {
+        // A hard-deleted row is physically gone, so it is not a restorable reference and correctly stops blocking.
+        // This is the operator's escape hatch out of the guard: purge the document, then the type will go.
+        var typeId = await ArrangeTypeAsync();
+        var documentId = await ArrangeDocumentAsync(typeId);
+        await WithUnitOfWorkAsync(() => _documentAppService.PermanentDeleteAsync(documentId));
+
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.DeleteAsync(typeId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentTypeRepository.FindAsync(typeId)).ShouldBeNull());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Does_Not_Count_A_Document_From_Another_Layer()
+    {
+        // The risk the #531 change itself introduces: disabling ISoftDelete for the in-use check must NOT take
+        // IMultiTenant down with it. Another layer's document is invisible here and must never block — or even be
+        // read by — this layer's type deletion.
+        var typeId = await ArrangeTypeAsync();
+        await ArrangeDocumentAsync(typeId, tenantId: OtherTenantId);
+
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.DeleteAsync(typeId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentTypeRepository.FindAsync(typeId)).ShouldBeNull());
+    }
+
+    // === RestoreAsync (the defense-in-depth twin) ===
+
+    [Fact]
+    public async Task RestoreAsync_Is_Blocked_When_The_Referenced_Type_Was_Deleted()
+    {
+        // The guard above makes this state unreachable through the app service, so the corrupted state is seeded
+        // out-of-band through the repository — which is exactly the population this check defends: legacy rows,
+        // manual DB edits, and a delete/classification race.
+        var typeId = await ArrangeTypeAsync();
+        var documentId = await ArrangeDocumentAsync(typeId);
+        await SoftDeleteDocumentAsync(documentId);
+        await SoftDeleteTypeOutOfBandAsync(typeId);
+
+        var exception = await Should.ThrowAsync<BusinessException>(() =>
+            WithUnitOfWorkAsync(() => _documentAppService.RestoreAsync(documentId)));
+
+        exception.Code.ShouldBe(VaultExtractErrorCodes.Document.RestoreTypeDeleted);
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                // A rejected restore changes nothing: the document stays in the recycle bin.
+                (await _documentRepository.GetAsync(documentId)).IsDeleted.ShouldBeTrue();
+            }
+        });
+
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<DocumentRestoredEto>());
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Succeeds_Once_The_Type_Is_Restored_First()
+    {
+        // The documented remedy for the error above, and the reason it names the type code.
+        var typeId = await ArrangeTypeAsync();
+        var documentId = await ArrangeDocumentAsync(typeId);
+        await SoftDeleteDocumentAsync(documentId);
+        await SoftDeleteTypeOutOfBandAsync(typeId);
+
+        await WithUnitOfWorkAsync(() => _documentTypeAppService.RestoreAsync(typeId));
+        await WithUnitOfWorkAsync(() => _documentAppService.RestoreAsync(documentId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.FindAsync(documentId)).ShouldNotBeNull());
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<DocumentRestoredEto>(e => e.DocumentId == documentId));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Skips_The_Type_Check_For_An_Unclassified_Document()
+    {
+        // DocumentTypeId is null until the classification stage runs, so the guard must not touch a document that
+        // never had a type to begin with.
+        var documentId = await ArrangeDocumentAsync(documentTypeId: null);
+        await SoftDeleteDocumentAsync(documentId);
+
+        await WithUnitOfWorkAsync(() => _documentAppService.RestoreAsync(documentId));
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.FindAsync(documentId)).ShouldNotBeNull());
+    }
+
+    // === Arrangement ===
+
+    private async Task<Guid> ArrangeTypeAsync(string typeCode = "contract")
+    {
+        var typeId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(() =>
+            _documentTypeRepository.InsertAsync(
+                new DocumentType(typeId, tenantId: null, typeCode, "Contract"),
+                autoSave: true));
+        return typeId;
+    }
+
+    private async Task<Guid> ArrangeFieldAsync(Guid documentTypeId)
+    {
+        var fieldId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(() =>
+            _fieldDefinitionRepository.InsertAsync(
+                new FieldDefinition(
+                    fieldId,
+                    tenantId: null,
+                    documentTypeId,
+                    name: "party_a_name",
+                    displayName: "Party A",
+                    prompt: null,
+                    FieldDataType.Text),
+                autoSave: true));
+        return fieldId;
+    }
+
+    private async Task<Guid> ArrangeDocumentAsync(Guid? documentTypeId = null, Guid? tenantId = null)
+    {
+        var documentId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_currentTenant.Change(tenantId))
+            {
+                var document = new Document(documentId, tenantId, DocumentTestData.NewFileOrigin(documentId));
+                if (documentTypeId.HasValue)
+                {
+                    DocumentTestData.MarkClassified(document, documentTypeId.Value);
+                }
+
+                await _documentRepository.InsertAsync(document, autoSave: true);
+            }
+        });
+        return documentId;
+    }
+
+    private Task SoftDeleteDocumentAsync(Guid documentId) =>
+        WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(documentId, autoSave: true));
+
+    /// <summary>
+    /// Soft-deletes the type straight through the repository, bypassing <c>DeleteAsync</c>'s in-use guard. Since
+    /// #531 that guard makes "a restorable document referencing a deleted type" unreachable through the app service,
+    /// so the corrupted state the restore check exists for has to be seeded directly.
+    /// </summary>
+    private Task SoftDeleteTypeOutOfBandAsync(Guid typeId) =>
+        WithUnitOfWorkAsync(() => _documentTypeRepository.DeleteAsync(typeId, autoSave: true));
+
+    private Task AssertTypeIsLiveAsync(Guid typeId) =>
+        WithUnitOfWorkAsync(async () =>
+            (await _documentTypeRepository.FindAsync(typeId)).ShouldNotBeNull());
+}


### PR DESCRIPTION
## Scope

Fixes the two v0.3.1 recycle-bin reference-integrity defects:

- #531 treats a document type as schema identity: deleting it fails closed while any live or recycle-bin document can still be restored with that type.
- #530 treats a cabinet as optional organization metadata: deleting it remains allowed and unassigns both live and recycle-bin documents.

The two paths disable only `ISoftDelete`; the tenant filter remains active.

## Restore defense

`DocumentAppService.RestoreAsync` rejects restoration when the referenced document type is deleted. This protects legacy/corrupted rows and makes the restore invariant explicit.

## Review hardening

The cabinet cleanup originally loaded every matching document and Markdown payload into memory. It now uses a tenant-scoped, set-based EF `ExecuteUpdateAsync` that only clears `CabinetId`. This keeps the operation bounded while preserving the aggregate's business fields and soft-delete state.

## Validation

- Full solution build: success, 0 errors (3 pre-existing nullable warnings in the host migration/seed code).
- `DocumentTypeDelete_Tests` + `CabinetDelete_Tests`: 14 passed, 0 failed.
- `git diff --check`: passed.

## Deployment and explicit out-of-scope

No migration is required.

The classification/cabinet-assignment commit-window races remain intentionally split to #535 because they require a separate concurrency design. Non-blocking derived schema staleness remains split to #537.

Closes #531
Closes #530