### PR TITLE
fix(fields): enforce per-type schema prompt budget

### DIFF
--- a/.claude/rules/llm-call-anti-patterns.md
+++ b/.claude/rules/llm-call-anti-patterns.md
@@ -333,6 +333,7 @@ Every LLM-facing path picks exactly one, and it follows from the semantics of th
 | `CabinetSuggestionWorkflow` | no | truncate (reuses `MaxTextLengthPerExtraction`) |
 | `DocumentSegmentationJob` | **yes** — a boundary can be anywhere | **gate** at `MaxSegmentationMarkdownLength` → `SegmentationIncomplete` |
 | `FieldExtractionService` | **yes** — a field can be anywhere | **gate** at `MaxFieldExtractionMarkdownLength` → `FieldExtractionIncomplete` |
+| `FieldExtractionWorkflow` field schema (`Σ FieldDefinition.Prompt`) | **yes** — every field instruction is load-bearing | **reject the configuration write** at the per-type `MaxFieldSchemaPromptLength`; assert again at the call site |
 | MCP `get_document` / `documents/{id}` | no — the client can re-read | truncate at `VaultExtractMcpConsts.MaxDocumentMarkdownChars` + announce |
 
 ```csharp
@@ -360,3 +361,4 @@ return new DocumentDetailResult
 4. **Never cut with a raw range slice** — `text[..n]` can split a surrogate pair; use `TextTruncator.AtCharBoundary`
 5. **Announce every truncation** — `Truncated` / `markdownTruncated` + a total, so an LLM cannot mistake a prefix for the whole
 6. **Prompt ceilings are configuration, egress ceilings are `const`** — a host tunes its own token budget (`VaultExtractBehaviorOptions`), but the safety boundary of an LLM-facing egress must not be widenable at runtime (`VaultExtractMcpConsts`)
+7. **Reject deterministic schema overflow at configuration write time** — an oversized field schema would affect every document of the type, while operators cannot edit admin-owned field definitions. Enforce the per-type total on create/update/restore/pack import; the workflow assertion is defense in depth, not the primary user-facing gate

--- a/.cursor/rules/project/llm-call-anti-patterns.mdc
+++ b/.cursor/rules/project/llm-call-anti-patterns.mdc
@@ -333,6 +333,7 @@ Every LLM-facing path picks exactly one, and it follows from the semantics of th
 | `CabinetSuggestionWorkflow` | no | truncate (reuses `MaxTextLengthPerExtraction`) |
 | `DocumentSegmentationJob` | **yes** — a boundary can be anywhere | **gate** at `MaxSegmentationMarkdownLength` → `SegmentationIncomplete` |
 | `FieldExtractionService` | **yes** — a field can be anywhere | **gate** at `MaxFieldExtractionMarkdownLength` → `FieldExtractionIncomplete` |
+| `FieldExtractionWorkflow` field schema (`Σ FieldDefinition.Prompt`) | **yes** — every field instruction is load-bearing | **reject the configuration write** at the per-type `MaxFieldSchemaPromptLength`; assert again at the call site |
 | MCP `get_document` / `documents/{id}` | no — the client can re-read | truncate at `VaultExtractMcpConsts.MaxDocumentMarkdownChars` + announce |
 
 ```csharp
@@ -360,3 +361,4 @@ return new DocumentDetailResult
 4. **Never cut with a raw range slice** — `text[..n]` can split a surrogate pair; use `TextTruncator.AtCharBoundary`
 5. **Announce every truncation** — `Truncated` / `markdownTruncated` + a total, so an LLM cannot mistake a prefix for the whole
 6. **Prompt ceilings are configuration, egress ceilings are `const`** — a host tunes its own token budget (`VaultExtractBehaviorOptions`), but the safety boundary of an LLM-facing egress must not be widenable at runtime (`VaultExtractMcpConsts`)
+7. **Reject deterministic schema overflow at configuration write time** — an oversized field schema would affect every document of the type, while operators cannot edit admin-owned field definitions. Enforce the per-type total on create/update/restore/pack import; the workflow assertion is defense in depth, not the primary user-facing gate

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackFieldDto.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/DocumentTypes/Packs/DocumentTypePackFieldDto.cs
@@ -20,7 +20,6 @@ public class DocumentTypePackFieldDto
     [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxDisplayNameLength))]
     public string DisplayName { get; set; } = default!;
 
-    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxPromptLength))]
     public string? Prompt { get; set; }
 
     public FieldDataType DataType { get; set; } = FieldDataType.Text;

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/Fields/DraftFieldDefinitionInput.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/Fields/DraftFieldDefinitionInput.cs
@@ -11,12 +11,12 @@ namespace Dignite.Vault.Extract.Documents.Fields;
 public class DraftFieldDefinitionInput
 {
     /// <summary>
-    /// Extraction instructions: the only input signal for drafting. Length limit reuses
-    /// <see cref="FieldDefinitionConsts.MaxPromptLength"/> because this value eventually lands in
-    /// <c>FieldDefinition.Prompt</c>, sharing the same guardrail.
+    /// Extraction instructions: the only input signal for drafting. Capped at
+    /// <see cref="FieldDefinitionConsts.MaxInteractivePromptInputLength"/> to bound this interactive
+    /// LLM call; the persisted <c>FieldDefinition.Prompt</c> remains uncapped per field (#447).
     /// </summary>
     [Required]
-    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxPromptLength))]
+    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxInteractivePromptInputLength))]
     public string Prompt { get; set; } = default!;
 
     /// <summary>

--- a/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/Fields/FieldPromptPolishInput.cs
+++ b/core/src/Dignite.Vault.Extract.Application.Contracts/Documents/Fields/FieldPromptPolishInput.cs
@@ -5,12 +5,12 @@ namespace Dignite.Vault.Extract.Documents.Fields;
 
 /// <summary>
 /// Input for AI-polishing a field-extraction prompt (#447): the administrator's raw prompt text, which the
-/// LLM normalizes into clean, well-formed Markdown. Capped at <see cref="FieldDefinitionConsts.MaxPromptLength"/>
+/// LLM normalizes into clean, well-formed Markdown. Capped at <see cref="FieldDefinitionConsts.MaxInteractivePromptInputLength"/>
 /// to bound the interactive LLM call (the persisted <c>FieldDefinition.Prompt</c> itself is uncapped).
 /// </summary>
 public class FieldPromptPolishInput
 {
     [Required]
-    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxPromptLength))]
+    [DynamicStringLength(typeof(FieldDefinitionConsts), nameof(FieldDefinitionConsts.MaxInteractivePromptInputLength))]
     public string Prompt { get; set; } = default!;
 }

--- a/core/src/Dignite.Vault.Extract.Application/Ai/VaultExtractBehaviorOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Ai/VaultExtractBehaviorOptions.cs
@@ -98,4 +98,14 @@ public class VaultExtractBehaviorOptions
     /// Default 200k chars, aligned with segmentation; hosts may raise it for bigger documents or lower it to cap spend.
     /// </summary>
     public int MaxFieldExtractionMarkdownLength { get; set; } = 200_000;
+
+    /// <summary>
+    /// Maximum total number of prompt characters across all active field definitions on one document type (#468).
+    /// One field prompt remains uncapped on its own (#447); the aggregate budget is what bounds the schema text sent
+    /// with every field-extraction call while preserving room for a single long structured-Markdown prompt. The
+    /// configuration write paths reject a projected schema above this ceiling, so an invalid type never mass-parks
+    /// its documents at extraction time. Default 32k characters: comfortably above ordinary 5-30-field schemas and
+    /// well below the default document-body ceiling.
+    /// </summary>
+    public int MaxFieldSchemaPromptLength { get; set; } = 32_000;
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
@@ -187,14 +187,31 @@ public class DocumentTypeAppService : VaultExtractAppService, IDocumentTypeAppSe
             // but extreme cases such as manual DB edits / seed bypass can still happen; the domain check rejects it (#304).
             await _documentTypeManager.CheckRestorableAsync(entity);
 
-            // Cascading restore reactivates every deleted field below, so validate their aggregate prompt budget
-            // before writing either the parent or a child. This closes the restore bypass around the CRUD guards.
+            // Build the exact field set the cascade will reactivate before writing either the parent or a child.
+            // A deleted field whose name conflicts with an already-active sibling is skipped by the established
+            // cascade semantics, so counting it would reject restores whose FINAL active schema is within budget.
             var fieldQueryable = await _fieldDefinitionRepository.GetQueryableAsync();
             var allFields = await AsyncExecuter.ToListAsync(
                 fieldQueryable.Where(f =>
                     f.TenantId == entity.TenantId &&
                     f.DocumentTypeId == entity.Id));
-            _schemaPromptBudget.EnsureCanPersist(entity.TypeCode, allFields.Select(f => f.Prompt));
+            var fieldsToRestore = new List<FieldDefinition>();
+            foreach (var field in allFields.Where(f => f.IsDeleted))
+            {
+                if (await _fieldDefinitionManager.HasActiveNameConflictAsync(entity.Id, field.Name))
+                {
+                    Logger.LogWarning(
+                        "Skip cascade restore of FieldDefinition {FieldId} (Name={Name}) under DocumentType {TypeCode}: an active field with the same name already exists.",
+                        field.Id, field.Name, entity.TypeCode);
+                    continue;
+                }
+
+                fieldsToRestore.Add(field);
+            }
+
+            _schemaPromptBudget.EnsureCanPersist(
+                entity.TypeCode,
+                allFields.Where(f => !f.IsDeleted).Concat(fieldsToRestore).Select(f => f.Prompt));
 
             entity.IsDeleted = false;
             entity.DeletionTime = null;
@@ -203,21 +220,8 @@ public class DocumentTypeAppService : VaultExtractAppService, IDocumentTypeAppSe
 
             // Cascading restore: also restore soft-deleted FieldDefinitions under the same (TenantId, TypeCode).
             // Unlike single-field RestoreAsync, skip conflicting fields here and log a warning rather than interrupting the whole restore.
-            var deletedFields = allFields.Where(f => f.IsDeleted).ToList();
-
-            foreach (var field in deletedFields)
+            foreach (var field in fieldsToRestore)
             {
-                // Per-field duplicate check routes through the domain service (#304); cascade restore skips conflicts
-                // (logs a warning) instead of aborting the whole type restore.
-                var nameConflict = await _fieldDefinitionManager.HasActiveNameConflictAsync(entity.Id, field.Name);
-                if (nameConflict)
-                {
-                    Logger.LogWarning(
-                        "Skip cascade restore of FieldDefinition {FieldId} (Name={Name}) under DocumentType {TypeCode}: an active field with the same name already exists.",
-                        field.Id, field.Name, entity.TypeCode);
-                    continue;
-                }
-
                 field.IsDeleted = false;
                 field.DeletionTime = null;
                 field.DeleterId = null;

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/DocumentTypeAppService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dignite.Vault.Extract.Documents.Fields;
 using Dignite.Vault.Extract.Permissions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
@@ -20,20 +21,23 @@ public class DocumentTypeAppService : VaultExtractAppService, IDocumentTypeAppSe
     private readonly IDocumentRepository _documentRepository;
     private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
     private readonly DocumentTypeManager _documentTypeManager;
-    private readonly Fields.FieldDefinitionManager _fieldDefinitionManager;
+    private readonly FieldDefinitionManager _fieldDefinitionManager;
+    private readonly FieldSchemaPromptBudgetGuard _schemaPromptBudget;
 
     public DocumentTypeAppService(
         IDocumentTypeRepository repository,
         IDocumentRepository documentRepository,
         IFieldDefinitionRepository fieldDefinitionRepository,
         DocumentTypeManager documentTypeManager,
-        Fields.FieldDefinitionManager fieldDefinitionManager)
+        FieldDefinitionManager fieldDefinitionManager,
+        FieldSchemaPromptBudgetGuard schemaPromptBudget)
     {
         _repository = repository;
         _documentRepository = documentRepository;
         _fieldDefinitionRepository = fieldDefinitionRepository;
         _documentTypeManager = documentTypeManager;
         _fieldDefinitionManager = fieldDefinitionManager;
+        _schemaPromptBudget = schemaPromptBudget;
     }
 
     public virtual async Task<List<DocumentTypeDto>> GetVisibleAsync()
@@ -183,6 +187,15 @@ public class DocumentTypeAppService : VaultExtractAppService, IDocumentTypeAppSe
             // but extreme cases such as manual DB edits / seed bypass can still happen; the domain check rejects it (#304).
             await _documentTypeManager.CheckRestorableAsync(entity);
 
+            // Cascading restore reactivates every deleted field below, so validate their aggregate prompt budget
+            // before writing either the parent or a child. This closes the restore bypass around the CRUD guards.
+            var fieldQueryable = await _fieldDefinitionRepository.GetQueryableAsync();
+            var allFields = await AsyncExecuter.ToListAsync(
+                fieldQueryable.Where(f =>
+                    f.TenantId == entity.TenantId &&
+                    f.DocumentTypeId == entity.Id));
+            _schemaPromptBudget.EnsureCanPersist(entity.TypeCode, allFields.Select(f => f.Prompt));
+
             entity.IsDeleted = false;
             entity.DeletionTime = null;
             entity.DeleterId = null;
@@ -190,12 +203,7 @@ public class DocumentTypeAppService : VaultExtractAppService, IDocumentTypeAppSe
 
             // Cascading restore: also restore soft-deleted FieldDefinitions under the same (TenantId, TypeCode).
             // Unlike single-field RestoreAsync, skip conflicting fields here and log a warning rather than interrupting the whole restore.
-            var fieldQueryable = await _fieldDefinitionRepository.GetQueryableAsync();
-            var deletedFields = await AsyncExecuter.ToListAsync(
-                fieldQueryable.Where(f =>
-                    f.TenantId == entity.TenantId &&
-                    f.DocumentTypeId == entity.Id &&
-                    f.IsDeleted));
+            var deletedFields = allFields.Where(f => f.IsDeleted).ToList();
 
             foreach (var field in deletedFields)
             {

--- a/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/Packs/DocumentTypePackAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/DocumentTypes/Packs/DocumentTypePackAppService.cs
@@ -35,19 +35,22 @@ public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypeP
     private readonly IDocumentRepository _documentRepository;
     private readonly DocumentTypeManager _documentTypeManager;
     private readonly FieldDefinitionManager _fieldDefinitionManager;
+    private readonly FieldSchemaPromptBudgetGuard _schemaPromptBudget;
 
     public DocumentTypePackAppService(
         IDocumentTypeRepository documentTypeRepository,
         IFieldDefinitionRepository fieldDefinitionRepository,
         IDocumentRepository documentRepository,
         DocumentTypeManager documentTypeManager,
-        FieldDefinitionManager fieldDefinitionManager)
+        FieldDefinitionManager fieldDefinitionManager,
+        FieldSchemaPromptBudgetGuard schemaPromptBudget)
     {
         _documentTypeRepository = documentTypeRepository;
         _fieldDefinitionRepository = fieldDefinitionRepository;
         _documentRepository = documentRepository;
         _documentTypeManager = documentTypeManager;
         _fieldDefinitionManager = fieldDefinitionManager;
+        _schemaPromptBudget = schemaPromptBudget;
     }
 
     [Authorize(VaultExtractPermissions.DocumentTypes.Default)]
@@ -101,6 +104,11 @@ public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypeP
             }
         }
 
+        // Validate every projected type schema before touching the store. This is aggregate-wide (not one DTO
+        // attribute per field) and simulates repeated packs in request order, preserving the method's unconditional
+        // no-partial-write guarantee even in the non-transactional test harness.
+        await ValidateSchemaPromptBudgetsAsync(input.Packs, input.Mode);
+
         var result = new DocumentTypePackImportResultDto();
         foreach (var pack in input.Packs)
         {
@@ -120,6 +128,43 @@ public class DocumentTypePackAppService : VaultExtractAppService, IDocumentTypeP
         }
 
         return result;
+    }
+
+    protected virtual async Task ValidateSchemaPromptBudgetsAsync(
+        List<DocumentTypePackDto> packs,
+        PackImportMode mode)
+    {
+        var projectedByTypeCode = new Dictionary<string, Dictionary<string, string?>>(
+            StringComparer.Ordinal);
+
+        foreach (var pack in packs)
+        {
+            if (!projectedByTypeCode.TryGetValue(pack.TypeCode, out var projectedFields))
+            {
+                projectedFields = new Dictionary<string, string?>(StringComparer.Ordinal);
+                var existingType = await _documentTypeRepository.FindByTypeCodeAsync(pack.TypeCode);
+                if (existingType != null)
+                {
+                    var existingFields = await _fieldDefinitionRepository.GetListAsync(existingType.Id);
+                    foreach (var field in existingFields)
+                    {
+                        projectedFields[field.Name] = field.Prompt;
+                    }
+                }
+
+                projectedByTypeCode[pack.TypeCode] = projectedFields;
+            }
+
+            foreach (var field in pack.Fields)
+            {
+                if (!projectedFields.ContainsKey(field.Name) || mode == PackImportMode.CreateOrUpdate)
+                {
+                    projectedFields[field.Name] = field.Prompt;
+                }
+            }
+
+            _schemaPromptBudget.EnsureCanPersist(pack.TypeCode, projectedFields.Values);
+        }
     }
 
     protected virtual async Task<DocumentTypePackItemResultDto> ImportPackAsync(

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldDefinitionAppService.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldDefinitionAppService.cs
@@ -23,19 +23,22 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
     private readonly IDocumentRepository _documentRepository;
     private readonly FieldDefinitionManager _fieldDefinitionManager;
     private readonly IBackgroundJobManager _backgroundJobManager;
+    private readonly FieldSchemaPromptBudgetGuard _schemaPromptBudget;
 
     public FieldDefinitionAppService(
         IFieldDefinitionRepository repository,
         IDocumentTypeRepository documentTypeRepository,
         IDocumentRepository documentRepository,
         FieldDefinitionManager fieldDefinitionManager,
-        IBackgroundJobManager backgroundJobManager)
+        IBackgroundJobManager backgroundJobManager,
+        FieldSchemaPromptBudgetGuard schemaPromptBudget)
     {
         _repository = repository;
         _documentTypeRepository = documentTypeRepository;
         _documentRepository = documentRepository;
         _fieldDefinitionManager = fieldDefinitionManager;
         _backgroundJobManager = backgroundJobManager;
+        _schemaPromptBudget = schemaPromptBudget;
     }
 
     public virtual async Task<List<FieldDefinitionDto>> GetListAsync(GetFieldDefinitionListInput input)
@@ -105,6 +108,7 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
         // Soft-delete-aware duplicate check owned by the domain service (#304): the same (TenantId, DocumentTypeId, Name)
         // counts as occupied even when soft-deleted, avoiding conflicts with new records on restore.
         await _fieldDefinitionManager.CheckNameAvailableAsync(input.DocumentTypeId, input.Name);
+        await EnsureSchemaPromptBudgetAsync(type, replacingFieldId: null, projectedPrompt: input.Prompt);
 
         var entity = new FieldDefinition(
             GuidGenerator.Create(),
@@ -162,6 +166,9 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
                     .WithData("Name", entity.Name);
             }
         }
+
+        var type = await _documentTypeRepository.GetAsync(entity.DocumentTypeId);
+        await EnsureSchemaPromptBudgetAsync(type, entity.Id, input.Prompt);
 
         entity.Update(input.Name, input.DisplayName, input.Prompt, input.DataType, input.DisplayOrder, input.IsRequired, input.AllowMultiple, input.IsUniqueKey);
         await _repository.UpdateAsync(entity, autoSave: true);
@@ -252,6 +259,20 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
             // service keeps a defensive guard and throws RestoreConflict (#304).
             await _fieldDefinitionManager.CheckRestorableAsync(entity);
 
+            // A deleted field is outside the active extraction schema. Restoring it is therefore another
+            // configuration write and must validate the projected active set, especially when siblings were added
+            // while this field was in the recycle bin or the host lowered the configured ceiling.
+            var queryable = await _repository.GetQueryableAsync();
+            var activePrompts = await AsyncExecuter.ToListAsync(
+                queryable
+                    .Where(f =>
+                        f.DocumentTypeId == entity.DocumentTypeId &&
+                        f.Id != entity.Id &&
+                        !f.IsDeleted)
+                    .Select(f => f.Prompt));
+            activePrompts.Add(entity.Prompt);
+            _schemaPromptBudget.EnsureCanPersist(parentType.TypeCode, activePrompts);
+
             entity.IsDeleted = false;
             entity.DeletionTime = null;
             entity.DeleterId = null;
@@ -259,5 +280,19 @@ public class FieldDefinitionAppService : VaultExtractAppService, IFieldDefinitio
 
             return ObjectMapper.Map<FieldDefinition, FieldDefinitionDto>(entity);
         }
+    }
+
+    protected virtual async Task EnsureSchemaPromptBudgetAsync(
+        DocumentType type,
+        Guid? replacingFieldId,
+        string? projectedPrompt)
+    {
+        var fields = await _repository.GetListAsync(type.Id);
+        var projectedPrompts = fields
+            .Where(f => f.Id != replacingFieldId)
+            .Select(f => f.Prompt)
+            .Append(projectedPrompt);
+
+        _schemaPromptBudget.EnsureCanPersist(type.TypeCode, projectedPrompts);
     }
 }

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldSchemaPromptBudgetGuard.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Fields/FieldSchemaPromptBudgetGuard.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Dignite.Vault.Extract.Ai;
+using Microsoft.Extensions.Options;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+
+namespace Dignite.Vault.Extract.Documents.Fields;
+
+/// <summary>
+/// Enforces the per-document-type budget for field-definition prompt text (#468). The invariant is deliberately
+/// aggregate-wide: a per-field limit cannot bound the schema message because the field count is not capped.
+/// </summary>
+public class FieldSchemaPromptBudgetGuard : ITransientDependency
+{
+    private readonly VaultExtractBehaviorOptions _options;
+
+    public FieldSchemaPromptBudgetGuard(IOptions<VaultExtractBehaviorOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public virtual void EnsureCanPersist(string documentTypeCode, IEnumerable<string?> prompts)
+    {
+        var totalLength = GetTotalLength(prompts);
+        if (totalLength <= MaxLength)
+        {
+            return;
+        }
+
+        throw new BusinessException(VaultExtractErrorCodes.FieldDefinition.SchemaPromptBudgetExceeded)
+            .WithData("DocumentTypeCode", documentTypeCode)
+            .WithData("ActualLength", totalLength)
+            .WithData("MaxLength", MaxLength);
+    }
+
+    /// <summary>
+    /// Defense-in-depth assertion at the final LLM call site. Normal configuration writes make this unreachable;
+    /// throwing prevents a repository bypass, seed, or future migration from sending an unbounded schema prompt.
+    /// </summary>
+    public virtual void AssertWithinBudget(IEnumerable<string?> prompts)
+    {
+        var totalLength = GetTotalLength(prompts);
+        if (totalLength > MaxLength)
+        {
+            throw new InvalidOperationException(
+                $"The persisted field schema contains {totalLength} prompt characters, exceeding the configured " +
+                $"MaxFieldSchemaPromptLength ceiling of {MaxLength}.");
+        }
+    }
+
+    protected virtual long GetTotalLength(IEnumerable<string?> prompts)
+    {
+        long totalLength = 0;
+        foreach (var prompt in prompts)
+        {
+            // FieldDefinition normalizes whitespace-only prompts to null, so projected writes must use the same
+            // semantics rather than charging budget for text that will not be persisted.
+            if (!string.IsNullOrWhiteSpace(prompt))
+            {
+                totalLength += prompt.Length;
+            }
+        }
+
+        return totalLength;
+    }
+
+    private int MaxLength
+    {
+        get
+        {
+            if (_options.MaxFieldSchemaPromptLength < 0)
+            {
+                throw new InvalidOperationException(
+                    "Vault:ExtractBehavior:MaxFieldSchemaPromptLength must be zero or greater.");
+            }
+
+            return _options.MaxFieldSchemaPromptLength;
+        }
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
+++ b/core/src/Dignite.Vault.Extract.Application/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow.cs
@@ -35,13 +35,16 @@ public class FieldExtractionWorkflow : ITransientDependency
 {
     private readonly IChatClient _chatClient;
     private readonly ILogger<FieldExtractionWorkflow> _logger;
+    private readonly FieldSchemaPromptBudgetGuard _schemaPromptBudget;
 
     public FieldExtractionWorkflow(
         [FromKeyedServices(VaultExtractConsts.StructuredChatClientKey)] IChatClient chatClient,
-        ILogger<FieldExtractionWorkflow> logger)
+        ILogger<FieldExtractionWorkflow> logger,
+        FieldSchemaPromptBudgetGuard schemaPromptBudget)
     {
         _chatClient = chatClient;
         _logger = logger;
+        _schemaPromptBudget = schemaPromptBudget;
     }
 
     /// <summary>
@@ -82,8 +85,10 @@ public class FieldExtractionWorkflow : ITransientDependency
         // "instructions" and "user data" separately, together with PromptBoundary.WrapField + BoundaryRule.
         // FieldDefinition.Name is already entity-layer allow-list validated as [A-Za-z0-9_-]{1,64}
         // (see FieldDefinitionConsts.NamePattern), so it cannot contain line breaks, quotes, or Markdown control characters.
-        // f.Prompt is admin-authored configuration (uncapped since #447); its injection defense is PromptBoundary.WrapField
-        // (applied in BuildSchemaUserMessage) + BoundaryRule, not a length limit.
+        // f.Prompt is admin-authored configuration and remains uncapped per field (#447). The persistence paths enforce
+        // MaxFieldSchemaPromptLength over the whole type (#468); assert it again here so a repository bypass, seed, or
+        // future migration can never hand an unbounded schema message to the LLM.
+        _schemaPromptBudget.AssertWithinBudget(fields.Select(f => f.Prompt));
         var schemaMessage = BuildSchemaUserMessage(fields);
         var messages = new List<ChatMessage>
         {

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Fields/FieldDefinitionConsts.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Documents/Fields/FieldDefinitionConsts.cs
@@ -10,9 +10,11 @@ public static class FieldDefinitionConsts
     /// AI-polish request (#447). The persisted <c>FieldDefinition.Prompt</c> is intentionally uncapped
     /// (<c>nvarchar(max)</c>, #447: it is admin-authored configuration, not end-user input), so this
     /// bounds only the interactive LLM call to guard cost / abuse — it is no longer a column or
-    /// create/update DTO constraint.
+    /// create/update DTO constraint. #468 deliberately renamed the former <c>MaxPromptLength</c> API rather than
+    /// preserving its ambiguous name: the small source break prevents another persistence path from mistaking this
+    /// interactive-call limit for a stored-field invariant.
     /// </summary>
-    public static int MaxPromptLength { get; set; } = 4000;
+    public static int MaxInteractivePromptInputLength { get; set; } = 4000;
 
     /// <summary>
     /// Whitelist for field <see cref="FieldDefinition.Name"/>: only letters / digits / underscore /

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/en.json
@@ -398,6 +398,7 @@
     "Extract:FieldDefinitionDataTypeChangeNotAllowed": "Cannot change the data type of field '{Name}': it already has extracted values stored. Create a new field instead.",
     "Extract:FieldDefinitionMultiValueRequiresStringType": "Multi-value is only supported for Text fields, but '{dataType}' was requested. Use a Text field to allow multiple values.",
     "Extract:FieldDefinitionMultiValueChangeNotAllowed": "Cannot turn off multi-value on field '{Name}': it already has extracted values stored, and narrowing to single-value would orphan the extra values. Create a new field instead.",
+    "Extract:FieldDefinitionSchemaPromptBudgetExceeded": "The field schema for document type '{DocumentTypeCode}' contains {ActualLength} prompt characters, exceeding the configured limit of {MaxLength}. Shorten one or more field prompts before saving.",
     "Extract:InvalidFieldDefinitionName": "Field name '{name}' is invalid. Names must match pattern '{pattern}' (letters, digits, underscore, hyphen; 1-64 chars).",
     "Extract:InvalidFieldDefinitionDisplayName": "Field display name '{displayName}' contains control characters (newlines, tabs, etc.), which are not allowed.",
     "Extract:InvalidDocumentTypeDisplayName": "Document type display name '{displayName}' contains control characters (newlines, tabs, etc.), which are not allowed.",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/ja.json
@@ -398,6 +398,7 @@
     "Extract:FieldDefinitionDataTypeChangeNotAllowed": "フィールド '{Name}' のデータ型は変更できません：既に抽出値が保存されています。代わりに新しいフィールドを作成してください。",
     "Extract:FieldDefinitionMultiValueRequiresStringType": "複数値はテキストフィールドのみ対応していますが、'{dataType}' が要求されました。複数値を許可するにはテキストフィールドを使用してください。",
     "Extract:FieldDefinitionMultiValueChangeNotAllowed": "フィールド '{Name}' の複数値を無効にできません：既に抽出値が保存されており、単一値に狭めると余分な値が孤立してしまいます。代わりに新しいフィールドを作成してください。",
+    "Extract:FieldDefinitionSchemaPromptBudgetExceeded": "ドキュメントタイプ '{DocumentTypeCode}' のフィールドスキーマには合計 {ActualLength} 文字のプロンプトがあり、設定上限 {MaxLength} 文字を超えています。保存する前に、1 つ以上のフィールドプロンプトを短くしてください。",
     "Extract:InvalidFieldDefinitionName": "フィールド名 '{name}' は無効です。名前はパターン '{pattern}' に一致する必要があります（英字・数字・アンダースコア・ハイフン。1〜64 文字）。",
     "Extract:InvalidFieldDefinitionDisplayName": "フィールド表示名 '{displayName}' に制御文字（改行、タブなど）が含まれており、使用できません。",
     "Extract:InvalidDocumentTypeDisplayName": "ドキュメントタイプ表示名 '{displayName}' に制御文字（改行、タブなど）が含まれており、使用できません。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hans.json
@@ -398,6 +398,7 @@
     "Extract:FieldDefinitionDataTypeChangeNotAllowed": "无法修改字段 '{Name}' 的数据类型：该字段已存在抽取值。请改为新建字段。",
     "Extract:FieldDefinitionMultiValueRequiresStringType": "多值仅支持文本类型字段，但请求的是 '{dataType}'。请将字段声明为文本类型再开启多值。",
     "Extract:FieldDefinitionMultiValueChangeNotAllowed": "无法关闭字段 '{Name}' 的多值：该字段已存在抽取值，收窄为单值会让多余的值变成孤儿行。请改为新建字段。",
+    "Extract:FieldDefinitionSchemaPromptBudgetExceeded": "文档类型 '{DocumentTypeCode}' 的字段 schema 共包含 {ActualLength} 个提示词字符，超过配置上限 {MaxLength}。请缩短一个或多个字段提示词后再保存。",
     "Extract:InvalidFieldDefinitionName": "字段名 '{name}' 不合法。名称只能包含字母 / 数字 / 下划线 / 短横线，长度 1-64 字符。",
     "Extract:InvalidFieldDefinitionDisplayName": "字段显示名 '{displayName}' 包含换行 / 制表符等控制字符，不允许使用。",
     "Extract:InvalidDocumentTypeDisplayName": "文档类型显示名 '{displayName}' 包含换行 / 制表符等控制字符，不允许使用。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/Localization/Extract/zh-Hant.json
@@ -398,6 +398,7 @@
     "Extract:FieldDefinitionDataTypeChangeNotAllowed": "無法修改欄位 '{Name}' 的資料類型：此欄位已存在擷取值。請改為新增欄位。",
     "Extract:FieldDefinitionMultiValueRequiresStringType": "多值僅支援文字類型欄位，但要求的是 '{dataType}'。請將欄位宣告為文字類型再開啟多值。",
     "Extract:FieldDefinitionMultiValueChangeNotAllowed": "無法關閉欄位 '{Name}' 的多值：此欄位已存在擷取值，收窄為單值會讓多餘的值變成孤立資料列。請改為新增欄位。",
+    "Extract:FieldDefinitionSchemaPromptBudgetExceeded": "文件類型 '{DocumentTypeCode}' 的欄位 schema 共包含 {ActualLength} 個提示詞字元，超過設定上限 {MaxLength}。請縮短一個或多個欄位提示詞後再儲存。",
     "Extract:InvalidFieldDefinitionName": "欄位名稱 '{name}' 不合法。名稱只能包含字母 / 數字 / 底線 / 連字號，長度 1-64 字元。",
     "Extract:InvalidFieldDefinitionDisplayName": "欄位顯示名稱 '{displayName}' 包含換行 / 定位字元等控制字元，不允許使用。",
     "Extract:InvalidDocumentTypeDisplayName": "文件類型顯示名稱 '{displayName}' 包含換行 / 定位字元等控制字元，不允許使用。",

--- a/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
+++ b/core/src/Dignite.Vault.Extract.Domain.Shared/VaultExtractErrorCodes.cs
@@ -80,6 +80,7 @@ public static class VaultExtractErrorCodes
         public const string DataTypeChangeNotAllowed = "Extract:FieldDefinitionDataTypeChangeNotAllowed";
         public const string MultiValueRequiresStringType = "Extract:FieldDefinitionMultiValueRequiresStringType";
         public const string MultiValueChangeNotAllowed = "Extract:FieldDefinitionMultiValueChangeNotAllowed";
+        public const string SchemaPromptBudgetExceeded = "Extract:FieldDefinitionSchemaPromptBudgetExceeded";
     }
 
     public static class ExtractedField

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Ai/VaultExtractBehaviorOptionsBinding_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Ai/VaultExtractBehaviorOptionsBinding_Tests.cs
@@ -30,6 +30,7 @@ public class VaultExtractBehaviorOptionsBindingTestModule : AbpModule
                 ["Vault:ExtractBehavior:MaxDocumentTypesInClassificationPrompt"] = "25",
                 ["Vault:ExtractBehavior:MaxTextLengthPerExtraction"] = "16000",
                 ["Vault:ExtractBehavior:MaxTitleGenerationMarkdownLength"] = "2048",
+                ["Vault:ExtractBehavior:MaxFieldSchemaPromptLength"] = "48000",
             })
             .Build();
 
@@ -61,5 +62,6 @@ public class VaultExtractBehaviorOptionsBinding_Tests
         _options.MaxDocumentTypesInClassificationPrompt.ShouldBe(25);                 // default 50
         _options.MaxTextLengthPerExtraction.ShouldBe(16000);                          // default 8000
         _options.MaxTitleGenerationMarkdownLength.ShouldBe(2048);                     // default 4000
+        _options.MaxFieldSchemaPromptLength.ShouldBe(48000);                          // default 32000
     }
 }

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionCascade_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionCascade_Tests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dignite.Vault.Extract.Abstractions.Documents;
+using Dignite.Vault.Extract.Ai;
 using Dignite.Vault.Extract.Documents;
 using Dignite.Vault.Extract.Documents.DocumentTypes;
 using Dignite.Vault.Extract.Documents.Fields;
@@ -14,6 +15,7 @@ using Dignite.Vault.Extract.Documents.Pipelines.FieldExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.EventBus.Distributed;
@@ -36,7 +38,8 @@ public class FieldExtractionCascadeTestModule : AbpModule
         // Each test case configures the virtual ExtractAsync with Returns / Throws.
         var workflow = Substitute.ForPartsOf<FieldExtractionWorkflow>(
             Substitute.For<IChatClient>(),
-            NullLogger<FieldExtractionWorkflow>.Instance);
+            NullLogger<FieldExtractionWorkflow>.Instance,
+            new FieldSchemaPromptBudgetGuard(Options.Create(new VaultExtractBehaviorOptions())));
         context.Services.AddSingleton(workflow);
     }
 }

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionService_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionService_Tests.cs
@@ -14,6 +14,7 @@ using Dignite.Vault.Extract.Documents.Pipelines.FieldExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.EventBus.Distributed;
@@ -42,7 +43,8 @@ public class FieldExtractionServiceTestModule : AbpModule
 
         var workflow = Substitute.ForPartsOf<FieldExtractionWorkflow>(
             Substitute.For<IChatClient>(),
-            NullLogger<FieldExtractionWorkflow>.Instance);
+            NullLogger<FieldExtractionWorkflow>.Instance,
+            new FieldSchemaPromptBudgetGuard(Options.Create(new VaultExtractBehaviorOptions())));
         context.Services.AddSingleton(workflow);
     }
 }

--- a/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Application.Tests/Documents/Pipelines/FieldExtraction/FieldExtractionWorkflow_Tests.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Dignite.Vault.Extract.Ai;
 using Dignite.Vault.Extract.Documents.Pipelines.FieldExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -33,7 +35,8 @@ public class FieldExtractionWorkflow_Tests
 
         return new FieldExtractionWorkflow(
             chatClient,
-            NullLogger<FieldExtractionWorkflow>.Instance);
+            NullLogger<FieldExtractionWorkflow>.Instance,
+            new FieldSchemaPromptBudgetGuard(Options.Create(new VaultExtractBehaviorOptions())));
     }
 
     private static FieldExtractionDescriptor Field(string name, FieldDataType type)
@@ -244,6 +247,31 @@ public class FieldExtractionWorkflow_Tests
 
         result.Values.ShouldBeEmpty();
         result.ValidationWarnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Over_budget_schema_assertion_blocks_the_llm_call()
+    {
+        var chatClient = Substitute.For<IChatClient>();
+        var workflow = new FieldExtractionWorkflow(
+            chatClient,
+            NullLogger<FieldExtractionWorkflow>.Instance,
+            new FieldSchemaPromptBudgetGuard(Options.Create(new VaultExtractBehaviorOptions
+            {
+                MaxFieldSchemaPromptLength = 4
+            })));
+        var fields = new[]
+        {
+            new FieldExtractionDescriptor(
+                Guid.NewGuid(), "body", "12345", FieldDataType.Text, IsRequired: false, AllowMultiple: false)
+        };
+
+        await Should.ThrowAsync<InvalidOperationException>(() => workflow.ExtractAsync(fields, "# doc"));
+
+        await chatClient.DidNotReceive().GetResponseAsync(
+            Arg.Any<IEnumerable<ChatMessage>>(),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     // ─── validationWarnings: server-side normalization (#527 §3) ───

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFieldExtractionBackgroundJob_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentFieldExtractionBackgroundJob_Tests.cs
@@ -13,6 +13,7 @@ using Dignite.Vault.Extract.Documents.Pipelines.FieldExtraction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Shouldly;
 using Volo.Abp.BackgroundJobs;
@@ -41,7 +42,9 @@ public class FieldExtractionJobTestModule : AbpModule
         // Register the stub workflow instance directly. ForPartsOf uses the real constructor; DI takes this
         // singleton and bypasses keyed IChatClient resolution.
         var workflow = Substitute.ForPartsOf<FieldExtractionWorkflow>(
-            Substitute.For<IChatClient>(), NullLogger<FieldExtractionWorkflow>.Instance);
+            Substitute.For<IChatClient>(),
+            NullLogger<FieldExtractionWorkflow>.Instance,
+            new FieldSchemaPromptBudgetGuard(Options.Create(new VaultExtractBehaviorOptions())));
         context.Services.AddSingleton(workflow);
     }
 }

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTypes/DocumentTypePackAppService_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/DocumentTypes/DocumentTypePackAppService_Tests.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dignite.Vault.Extract.Ai;
 using Dignite.Vault.Extract.Documents.DocumentTypes;
 using Dignite.Vault.Extract.Documents.DocumentTypes.Packs;
 using Dignite.Vault.Extract.Documents.Fields;
 using Shouldly;
+using Microsoft.Extensions.Options;
 using Volo.Abp;
 using Volo.Abp.Data;
 using Xunit;
@@ -21,12 +23,18 @@ public class DocumentTypePackAppService_Tests : VaultExtractEntityFrameworkCoreT
     private readonly IDocumentTypePackAppService _packAppService;
     private readonly IDocumentTypeRepository _documentTypeRepository;
     private readonly IFieldDefinitionRepository _fieldDefinitionRepository;
+    private readonly IDocumentTypeAppService _documentTypeAppService;
+    private readonly IFieldDefinitionAppService _fieldDefinitionAppService;
+    private readonly VaultExtractBehaviorOptions _behaviorOptions;
 
     public DocumentTypePackAppService_Tests()
     {
         _packAppService = GetRequiredService<IDocumentTypePackAppService>();
         _documentTypeRepository = GetRequiredService<IDocumentTypeRepository>();
         _fieldDefinitionRepository = GetRequiredService<IFieldDefinitionRepository>();
+        _documentTypeAppService = GetRequiredService<IDocumentTypeAppService>();
+        _fieldDefinitionAppService = GetRequiredService<IFieldDefinitionAppService>();
+        _behaviorOptions = GetRequiredService<IOptions<VaultExtractBehaviorOptions>>().Value;
     }
 
     private static DocumentTypePackDto SamplePack(string typeCode = "host.invoice") => new()
@@ -164,6 +172,69 @@ public class DocumentTypePackAppService_Tests : VaultExtractEntityFrameworkCoreT
             fields.Count.ShouldBe(3); // the new field was added
             fields.Single(f => f.Name == "amount").Prompt.ShouldBe("the total"); // existing field untouched
         });
+    }
+
+    [Fact]
+    public async Task Prompt_longer_than_4000_round_trips_through_export_and_reimport()
+    {
+        var type = await _documentTypeAppService.CreateAsync(new CreateDocumentTypeDto
+        {
+            TypeCode = "host.long-prompt",
+            DisplayName = "Long prompt"
+        });
+        var prompt = new string('x', 5_000);
+        await _fieldDefinitionAppService.CreateAsync(new CreateFieldDefinitionDto
+        {
+            DocumentTypeId = type.Id,
+            Name = "body",
+            DisplayName = "Body",
+            Prompt = prompt,
+            DataType = FieldDataType.LongText
+        });
+
+        var exported = await _packAppService.ExportAsync(type.Id);
+        exported.Fields.Single().Prompt.ShouldBe(prompt);
+
+        var result = await _packAppService.ImportAsync(new ImportDocumentTypePacksInput
+        {
+            Packs = new List<DocumentTypePackDto> { exported }
+        });
+
+        result.FieldsUpdated.ShouldBe(1);
+        var reExported = await _packAppService.ExportAsync(type.Id);
+        reExported.Fields.Single().Prompt.ShouldBe(prompt);
+    }
+
+    [Fact]
+    public async Task Import_rejects_a_whole_pack_whose_total_prompt_budget_is_exceeded_before_writing()
+    {
+        var firstLength = _behaviorOptions.MaxFieldSchemaPromptLength / 2;
+        var pack = SamplePack("host.over-budget");
+        pack.Fields = new List<DocumentTypePackFieldDto>
+        {
+            new()
+            {
+                Name = "first",
+                DisplayName = "First",
+                Prompt = new string('a', firstLength),
+                DataType = FieldDataType.Text
+            },
+            new()
+            {
+                Name = "second",
+                DisplayName = "Second",
+                Prompt = new string('b', _behaviorOptions.MaxFieldSchemaPromptLength - firstLength + 1),
+                DataType = FieldDataType.Text
+            }
+        };
+
+        var ex = await Should.ThrowAsync<BusinessException>(() => _packAppService.ImportAsync(
+            new ImportDocumentTypePacksInput { Packs = new List<DocumentTypePackDto> { pack } }));
+
+        ex.Code.ShouldBe(VaultExtractErrorCodes.FieldDefinition.SchemaPromptBudgetExceeded);
+        ex.Data["ActualLength"].ShouldBe((long)_behaviorOptions.MaxFieldSchemaPromptLength + 1);
+        await WithUnitOfWorkAsync(async () =>
+            (await _documentTypeRepository.FindByTypeCodeAsync(pack.TypeCode)).ShouldBeNull());
     }
 
     [Fact]

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldSchemaPromptBudget_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldSchemaPromptBudget_Tests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading.Tasks;
+using Dignite.Vault.Extract.Ai;
+using Dignite.Vault.Extract.Documents.DocumentTypes;
+using Dignite.Vault.Extract.Documents.Fields;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace Dignite.Vault.Extract.EntityFrameworkCore.Documents.Fields;
+
+[DependsOn(typeof(VaultExtractEntityFrameworkCoreTestModule))]
+public class FieldSchemaPromptBudgetTestModule : AbpModule
+{
+    public const int PromptBudget = 10;
+
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<VaultExtractBehaviorOptions>(options =>
+        {
+            options.MaxFieldSchemaPromptLength = PromptBudget;
+        });
+    }
+}
+
+/// <summary>
+/// #468 aggregate-budget coverage for field CRUD and restore paths against real repositories.
+/// </summary>
+public class FieldSchemaPromptBudget_Tests : VaultExtractTestBase<FieldSchemaPromptBudgetTestModule>
+{
+    private readonly IFieldDefinitionAppService _fieldAppService;
+    private readonly IDocumentTypeAppService _typeAppService;
+    private readonly VaultExtractBehaviorOptions _options;
+
+    public FieldSchemaPromptBudget_Tests()
+    {
+        _fieldAppService = GetRequiredService<IFieldDefinitionAppService>();
+        _typeAppService = GetRequiredService<IDocumentTypeAppService>();
+        _options = GetRequiredService<IOptions<VaultExtractBehaviorOptions>>().Value;
+    }
+
+    [Fact]
+    public async Task Create_rejects_a_projected_schema_above_the_type_budget()
+    {
+        var type = await CreateTypeAsync();
+        await CreateFieldAsync(type.Id, "first", new string('a', 6));
+
+        var ex = await Should.ThrowAsync<BusinessException>(
+            () => CreateFieldAsync(type.Id, "second", new string('b', 5)));
+
+        ex.Code.ShouldBe(VaultExtractErrorCodes.FieldDefinition.SchemaPromptBudgetExceeded);
+        ex.Data["ActualLength"].ShouldBe(11L);
+        ex.Data["MaxLength"].ShouldBe(FieldSchemaPromptBudgetTestModule.PromptBudget);
+    }
+
+    [Fact]
+    public async Task Update_accepts_the_exact_budget_and_rejects_one_character_more()
+    {
+        var type = await CreateTypeAsync();
+        await CreateFieldAsync(type.Id, "first", new string('a', 6));
+        var second = await CreateFieldAsync(type.Id, "second", new string('b', 3));
+
+        var atLimit = await _fieldAppService.UpdateAsync(second.Id, Update(second, new string('b', 4)));
+        atLimit.Prompt!.Length.ShouldBe(FieldSchemaPromptBudgetTestModule.PromptBudget - 6);
+
+        var ex = await Should.ThrowAsync<BusinessException>(
+            () => _fieldAppService.UpdateAsync(second.Id, Update(second, new string('b', 5))));
+
+        ex.Code.ShouldBe(VaultExtractErrorCodes.FieldDefinition.SchemaPromptBudgetExceeded);
+    }
+
+    [Fact]
+    public async Task Restoring_a_field_validates_the_projected_active_schema()
+    {
+        var type = await CreateTypeAsync();
+        await CreateFieldAsync(type.Id, "first", new string('a', 6));
+        var deleted = await CreateFieldAsync(type.Id, "deleted", new string('b', 4));
+        await _fieldAppService.DeleteAsync(deleted.Id);
+        await CreateFieldAsync(type.Id, "replacement", new string('c', 4));
+
+        var ex = await Should.ThrowAsync<BusinessException>(() => _fieldAppService.RestoreAsync(deleted.Id));
+
+        ex.Code.ShouldBe(VaultExtractErrorCodes.FieldDefinition.SchemaPromptBudgetExceeded);
+        ex.Data["ActualLength"].ShouldBe(14L);
+    }
+
+    [Fact]
+    public async Task Cascading_type_restore_rechecks_the_current_host_budget()
+    {
+        var type = await CreateTypeAsync();
+        await CreateFieldAsync(type.Id, "only", new string('a', FieldSchemaPromptBudgetTestModule.PromptBudget));
+        await _typeAppService.DeleteAsync(type.Id);
+
+        _options.MaxFieldSchemaPromptLength = FieldSchemaPromptBudgetTestModule.PromptBudget - 1;
+        try
+        {
+            var ex = await Should.ThrowAsync<BusinessException>(() => _typeAppService.RestoreAsync(type.Id));
+            ex.Code.ShouldBe(VaultExtractErrorCodes.FieldDefinition.SchemaPromptBudgetExceeded);
+        }
+        finally
+        {
+            _options.MaxFieldSchemaPromptLength = FieldSchemaPromptBudgetTestModule.PromptBudget;
+        }
+    }
+
+    private async Task<DocumentTypeDto> CreateTypeAsync()
+        => await _typeAppService.CreateAsync(new CreateDocumentTypeDto
+        {
+            TypeCode = $"host.budget-{Guid.NewGuid():N}",
+            DisplayName = "Budget test"
+        });
+
+    private async Task<FieldDefinitionDto> CreateFieldAsync(Guid documentTypeId, string name, string? prompt)
+        => await _fieldAppService.CreateAsync(new CreateFieldDefinitionDto
+        {
+            DocumentTypeId = documentTypeId,
+            Name = name,
+            DisplayName = name,
+            Prompt = prompt,
+            DataType = FieldDataType.Text
+        });
+
+    private static UpdateFieldDefinitionDto Update(FieldDefinitionDto field, string? prompt)
+        => new()
+        {
+            Name = field.Name,
+            DisplayName = field.DisplayName,
+            Prompt = prompt,
+            DataType = field.DataType,
+            DisplayOrder = field.DisplayOrder,
+            IsRequired = field.IsRequired,
+            AllowMultiple = field.AllowMultiple,
+            IsUniqueKey = field.IsUniqueKey
+        };
+}

--- a/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldSchemaPromptBudget_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.EntityFrameworkCore.Tests/EntityFrameworkCore/Documents/Fields/FieldSchemaPromptBudget_Tests.cs
@@ -32,12 +32,14 @@ public class FieldSchemaPromptBudget_Tests : VaultExtractTestBase<FieldSchemaPro
 {
     private readonly IFieldDefinitionAppService _fieldAppService;
     private readonly IDocumentTypeAppService _typeAppService;
+    private readonly IFieldDefinitionRepository _fieldRepository;
     private readonly VaultExtractBehaviorOptions _options;
 
     public FieldSchemaPromptBudget_Tests()
     {
         _fieldAppService = GetRequiredService<IFieldDefinitionAppService>();
         _typeAppService = GetRequiredService<IDocumentTypeAppService>();
+        _fieldRepository = GetRequiredService<IFieldDefinitionRepository>();
         _options = GetRequiredService<IOptions<VaultExtractBehaviorOptions>>().Value;
     }
 
@@ -103,6 +105,39 @@ public class FieldSchemaPromptBudget_Tests : VaultExtractTestBase<FieldSchemaPro
         {
             _options.MaxFieldSchemaPromptLength = FieldSchemaPromptBudgetTestModule.PromptBudget;
         }
+    }
+
+    [Fact]
+    public async Task Cascading_type_restore_budgets_only_fields_that_will_actually_be_restored()
+    {
+        var type = await CreateTypeAsync();
+        await CreateFieldAsync(
+            type.Id,
+            "conflicting_name",
+            new string('a', FieldSchemaPromptBudgetTestModule.PromptBudget));
+        await _typeAppService.DeleteAsync(type.Id);
+
+        // Reproduce the defensive conflict case the cascade already supports (possible through a legacy/manual
+        // store bypass): the active field wins and the deleted same-name field is deliberately skipped.
+        var activeFieldId = Guid.NewGuid();
+        await WithUnitOfWorkAsync(() =>
+            _fieldRepository.InsertAsync(
+                new FieldDefinition(
+                    activeFieldId,
+                    tenantId: null,
+                    type.Id,
+                    "conflicting_name",
+                    "active",
+                    prompt: "b",
+                    dataType: FieldDataType.Text),
+                autoSave: true));
+
+        await _typeAppService.RestoreAsync(type.Id);
+
+        var activeFields = await _fieldAppService.GetListAsync(
+            new GetFieldDefinitionListInput { DocumentTypeId = type.Id });
+        activeFields.Count.ShouldBe(1);
+        activeFields[0].Id.ShouldBe(activeFieldId);
     }
 
     private async Task<DocumentTypeDto> CreateTypeAsync()

--- a/docs/en/configuration/ai-provider.md
+++ b/docs/en/configuration/ai-provider.md
@@ -172,7 +172,9 @@ These knobs describe *how Dignite Vault Extract calls the model* (language hint,
 "Vault": {
   "ExtractBehavior": {
     "DefaultLanguage": "ja",
-    "MaxTextLengthPerExtraction": 8000
+    "MaxTextLengthPerExtraction": 8000,
+    "MaxFieldExtractionMarkdownLength": 200000,
+    "MaxFieldSchemaPromptLength": 32000
   }
 }
 ```
@@ -180,7 +182,9 @@ These knobs describe *how Dignite Vault Extract calls the model* (language hint,
 | Key | Default | Description |
 | --- | --- | --- |
 | `DefaultLanguage` | `"ja"` | Language hint appended to every system prompt. Match this to your primary user base — Dignite Vault Extract prompts are written language-agnostic and switch via this hint |
-| `MaxTextLengthPerExtraction` | `8000` | Per-call character cap on Markdown fed to **classification** and **cabinet suggestion** (both only need the document's opening for a verdict). **Field extraction is not capped** — it sends the full Markdown, since a type-bound field can appear anywhere in the document and tail truncation would silently drop it. CJK-safe (one character ≈ one CJK glyph). Raise for long contracts / policies if your model's context window allows |
+| `MaxTextLengthPerExtraction` | `8000` | Per-call character cap on Markdown fed to **classification** and **cabinet suggestion** (both only need the document's opening for a verdict). CJK-safe (one character ≈ one CJK glyph). Raise for long contracts / policies if your model's context window allows |
+| `MaxFieldExtractionMarkdownLength` | `200000` | Maximum complete document body accepted by field extraction. Field extraction cannot safely truncate because a field may appear anywhere; an oversized document is declined with a blocking review reason instead of calling the model |
+| `MaxFieldSchemaPromptLength` | `32000` | Maximum total prompt characters across all active field definitions on one document type. Individual prompts remain uncapped; schema create/update/restore/import rejects only when the per-type total exceeds this host-funded LLM budget |
 
 Per-pipeline tuning lives in `ExtractBehavior` — see [classification.md](../pipeline/classification.md) for the keys the classification workflow reads.
 

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -56,7 +56,8 @@
     "ExtractBehavior": {
       "DefaultLanguage": "ja",
       "MaxDocumentTypesInClassificationPrompt": 50,
-      "MaxTextLengthPerExtraction": 8000
+      "MaxTextLengthPerExtraction": 8000,
+      "MaxFieldSchemaPromptLength": 32000
     }
   },
   "Mcp": {


### PR DESCRIPTION
## What changed

- remove the interactive 4,000-character DTO limit from persisted config-pack field prompts
- enforce a host-configured per-document-type total prompt budget on create, update, field restore, document-type cascade restore, and pack import
- preflight the final projected active schema for a full pack batch before the first write
- assert the invariant again before constructing the LLM request
- rename `MaxPromptLength` to `MaxInteractivePromptInputLength`
- add configuration, documentation, localized business errors, and regression coverage

## Confirmed design

The decision record on #468 is implemented as agreed: write-time enforcement plus call-site assertion; sum of non-blank active prompt lengths; `VaultExtractBehaviorOptions.MaxFieldSchemaPromptLength` defaulting to 32,000; no compatibility alias for the renamed interactive constant.

## Review hardening

Cascade restore originally budgeted every soft-deleted field before applying same-name conflict skips. That could reject a restore even though the conflicting fields would never become active. The preflight now builds the exact restore set first, budgets only that set with the active schema, and restores that same set.

## Validation

- Full solution build: success, 0 errors (3 pre-existing nullable warnings in host code).
- `FieldSchemaPromptBudget_Tests`: 5 passed, 0 failed, including same-name cascade conflict coverage.
- JSON validation and `git diff --check`: passed.

Closes #468