### PR TITLE
fix(mcp): harden forwarded client IP trust (#469)

### DIFF
--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpForwardedClientIpOptions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpForwardedClientIpOptions.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Controls whether the host may restore the originating client IP from a reverse proxy for
+/// <c>/mcp</c> rate-limit partitioning. Forwarded client IPs are disabled by default and, when
+/// enabled, require an explicit proxy/network allowlist so arbitrary clients cannot spoof their
+/// partition through <c>X-Forwarded-For</c>.
+/// </summary>
+public sealed class McpForwardedClientIpOptions
+{
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Maximum number of forwarded entries consumed from the right-hand side of the header.
+    /// Keep this aligned with the number of trusted proxy hops in front of the host.
+    /// </summary>
+    public int ForwardLimit { get; set; } = 1;
+
+    /// <summary>
+    /// Exact IP addresses of trusted reverse proxies.
+    /// </summary>
+    public List<string> KnownProxies { get; set; } = [];
+
+    /// <summary>
+    /// Trusted reverse-proxy networks in CIDR notation.
+    /// </summary>
+    public List<string> KnownNetworks { get; set; } = [];
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpForwardedClientIpServiceCollectionExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpForwardedClientIpServiceCollectionExtensions.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dignite.Vault.Extract.Mcp.Authentication;
+
+/// <summary>
+/// Configures ASP.NET Core forwarded-header processing for the MCP per-IP rate limiter (#469).
+/// The MCP exit owns the fail-closed trust-list mechanism; the host still owns the deployment
+/// configuration and remains responsible for placing <c>UseForwardedHeaders</c> before routing.
+/// </summary>
+public static class McpForwardedClientIpServiceCollectionExtensions
+{
+    public static IServiceCollection AddVaultExtractMcpForwardedClientIp(
+        this IServiceCollection services,
+        IConfigurationSection configuration,
+        bool includeForwardedProto = false)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var settings = configuration.Get<McpForwardedClientIpOptions>() ?? new McpForwardedClientIpOptions();
+        if (!settings.Enabled)
+        {
+            if (includeForwardedProto)
+            {
+                // Preserve the host's existing development/non-HTTPS-metadata scheme forwarding,
+                // but retain ASP.NET Core's loopback-only trust defaults instead of trusting any sender.
+                services.Configure<ForwardedHeadersOptions>(options =>
+                    options.ForwardedHeaders |= ForwardedHeaders.XForwardedProto);
+            }
+
+            return services;
+        }
+
+        if (settings.ForwardLimit <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{configuration.Path}:ForwardLimit must be greater than zero when forwarded client IP handling is enabled.");
+        }
+
+        var knownProxies = ParseKnownProxies(configuration.Path, settings.KnownProxies);
+        var knownNetworks = ParseKnownNetworks(configuration.Path, settings.KnownNetworks);
+        if (knownProxies.Count == 0 && knownNetworks.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"{configuration.Path} is enabled but no trusted source is configured. " +
+                "Set KnownProxies and/or KnownNetworks; accepting X-Forwarded-For from every sender would permit IP spoofing.");
+        }
+
+        services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders |= ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            options.ForwardLimit = settings.ForwardLimit;
+
+            // The configured allowlist is authoritative. Do not retain implicit loopback entries that
+            // the operator did not include in the deployment's declared proxy trust boundary.
+            options.KnownProxies.Clear();
+            options.KnownIPNetworks.Clear();
+
+            foreach (var proxy in knownProxies)
+            {
+                options.KnownProxies.Add(proxy);
+            }
+
+            foreach (var network in knownNetworks)
+            {
+                options.KnownIPNetworks.Add(network);
+            }
+        });
+
+        return services;
+    }
+
+    private static List<IPAddress> ParseKnownProxies(string sectionPath, IEnumerable<string> values)
+    {
+        var result = new List<IPAddress>();
+        foreach (var value in values.Where(value => !string.IsNullOrWhiteSpace(value)))
+        {
+            if (!IPAddress.TryParse(value.Trim(), out var address))
+            {
+                throw new InvalidOperationException(
+                    $"{sectionPath}:KnownProxies contains invalid IP address '{value}'.");
+            }
+
+            result.Add(address);
+        }
+
+        return result;
+    }
+
+    private static List<System.Net.IPNetwork> ParseKnownNetworks(string sectionPath, IEnumerable<string> values)
+    {
+        var result = new List<System.Net.IPNetwork>();
+        foreach (var value in values.Where(value => !string.IsNullOrWhiteSpace(value)))
+        {
+            var cidr = value.Trim();
+            if (!cidr.Contains('/') || !System.Net.IPNetwork.TryParse(cidr, out var network))
+            {
+                throw new InvalidOperationException(
+                    $"{sectionPath}:KnownNetworks contains invalid CIDR network '{value}'.");
+            }
+
+            result.Add(network);
+        }
+
+        return result;
+    }
+}

--- a/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpForwardedClientIpServiceCollectionExtensions.cs
+++ b/core/src/Dignite.Vault.Extract.Mcp/Authentication/McpForwardedClientIpServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
@@ -88,7 +89,7 @@ public static class McpForwardedClientIpServiceCollectionExtensions
                     $"{sectionPath}:KnownProxies contains invalid IP address '{value}'.");
             }
 
-            result.Add(address);
+            AddEquivalentAddresses(result, address);
         }
 
         return result;
@@ -106,9 +107,60 @@ public static class McpForwardedClientIpServiceCollectionExtensions
                     $"{sectionPath}:KnownNetworks contains invalid CIDR network '{value}'.");
             }
 
-            result.Add(network);
+            AddEquivalentNetworks(result, network);
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Kestrel can expose an IPv4 peer either as an IPv4 address or as its IPv4-mapped IPv6 representation when
+    /// dual-mode sockets are in use. Forwarded Headers performs exact proxy/network matching, so trust both
+    /// representations of the same configured endpoint rather than making an operator guess the runtime form.
+    /// </summary>
+    private static void AddEquivalentAddresses(List<IPAddress> result, IPAddress address)
+    {
+        AddDistinct(result, address);
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            AddDistinct(result, address.MapToIPv6());
+        }
+        else if (address.IsIPv4MappedToIPv6)
+        {
+            AddDistinct(result, address.MapToIPv4());
+        }
+    }
+
+    private static void AddEquivalentNetworks(List<System.Net.IPNetwork> result, System.Net.IPNetwork network)
+    {
+        AddDistinct(result, network);
+        if (network.BaseAddress.AddressFamily == AddressFamily.InterNetwork)
+        {
+            AddDistinct(
+                result,
+                new System.Net.IPNetwork(network.BaseAddress.MapToIPv6(), network.PrefixLength + 96));
+        }
+        else if (network.BaseAddress.IsIPv4MappedToIPv6 && network.PrefixLength >= 96)
+        {
+            AddDistinct(
+                result,
+                new System.Net.IPNetwork(network.BaseAddress.MapToIPv4(), network.PrefixLength - 96));
+        }
+    }
+
+    private static void AddDistinct(List<IPAddress> values, IPAddress candidate)
+    {
+        if (!values.Contains(candidate))
+        {
+            values.Add(candidate);
+        }
+    }
+
+    private static void AddDistinct(List<System.Net.IPNetwork> values, System.Net.IPNetwork candidate)
+    {
+        if (!values.Contains(candidate))
+        {
+            values.Add(candidate);
+        }
     }
 }

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpRateLimiter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpRateLimiter_Tests.cs
@@ -67,7 +67,9 @@ public class McpRateLimiter_Tests
     {
         using var server = await BuildServerAsync(
             permitLimit: 1,
-            transportPeer: IPAddress.Parse("10.0.0.100"),
+            // Kestrel commonly exposes an IPv4 peer in this mapped form on dual-mode sockets. A configured
+            // "10.0.0.100" proxy must match both runtime representations.
+            transportPeer: IPAddress.Parse("10.0.0.100").MapToIPv6(),
             trustedProxy: "10.0.0.100");
         using var client = server.CreateClient();
 
@@ -91,6 +93,19 @@ public class McpRateLimiter_Tests
     }
 
     [Fact]
+    public async Task Trusted_ipv4_network_matches_an_ipv4_mapped_transport_peer()
+    {
+        using var server = await BuildServerAsync(
+            permitLimit: 1,
+            transportPeer: IPAddress.Parse("10.1.2.3").MapToIPv6(),
+            trustedNetwork: "10.1.0.0/16");
+        using var client = server.CreateClient();
+
+        (await SendFromAsync(client, "203.0.113.10")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await SendFromAsync(client, "203.0.113.11")).StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public void Forwarded_client_ip_without_a_trusted_source_fails_closed()
     {
         var configuration = new ConfigurationBuilder()
@@ -110,12 +125,14 @@ public class McpRateLimiter_Tests
         int permitLimit,
         bool enabled = true,
         IPAddress? transportPeer = null,
-        string? trustedProxy = null)
+        string? trustedProxy = null,
+        string? trustedNetwork = null)
     {
         var forwardedHeadersValues = new Dictionary<string, string?>
         {
-            ["Mcp:ForwardedClientIp:Enabled"] = (trustedProxy != null).ToString(),
-            ["Mcp:ForwardedClientIp:KnownProxies:0"] = trustedProxy
+            ["Mcp:ForwardedClientIp:Enabled"] = (trustedProxy != null || trustedNetwork != null).ToString(),
+            ["Mcp:ForwardedClientIp:KnownProxies:0"] = trustedProxy,
+            ["Mcp:ForwardedClientIp:KnownNetworks:0"] = trustedNetwork
         };
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(forwardedHeadersValues)

--- a/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpRateLimiter_Tests.cs
+++ b/core/test/Dignite.Vault.Extract.Mcp.Tests/Authentication/McpRateLimiter_Tests.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -58,8 +62,65 @@ public class McpRateLimiter_Tests
         }
     }
 
-    private static async Task<TestServer> BuildServerAsync(int permitLimit, bool enabled = true)
+    [Fact]
+    public async Task Trusted_forwarded_client_ips_get_independent_rate_limit_partitions()
     {
+        using var server = await BuildServerAsync(
+            permitLimit: 1,
+            transportPeer: IPAddress.Parse("10.0.0.100"),
+            trustedProxy: "10.0.0.100");
+        using var client = server.CreateClient();
+
+        (await SendFromAsync(client, "203.0.113.10")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await SendFromAsync(client, "203.0.113.11")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await SendFromAsync(client, "203.0.113.10")).StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task An_unknown_transport_peer_cannot_spoof_rate_limit_partitions()
+    {
+        using var server = await BuildServerAsync(
+            permitLimit: 1,
+            transportPeer: IPAddress.Parse("10.0.0.200"),
+            trustedProxy: "10.0.0.100");
+        using var client = server.CreateClient();
+
+        (await SendFromAsync(client, "203.0.113.10")).StatusCode.ShouldBe(HttpStatusCode.OK);
+        // The untrusted peer's X-Forwarded-For is ignored, so both requests share 10.0.0.200's bucket.
+        (await SendFromAsync(client, "203.0.113.11")).StatusCode.ShouldBe(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public void Forwarded_client_ip_without_a_trusted_source_fails_closed()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Mcp:ForwardedClientIp:Enabled"] = "true"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        Should.Throw<InvalidOperationException>(() =>
+            services.AddVaultExtractMcpForwardedClientIp(
+                configuration.GetSection("Mcp:ForwardedClientIp")));
+    }
+
+    private static async Task<TestServer> BuildServerAsync(
+        int permitLimit,
+        bool enabled = true,
+        IPAddress? transportPeer = null,
+        string? trustedProxy = null)
+    {
+        var forwardedHeadersValues = new Dictionary<string, string?>
+        {
+            ["Mcp:ForwardedClientIp:Enabled"] = (trustedProxy != null).ToString(),
+            ["Mcp:ForwardedClientIp:KnownProxies:0"] = trustedProxy
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(forwardedHeadersValues)
+            .Build();
+
         var host = await new HostBuilder()
             .ConfigureWebHost(web =>
             {
@@ -74,9 +135,21 @@ public class McpRateLimiter_Tests
                         options.WindowSeconds = 60;
                         options.QueueLimit = 0;
                     });
+                    services.AddVaultExtractMcpForwardedClientIp(
+                        configuration.GetSection("Mcp:ForwardedClientIp"));
                 });
                 web.Configure(app =>
                 {
+                    if (transportPeer != null)
+                    {
+                        app.Use(async (context, next) =>
+                        {
+                            context.Connection.RemoteIpAddress = transportPeer;
+                            await next();
+                        });
+                    }
+
+                    app.UseForwardedHeaders();
                     app.UseRouting();
                     app.UseRateLimiter();
                     app.UseEndpoints(endpoints =>
@@ -92,5 +165,13 @@ public class McpRateLimiter_Tests
             .StartAsync();
 
         return host.GetTestServer();
+    }
+
+    private static Task<HttpResponseMessage> SendFromAsync(HttpClient client, string clientIp)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/mcp");
+        request.Headers.Add("X-Forwarded-For", clientIp);
+        request.Headers.Add("X-Forwarded-Proto", "https");
+        return client.SendAsync(request);
     }
 }

--- a/docs/en/egress/mcp-server.md
+++ b/docs/en/egress/mcp-server.md
@@ -153,6 +153,8 @@ Environment-variable equivalents use configuration indexes, for example `Mcp__Fo
 
 When enabled, Extract processes `X-Forwarded-For` and `X-Forwarded-Proto` before routing and rate limiting. Startup fails if neither allowlist is populated, if an address/CIDR is invalid, or if `ForwardLimit` is less than one. This is intentional: trusting forwarded headers from arbitrary senders lets a client spoof its IP, rotate rate-limit partitions, and potentially influence scheme-sensitive behavior. Keep the host reachable only through the declared proxies, and set `ForwardLimit` to the actual number of trusted hops. For multi-hop chains, list every trusted hop/network and increase the limit accordingly.
 
+On dual-mode sockets Kestrel may expose an IPv4 peer as an IPv4-mapped IPv6 address (`::ffff:10.0.0.100`). Extract automatically registers both representations for configured IPv4 proxies and networks, so the IPv4 configuration above remains valid in either runtime form.
+
 ## Connect Claude Desktop
 
 Claude Desktop talks to remote HTTP MCP servers through the `mcp-remote` stdio bridge. In `claude_desktop_config.json`:

--- a/docs/en/egress/mcp-server.md
+++ b/docs/en/egress/mcp-server.md
@@ -132,7 +132,26 @@ The `/mcp` endpoint is rate-limited per client IP (#433) — a DoS / abuse backs
 }
 ```
 
-Behind a reverse proxy the per-IP partition is only as accurate as the host's forwarded-headers handling — without client-IP forwarding, all external clients share a single bucket (reverse-proxy hardening and docs are tracked in #469).
+### Reverse proxy client IPs
+
+By default, Extract does **not** trust `X-Forwarded-For`. A direct deployment partitions the limiter by the transport peer IP. Behind a reverse proxy, that peer is the proxy itself, so all external clients share one rate-limit bucket until trusted client-IP forwarding is explicitly enabled.
+
+Configure the proxy to replace (not blindly append to) `X-Forwarded-For` with the originating address, then declare only the proxy addresses or networks that may supply forwarded headers:
+
+```jsonc
+"Mcp": {
+  "ForwardedClientIp": {
+    "Enabled": true,
+    "ForwardLimit": 1,                  // number of trusted proxy hops
+    "KnownProxies": [ "10.0.0.100" ],  // exact proxy IPs
+    "KnownNetworks": [ "10.1.0.0/16" ] // and/or trusted CIDR ranges
+  }
+}
+```
+
+Environment-variable equivalents use configuration indexes, for example `Mcp__ForwardedClientIp__Enabled=true` and `Mcp__ForwardedClientIp__KnownProxies__0=10.0.0.100`.
+
+When enabled, Extract processes `X-Forwarded-For` and `X-Forwarded-Proto` before routing and rate limiting. Startup fails if neither allowlist is populated, if an address/CIDR is invalid, or if `ForwardLimit` is less than one. This is intentional: trusting forwarded headers from arbitrary senders lets a client spoof its IP, rotate rate-limit partitions, and potentially influence scheme-sensitive behavior. Keep the host reachable only through the declared proxies, and set `ForwardLimit` to the actual number of trusted hops. For multi-hop chains, list every trusted hop/network and increase the limit accordingly.
 
 ## Connect Claude Desktop
 

--- a/host/src/VaultExtractHostModule.cs
+++ b/host/src/VaultExtractHostModule.cs
@@ -23,7 +23,6 @@ using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.OpenApi;
@@ -236,14 +235,16 @@ public class VaultExtractHostModule : AbpModule
             {
                 options.DisableTransportSecurityRequirement = true;
             });
-
-            Configure<ForwardedHeadersOptions>(options =>
-            {
-                options.ForwardedHeaders = ForwardedHeaders.XForwardedProto;
-                options.KnownIPNetworks.Clear();
-                options.KnownProxies.Clear();
-            });
         }
+
+        // #469: when explicitly enabled, restore the originating client IP before /mcp rate limiting
+        // so clients behind the same reverse proxy do not collapse into one partition. The MCP module's
+        // registration fails closed unless the deployment declares trusted proxy IPs or CIDR networks.
+        // Forwarded headers remain disabled for client IPs by default; UseForwardedHeaders is already the
+        // first middleware in OnApplicationInitialization.
+        context.Services.AddVaultExtractMcpForwardedClientIp(
+            configuration.GetSection("Mcp:ForwardedClientIp"),
+            includeForwardedProto: !configuration.GetValue<bool>("AuthServer:RequireHttpsMetadata"));
 
         if (hostingEnvironment.IsDevelopment())
         {

--- a/host/src/appsettings.json
+++ b/host/src/appsettings.json
@@ -65,6 +65,12 @@
       "Enabled": true,
       "PermitLimit": 300,
       "WindowSeconds": 60
+    },
+    "ForwardedClientIp": {
+      "Enabled": false,
+      "ForwardLimit": 1,
+      "KnownProxies": [],
+      "KnownNetworks": []
     }
   },
   "VisionLlmOcr": {


### PR DESCRIPTION
## What changed

- keep forwarded client IP processing disabled by default
- when enabled, require an explicit `KnownProxies` or `KnownNetworks` allowlist and a positive `ForwardLimit`
- run forwarded-header handling before routing/rate limiting so trusted clients receive independent limiter partitions
- ignore spoofed `X-Forwarded-For` values from unknown transport peers
- document proxy-chain and deployment requirements

## Review hardening

ASP.NET Core only consumes forwarded headers from configured trusted peers. Kestrel dual-mode sockets can expose an IPv4 peer as an IPv4-mapped IPv6 address, so exact IPv4-only entries can otherwise fail to match at runtime.

Configuration now registers equivalent IPv4 and mapped-IPv6 forms for both exact proxies and CIDR networks. Regression coverage uses mapped transport peers and verifies both exact-address and network trust.

The behavior follows Microsoft's forwarded-header trust model:
https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer
https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/forwarded-headers-unknown-proxies

## Validation

- Full solution build: success, 0 errors (3 pre-existing nullable warnings in host code).
- `McpRateLimiter_Tests`: 7 passed, 0 failed.
- `git diff --check`: passed.

No migration or public API contract change is required.

Closes #469