### PR TITLE
fix(fields): clean up orphaned validation warnings on delete

### DIFF
--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/Cleanup/DuplicateBasisCleanupJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/Cleanup/DuplicateBasisCleanupJob.cs
@@ -25,8 +25,9 @@ namespace Dignite.Vault.Extract.Documents.Fields.Cleanup;
 /// <b>Only the last-key case.</b> Deleting one of <i>several</i> unique-key fields merely <i>narrows</i> the key, and
 /// two documents whose wide key values were equal necessarily have equal narrow key values — existing
 /// <c>DuplicateSuspected</c> flags stay valid there, and clearing them would hide real duplicates. That case is an
-/// under-detection of new collisions, not a park, and is tracked in #537. <c>FieldDefinitionAppService.DeleteAsync</c>
-/// is what decides which case applies and only enqueues this job for the former.
+/// under-detection of new collisions, not a park, and is tracked in #537. Every unique-key deletion enqueues this
+/// job; the job rechecks the final active schema and only runs when no unique-key field remains. That execution-time
+/// decision is resilient to concurrent deletes and to a field restore/new key before the queued work starts.
 /// </para>
 /// <para>
 /// Note this clears the reason through <see cref="Document.SetReviewReason"/>, <b>not</b>
@@ -45,6 +46,7 @@ public class DuplicateBasisCleanupJob
     : AsyncBackgroundJob<DuplicateBasisCleanupArgs>, ITransientDependency
 {
     private readonly IDocumentRepository _documentRepository;
+    private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
     private readonly DocumentPipelineRunManager _pipelineRunManager;
     private readonly IBackgroundJobManager _backgroundJobManager;
     private readonly ICurrentTenant _currentTenant;
@@ -53,6 +55,7 @@ public class DuplicateBasisCleanupJob
 
     public DuplicateBasisCleanupJob(
         IDocumentRepository documentRepository,
+        IFieldDefinitionRepository fieldDefinitionRepository,
         DocumentPipelineRunManager pipelineRunManager,
         IBackgroundJobManager backgroundJobManager,
         ICurrentTenant currentTenant,
@@ -60,6 +63,7 @@ public class DuplicateBasisCleanupJob
         IDataFilter dataFilter)
     {
         _documentRepository = documentRepository;
+        _fieldDefinitionRepository = fieldDefinitionRepository;
         _pipelineRunManager = pipelineRunManager;
         _backgroundJobManager = backgroundJobManager;
         _currentTenant = currentTenant;
@@ -77,6 +81,21 @@ public class DuplicateBasisCleanupJob
 
             using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
             {
+                // Decide against the active schema at execution time, not against a snapshot taken before the
+                // delete committed. Every unique-key deletion enqueues this job, which closes two races:
+                // - concurrent deletion of the final two keys cannot result in neither request enqueueing cleanup;
+                // - restoring/adding a key before cleanup cannot cause valid duplicate state to be erased.
+                // Recheck on every chained batch so a key restored between batches stops further clearing.
+                var activeDefinitions = await _fieldDefinitionRepository.GetListAsync(args.DocumentTypeId);
+                if (activeDefinitions.Exists(field => field.IsUniqueKey))
+                {
+                    await uow.CompleteAsync();
+                    Logger.LogInformation(
+                        "Duplicate basis cleanup skipped for type {DocumentTypeId}: the active schema still has a unique-key field.",
+                        args.DocumentTypeId);
+                    return;
+                }
+
                 ids = await _documentRepository.GetIdsWithDuplicateBasisAsync(
                     args.DocumentTypeId, args.AfterId, batchSize);
 

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/Cleanup/DuplicateBasisCleanupJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/Cleanup/DuplicateBasisCleanupJob.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents.Pipelines;
+using Microsoft.Extensions.Logging;
+using Volo.Abp;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Uow;
+
+namespace Dignite.Vault.Extract.Documents.Fields.Cleanup;
+
+/// <summary>
+/// Drops the duplicate basis left behind when a document type loses its <b>last active unique-key field</b> (#528).
+/// <para>
+/// <see cref="Document.FieldFingerprint"/> is the hash of the type's unique-key field values (#411), so once no
+/// unique-key field remains the type has no duplicate basis at all: every fingerprint should be <c>null</c>, and any
+/// lingering blocking <see cref="DocumentReviewReasons.DuplicateSuspected"/> is derived from a schema that no longer
+/// exists — a false park identical in shape to the orphaned-warning bug this issue is named for. This mirrors what
+/// <c>FieldExtractionService</c>'s no-field-definition branch already does for the whole-type case.
+/// </para>
+/// <para>
+/// <b>Only the last-key case.</b> Deleting one of <i>several</i> unique-key fields merely <i>narrows</i> the key, and
+/// two documents whose wide key values were equal necessarily have equal narrow key values — existing
+/// <c>DuplicateSuspected</c> flags stay valid there, and clearing them would hide real duplicates. That case is an
+/// under-detection of new collisions, not a park, and is tracked in #537. <c>FieldDefinitionAppService.DeleteAsync</c>
+/// is what decides which case applies and only enqueues this job for the former.
+/// </para>
+/// <para>
+/// Note this clears the reason through <see cref="Document.SetReviewReason"/>, <b>not</b>
+/// <see cref="Document.AllowDuplicate"/>: the latter also sets <c>DuplicateAllowed</c>, durably recording an operator
+/// "not a duplicate" decision that nobody made and suppressing re-raises on every later re-extraction. Schema
+/// reconciliation must not forge a human judgement.
+/// </para>
+/// <para>
+/// Idempotent, retry-safe, and chained in bounded batches on the same terms as
+/// <see cref="FieldValidationWarningCleanupJob"/>; publishes no <c>FieldsExtractedEto</c> because no field value is
+/// re-extracted. A later re-extraction recomputes a fingerprint from the remaining schema, as it always has.
+/// </para>
+/// </summary>
+[BackgroundJobName("VaultExtract.DuplicateBasisCleanup")]
+public class DuplicateBasisCleanupJob
+    : AsyncBackgroundJob<DuplicateBasisCleanupArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineRunManager _pipelineRunManager;
+    private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly IDataFilter _dataFilter;
+
+    public DuplicateBasisCleanupJob(
+        IDocumentRepository documentRepository,
+        DocumentPipelineRunManager pipelineRunManager,
+        IBackgroundJobManager backgroundJobManager,
+        ICurrentTenant currentTenant,
+        IUnitOfWorkManager unitOfWorkManager,
+        IDataFilter dataFilter)
+    {
+        _documentRepository = documentRepository;
+        _pipelineRunManager = pipelineRunManager;
+        _backgroundJobManager = backgroundJobManager;
+        _currentTenant = currentTenant;
+        _unitOfWorkManager = unitOfWorkManager;
+        _dataFilter = dataFilter;
+    }
+
+    public override async Task ExecuteAsync(DuplicateBasisCleanupArgs args)
+    {
+        var batchSize = DocumentConsts.ReprocessingDispatchBatchSize;
+
+        using (_currentTenant.Change(args.TenantId))
+        {
+            List<Guid> ids;
+
+            using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+            {
+                ids = await _documentRepository.GetIdsWithDuplicateBasisAsync(
+                    args.DocumentTypeId, args.AfterId, batchSize);
+
+                foreach (var id in ids)
+                {
+                    // Recycle-bin documents are in scope too: restoring one must not bring back a duplicate flag
+                    // derived from a unique-key schema that no longer exists.
+                    using (_dataFilter.Disable<ISoftDelete>())
+                    {
+                        var document = await _documentRepository.FindWithFieldValuesAsync(id);
+                        if (document == null)
+                        {
+                            continue;
+                        }
+
+                        document.SetFieldFingerprint(null);
+                        document.SetReviewReason(DocumentReviewReasons.DuplicateSuspected, present: false);
+
+                        if (!document.IsDeleted)
+                        {
+                            await _pipelineRunManager.ReDeriveLifecycleAsync(document);
+                        }
+
+                        await _documentRepository.UpdateAsync(document);
+                    }
+                }
+
+                if (ids.Count == batchSize)
+                {
+                    await _backgroundJobManager.EnqueueAsync(
+                        new DuplicateBasisCleanupArgs
+                        {
+                            DocumentTypeId = args.DocumentTypeId,
+                            TenantId = args.TenantId,
+                            AfterId = ids[^1]
+                        });
+                }
+
+                await uow.CompleteAsync();
+            }
+
+            Logger.LogInformation(
+                "Duplicate basis cleanup: cleared {Count} document(s) for type {DocumentTypeId} after its last unique-key field was deleted (afterId={AfterId}, continued={Continued}).",
+                ids.Count, args.DocumentTypeId, args.AfterId, ids.Count == batchSize);
+        }
+    }
+}
+
+public class DuplicateBasisCleanupArgs
+{
+    public Guid DocumentTypeId { get; set; }
+
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Keyset cursor: only documents with <c>Id &gt; AfterId</c>; null for the first batch.</summary>
+    public Guid? AfterId { get; set; }
+}

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/Cleanup/FieldValidationWarningCleanupJob.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/Cleanup/FieldValidationWarningCleanupJob.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents.Pipelines;
+using Microsoft.Extensions.Logging;
+using Volo.Abp;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.Data;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.MultiTenancy;
+using Volo.Abp.Uow;
+
+namespace Dignite.Vault.Extract.Documents.Fields.Cleanup;
+
+/// <summary>
+/// Removes the now-orphaned field validation warnings left behind when a <see cref="FieldDefinition"/> is deleted
+/// (#528). A warning naming a field that no longer exists keeps the blocking
+/// <see cref="DocumentReviewReasons.FieldValidationWarning"/> bit set, so the document stays parked out of
+/// <c>DocumentReadyEto</c> until an operator resolves it by hand or a re-extraction happens to run — silently
+/// withheld from every downstream consumer in the meantime.
+/// <para>
+/// A job rather than inline work in <c>FieldDefinitionAppService.DeleteAsync</c>: the affected set is bounded only by
+/// the type's document count, so the delete request must not carry it. It chains itself forward one bounded batch at a
+/// time (the #289 dispatcher pattern), keeping job granularity short. Enqueued inside the delete's UoW, so it never
+/// runs for a delete that rolled back.
+/// </para>
+/// <para>
+/// Idempotent and retry-safe: cleaned documents drop out of the scan predicate, so a re-run of the same batch finds
+/// nothing and the chain still makes forward progress through the keyset cursor. At-least-once chaining may re-run a
+/// batch after a crash; that is a no-op here, not a double-apply.
+/// </para>
+/// <para>
+/// Deliberately publishes no <c>FieldsExtractedEto</c>: field <b>values</b> were not re-extracted and remain
+/// historical data — only the warning derived from a deleted schema element goes away (#528 acceptance criteria).
+/// </para>
+/// </summary>
+[BackgroundJobName("VaultExtract.FieldValidationWarningCleanup")]
+public class FieldValidationWarningCleanupJob
+    : AsyncBackgroundJob<FieldValidationWarningCleanupArgs>, ITransientDependency
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly DocumentPipelineRunManager _pipelineRunManager;
+    private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly ICurrentTenant _currentTenant;
+    private readonly IUnitOfWorkManager _unitOfWorkManager;
+    private readonly IDataFilter _dataFilter;
+
+    public FieldValidationWarningCleanupJob(
+        IDocumentRepository documentRepository,
+        DocumentPipelineRunManager pipelineRunManager,
+        IBackgroundJobManager backgroundJobManager,
+        ICurrentTenant currentTenant,
+        IUnitOfWorkManager unitOfWorkManager,
+        IDataFilter dataFilter)
+    {
+        _documentRepository = documentRepository;
+        _pipelineRunManager = pipelineRunManager;
+        _backgroundJobManager = backgroundJobManager;
+        _currentTenant = currentTenant;
+        _unitOfWorkManager = unitOfWorkManager;
+        _dataFilter = dataFilter;
+    }
+
+    public override async Task ExecuteAsync(FieldValidationWarningCleanupArgs args)
+    {
+        // Same bounded granularity as the #289 reprocessing dispatch: this is the same "one page of documents per
+        // job run" trade, and a second knob for it would only be a second thing to tune wrong.
+        var batchSize = DocumentConsts.ReprocessingDispatchBatchSize;
+
+        // Background workers do not restore the tenant context on their own; the scans below are isolated by the
+        // ambient IMultiTenant filter, so it must be the field definition's own layer.
+        using (_currentTenant.Change(args.TenantId))
+        {
+            List<Guid> ids;
+
+            // One short UoW per batch: the document writes and the next chained job commit together, so the chain
+            // cannot survive a rolled-back batch. No external work happens here (pure DB), so the three-phase split
+            // background-jobs.md requires for OCR/LLM jobs does not apply.
+            using (var uow = _unitOfWorkManager.Begin(requiresNew: true))
+            {
+                ids = await _documentRepository.GetIdsWithFieldValidationWarningAsync(
+                    args.FieldDefinitionId, args.AfterId, batchSize);
+
+                foreach (var id in ids)
+                {
+                    // Recycle-bin documents are in scope (see the repository contract), so both the load and the
+                    // write run with ISoftDelete disabled — otherwise the scan would hand back an id the load then
+                    // resolves to null.
+                    using (_dataFilter.Disable<ISoftDelete>())
+                    {
+                        // FindWithFieldValuesAsync, not the lean load: removing a warning must delete the persisted
+                        // child row, not merely clear the bit (#527 load-path contract).
+                        var document = await _documentRepository.FindWithFieldValuesAsync(id);
+                        if (document == null)
+                        {
+                            continue;
+                        }
+
+                        // The aggregate keeps the collection and the blocking bit coupled: the bit clears only when
+                        // no warning remains, so a document warned on another field stays parked (#527 §9).
+                        document.ResolveFieldValidationWarnings(new List<Guid> { args.FieldDefinitionId });
+
+                        // Only a live document has a lifecycle to re-derive; a recycle-bin document is cleaned so
+                        // that restoring it later cannot resurrect review state for a field that no longer exists,
+                        // and its own restore re-derives from there.
+                        if (!document.IsDeleted)
+                        {
+                            await _pipelineRunManager.ReDeriveLifecycleAsync(document);
+                        }
+
+                        await _documentRepository.UpdateAsync(document);
+                    }
+                }
+
+                // A full batch means there may be more: chain forward with the last Id as the keyset cursor. A
+                // partial batch means the range is exhausted.
+                if (ids.Count == batchSize)
+                {
+                    await _backgroundJobManager.EnqueueAsync(
+                        new FieldValidationWarningCleanupArgs
+                        {
+                            FieldDefinitionId = args.FieldDefinitionId,
+                            TenantId = args.TenantId,
+                            AfterId = ids[^1]
+                        });
+                }
+
+                await uow.CompleteAsync();
+            }
+
+            Logger.LogInformation(
+                "Field validation warning cleanup: cleared {Count} document(s) for deleted field {FieldDefinitionId} (afterId={AfterId}, continued={Continued}).",
+                ids.Count, args.FieldDefinitionId, args.AfterId, ids.Count == batchSize);
+        }
+    }
+}
+
+public class FieldValidationWarningCleanupArgs
+{
+    public Guid FieldDefinitionId { get; set; }
+
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Keyset cursor: only documents with <c>Id &gt; AfterId</c>; null for the first batch.</summary>
+    public Guid? AfterId { get; set; }
+}

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldDefinitionAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldDefinitionAppService.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Documents.Fields.Cleanup;
 using Dignite.Vault.Extract.Permissions;
 using Microsoft.AspNetCore.Authorization;
 using Volo.Abp;
 using Volo.Abp.Authorization;
+using Volo.Abp.BackgroundJobs;
 using Volo.Abp.Domain.Entities;
 
 namespace Dignite.Vault.Extract.Documents.Fields;
@@ -20,17 +22,20 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly IDocumentRepository _documentRepository;
     private readonly FieldDefinitionManager _fieldDefinitionManager;
+    private readonly IBackgroundJobManager _backgroundJobManager;
 
     public FieldDefinitionAppService(
         IFieldDefinitionRepository repository,
         IDocumentTypeRepository documentTypeRepository,
         IDocumentRepository documentRepository,
-        FieldDefinitionManager fieldDefinitionManager)
+        FieldDefinitionManager fieldDefinitionManager,
+        IBackgroundJobManager backgroundJobManager)
     {
         _repository = repository;
         _documentTypeRepository = documentTypeRepository;
         _documentRepository = documentRepository;
         _fieldDefinitionManager = fieldDefinitionManager;
+        _backgroundJobManager = backgroundJobManager;
     }
 
     public virtual async Task<List<FieldDefinitionDto>> GetListAsync(GetFieldDefinitionListInput input)
@@ -163,6 +168,23 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
         return ObjectMapper.Map<FieldDefinition, FieldDefinitionDto>(entity);
     }
 
+    /// <summary>
+    /// Soft-deletes a field definition and reconciles the document state derived from it (#528).
+    /// <para>
+    /// Deletion alone used to leave every <see cref="DocumentFieldValidationWarning"/> naming this field in place,
+    /// and with it the blocking <see cref="DocumentReviewReasons.FieldValidationWarning"/> bit — parking those
+    /// documents out of <c>DocumentReadyEto</c> until an operator resolved them by hand or a re-extraction happened
+    /// to run. The cleanup is deferred to <see cref="FieldValidationWarningCleanupJob"/> because the affected set is
+    /// bounded only by the type's document count; enqueueing happens inside this UoW, so it cannot run for a delete
+    /// that rolled back.
+    /// </para>
+    /// <para>
+    /// The scope line is the Ready gate (<c>ReviewReasonPolicy.Blocking</c>): state that <b>withholds</b> a document
+    /// is reconciled here, state that is merely stale is not. Hence the second, conditional job — and hence
+    /// <c>MissingRequiredFields</c> (non-blocking) and a stale fingerprint under a narrowed-but-non-empty unique-key
+    /// set (an under-detection, not a park) are #537, not this path.
+    /// </para>
+    /// </summary>
     [Authorize(VaultExtractPermissions.FieldDefinitions.Delete)]
     public virtual async Task DeleteAsync(Guid id)
     {
@@ -171,7 +193,35 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
         {
             throw new EntityNotFoundException(typeof(FieldDefinition), id);
         }
+
+        // #528: decided BEFORE the delete, while this row is still active and therefore still visible to
+        // GetListAsync. Losing the type's LAST unique-key field is the one case where deletion invalidates the
+        // duplicate basis outright: FieldFingerprint is the hash of the unique-key values (#411), so with none left
+        // every fingerprint should be null and any surviving DuplicateSuspected is a blocking false park. Deleting
+        // one of several unique-key fields only narrows the key, which keeps existing flags valid (#537).
+        var wasLastUniqueKeyField =
+            entity.IsUniqueKey &&
+            !(await _repository.GetListAsync(entity.DocumentTypeId))
+                .Any(f => f.Id != entity.Id && f.IsUniqueKey);
+
         await _repository.DeleteAsync(entity);
+
+        await _backgroundJobManager.EnqueueAsync(
+            new FieldValidationWarningCleanupArgs
+            {
+                FieldDefinitionId = entity.Id,
+                TenantId = entity.TenantId
+            });
+
+        if (wasLastUniqueKeyField)
+        {
+            await _backgroundJobManager.EnqueueAsync(
+                new DuplicateBasisCleanupArgs
+                {
+                    DocumentTypeId = entity.DocumentTypeId,
+                    TenantId = entity.TenantId
+                });
+        }
     }
 
     [Authorize(VaultExtractPermissions.FieldDefinitions.Delete)]

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldDefinitionAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldDefinitionAppService.cs
@@ -194,16 +194,6 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
             throw new EntityNotFoundException(typeof(FieldDefinition), id);
         }
 
-        // #528: decided BEFORE the delete, while this row is still active and therefore still visible to
-        // GetListAsync. Losing the type's LAST unique-key field is the one case where deletion invalidates the
-        // duplicate basis outright: FieldFingerprint is the hash of the unique-key values (#411), so with none left
-        // every fingerprint should be null and any surviving DuplicateSuspected is a blocking false park. Deleting
-        // one of several unique-key fields only narrows the key, which keeps existing flags valid (#537).
-        var wasLastUniqueKeyField =
-            entity.IsUniqueKey &&
-            !(await _repository.GetListAsync(entity.DocumentTypeId))
-                .Any(f => f.Id != entity.Id && f.IsUniqueKey);
-
         await _repository.DeleteAsync(entity);
 
         await _backgroundJobManager.EnqueueAsync(
@@ -213,8 +203,12 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
                 TenantId = entity.TenantId
             });
 
-        if (wasLastUniqueKeyField)
+        if (entity.IsUniqueKey)
         {
+            // Always enqueue for a deleted unique-key field; the job re-evaluates the FINAL active schema when it
+            // runs and only clears the duplicate basis when no unique-key field remains. Deciding "last key" here
+            // is racy: two concurrent deletes could each observe the other key and enqueue nothing, while a restore
+            // or a newly-created key before job execution could make an enqueue-time "last key" decision stale.
             await _backgroundJobManager.EnqueueAsync(
                 new DuplicateBasisCleanupArgs
                 {

--- a/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.Domain/Documents/IDocumentRepository.cs
@@ -210,6 +210,53 @@ public interface IDocumentRepository : IRepository<Document, Guid>
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Keyset-paginated Ids of documents carrying a <see cref="DocumentFieldValidationWarning"/> for
+    /// <paramref name="fieldDefinitionId"/> (#528) — the cleanup scope after that field definition is deleted, since
+    /// a warning naming a field that no longer exists keeps the blocking
+    /// <see cref="DocumentReviewReasons.FieldValidationWarning"/> bit set and parks the document out of
+    /// <c>DocumentReadyEto</c> forever.
+    /// <para>
+    /// <b>Traverses soft delete</b> (the implementation disables <c>ISoftDelete</c>, like
+    /// <see cref="FindByContentHashAsync"/>): a recycle-bin document must be cleaned too, otherwise restoring it
+    /// resurrects review state for a field that no longer exists. The caller distinguishes live from recycle-bin rows
+    /// by reading <c>Document.IsDeleted</c> per row, because only live documents need lifecycle re-derivation.
+    /// <c>IMultiTenant</c> still applies by ambient state, so the scan never leaves the field definition's own layer.
+    /// </para>
+    /// <para>
+    /// Ordered by <c>Id</c> with <c>Id &gt; afterId</c> (null = from the beginning), <c>AsNoTracking</c> +
+    /// <c>Select(d =&gt; d.Id)</c> so no full row (especially Markdown) is ever materialized. The caller chains the
+    /// next batch with the last Id as the cursor.
+    /// </para>
+    /// </summary>
+    Task<List<Guid>> GetIdsWithFieldValidationWarningAsync(
+        Guid fieldDefinitionId,
+        Guid? afterId,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Keyset-paginated Ids of documents under <paramref name="documentTypeId"/> that still carry a duplicate basis —
+    /// a non-null <see cref="Document.FieldFingerprint"/> or the <see cref="DocumentReviewReasons.DuplicateSuspected"/>
+    /// reason (#528).
+    /// <para>
+    /// Used only when a deleted field definition was the type's <b>last active unique-key field</b>. The type then has
+    /// no duplicate basis left, every document's fingerprint should be <c>null</c>, and any lingering
+    /// <c>DuplicateSuspected</c> is definitively obsolete — a blocking false park. Deleting one of <i>several</i>
+    /// unique-key fields is <b>not</b> this case and must not use this scan: narrowing the key preserves equality, so
+    /// existing flags stay valid and clearing them would hide real duplicates (tracked as under-detection in #537).
+    /// </para>
+    /// <para>
+    /// Same contract as <see cref="GetIdsWithFieldValidationWarningAsync"/>: traverses soft delete, keeps
+    /// <c>IMultiTenant</c>, Ids only, keyset cursor.
+    /// </para>
+    /// </summary>
+    Task<List<Guid>> GetIdsWithDuplicateBasisAsync(
+        Guid documentTypeId,
+        Guid? afterId,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Aggregate overview statistics for the current ambient layer (#333): per-lifecycle document counts,
     /// the needs-review count, and the total original uploaded size (sum of <c>FileOrigin.FileSize</c>).
     /// <para>

--- a/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
+++ b/core/src/Dignite.Vault.Extract.EntityFrameworkCore/Documents/EfCoreDocumentRepository.cs
@@ -202,6 +202,65 @@ public class EfCoreDocumentRepository
             .AnyAsync(f => f.FieldDefinitionId == fieldDefinitionId, GetCancellationToken(cancellationToken));
     }
 
+    public virtual async Task<List<Guid>> GetIdsWithFieldValidationWarningAsync(
+        Guid fieldDefinitionId,
+        Guid? afterId,
+        int maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        // #528: recycle-bin documents must be cleaned too — restoring one would otherwise resurrect a blocking
+        // warning for a field that no longer exists. IMultiTenant stays on, so the scan never leaves this layer.
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            var dbSet = await GetDbSetAsync();
+            return await ApplyKeysetPage(
+                    dbSet.Where(d => d.FieldValidationWarnings.Any(w => w.FieldDefinitionId == fieldDefinitionId)),
+                    afterId,
+                    maxCount)
+                .ToListAsync(GetCancellationToken(cancellationToken));
+        }
+    }
+
+    public virtual async Task<List<Guid>> GetIdsWithDuplicateBasisAsync(
+        Guid documentTypeId,
+        Guid? afterId,
+        int maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        using (DataFilter.Disable<ISoftDelete>())
+        {
+            var dbSet = await GetDbSetAsync();
+            return await ApplyKeysetPage(
+                    dbSet.Where(d =>
+                        d.DocumentTypeId == documentTypeId &&
+                        (d.FieldFingerprint != null ||
+                         (d.ReviewReasons & DocumentReviewReasons.DuplicateSuspected) != DocumentReviewReasons.None)),
+                    afterId,
+                    maxCount)
+                .ToListAsync(GetCancellationToken(cancellationToken));
+        }
+    }
+
+    /// <summary>
+    /// Shared keyset page for the #528 cleanup scans: <c>WHERE Id &gt; afterId ORDER BY Id Take(N)</c>, riding the
+    /// primary-key index (O(batch), unlike deep OFFSET paging), projecting Ids only so no full row — especially
+    /// Markdown — is ever materialized.
+    /// </summary>
+    private static IQueryable<Guid> ApplyKeysetPage(IQueryable<Document> query, Guid? afterId, int maxCount)
+    {
+        if (afterId.HasValue)
+        {
+            var cursor = afterId.Value;
+            query = query.Where(d => d.Id.CompareTo(cursor) > 0);
+        }
+
+        return query
+            .OrderBy(d => d.Id)
+            .Take(maxCount)
+            .AsNoTracking()
+            .Select(d => d.Id);
+    }
+
     public virtual async Task<long> CountForReprocessingAsync(
         Guid? documentTypeId,
         DocumentReviewReasons? withReason,

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldDefinitionCleanup_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldDefinitionCleanup_Tests.cs
@@ -86,7 +86,7 @@ public class FieldDefinitionCleanup_Tests : VaultExtractTestBase<FieldDefinition
     }
 
     [Fact]
-    public async Task DeleteAsync_Enqueues_Duplicate_Basis_Cleanup_When_The_Last_Unique_Key_Field_Goes()
+    public async Task DeleteAsync_Enqueues_Duplicate_Basis_Cleanup_For_A_Unique_Key_Field()
     {
         // The one case where deletion invalidates the duplicate basis outright: no unique-key field remains, so the
         // type has nothing to fingerprint and any surviving DuplicateSuspected is a blocking false park.
@@ -103,20 +103,18 @@ public class FieldDefinitionCleanup_Tests : VaultExtractTestBase<FieldDefinition
     }
 
     [Fact]
-    public async Task DeleteAsync_Does_Not_Enqueue_Duplicate_Basis_Cleanup_While_Another_Unique_Key_Field_Remains()
+    public async Task DeleteAsync_Still_Enqueues_Duplicate_Basis_Check_While_Another_Unique_Key_Field_Remains()
     {
-        // Deleting one of several unique-key fields only NARROWS the key. Two documents whose wide key values were
-        // equal necessarily have equal narrow key values, so existing DuplicateSuspected flags stay valid — clearing
-        // them would hide real duplicates. The residual (collisions the narrower key would newly create) is
-        // under-detection, not a park, and is #537.
+        // The job, rather than the request's pre-delete snapshot, decides whether this was the last key. Always
+        // enqueueing closes the concurrent-final-two-deletes race; when this other key survives, the job is a no-op.
         var typeId = await ArrangeTypeAsync();
         var firstKeyFieldId = await ArrangeFieldAsync(typeId, "invoice_number", isUniqueKey: true);
         await ArrangeFieldAsync(typeId, "vendor", isUniqueKey: true);
 
         await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.DeleteAsync(firstKeyFieldId));
 
-        await _backgroundJobManager.DidNotReceive().EnqueueAsync(
-            Arg.Any<DuplicateBasisCleanupArgs>(),
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DuplicateBasisCleanupArgs>(a => a.DocumentTypeId == typeId),
             Arg.Any<BackgroundJobPriority>(),
             Arg.Any<TimeSpan?>());
     }
@@ -264,6 +262,30 @@ public class FieldDefinitionCleanup_Tests : VaultExtractTestBase<FieldDefinition
             document!.FieldFingerprint.ShouldBeNull();
             ((document.ReviewReasons & DocumentReviewReasons.DuplicateSuspected) != DocumentReviewReasons.None)
                 .ShouldBeFalse();
+        });
+    }
+
+    [Fact]
+    public async Task DuplicateBasisCleanup_Skips_When_The_Active_Schema_Has_A_Unique_Key()
+    {
+        // Covers both a surviving sibling key and a deleted last key restored/replaced before the queued job runs:
+        // valid duplicate state must not be erased from a schema that still has a duplicate basis.
+        var typeId = await ArrangeTypeAsync();
+        await ArrangeFieldAsync(typeId, "invoice_number", isUniqueKey: true);
+        var documentId = await ArrangeDuplicateSuspectedDocumentAsync(typeId);
+
+        await _duplicateBasisCleanupJob.ExecuteAsync(new DuplicateBasisCleanupArgs
+        {
+            DocumentTypeId = typeId,
+            TenantId = null
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.FindWithFieldValuesAsync(documentId);
+            document!.FieldFingerprint.ShouldNotBeNull();
+            ((document.ReviewReasons & DocumentReviewReasons.DuplicateSuspected) != DocumentReviewReasons.None)
+                .ShouldBeTrue();
         });
     }
 

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldDefinitionCleanup_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldDefinitionCleanup_Tests.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Abstractions.Documents;
+using Dignite.Vault.Extract.Documents;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Documents.Fields;
+using Dignite.Vault.Extract.Documents.Fields.Cleanup;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.BackgroundJobs;
+using Volo.Abp.BlobStoring;
+using Volo.Abp.Data;
+using Volo.Abp.EventBus.Distributed;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents;
+
+[DependsOn(typeof(VaultExtractEntityFrameworkCoreTestModule))]
+public class FieldDefinitionCleanupTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // IBackgroundJobManager is substituted for two reasons: to assert what DeleteAsync enqueues, and to stop the
+        // jobs' self-chaining from actually running a second batch inside a test.
+        context.Services.AddSingleton(Substitute.For<IBackgroundJobManager>());
+        context.Services.AddSingleton(Substitute.For<IBlobContainer<VaultExtractDocumentContainer>>());
+        context.Services.AddSingleton(Substitute.For<IDistributedEventBus>());
+    }
+}
+
+/// <summary>
+/// Integration tests for the #528 field-definition delete reconciliation, against the real SQLite DB so the cleanup
+/// scans meet ABP's ambient <c>ISoftDelete</c> / <c>IMultiTenant</c> filters and the warning rows are really deleted
+/// rather than just detached in memory.
+/// <para>
+/// The scope line under test is the Ready gate: state that <b>withholds</b> a document is reconciled on delete, state
+/// that is merely stale is not (#537). So these tests pin two things — that an orphaned warning stops parking the
+/// document, and that the duplicate basis is dropped only in the one case where it becomes a false park (the type's
+/// last unique-key field going away).
+/// </para>
+/// </summary>
+public class FieldDefinitionCleanup_Tests : VaultExtractTestBase<FieldDefinitionCleanupTestModule>
+{
+    private readonly IFieldDefinitionAppService _fieldDefinitionAppService;
+    private readonly FieldValidationWarningCleanupJob _warningCleanupJob;
+    private readonly DuplicateBasisCleanupJob _duplicateBasisCleanupJob;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IDocumentTypeRepository _documentTypeRepository;
+    private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+    private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly IDataFilter _dataFilter;
+
+    public FieldDefinitionCleanup_Tests()
+    {
+        _fieldDefinitionAppService = GetRequiredService<IFieldDefinitionAppService>();
+        _warningCleanupJob = GetRequiredService<FieldValidationWarningCleanupJob>();
+        _duplicateBasisCleanupJob = GetRequiredService<DuplicateBasisCleanupJob>();
+        _documentRepository = GetRequiredService<IDocumentRepository>();
+        _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
+        _fieldDefinitionRepository = GetRequiredService<IFieldDefinitionRepository>();
+        _backgroundJobManager = GetRequiredService<IBackgroundJobManager>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _dataFilter = GetRequiredService<IDataFilter>();
+    }
+
+    // === FieldDefinitionAppService.DeleteAsync wiring ===
+
+    [Fact]
+    public async Task DeleteAsync_Enqueues_The_Warning_Cleanup_For_The_Deleted_Field()
+    {
+        var typeId = await ArrangeTypeAsync();
+        var fieldId = await ArrangeFieldAsync(typeId, "party_a_name");
+
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.DeleteAsync(fieldId));
+
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<FieldValidationWarningCleanupArgs>(a => a.FieldDefinitionId == fieldId && a.AfterId == null),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Enqueues_Duplicate_Basis_Cleanup_When_The_Last_Unique_Key_Field_Goes()
+    {
+        // The one case where deletion invalidates the duplicate basis outright: no unique-key field remains, so the
+        // type has nothing to fingerprint and any surviving DuplicateSuspected is a blocking false park.
+        var typeId = await ArrangeTypeAsync();
+        var uniqueKeyFieldId = await ArrangeFieldAsync(typeId, "invoice_number", isUniqueKey: true);
+        await ArrangeFieldAsync(typeId, "note");
+
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.DeleteAsync(uniqueKeyFieldId));
+
+        await _backgroundJobManager.Received(1).EnqueueAsync(
+            Arg.Is<DuplicateBasisCleanupArgs>(a => a.DocumentTypeId == typeId),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Does_Not_Enqueue_Duplicate_Basis_Cleanup_While_Another_Unique_Key_Field_Remains()
+    {
+        // Deleting one of several unique-key fields only NARROWS the key. Two documents whose wide key values were
+        // equal necessarily have equal narrow key values, so existing DuplicateSuspected flags stay valid — clearing
+        // them would hide real duplicates. The residual (collisions the narrower key would newly create) is
+        // under-detection, not a park, and is #537.
+        var typeId = await ArrangeTypeAsync();
+        var firstKeyFieldId = await ArrangeFieldAsync(typeId, "invoice_number", isUniqueKey: true);
+        await ArrangeFieldAsync(typeId, "vendor", isUniqueKey: true);
+
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.DeleteAsync(firstKeyFieldId));
+
+        await _backgroundJobManager.DidNotReceive().EnqueueAsync(
+            Arg.Any<DuplicateBasisCleanupArgs>(),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Does_Not_Enqueue_Duplicate_Basis_Cleanup_For_A_Plain_Field()
+    {
+        var typeId = await ArrangeTypeAsync();
+        var plainFieldId = await ArrangeFieldAsync(typeId, "note");
+        await ArrangeFieldAsync(typeId, "invoice_number", isUniqueKey: true);
+
+        await WithUnitOfWorkAsync(() => _fieldDefinitionAppService.DeleteAsync(plainFieldId));
+
+        await _backgroundJobManager.DidNotReceive().EnqueueAsync(
+            Arg.Any<DuplicateBasisCleanupArgs>(),
+            Arg.Any<BackgroundJobPriority>(),
+            Arg.Any<TimeSpan?>());
+    }
+
+    // === FieldValidationWarningCleanupJob ===
+
+    [Fact]
+    public async Task Cleanup_Removes_The_Orphaned_Warning_And_Unblocks_The_Document()
+    {
+        // #528 itself: the warning row survives the field-definition delete, and with it the blocking
+        // FieldValidationWarning bit, so the document stays withheld from DocumentReadyEto with nothing having
+        // happened to it.
+        var typeId = await ArrangeTypeAsync();
+        var fieldId = await ArrangeFieldAsync(typeId, "party_a_name");
+        var documentId = await ArrangeDocumentWithWarningsAsync(typeId, (fieldId, "Value looks truncated."));
+
+        await _warningCleanupJob.ExecuteAsync(NewWarningArgs(fieldId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.FindWithFieldValuesAsync(documentId);
+            document!.FieldValidationWarnings.ShouldBeEmpty();
+            HasWarningReason(document).ShouldBeFalse();
+        });
+    }
+
+    [Fact]
+    public async Task Cleanup_Keeps_Warnings_For_Other_Fields_And_Leaves_The_Document_Blocked()
+    {
+        // The collection and the bit stay coupled through the aggregate: only the last warning clears the bit, so a
+        // document still warned on another field must remain parked.
+        var typeId = await ArrangeTypeAsync();
+        var deletedFieldId = await ArrangeFieldAsync(typeId, "party_a_name");
+        var survivingFieldId = await ArrangeFieldAsync(typeId, "amount");
+        var documentId = await ArrangeDocumentWithWarningsAsync(
+            typeId,
+            (deletedFieldId, "Value looks truncated."),
+            (survivingFieldId, "Not a number."));
+
+        await _warningCleanupJob.ExecuteAsync(NewWarningArgs(deletedFieldId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.FindWithFieldValuesAsync(documentId);
+            document!.FieldValidationWarnings.Count.ShouldBe(1);
+            document.FieldValidationWarnings.ShouldContain(w => w.FieldDefinitionId == survivingFieldId);
+            HasWarningReason(document).ShouldBeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task Cleanup_Also_Cleans_Recycle_Bin_Documents_Without_Resurrecting_Them()
+    {
+        // Required by #528: otherwise restoring the document later resurrects review state for a field that no
+        // longer exists. The scan therefore traverses soft delete — and the write must not undo the deletion.
+        var typeId = await ArrangeTypeAsync();
+        var fieldId = await ArrangeFieldAsync(typeId, "party_a_name");
+        var documentId = await ArrangeDocumentWithWarningsAsync(typeId, (fieldId, "Value looks truncated."));
+        await WithUnitOfWorkAsync(() => _documentRepository.DeleteAsync(documentId, autoSave: true));
+
+        await _warningCleanupJob.ExecuteAsync(NewWarningArgs(fieldId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            using (_dataFilter.Disable<ISoftDelete>())
+            {
+                var document = await _documentRepository.FindWithFieldValuesAsync(documentId);
+                document!.FieldValidationWarnings.ShouldBeEmpty();
+                HasWarningReason(document).ShouldBeFalse();
+                document.IsDeleted.ShouldBeTrue();
+            }
+        });
+    }
+
+    [Fact]
+    public async Task Cleanup_Ignores_Documents_Warned_Only_On_Other_Fields()
+    {
+        var typeId = await ArrangeTypeAsync();
+        var deletedFieldId = await ArrangeFieldAsync(typeId, "party_a_name");
+        var otherFieldId = await ArrangeFieldAsync(typeId, "amount");
+        var untouchedId = await ArrangeDocumentWithWarningsAsync(typeId, (otherFieldId, "Not a number."));
+
+        await _warningCleanupJob.ExecuteAsync(NewWarningArgs(deletedFieldId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.FindWithFieldValuesAsync(untouchedId);
+            document!.FieldValidationWarnings.Count.ShouldBe(1);
+            HasWarningReason(document).ShouldBeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task Cleanup_Is_Idempotent()
+    {
+        // At-least-once chaining can re-run a batch after a crash. Cleaned documents drop out of the scan predicate,
+        // so the second run must be a no-op rather than a double-apply or a failure.
+        var typeId = await ArrangeTypeAsync();
+        var fieldId = await ArrangeFieldAsync(typeId, "party_a_name");
+        var documentId = await ArrangeDocumentWithWarningsAsync(typeId, (fieldId, "Value looks truncated."));
+
+        await _warningCleanupJob.ExecuteAsync(NewWarningArgs(fieldId));
+        await _warningCleanupJob.ExecuteAsync(NewWarningArgs(fieldId));
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.FindWithFieldValuesAsync(documentId);
+            document!.FieldValidationWarnings.ShouldBeEmpty();
+            HasWarningReason(document).ShouldBeFalse();
+        });
+    }
+
+    // === DuplicateBasisCleanupJob ===
+
+    [Fact]
+    public async Task DuplicateBasisCleanup_Clears_The_Fingerprint_And_The_Blocking_Reason()
+    {
+        var typeId = await ArrangeTypeAsync();
+        var documentId = await ArrangeDuplicateSuspectedDocumentAsync(typeId);
+
+        await _duplicateBasisCleanupJob.ExecuteAsync(new DuplicateBasisCleanupArgs
+        {
+            DocumentTypeId = typeId,
+            TenantId = null
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = await _documentRepository.FindWithFieldValuesAsync(documentId);
+            document!.FieldFingerprint.ShouldBeNull();
+            ((document.ReviewReasons & DocumentReviewReasons.DuplicateSuspected) != DocumentReviewReasons.None)
+                .ShouldBeFalse();
+        });
+    }
+
+    [Fact]
+    public async Task DuplicateBasisCleanup_Does_Not_Forge_An_Operator_Duplicate_Decision()
+    {
+        // Document.AllowDuplicate() would ALSO set DuplicateAllowed, durably recording a "not a duplicate" call that
+        // no operator made and suppressing re-raises on every later re-extraction. Schema reconciliation clears the
+        // reason only; a future re-extraction must be free to flag the document again on the remaining schema.
+        var typeId = await ArrangeTypeAsync();
+        var documentId = await ArrangeDuplicateSuspectedDocumentAsync(typeId);
+
+        await _duplicateBasisCleanupJob.ExecuteAsync(new DuplicateBasisCleanupArgs
+        {
+            DocumentTypeId = typeId,
+            TenantId = null
+        });
+
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentRepository.FindWithFieldValuesAsync(documentId))!.DuplicateAllowed.ShouldBeFalse());
+    }
+
+    // === Arrangement ===
+
+    private static FieldValidationWarningCleanupArgs NewWarningArgs(Guid fieldDefinitionId) =>
+        new() { FieldDefinitionId = fieldDefinitionId, TenantId = null };
+
+    private static bool HasWarningReason(Document document) =>
+        (document.ReviewReasons & DocumentReviewReasons.FieldValidationWarning) != DocumentReviewReasons.None;
+
+    private async Task<Guid> ArrangeTypeAsync(string typeCode = "invoice")
+    {
+        var typeId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(() =>
+            _documentTypeRepository.InsertAsync(
+                new DocumentType(typeId, tenantId: null, typeCode, "Invoice"), autoSave: true));
+        return typeId;
+    }
+
+    private async Task<Guid> ArrangeFieldAsync(Guid documentTypeId, string name, bool isUniqueKey = false)
+    {
+        var fieldId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(() =>
+            _fieldDefinitionRepository.InsertAsync(
+                new FieldDefinition(
+                    fieldId,
+                    tenantId: null,
+                    documentTypeId,
+                    name,
+                    displayName: name,
+                    prompt: null,
+                    FieldDataType.Text,
+                    isUniqueKey: isUniqueKey),
+                autoSave: true));
+        return fieldId;
+    }
+
+    private async Task<Guid> ArrangeDocumentWithWarningsAsync(
+        Guid documentTypeId,
+        params (Guid FieldId, string Message)[] warnings)
+    {
+        var documentId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = new Document(documentId, tenantId: null, DocumentTestData.NewFileOrigin(documentId));
+            DocumentTestData.MarkClassified(document, documentTypeId);
+
+            // ReplaceFieldValidationWarnings couples the blocking bit itself, so seeding through the aggregate
+            // reproduces exactly the state the field-extraction write phase leaves behind.
+            var incoming = new List<FieldValidationWarning>();
+            foreach (var (fieldId, message) in warnings)
+            {
+                incoming.Add(new FieldValidationWarning(fieldId, message));
+            }
+
+            document.ReplaceFieldValidationWarnings(incoming);
+            await _documentRepository.InsertAsync(document, autoSave: true);
+        });
+        return documentId;
+    }
+
+    private async Task<Guid> ArrangeDuplicateSuspectedDocumentAsync(Guid documentTypeId)
+    {
+        var documentId = _guidGenerator.Create();
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var document = new Document(documentId, tenantId: null, DocumentTestData.NewFileOrigin(documentId));
+            DocumentTestData.MarkClassified(document, documentTypeId);
+            document.SetFieldFingerprint(new string('a', 64));
+            document.SetReviewReason(DocumentReviewReasons.DuplicateSuspected, present: true);
+            await _documentRepository.InsertAsync(document, autoSave: true);
+        });
+        return documentId;
+    }
+}


### PR DESCRIPTION
## What changed

- enqueue tenant-scoped, bounded cleanup whenever a field definition is deleted
- remove only warnings tied to the deleted field and re-derive lifecycle through the `Document` aggregate
- include recycle-bin documents so restore cannot resurrect obsolete blocking state
- reconcile duplicate basis when a unique-key field is deleted
- preserve operator duplicate decisions and unrelated warning state

## Review hardening

The first implementation decided at enqueue time whether the deleted field was the last unique key. Two concurrent key deletions could both observe another key and enqueue no duplicate cleanup; the inverse race could also clear a newly valid basis.

The delete path now always schedules the duplicate-basis check for a deleted unique key. Each cleanup batch re-reads the active schema inside its unit of work and skips safely while any active unique key exists, including chained batches. This makes the job retry-safe and correct under schema changes.

## Impact

Only Ready-gate-blocking derived state is reconciled. The job does not publish `FieldsExtractedEto`, and non-blocking schema staleness remains scoped to #537.

## Validation

- Full solution build: success, 0 errors (3 pre-existing nullable warnings in host code).
- `FieldDefinitionCleanup_Tests`: 12 passed, 0 failed.
- `git diff --check`: passed.

Closes #528